### PR TITLE
Enable running core test suite in parallel

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -32,3 +32,6 @@
 [submodule "magic_enum"]
 	path = submodules/magic_enum
 	url = https://github.com/Neargye/magic_enum.git
+[submodule "submodules/gtest-parallel"]
+	path = submodules/gtest-parallel
+	url = https://github.com/google/gtest-parallel.git

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -150,7 +150,7 @@ TEST (active_transactions, keep_local)
 {
 	nano::test::system system{};
 
-	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = false;
 	// Bound to 2, won't drop wallet created transactions, but good to test dropping remote
 	node_config.active_elections_size = 2;
@@ -316,7 +316,7 @@ TEST (active_transactions, inactive_votes_cache_fork)
 TEST (active_transactions, inactive_votes_cache_existing_vote)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	nano::block_hash latest (node.latest (nano::dev::genesis_key.pub));
@@ -372,7 +372,7 @@ TEST (active_transactions, inactive_votes_cache_existing_vote)
 TEST (active_transactions, inactive_votes_cache_multiple_votes)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	nano::keypair key1;
@@ -428,7 +428,7 @@ TEST (active_transactions, inactive_votes_cache_multiple_votes)
 TEST (active_transactions, inactive_votes_cache_election_start)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	node_config.optimistic_scheduler.enabled = false;
 	auto & node = *system.add_node (node_config);
@@ -528,7 +528,7 @@ namespace nano
 TEST (active_transactions, vote_replays)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = false;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
@@ -674,10 +674,10 @@ TEST (active_transactions, dropped_cleanup)
 TEST (active_transactions, republish_winner)
 {
 	nano::test::system system;
-	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 = *system.add_node (node_config);
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto & node2 = *system.add_node (node_config);
 
 	nano::keypair key;
@@ -742,7 +742,7 @@ TEST (active_transactions, fork_filter_cleanup)
 {
 	nano::test::system system{};
 
-	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
 	auto & node1 = *system.add_node (node_config);
@@ -790,7 +790,7 @@ TEST (active_transactions, fork_filter_cleanup)
 	ASSERT_EQ (1, node1.active.size ());
 
 	// Instantiate a new node
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto & node2 = *system.add_node (node_config);
 
 	// Process the first initial block on node2
@@ -823,7 +823,7 @@ TEST (active_transactions, fork_filter_cleanup)
 TEST (active_transactions, fork_replacement_tally)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 (*system.add_node (node_config));
 
@@ -941,7 +941,7 @@ TEST (active_transactions, fork_replacement_tally)
 	ASSERT_EQ (max_blocks, election->blocks ().size ());
 
 	// Process correct block
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto & node2 (*system.add_node (node_config));
 	node1.network.publish_filter.clear ();
 	node2.network.flood_block (send_last);
@@ -985,7 +985,7 @@ namespace nano
 TEST (active_transactions, confirmation_consistency)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -1083,7 +1083,7 @@ TEST (active_transactions, activate_account_chain)
 {
 	nano::test::system system;
 	nano::node_flags flags;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (config, flags);
 
@@ -1183,7 +1183,7 @@ TEST (active_transactions, activate_inactive)
 {
 	nano::test::system system;
 	nano::node_flags flags;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (config, flags);
 
@@ -1297,7 +1297,7 @@ TEST (active_transactions, vacancy)
 	std::atomic<bool> updated = false;
 	{
 		nano::test::system system;
-		nano::node_config config{ nano::test::get_available_port (), system.logging };
+		nano::node_config config = system.default_config ();
 		config.active_elections_size = 1;
 		auto & node = *system.add_node (config);
 		nano::state_block_builder builder;
@@ -1333,7 +1333,7 @@ TEST (active_transactions, fifo)
 {
 	nano::test::system system{};
 
-	nano::node_config config{ nano::test::get_available_port (), system.logging };
+	nano::node_config config = system.default_config ();
 	config.active_elections_size = 1;
 
 	auto & node = *system.add_node (config);

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -639,7 +639,7 @@ namespace lmdb
 			GTEST_SKIP ();
 		}
 		// Check that upgrading from an unsupported version is not supported
-		auto path (nano::unique_path ());
+		auto path (nano::unique_path () / "data.ldb");
 		nano::logger_mt logger;
 		{
 			nano::lmdb::store store (logger, path, nano::dev::constants);
@@ -657,7 +657,7 @@ namespace lmdb
 			ASSERT_TRUE (store.init_error ());
 		}
 
-		auto path1 (nano::unique_path ());
+		auto path1 (nano::unique_path () / "data.ldb");
 		// Now try with the minimum version
 		{
 			nano::lmdb::store store (logger, path1, nano::dev::constants);
@@ -1012,7 +1012,7 @@ TEST (mdb_block_store, sideband_height)
 	nano::keypair key1;
 	nano::keypair key2;
 	nano::keypair key3;
-	nano::lmdb::store store (logger, nano::unique_path (), nano::dev::constants);
+	nano::lmdb::store store (logger, nano::unique_path () / "data.ldb", nano::dev::constants);
 	ASSERT_FALSE (store.init_error ());
 	nano::stats stats;
 	nano::ledger ledger (store, stats, nano::dev::constants);
@@ -1382,7 +1382,7 @@ namespace lmdb
 			GTEST_SKIP ();
 		}
 		// Extract confirmation height to a separate database
-		auto path (nano::unique_path ());
+		auto path (nano::unique_path () / "data.ldb");
 		nano::block_builder builder;
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		auto send = builder
@@ -1544,7 +1544,7 @@ namespace lmdb
 			// Don't test this in rocksdb mode
 			GTEST_SKIP ();
 		}
-		auto path (nano::unique_path ());
+		auto path (nano::unique_path () / "data.ldb");
 		nano::mdb_val value;
 		{
 			nano::logger_mt logger;
@@ -1625,7 +1625,7 @@ namespace lmdb
 					  .build ();
 
 		auto code = [&block1, &block2, &block3] (auto confirmation_height, nano::block_hash const & expected_cemented_frontier) {
-			auto path (nano::unique_path ());
+			auto path (nano::unique_path () / "data.ldb");
 			nano::mdb_val value;
 			{
 				nano::logger_mt logger;
@@ -1681,7 +1681,7 @@ namespace lmdb
 			// Don't test this in rocksdb mode
 			GTEST_SKIP ();
 		}
-		auto path (nano::unique_path ());
+		auto path (nano::unique_path () / "data.ldb");
 		nano::block_builder builder;
 		nano::keypair key1;
 		nano::keypair key2;
@@ -1990,7 +1990,7 @@ namespace lmdb
 			// Don't test this in rocksdb mode
 			GTEST_SKIP ();
 		}
-		auto path (nano::unique_path ());
+		auto path (nano::unique_path () / "data.ldb");
 		nano::keypair key1;
 		nano::block_builder builder;
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -2127,7 +2127,7 @@ namespace lmdb
 			// Don't test this in rocksdb mode
 			GTEST_SKIP ();
 		}
-		auto path (nano::unique_path ());
+		auto path (nano::unique_path () / "data.ldb");
 		nano::logger_mt logger;
 		nano::stats stats;
 		{
@@ -2156,7 +2156,7 @@ namespace lmdb
 			// Don't test this in rocksdb mode
 			GTEST_SKIP ();
 		}
-		auto path (nano::unique_path ());
+		auto path (nano::unique_path () / "data.ldb");
 		nano::logger_mt logger;
 		nano::stats stats;
 		{
@@ -2186,7 +2186,7 @@ namespace lmdb
 			GTEST_SKIP ();
 		}
 
-		auto path (nano::unique_path ());
+		auto path (nano::unique_path () / "data.ldb");
 		nano::logger_mt logger;
 		nano::stats stats;
 		auto const check_correct_state = [&] () {
@@ -2225,7 +2225,7 @@ namespace rocksdb
 			GTEST_SKIP ();
 		}
 
-		auto const path = nano::unique_path ();
+		auto const path = nano::unique_path () / "rocksdb";
 		nano::logger_mt logger;
 		nano::stats stats;
 		auto const check_correct_state = [&] () {
@@ -2477,7 +2477,7 @@ TEST (rocksdb_block_store, tombstone_count)
 	}
 	nano::test::system system;
 	nano::logger_mt logger;
-	auto store = std::make_unique<nano::rocksdb::store> (logger, nano::unique_path (), nano::dev::constants);
+	auto store = std::make_unique<nano::rocksdb::store> (logger, nano::unique_path () / "rocksdb", nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	nano::block_builder builder;
 	auto block = builder

--- a/nano/core_test/blockprocessor.cpp
+++ b/nano/core_test/blockprocessor.cpp
@@ -13,10 +13,10 @@ using namespace std::chrono_literals;
 TEST (block_processor, broadcast_block_on_arrival)
 {
 	nano::test::system system;
-	nano::node_config config1{ nano::test::get_available_port (), system.logging };
+	nano::node_config config1 = system.default_config ();
 	// Deactivates elections on both nodes.
 	config1.active_elections_size = 0;
-	nano::node_config config2{ nano::test::get_available_port (), system.logging };
+	nano::node_config config2 = system.default_config ();
 	config2.active_elections_size = 0;
 	nano::node_flags flags;
 	// Disables bootstrap listener to make sure the block won't be shared by this channel.

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -94,7 +94,7 @@ TEST (confirmation_height, multiple_accounts)
 		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 		nano::keypair key1;
@@ -440,10 +440,10 @@ TEST (confirmation_height, gap_live)
 		nano::test::system system{};
 		nano::node_flags node_flags{};
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
-		node_config.peering_port = nano::test::get_available_port ();
+		node_config.peering_port = system.get_available_port ();
 		node_config.receive_minimum = nano::dev::constants.genesis_amount; // Prevent auto-receive & open1/receive1/receive2 blocks conflicts
 		system.add_node (node_config, node_flags);
 		nano::keypair destination;
@@ -574,7 +574,7 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 		nano::keypair key1;
@@ -729,7 +729,7 @@ TEST (confirmation_height, send_receive_self)
 		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 		nano::block_hash latest (node->latest (nano::dev::genesis_key.pub));
@@ -837,7 +837,7 @@ TEST (confirmation_height, all_block_types)
 		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 		nano::block_hash latest (node->latest (nano::dev::genesis_key.pub));
@@ -1410,7 +1410,7 @@ TEST (confirmation_height, pending_observer_callbacks)
 		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
@@ -1468,7 +1468,7 @@ TEST (confirmation_height, callback_confirmed_history)
 		nano::node_flags node_flags;
 		node_flags.force_use_write_database_queue = true;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
@@ -1560,7 +1560,7 @@ TEST (confirmation_height, dependent_election)
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
 		node_flags.force_use_write_database_queue = true;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
@@ -1631,7 +1631,7 @@ TEST (confirmation_height, cemented_gap_below_receive)
 		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
@@ -1791,7 +1791,7 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 		nano::test::system system;
 		nano::node_flags node_flags;
 		node_flags.confirmation_height_processor_mode = mode_a;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 
@@ -1951,7 +1951,7 @@ TEST (confirmation_height, election_winner_details_clearing)
 		nano::node_flags node_flags{};
 		node_flags.confirmation_height_processor_mode = mode_a;
 
-		nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
 		auto node = system.add_node (node_config, node_flags);

--- a/nano/core_test/core_test_main.cc
+++ b/nano/core_test/core_test_main.cc
@@ -6,6 +6,8 @@
 
 #include <boost/filesystem/path.hpp>
 
+constexpr std::size_t OPEN_FILE_DESCRIPTORS_LIMIT = 16384;
+
 namespace nano
 {
 namespace test
@@ -18,6 +20,7 @@ void force_nano_dev_network ();
 GTEST_API_ int main (int argc, char ** argv)
 {
 	printf ("Running main() from core_test_main.cc\n");
+	nano::set_file_descriptor_limit (OPEN_FILE_DESCRIPTORS_LIMIT);
 	nano::force_nano_dev_network ();
 	nano::node_singleton_memory_pool_purge_guard memory_pool_cleanup_guard;
 	// Setting up logging so that there aren't any piped to standard output.

--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -40,7 +40,7 @@ TEST (distributed_work, no_peers)
 TEST (distributed_work, no_peers_disabled)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.work_threads = 0;
 	auto & node = *system.add_node (node_config);
 	ASSERT_TRUE (node.distributed_work.make (nano::work_version::work_1, nano::block_hash (), node.config.work_peers, nano::dev::network_params.work.base, {}));
@@ -49,7 +49,7 @@ TEST (distributed_work, no_peers_disabled)
 TEST (distributed_work, no_peers_cancel)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.max_work_generate_multiplier = 1e6;
 	auto & node = *system.add_node (node_config);
 	nano::block_hash hash{ 1 };
@@ -119,7 +119,7 @@ TEST (distributed_work, peer)
 {
 	nano::test::system system;
 	nano::node_config node_config;
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	// Disable local work generation
 	node_config.work_threads = 0;
 	auto node (system.add_node (node_config));
@@ -132,7 +132,7 @@ TEST (distributed_work, peer)
 		work = work_a;
 		done = true;
 	};
-	auto work_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::good));
+	auto work_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, system.get_available_port (), work_peer_type::good));
 	work_peer->start ();
 	decltype (node->config.work_peers) peers;
 	peers.emplace_back ("::ffff:127.0.0.1", work_peer->port ());
@@ -158,7 +158,7 @@ TEST (distributed_work, peer_malicious)
 		work = work_a;
 		done = true;
 	};
-	auto malicious_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::malicious));
+	auto malicious_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, system.get_available_port (), work_peer_type::malicious));
 	malicious_peer->start ();
 	decltype (node->config.work_peers) peers;
 	peers.emplace_back ("::ffff:127.0.0.1", malicious_peer->port ());
@@ -176,7 +176,7 @@ TEST (distributed_work, peer_malicious)
 	// Test again with no local work generation enabled to make sure the malicious peer is sent more than one request
 	node->config.work_threads = 0;
 	ASSERT_FALSE (node->local_work_generation_enabled ());
-	auto malicious_peer2 (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::malicious));
+	auto malicious_peer2 (std::make_shared<fake_work_peer> (node->work, node->io_ctx, system.get_available_port (), work_peer_type::malicious));
 	malicious_peer2->start ();
 	peers[0].second = malicious_peer2->port ();
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, {}, nano::account ()));
@@ -201,9 +201,9 @@ TEST (distributed_work, DISABLED_peer_multi)
 		work = work_a;
 		done = true;
 	};
-	auto good_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::good));
-	auto malicious_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::malicious));
-	auto slow_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, nano::test::get_available_port (), work_peer_type::slow));
+	auto good_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, system.get_available_port (), work_peer_type::good));
+	auto malicious_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, system.get_available_port (), work_peer_type::malicious));
+	auto slow_peer (std::make_shared<fake_work_peer> (node->work, node->io_ctx, system.get_available_port (), work_peer_type::slow));
 	good_peer->start ();
 	malicious_peer->start ();
 	slow_peer->start ();

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -32,7 +32,7 @@ TEST (election, quorum_minimum_flip_success)
 {
 	nano::test::system system{};
 
-	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config = system.default_config ();
 	node_config.online_weight_minimum = nano::dev::constants.genesis_amount;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
@@ -82,7 +82,7 @@ TEST (election, quorum_minimum_flip_success)
 TEST (election, quorum_minimum_flip_fail)
 {
 	nano::test::system system;
-	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config = system.default_config ();
 	node_config.online_weight_minimum = nano::dev::constants.genesis_amount;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
@@ -133,7 +133,7 @@ TEST (election, quorum_minimum_flip_fail)
 TEST (election, quorum_minimum_confirm_success)
 {
 	nano::test::system system;
-	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config = system.default_config ();
 	node_config.online_weight_minimum = nano::dev::constants.genesis_amount;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 = *system.add_node (node_config);
@@ -165,7 +165,7 @@ TEST (election, quorum_minimum_confirm_success)
 TEST (election, quorum_minimum_confirm_fail)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.online_weight_minimum = nano::dev::constants.genesis_amount;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 = *system.add_node (node_config);
@@ -204,7 +204,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 {
 	nano::test::system system;
 
-	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
 	auto & node1 = *system.add_node (node_config);
@@ -239,7 +239,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
 	ASSERT_TIMELY (5s, node1.ledger.cache.block_count == 4);
 
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto & node2 = *system.add_node (node_config);
 
 	system.wallet (1)->insert_adhoc (key1.prv);

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -69,7 +69,7 @@ TEST (election_scheduler, no_vacancy)
 {
 	nano::test::system system{};
 
-	nano::node_config config{ nano::test::get_available_port (), system.logging };
+	nano::node_config config = system.default_config ();
 	config.active_elections_size = 1;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
@@ -145,7 +145,7 @@ TEST (election_scheduler, no_vacancy)
 TEST (election_scheduler, flush_vacancy)
 {
 	nano::test::system system;
-	nano::node_config config{ nano::test::get_available_port (), system.logging };
+	nano::node_config config = system.default_config ();
 	// No elections can be activated
 	config.active_elections_size = 0;
 	auto & node = *system.add_node (config);

--- a/nano/core_test/frontiers_confirmation.cpp
+++ b/nano/core_test/frontiers_confirmation.cpp
@@ -14,7 +14,7 @@ TEST (frontiers_confirmation, mode)
 	// Always mode
 	{
 		nano::test::system system;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::always;
 		auto node = system.add_node (node_config, node_flags);
 		auto send = builder
@@ -36,7 +36,7 @@ TEST (frontiers_confirmation, mode)
 	// Auto mode
 	{
 		nano::test::system system;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::automatic;
 		auto node = system.add_node (node_config, node_flags);
 		auto send = builder
@@ -58,7 +58,7 @@ TEST (frontiers_confirmation, mode)
 	// Disabled mode
 	{
 		nano::test::system system;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config, node_flags);
 		auto send = builder

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -895,7 +895,7 @@ TEST (ledger, double_receive)
 TEST (votes, check_signature)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.online_weight_minimum = std::numeric_limits<nano::uint128_t>::max ();
 	auto & node1 = *system.add_node (node_config);
 	nano::keypair key1;
@@ -967,7 +967,7 @@ namespace nano
 TEST (votes, add_existing)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.online_weight_minimum = nano::dev::constants.genesis_amount;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 = *system.add_node (node_config);
@@ -4314,7 +4314,7 @@ TEST (ledger, unchecked_epoch)
 TEST (ledger, unchecked_epoch_invalid)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 (*system.add_node (node_config));
 	nano::keypair destination;

--- a/nano/core_test/ledger_walker.cpp
+++ b/nano/core_test/ledger_walker.cpp
@@ -42,7 +42,7 @@ namespace nano
 TEST (ledger_walker, genesis_account_longer)
 {
 	nano::test::system system{};
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = true;
 	node_config.receive_minimum = 1;
 
@@ -91,7 +91,7 @@ TEST (ledger_walker, genesis_account_longer)
 TEST (ledger_walker, cross_account)
 {
 	nano::test::system system{};
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = true;
 	node_config.receive_minimum = 1;
 
@@ -142,7 +142,7 @@ TEST (ledger_walker, DISABLED_ladder_geometry)
 {
 	nano::test::system system{};
 
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = true;
 	node_config.receive_minimum = 1;
 

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -18,98 +18,46 @@ using namespace std::chrono_literals;
 
 TEST (network, tcp_connection)
 {
-	// Organizes the code used for a connection into distinguished classes (base class/client/server)
-	struct simple_socket : public boost::enable_shared_from_this<simple_socket>
-	{
-		std::atomic<bool> connected;
-		uint16_t port;
-		boost::asio::ip::tcp::endpoint endpoint;
-		boost::asio::ip::tcp::socket socket;
-		std::string error_message;
-
-		explicit simple_socket (boost::asio::io_context & io_ctx_a, boost::asio::ip::address ip_address_a, uint16_t port_a) :
-			connected{ false },
-			port{ port_a },
-			endpoint{ ip_address_a, port_a },
-			socket{ io_ctx_a }
-		{
-		}
-
-		virtual void async_write (std::string message)
-		{
-		}
-		virtual void async_read ()
-		{
-		}
-	};
-
-	struct simple_server_socket final : public simple_socket
-	{
-		boost::asio::ip::tcp::acceptor acceptor;
-
-		explicit simple_server_socket (boost::asio::io_context & io_ctx_a, boost::asio::ip::address ip_address_a, uint16_t port_a) :
-			simple_socket{ io_ctx_a, ip_address_a, port_a },
-			acceptor{ io_ctx_a }
-		{
-			accept ();
-		}
-
-		void accept ()
-		{
-			acceptor.open (endpoint.protocol ());
-			acceptor.set_option (boost::asio::ip::tcp::acceptor::reuse_address (true));
-			acceptor.bind (endpoint);
-			acceptor.listen ();
-			acceptor.async_accept (socket,
-			[this] (boost::system::error_code const & ec_a) {
-				if (ec_a)
-				{
-					this->error_message = ec_a.message ();
-					std::cerr << this->error_message;
-				}
-				else
-				{
-					this->connected = true;
-					this->async_read ();
-				}
-			});
-		}
-	};
-
-	struct simple_client_socket final : public simple_socket
-	{
-		explicit simple_client_socket (boost::asio::io_context & io_ctx_a, boost::asio::ip::address ip_address_a, uint16_t port_a) :
-			simple_socket{ io_ctx_a, ip_address_a, port_a }
-		{
-			socket.async_connect (boost::asio::ip::tcp::endpoint (ip_address_a, port_a),
-			[this] (boost::system::error_code const & ec_a) {
-				if (ec_a)
-				{
-					this->error_message = ec_a.message ();
-					std::cerr << error_message;
-				}
-				else
-				{
-					this->connected = true;
-				}
-			});
-		}
-	};
-
 	nano::test::system system;
+	boost::asio::ip::tcp::acceptor acceptor (system.io_ctx);
 	auto port = system.get_available_port ();
-	simple_server_socket server (system.io_ctx, boost::asio::ip::address_v4::any (), port);
-	simple_client_socket client (system.io_ctx, boost::asio::ip::address_v4::loopback (), port);
-
-	ASSERT_TIMELY (5s, server.connected && client.connected);
-	ASSERT_EQ (0, client.error_message.size ());
-	ASSERT_EQ (0, server.error_message.size ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v4::any (), port);
+	acceptor.open (endpoint.protocol ());
+	acceptor.set_option (boost::asio::ip::tcp::acceptor::reuse_address (true));
+	acceptor.bind (endpoint);
+	acceptor.listen ();
+	boost::asio::ip::tcp::socket incoming (system.io_ctx);
+	std::atomic<bool> done1 (false);
+	std::string message1;
+	acceptor.async_accept (incoming, [&done1, &message1] (boost::system::error_code const & ec_a) {
+		if (ec_a)
+		{
+			message1 = ec_a.message ();
+			std::cerr << message1;
+		}
+		done1 = true;
+	});
+	boost::asio::ip::tcp::socket connector (system.io_ctx);
+	std::atomic<bool> done2 (false);
+	std::string message2;
+	connector.async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v4::loopback (), acceptor.local_endpoint ().port ()),
+	[&done2, &message2] (boost::system::error_code const & ec_a) {
+		if (ec_a)
+		{
+			message2 = ec_a.message ();
+			std::cerr << message2;
+		}
+		done2 = true;
+	});
+	ASSERT_TIMELY (5s, done1 && done2);
+	ASSERT_EQ (0, message1.size ());
+	ASSERT_EQ (0, message2.size ());
 }
 
 TEST (network, construction_with_specified_port)
 {
 	nano::test::system system{};
-	auto const port = system.get_available_port ();
+	auto const port = system.get_available_port (/* do not allow 0 port */ false);
 	auto const node = system.add_node (nano::node_config{ port, system.logging });
 	EXPECT_EQ (port, node->network.port);
 	EXPECT_EQ (port, node->network.endpoint ().port ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -66,12 +66,13 @@ TEST (node, work_generate)
 
 TEST (node, block_store_path_failure)
 {
+	nano::test::system system;
 	auto service (boost::make_shared<boost::asio::io_context> ());
 	auto path (nano::unique_path ());
 	nano::logging logging;
 	logging.init (path);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	auto node (std::make_shared<nano::node> (*service, nano::test::get_available_port (), path, logging, pool));
+	auto node (std::make_shared<nano::node> (*service, system.get_available_port (), path, logging, pool));
 	ASSERT_TRUE (node->wallets.items.empty ());
 	node->stop ();
 }
@@ -96,10 +97,11 @@ TEST (node_DeathTest, readonly_block_store_not_exist)
 
 TEST (node, password_fanout)
 {
+	nano::test::system system;
 	boost::asio::io_context io_ctx;
 	auto path (nano::unique_path ());
 	nano::node_config config;
-	config.peering_port = nano::test::get_available_port ();
+	config.peering_port = system.get_available_port ();
 	config.logging.init (path);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	config.password_fanout = 10;
@@ -266,7 +268,7 @@ TEST (node, node_receive_quorum)
 TEST (node, auto_bootstrap)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config (system.get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -278,7 +280,7 @@ TEST (node, auto_bootstrap)
 	auto send1 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node0->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send1);
 	ASSERT_TIMELY (10s, node0->balance (key2.pub) == node0->config.receive_minimum.number ());
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	ASSERT_FALSE (node1->init_error ());
 	node1->start ();
 	system.nodes.push_back (node1);
@@ -298,7 +300,7 @@ TEST (node, auto_bootstrap)
 TEST (node, auto_bootstrap_reverse)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config (system.get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
@@ -307,7 +309,7 @@ TEST (node, auto_bootstrap_reverse)
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key2.prv);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	ASSERT_FALSE (node1->init_error ());
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node0->config.receive_minimum.number ()));
 	node1->start ();
@@ -319,14 +321,14 @@ TEST (node, auto_bootstrap_reverse)
 TEST (node, auto_bootstrap_age)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config (system.get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
 	node_flags.bootstrap_interval = 1;
 	auto node0 = system.add_node (config, node_flags);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	ASSERT_FALSE (node1->init_error ());
 	node1->start ();
 	system.nodes.push_back (node1);
@@ -365,8 +367,8 @@ TEST (node, merge_peers)
 {
 	nano::test::system system (1);
 	std::array<nano::endpoint, 8> endpoints;
-	endpoints.fill (nano::endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ()));
-	endpoints[0] = nano::endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
+	endpoints.fill (nano::endpoint (boost::asio::ip::address_v6::loopback (), system.get_available_port ()));
+	endpoints[0] = nano::endpoint (boost::asio::ip::address_v6::loopback (), system.get_available_port ());
 	system.nodes[0]->network.merge_peers (endpoints);
 	ASSERT_EQ (0, system.nodes[0]->network.size ());
 }
@@ -416,7 +418,7 @@ TEST (node, search_receivable_multiple)
 TEST (node, search_receivable_confirmed)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
 	nano::keypair key2;
@@ -450,12 +452,12 @@ TEST (node, search_receivable_confirmed)
 TEST (node, search_receivable_pruned)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node1 = system.add_node (node_config);
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config (system.get_available_port (), system.logging);
 	config.enable_voting = false; // Remove after allowing pruned voting
 	auto node2 = system.add_node (config, node_flags);
 	nano::keypair key2;
@@ -761,10 +763,10 @@ TEST (node, fork_multi_flip)
 	auto type = nano::transport::transport_type::tcp;
 	nano::test::system system;
 	nano::node_flags node_flags;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 (*system.add_node (node_config, node_flags, type));
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto & node2 (*system.add_node (node_config, node_flags, type));
 	ASSERT_EQ (1, node1.network.size ());
 	nano::keypair key1;
@@ -831,15 +833,16 @@ TEST (node, fork_multi_flip)
 // This could happen if a fork wasn't resolved before the process previously shut down
 TEST (node, fork_bootstrap_flip)
 {
+	nano::test::system system;
 	nano::test::system system0;
 	nano::test::system system1;
-	nano::node_config config0{ nano::test::get_available_port (), system0.logging };
+	nano::node_config config0{ system.get_available_port (), system0.logging };
 	config0.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
 	auto & node1 = *system0.add_node (config0, node_flags);
-	nano::node_config config1 (nano::test::get_available_port (), system1.logging);
+	nano::node_config config1 (system.get_available_port (), system1.logging);
 	auto & node2 = *system1.add_node (config1, node_flags);
 	system0.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::block_hash latest = node1.latest (nano::dev::genesis_key.pub);
@@ -1245,12 +1248,12 @@ TEST (node, DISABLED_broadcast_elected)
 	auto type = nano::transport::transport_type::tcp;
 	nano::node_flags node_flags;
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 = system.add_node (node_config, node_flags, type);
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto node1 = system.add_node (node_config, node_flags, type);
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto node2 = system.add_node (node_config, node_flags, type);
 	nano::keypair rep_big;
 	nano::keypair rep_small;
@@ -1371,7 +1374,7 @@ TEST (node, DISABLED_broadcast_elected)
 TEST (node, rep_self_vote)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.online_weight_minimum = std::numeric_limits<nano::uint128_t>::max ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 = system.add_node (node_config);
@@ -1466,12 +1469,13 @@ TEST (node, DISABLED_bootstrap_no_publish)
 // Issue for investigating it: https://github.com/nanocurrency/nano-node/issues/3515
 TEST (node, DISABLED_bootstrap_bulk_push)
 {
+	nano::test::system system;
 	nano::test::system system0;
 	nano::test::system system1;
-	nano::node_config config0 (nano::test::get_available_port (), system0.logging);
+	nano::node_config config0 (system.get_available_port (), system0.logging);
 	config0.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 (system0.add_node (config0));
-	nano::node_config config1 (nano::test::get_available_port (), system1.logging);
+	nano::node_config config1 (system.get_available_port (), system1.logging);
 	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node1 (system1.add_node (config1));
 	nano::keypair key0;
@@ -1508,9 +1512,9 @@ TEST (node, DISABLED_bootstrap_bulk_push)
 TEST (node, bootstrap_fork_open)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	auto node0 = system.add_node (node_config);
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto node1 = system.add_node (node_config);
 	nano::keypair key0;
 	nano::block_builder builder;
@@ -1681,7 +1685,7 @@ TEST (node, rep_weight)
 {
 	nano::test::system system;
 	auto add_node = [&system] {
-		auto node = std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work);
+		auto node = std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.logging, system.work);
 		node->start ();
 		system.nodes.push_back (node);
 		return node;
@@ -1851,7 +1855,7 @@ TEST (node, rep_remove)
 	ASSERT_TIMELY (5s, searching_node.rep_crawler.representative_count () == 0);
 
 	// Add working node for genesis representative
-	auto node_genesis_rep = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging));
+	auto node_genesis_rep = system.add_node (nano::node_config (system.get_available_port (), system.logging));
 	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto channel_genesis_rep (searching_node.network.find_node_id (node_genesis_rep->get_node_id ()));
 	ASSERT_NE (nullptr, channel_genesis_rep);
@@ -1862,7 +1866,7 @@ TEST (node, rep_remove)
 	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 1);
 
 	// Start a node for Rep2 and wait until it is connected
-	auto node_rep2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), nano::node_config (nano::test::get_available_port (), system.logging), system.work));
+	auto node_rep2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), nano::node_config (system.get_available_port (), system.logging), system.work));
 	node_rep2->start ();
 	searching_node.network.tcp_channels.start_tcp (node_rep2->network.endpoint ());
 	std::shared_ptr<nano::transport::channel> channel_rep2;
@@ -1903,7 +1907,7 @@ TEST (node, no_voting)
 {
 	nano::test::system system (1);
 	auto & node0 (*system.nodes[0]);
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.enable_voting = false;
 	system.add_node (node_config);
 
@@ -2225,7 +2229,7 @@ TEST (node, confirm_quorum)
 TEST (node, local_votes_cache)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	node_config.receive_minimum = nano::dev::constants.genesis_amount;
 	auto & node (*system.add_node (node_config));
@@ -2313,7 +2317,7 @@ TEST (node, local_votes_cache)
 TEST (node, DISABLED_local_votes_cache_batch)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	ASSERT_GE (node.network_params.voting.max_cache, 2);
@@ -2386,7 +2390,7 @@ TEST (node, DISABLED_local_votes_cache_batch)
 TEST (node, local_votes_cache_generate_new_vote)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -2439,7 +2443,7 @@ TEST (node, local_votes_cache_fork)
 	node_flags.disable_lazy_bootstrap = true;
 	node_flags.disable_legacy_bootstrap = true;
 	node_flags.disable_wallet_bootstrap = true;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 (*system.add_node (node_config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -2470,7 +2474,7 @@ TEST (node, local_votes_cache_fork)
 	ASSERT_EQ (1, votes2.size ());
 	ASSERT_EQ (1, votes2[0]->hashes.size ());
 	// Start election for forked block
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto & node2 (*system.add_node (node_config, node_flags));
 	node2.process_active (send1_fork);
 	node2.block_processor.flush ();
@@ -2690,10 +2694,10 @@ TEST (node, DISABLED_vote_by_hash_epoch_block_republish)
 TEST (node, epoch_conflict_confirm)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node0 = *system.add_node (node_config);
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto & node1 = *system.add_node (node_config);
 	nano::keypair key;
 	nano::keypair epoch_signer (nano::dev::genesis_key);
@@ -3021,7 +3025,7 @@ TEST (node, block_processor_full)
 	nano::node_flags node_flags;
 	node_flags.force_use_write_database_queue = true;
 	node_flags.block_processor_full_size = 3;
-	auto & node = *system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
+	auto & node = *system.add_node (nano::node_config (system.get_available_port (), system.logging), node_flags);
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
 				 .account (nano::dev::genesis_key.pub)
@@ -3066,7 +3070,7 @@ TEST (node, block_processor_half_full)
 	nano::node_flags node_flags;
 	node_flags.block_processor_full_size = 6;
 	node_flags.force_use_write_database_queue = true;
-	auto & node = *system.add_node (nano::node_config (nano::test::get_available_port (), system.logging), node_flags);
+	auto & node = *system.add_node (nano::node_config (system.get_available_port (), system.logging), node_flags);
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
 				 .account (nano::dev::genesis_key.pub)
@@ -3158,7 +3162,7 @@ TEST (node, peers)
 	auto node1 (system.nodes[0]);
 	ASSERT_TRUE (node1->network.empty ());
 
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node2 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.logging, system.work));
 	system.nodes.push_back (node2);
 
 	auto endpoint = node1->network.endpoint ();
@@ -3208,7 +3212,7 @@ TEST (node, peer_cache_restart)
 	nano::endpoint_key endpoint_key{ endpoint.address ().to_v6 ().to_bytes (), endpoint.port () };
 	auto path (nano::unique_path ());
 	{
-		auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), path, system.logging, system.work));
+		auto node2 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), path, system.logging, system.work));
 		system.nodes.push_back (node2);
 		auto & store = node2->store;
 		{
@@ -3228,7 +3232,7 @@ TEST (node, peer_cache_restart)
 	{
 		nano::node_flags node_flags;
 		node_flags.read_only = true;
-		auto node3 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), path, system.logging, system.work, node_flags));
+		auto node3 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), path, system.logging, system.work, node_flags));
 		system.nodes.push_back (node3);
 		// Check cached peers after restart
 		node3->network.start ();
@@ -3333,10 +3337,10 @@ TEST (node, bidirectional_tcp)
 	node_flags.disable_legacy_bootstrap = true;
 	node_flags.disable_lazy_bootstrap = true;
 	node_flags.disable_wallet_bootstrap = true;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node1 = system.add_node (node_config, node_flags);
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	node_config.tcp_incoming_connections_max = 0; // Disable incoming TCP connections for node 2
 	auto node2 = system.add_node (node_config, node_flags);
 	// Check network connections
@@ -3531,7 +3535,7 @@ TEST (node, rollback_vote_self)
 TEST (node, rollback_gap_source)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config (system.get_available_port (), system.logging);
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	nano::state_block_builder builder;
@@ -3599,7 +3603,7 @@ TEST (node, rollback_gap_source)
 TEST (node, dependency_graph)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config (system.get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (config);
 
@@ -3797,10 +3801,10 @@ TEST (node, dependency_graph)
 TEST (node, dependency_graph_frontier)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config (system.get_available_port (), system.logging);
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node1 = *system.add_node (config);
-	config.peering_port = nano::test::get_available_port ();
+	config.peering_port = system.get_available_port ();
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::always;
 	auto & node2 = *system.add_node (config);
 
@@ -3964,9 +3968,9 @@ namespace nano
 TEST (node, deferred_dependent_elections)
 {
 	nano::test::system system;
-	nano::node_config node_config_1{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config_1{ system.get_available_port (), system.logging };
 	node_config_1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	nano::node_config node_config_2{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config_2{ system.get_available_port (), system.logging };
 	node_config_2.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags flags;
 	flags.disable_request_loop = true;
@@ -4125,7 +4129,7 @@ TEST (node, pruning_automatic)
 {
 	nano::test::system system{};
 
-	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config{ system.get_available_port (), system.logging };
 	// TODO: remove after allowing pruned voting
 	node_config.enable_voting = false;
 	node_config.max_pruning_age = std::chrono::seconds (1);
@@ -4180,7 +4184,7 @@ TEST (node, pruning_age)
 {
 	nano::test::system system{};
 
-	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config{ system.get_available_port (), system.logging };
 	// TODO: remove after allowing pruned voting
 	node_config.enable_voting = false;
 
@@ -4243,7 +4247,7 @@ TEST (node, pruning_depth)
 {
 	nano::test::system system{};
 
-	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config{ system.get_available_port (), system.logging };
 	// TODO: remove after allowing pruned voting
 	node_config.enable_voting = false;
 

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -59,7 +59,7 @@ TEST (peer_container, reserved_ip_is_not_a_peer)
 TEST (peer_container, tcp_channel_cleanup_works)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	// Set the keepalive period to avoid background messages affecting the last_packet_set time
 	node_config.network_params.network.keepalive_period = std::chrono::minutes (10);
 	nano::node_flags node_flags;
@@ -68,9 +68,9 @@ TEST (peer_container, tcp_channel_cleanup_works)
 	// Disable the confirm_req messages avoiding them to affect the last_packet_set time
 	node_flags.disable_rep_crawler = true;
 	auto & node1 = *system.add_node (node_config, node_flags);
-	auto outer_node1 = nano::test::add_outer_node (system, nano::test::get_available_port (), node_flags);
+	auto outer_node1 = nano::test::add_outer_node (system, node_flags);
 	outer_node1->config.network_params.network.keepalive_period = std::chrono::minutes (10);
-	auto outer_node2 = nano::test::add_outer_node (system, nano::test::get_available_port (), node_flags);
+	auto outer_node2 = nano::test::add_outer_node (system, node_flags);
 	outer_node2->config.network_params.network.keepalive_period = std::chrono::minutes (10);
 	auto now = std::chrono::steady_clock::now ();
 	auto channel1 = nano::test::establish_tcp (system, node1, outer_node1->network.endpoint ());

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -12,7 +12,7 @@ using namespace std::chrono_literals;
 TEST (request_aggregator, one)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -58,7 +58,7 @@ TEST (request_aggregator, one)
 TEST (request_aggregator, one_update)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -124,7 +124,7 @@ TEST (request_aggregator, one_update)
 TEST (request_aggregator, two)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -197,12 +197,12 @@ TEST (request_aggregator, two)
 TEST (request_aggregator, two_endpoints)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_rep_crawler = true;
 	auto & node1 (*system.add_node (node_config, node_flags));
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto & node2 (*system.add_node (node_config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::block_builder builder;
@@ -256,7 +256,7 @@ TEST (request_aggregator, split)
 {
 	constexpr size_t max_vbh = nano::network::confirm_ack_hashes_max;
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -310,7 +310,7 @@ TEST (request_aggregator, split)
 TEST (request_aggregator, channel_lifetime)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -341,7 +341,7 @@ TEST (request_aggregator, channel_lifetime)
 TEST (request_aggregator, channel_update)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -380,7 +380,7 @@ TEST (request_aggregator, channel_update)
 TEST (request_aggregator, channel_max_queue)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	node_config.max_queued_requests = 1;
 	auto & node (*system.add_node (node_config));
@@ -409,7 +409,7 @@ TEST (request_aggregator, channel_max_queue)
 TEST (request_aggregator, unique)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -22,7 +22,7 @@ TEST (socket, max_connections)
 
 	auto node = system.add_node ();
 
-	auto server_port = nano::test::get_available_port ();
+	auto server_port = system.get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
 	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
@@ -114,7 +114,7 @@ TEST (socket, max_connections_per_ip)
 	auto node = system.add_node ();
 	ASSERT_FALSE (node->flags.disable_max_peers_per_ip);
 
-	auto server_port = nano::test::get_available_port ();
+	auto server_port = system.get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
 	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
@@ -236,7 +236,7 @@ TEST (socket, max_connections_per_subnetwork)
 	ASSERT_TRUE (node->flags.disable_max_peers_per_ip);
 	ASSERT_FALSE (node->flags.disable_max_peers_per_subnetwork);
 
-	auto server_port = nano::test::get_available_port ();
+	auto server_port = system.get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
 	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
@@ -299,7 +299,7 @@ TEST (socket, disabled_max_peers_per_ip)
 	auto node = system.add_node (node_flags);
 	ASSERT_TRUE (node->flags.disable_max_peers_per_ip);
 
-	auto server_port = nano::test::get_available_port ();
+	auto server_port = system.get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
 	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
@@ -366,7 +366,7 @@ TEST (socket, disconnection_of_silent_connections)
 
 	auto node = system.add_node (config);
 
-	auto server_port = nano::test::get_available_port ();
+	auto server_port = system.get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
 	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
@@ -412,6 +412,8 @@ TEST (socket, disconnection_of_silent_connections)
 
 TEST (socket, drop_policy)
 {
+	nano::test::system system;
+
 	auto node_flags = nano::inactive_node_flag_defaults ();
 	node_flags.read_only = false;
 	nano::inactive_node inactivenode (nano::unique_path (), node_flags);
@@ -422,7 +424,7 @@ TEST (socket, drop_policy)
 	std::vector<std::shared_ptr<nano::transport::socket>> connections;
 
 	auto func = [&] (size_t total_message_count, nano::transport::buffer_drop_policy drop_policy) {
-		auto server_port (nano::test::get_available_port ());
+		auto server_port (system.get_available_port ());
 		boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::any (), server_port);
 
 		auto server_socket = std::make_shared<nano::transport::server_socket> (*node, endpoint, 1);
@@ -625,7 +627,7 @@ TEST (socket_timeout, connect)
 	// try to connect to an IP address that most likely does not exist and will not reply
 	// we want the tcp stack to not receive a negative reply, we want it to see silence and to keep trying
 	// I use the un-routable IP address 10.255.254.253, which is likely to not exist
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::make_address_v6 ("::ffff:10.255.254.253"), nano::test::get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::make_address_v6 ("::ffff:10.255.254.253"), system.get_available_port ());
 
 	// create a client socket and try to connect to the IP address that wil not respond
 	auto socket = std::make_shared<nano::transport::client_socket> (*node);
@@ -656,7 +658,7 @@ TEST (socket_timeout, read)
 	node->config.tcp_io_timeout = std::chrono::seconds (2);
 
 	// create a server socket
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), system.get_available_port ());
 	boost::asio::ip::tcp::acceptor acceptor (system.io_ctx);
 	acceptor.open (endpoint.protocol ());
 	acceptor.bind (endpoint);
@@ -701,7 +703,7 @@ TEST (socket_timeout, write)
 	node->config.tcp_io_timeout = std::chrono::seconds (2);
 
 	// create a server socket
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), system.get_available_port ());
 	boost::asio::ip::tcp::acceptor acceptor (system.io_ctx);
 	acceptor.open (endpoint.protocol ());
 	acceptor.bind (endpoint);
@@ -751,7 +753,7 @@ TEST (socket_timeout, read_overlapped)
 	node->config.tcp_io_timeout = std::chrono::seconds (2);
 
 	// create a server socket
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), system.get_available_port ());
 	boost::asio::ip::tcp::acceptor acceptor (system.io_ctx);
 	acceptor.open (endpoint.protocol ());
 	acceptor.bind (endpoint);
@@ -807,7 +809,7 @@ TEST (socket_timeout, write_overlapped)
 	node->config.tcp_io_timeout = std::chrono::seconds (2);
 
 	// create a server socket
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), nano::test::get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::loopback (), system.get_available_port ());
 	boost::asio::ip::tcp::acceptor acceptor (system.io_ctx);
 	acceptor.open (endpoint.protocol ());
 	acceptor.bind (endpoint);

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -24,13 +24,14 @@ TEST (socket, max_connections)
 
 	auto server_port = system.get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
-	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
 	// start a server socket that allows max 2 live connections
 	auto server_socket = std::make_shared<nano::transport::server_socket> (*node, listen_endpoint, 2);
 	boost::system::error_code ec;
 	server_socket->start (ec);
 	ASSERT_FALSE (ec);
+
+	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_socket->listening_port () };
 
 	// successful incoming connections are stored in server_sockets to keep them alive (server side)
 	std::vector<std::shared_ptr<nano::transport::socket>> server_sockets;
@@ -116,7 +117,6 @@ TEST (socket, max_connections_per_ip)
 
 	auto server_port = system.get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
-	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
 	const auto max_ip_connections = node->network_params.network.max_peers_per_ip;
 	ASSERT_TRUE (max_ip_connections >= 1);
@@ -127,6 +127,8 @@ TEST (socket, max_connections_per_ip)
 	boost::system::error_code ec;
 	server_socket->start (ec);
 	ASSERT_FALSE (ec);
+
+	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_socket->listening_port () };
 
 	// successful incoming connections are stored in server_sockets to keep them alive (server side)
 	std::vector<std::shared_ptr<nano::transport::socket>> server_sockets;
@@ -238,7 +240,6 @@ TEST (socket, max_connections_per_subnetwork)
 
 	auto server_port = system.get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
-	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
 	const auto max_subnetwork_connections = node->network_params.network.max_peers_per_subnetwork;
 	ASSERT_TRUE (max_subnetwork_connections >= 1);
@@ -249,6 +250,8 @@ TEST (socket, max_connections_per_subnetwork)
 	boost::system::error_code ec;
 	server_socket->start (ec);
 	ASSERT_FALSE (ec);
+
+	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_socket->listening_port () };
 
 	// successful incoming connections are stored in server_sockets to keep them alive (server side)
 	std::vector<std::shared_ptr<nano::transport::socket>> server_sockets;
@@ -301,7 +304,6 @@ TEST (socket, disabled_max_peers_per_ip)
 
 	auto server_port = system.get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
-	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
 	const auto max_ip_connections = node->network_params.network.max_peers_per_ip;
 	ASSERT_TRUE (max_ip_connections >= 1);
@@ -312,6 +314,8 @@ TEST (socket, disabled_max_peers_per_ip)
 	boost::system::error_code ec;
 	server_socket->start (ec);
 	ASSERT_FALSE (ec);
+
+	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_socket->listening_port () };
 
 	// successful incoming connections are stored in server_sockets to keep them alive (server side)
 	std::vector<std::shared_ptr<nano::transport::socket>> server_sockets;
@@ -368,13 +372,14 @@ TEST (socket, disconnection_of_silent_connections)
 
 	auto server_port = system.get_available_port ();
 	boost::asio::ip::tcp::endpoint listen_endpoint{ boost::asio::ip::address_v6::any (), server_port };
-	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_port };
 
 	// start a server listening socket
 	auto server_socket = std::make_shared<nano::transport::server_socket> (*node, listen_endpoint, 1);
 	boost::system::error_code ec;
 	server_socket->start (ec);
 	ASSERT_FALSE (ec);
+
+	boost::asio::ip::tcp::endpoint dst_endpoint{ boost::asio::ip::address_v6::loopback (), server_socket->listening_port () };
 
 	// on a connection, a server data socket is created. The shared pointer guarantees the object's lifecycle until the end of this test.
 	std::shared_ptr<nano::transport::socket> server_data_socket;
@@ -477,6 +482,8 @@ TEST (socket, drop_policy)
 
 TEST (socket, concurrent_writes)
 {
+	nano::test::system system;
+
 	auto node_flags = nano::inactive_node_flag_defaults ();
 	node_flags.read_only = false;
 	node_flags.disable_max_peers_per_ip = true;
@@ -498,15 +505,6 @@ TEST (socket, concurrent_writes)
 	std::function<void (std::shared_ptr<nano::transport::socket> const &)> reader = [&read_count_completion, &total_message_count, &reader] (std::shared_ptr<nano::transport::socket> const & socket_a) {
 		auto buff (std::make_shared<std::vector<uint8_t>> ());
 		buff->resize (1);
-#ifndef _WIN32
-#pragma GCC diagnostic push
-#if defined(__has_warning)
-#if __has_warning("-Wunused-lambda-capture")
-/** total_message_count is constexpr and a capture isn't needed. However, removing it fails to compile on VS2017 due to a known compiler bug. */
-#pragma GCC diagnostic ignored "-Wunused-lambda-capture"
-#endif
-#endif
-#endif
 		socket_a->async_read (buff, 1, [&read_count_completion, &reader, &total_message_count, socket_a, buff] (boost::system::error_code const & ec, size_t size_a) {
 			if (!ec)
 			{
@@ -520,12 +518,10 @@ TEST (socket, concurrent_writes)
 				std::cerr << "async_read: " << ec.message () << std::endl;
 			}
 		});
-#ifndef _WIN32
-#pragma GCC diagnostic pop
-#endif
 	};
 
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v4::any (), 25000);
+	auto server_port (system.get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::address_v6::any (), server_port);
 
 	auto server_socket = std::make_shared<nano::transport::server_socket> (*node, endpoint, max_connections);
 	boost::system::error_code ec;
@@ -554,7 +550,7 @@ TEST (socket, concurrent_writes)
 	{
 		auto client = std::make_shared<nano::transport::client_socket> (*node);
 		clients.push_back (client);
-		client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v4::loopback (), 25000),
+		client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v4::loopback (), server_socket->listening_port ()),
 		[&connection_count_completion] (boost::system::error_code const & ec_a) {
 			if (ec_a)
 			{
@@ -573,15 +569,6 @@ TEST (socket, concurrent_writes)
 	std::vector<std::thread> client_threads;
 	for (int i = 0; i < client_count; i++)
 	{
-#ifndef _WIN32
-#pragma GCC diagnostic push
-#if defined(__has_warning)
-#if __has_warning("-Wunused-lambda-capture")
-/** total_message_count is constexpr and a capture isn't needed. However, removing it fails to compile on VS2017 due to a known compiler bug. */
-#pragma GCC diagnostic ignored "-Wunused-lambda-capture"
-#endif
-#endif
-#endif
 		client_threads.emplace_back ([&client, &message_count] () {
 			for (int i = 0; i < message_count; i++)
 			{
@@ -590,9 +577,6 @@ TEST (socket, concurrent_writes)
 				client->async_write (nano::shared_const_buffer (std::move (buff)));
 			}
 		});
-#ifndef _WIN32
-#pragma GCC diagnostic pop
-#endif
 	}
 
 	ASSERT_FALSE (read_count_completion.await_count_for (10s));
@@ -627,7 +611,7 @@ TEST (socket_timeout, connect)
 	// try to connect to an IP address that most likely does not exist and will not reply
 	// we want the tcp stack to not receive a negative reply, we want it to see silence and to keep trying
 	// I use the un-routable IP address 10.255.254.253, which is likely to not exist
-	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::make_address_v6 ("::ffff:10.255.254.253"), system.get_available_port ());
+	boost::asio::ip::tcp::endpoint endpoint (boost::asio::ip::make_address_v6 ("::ffff:10.255.254.253"), 1234);
 
 	// create a client socket and try to connect to the IP address that wil not respond
 	auto socket = std::make_shared<nano::transport::client_socket> (*node);
@@ -667,15 +651,16 @@ TEST (socket_timeout, read)
 	// asynchronously accept an incoming connection and create a newsock and do not send any data
 	boost::asio::ip::tcp::socket newsock (system.io_ctx);
 	acceptor.async_accept (newsock, [] (boost::system::error_code const & ec_a) {
-		debug_assert (!ec_a);
+		EXPECT_FALSE (ec_a);
 	});
 
 	// create a client socket to connect and call async_read, which should time out
 	auto socket = std::make_shared<nano::transport::client_socket> (*node);
 	std::atomic<bool> done = false;
 	boost::system::error_code ec;
-	socket->async_connect (endpoint, [&socket, &ec, &done] (boost::system::error_code const & ec_a) {
-		debug_assert (!ec_a);
+	socket->async_connect (acceptor.local_endpoint (), [&socket, &ec, &done] (boost::system::error_code const & ec_a) {
+		EXPECT_FALSE (ec_a);
+
 		auto buffer = std::make_shared<std::vector<uint8_t>> (1);
 		socket->async_read (buffer, 1, [&ec, &done] (boost::system::error_code const & ec_a, size_t size_a) {
 			if (ec_a)
@@ -712,7 +697,7 @@ TEST (socket_timeout, write)
 	// asynchronously accept an incoming connection and create a newsock and do not receive any data
 	boost::asio::ip::tcp::socket newsock (system.io_ctx);
 	acceptor.async_accept (newsock, [] (boost::system::error_code const & ec_a) {
-		debug_assert (!ec_a);
+		EXPECT_FALSE (ec_a);
 	});
 
 	// create a client socket and send lots of data to fill the socket queue on the local and remote side
@@ -721,8 +706,9 @@ TEST (socket_timeout, write)
 	auto socket = std::make_shared<nano::transport::client_socket> (*node, 1024 * 64); // socket with a max queue size much larger than OS buffers
 	std::atomic<bool> done = false;
 	boost::system::error_code ec;
-	socket->async_connect (endpoint, [&socket, &ec, &done] (boost::system::error_code const & ec_a) {
-		debug_assert (!ec_a);
+	socket->async_connect (acceptor.local_endpoint (), [&socket, &ec, &done] (boost::system::error_code const & ec_a) {
+		EXPECT_FALSE (ec_a);
+
 		auto buffer = std::make_shared<std::vector<uint8_t>> (128 * 1024);
 		for (auto i = 0; i < 1024; ++i)
 		{
@@ -762,7 +748,8 @@ TEST (socket_timeout, read_overlapped)
 	// asynchronously accept an incoming connection and send one byte only
 	boost::asio::ip::tcp::socket newsock (system.io_ctx);
 	acceptor.async_accept (newsock, [&newsock] (boost::system::error_code const & ec_a) {
-		debug_assert (!ec_a);
+		EXPECT_FALSE (ec_a);
+
 		auto buffer = std::make_shared<std::vector<uint8_t>> (1);
 		nano::async_write (newsock, nano::shared_const_buffer (buffer), [] (boost::system::error_code const & ec_a, size_t size_a) {
 			debug_assert (!ec_a);
@@ -774,8 +761,9 @@ TEST (socket_timeout, read_overlapped)
 	auto socket = std::make_shared<nano::transport::client_socket> (*node);
 	std::atomic<bool> done = false;
 	boost::system::error_code ec;
-	socket->async_connect (endpoint, [&socket, &ec, &done] (boost::system::error_code const & ec_a) {
-		debug_assert (!ec_a);
+	socket->async_connect (acceptor.local_endpoint (), [&socket, &ec, &done] (boost::system::error_code const & ec_a) {
+		EXPECT_FALSE (ec_a);
+
 		auto buffer = std::make_shared<std::vector<uint8_t>> (1);
 
 		socket->async_read (buffer, 1, [] (boost::system::error_code const & ec_a, size_t size_a) {
@@ -819,7 +807,8 @@ TEST (socket_timeout, write_overlapped)
 	boost::asio::ip::tcp::socket newsock (system.io_ctx);
 	auto buffer = std::make_shared<std::vector<uint8_t>> (1);
 	acceptor.async_accept (newsock, [&newsock, &buffer] (boost::system::error_code const & ec_a) {
-		debug_assert (!ec_a);
+		EXPECT_FALSE (ec_a);
+
 		boost::asio::async_read (newsock, boost::asio::buffer (buffer->data (), buffer->size ()), [] (boost::system::error_code const & ec_a, size_t size_a) {
 			debug_assert (size_a == 1);
 		});
@@ -831,8 +820,9 @@ TEST (socket_timeout, write_overlapped)
 	auto socket = std::make_shared<nano::transport::client_socket> (*node, 1024 * 64); // socket with a max queue size much larger than OS buffers
 	std::atomic<bool> done = false;
 	boost::system::error_code ec;
-	socket->async_connect (endpoint, [&socket, &ec, &done] (boost::system::error_code const & ec_a) {
-		debug_assert (!ec_a);
+	socket->async_connect (acceptor.local_endpoint (), [&socket, &ec, &done] (boost::system::error_code const & ec_a) {
+		EXPECT_FALSE (ec_a);
+
 		auto buffer1 = std::make_shared<std::vector<uint8_t>> (1);
 		auto buffer2 = std::make_shared<std::vector<uint8_t>> (128 * 1024);
 		socket->async_write (nano::shared_const_buffer{ buffer1 }, [] (boost::system::error_code const & ec_a, size_t size_a) {

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -184,7 +184,7 @@ TEST (vote_processor, no_broadcast_local)
 	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (config1, flags));
 	config2.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config2.peering_port = nano::test::get_available_port ();
+	config2.peering_port = system.get_available_port ();
 	system.add_node (config2, flags);
 	nano::block_builder builder;
 	std::error_code ec;
@@ -237,7 +237,7 @@ TEST (vote_processor, local_broadcast_without_a_representative)
 	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (config1, flags));
 	config2.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config2.peering_port = nano::test::get_available_port ();
+	config2.peering_port = system.get_available_port ();
 	system.add_node (config2, flags);
 	nano::block_builder builder;
 	std::error_code ec;
@@ -285,7 +285,7 @@ TEST (vote_processor, no_broadcast_local_with_a_principal_representative)
 	config1.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (config1, flags));
 	config2.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config2.peering_port = nano::test::get_available_port ();
+	config2.peering_port = system.get_available_port ();
 	system.add_node (config2, flags);
 	nano::block_builder builder;
 	std::error_code ec;

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1158,7 +1158,7 @@ TEST (wallet, foreach_representative_deadlock)
 TEST (wallet, search_receivable)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.enable_voting = false;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags flags;
@@ -1214,7 +1214,7 @@ TEST (wallet, receive_pruned)
 	node_flags.disable_request_loop = true;
 	auto & node1 = *system.add_node (node_flags);
 	node_flags.enable_pruning = true;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.enable_voting = false; // Remove after allowing pruned voting
 	auto & node2 = *system.add_node (config, node_flags);
 

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -185,7 +185,7 @@ TEST (wallets, search_receivable)
 	for (auto search_all : { false, true })
 	{
 		nano::test::system system;
-		nano::node_config config (nano::test::get_available_port (), system.logging);
+		nano::node_config config = system.default_config ();
 		config.enable_voting = false;
 		config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		nano::node_flags flags;

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -466,7 +466,7 @@ TEST (websocket, confirmation_options_sideband)
 
 	std::atomic<bool> ack_ready{ false };
 	auto task1 = ([&ack_ready, config, &node1] () {
-		fake_websocket_client client (config.websocket_config.port);
+		fake_websocket_client client (node1->websocket.server->listening_port ());
 		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"confirmation_type": "active_quorum", "include_block": "false", "include_sideband_info": "true"}})json");
 		client.await_ack ();
 		ack_ready = true;

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -23,9 +23,9 @@ using namespace std::chrono_literals;
 TEST (websocket, subscription_edge)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	ASSERT_EQ (0, node1->websocket.server->subscriber_count (nano::websocket::topic::confirmation));
@@ -54,9 +54,9 @@ TEST (websocket, subscription_edge)
 TEST (websocket, confirmation)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -130,9 +130,9 @@ TEST (websocket, confirmation)
 TEST (websocket, started_election)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 = system.add_node (config);
 
 	std::atomic<bool> ack_ready{ false };
@@ -178,9 +178,9 @@ TEST (websocket, started_election)
 TEST (websocket, stopped_election)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -229,9 +229,9 @@ TEST (websocket, stopped_election)
 TEST (websocket, confirmation_options)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -372,9 +372,9 @@ TEST (websocket, confirmation_options)
 TEST (websocket, confirmation_options_votes)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -459,9 +459,9 @@ TEST (websocket, confirmation_options_votes)
 TEST (websocket, confirmation_options_sideband)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -529,9 +529,9 @@ TEST (websocket, confirmation_options_sideband)
 TEST (websocket, confirmation_options_update)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> added{ false };
@@ -604,9 +604,9 @@ TEST (websocket, confirmation_options_update)
 TEST (websocket, vote)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -654,9 +654,9 @@ TEST (websocket, vote)
 TEST (websocket, vote_options_type)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -695,9 +695,9 @@ TEST (websocket, vote_options_type)
 TEST (websocket, vote_options_representatives)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };
@@ -770,9 +770,9 @@ TEST (websocket, vote_options_representatives)
 TEST (websocket, work)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	ASSERT_EQ (0, node1->websocket.server->subscriber_count (nano::websocket::topic::work));
@@ -840,9 +840,9 @@ TEST (websocket, work)
 TEST (websocket, bootstrap)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	ASSERT_EQ (0, node1->websocket.server->subscriber_count (nano::websocket::topic::bootstrap));
@@ -890,9 +890,9 @@ TEST (websocket, bootstrap)
 TEST (websocket, bootstrap_exited)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	// Start bootstrap, exit after subscription
@@ -955,9 +955,9 @@ TEST (websocket, bootstrap_exited)
 TEST (websocket, ws_keepalive)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	auto task = ([&node1] () {
@@ -974,14 +974,14 @@ TEST (websocket, ws_keepalive)
 TEST (websocket, telemetry)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	nano::node_flags node_flags;
 	auto node1 (system.add_node (config, node_flags));
-	config.peering_port = nano::test::get_available_port ();
+	config.peering_port = system.get_available_port ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node2 (system.add_node (config, node_flags));
 
 	nano::test::wait_peer_connections (system);
@@ -1032,9 +1032,9 @@ TEST (websocket, telemetry)
 TEST (websocket, new_unconfirmed_block)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	config.websocket_config.enabled = true;
-	config.websocket_config.port = nano::test::get_available_port ();
+	config.websocket_config.port = system.get_available_port ();
 	auto node1 (system.add_node (config));
 
 	std::atomic<bool> ack_ready{ false };

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -70,6 +70,8 @@ nano::lmdb::store::store (nano::logger_mt & logger_a, boost::filesystem::path co
 {
 	if (!error)
 	{
+		debug_assert (path_a.filename () == "data.ldb");
+
 		auto is_fully_upgraded (false);
 		auto is_fresh_db (false);
 		{

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -101,6 +101,8 @@ nano::rocksdb::store::store (nano::logger_mt & logger_a, boost::filesystem::path
 		return;
 	}
 
+	debug_assert (path_a.filename () == "rocksdb");
+
 	generate_tombstone_map ();
 	small_table_factory.reset (::rocksdb::NewBlockBasedTableFactory (get_small_table_options ()));
 

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -45,7 +45,7 @@ TEST (wallet, DISABLED_status)
 		return wallet->active_status.active.find (status_ty) != wallet->active_status.active.end ();
 	};
 	ASSERT_EQ ("Status: Disconnected, Blocks: 1", wallet->status->text ().toStdString ());
-	auto outer_node = nano::test::add_outer_node (system, nano::test::get_available_port ());
+	auto outer_node = nano::test::add_outer_node (system);
 	nano::test::establish_tcp (system, *system.nodes[0], outer_node->network.endpoint ());
 	// Because of the wallet "vulnerable" message, this won't be the message displayed.
 	// However, it will still be part of the status set.

--- a/nano/rpc_test/common.cpp
+++ b/nano/rpc_test/common.cpp
@@ -87,7 +87,7 @@ nano::test::rpc_context::rpc_context (std::shared_ptr<nano::rpc> & rpc_a, std::u
 std::shared_ptr<nano::node> nano::test::add_ipc_enabled_node (nano::test::system & system, nano::node_config & node_config, nano::node_flags const & node_flags)
 {
 	node_config.ipc_config.transport_tcp.enabled = true;
-	node_config.ipc_config.transport_tcp.port = nano::test::get_available_port ();
+	node_config.ipc_config.transport_tcp.port = system.get_available_port ();
 	return system.add_node (node_config, node_flags);
 }
 
@@ -98,7 +98,7 @@ std::shared_ptr<nano::node> nano::test::add_ipc_enabled_node (nano::test::system
 
 std::shared_ptr<nano::node> nano::test::add_ipc_enabled_node (nano::test::system & system)
 {
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	return add_ipc_enabled_node (system, node_config);
 }
 
@@ -138,7 +138,7 @@ nano::test::rpc_context nano::test::add_rpc (nano::test::system & system, std::s
 {
 	auto node_rpc_config (std::make_unique<nano::node_rpc_config> ());
 	auto ipc_server (std::make_unique<nano::ipc::ipc_server> (*node_a, *node_rpc_config));
-	nano::rpc_config rpc_config (node_a->network_params.network, nano::test::get_available_port (), true);
+	nano::rpc_config rpc_config (node_a->network_params.network, system.get_available_port (), true);
 	const auto ipc_tcp_port = ipc_server->listening_tcp_port ();
 	debug_assert (ipc_tcp_port.has_value ());
 	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (system.io_ctx, rpc_config, ipc_tcp_port.value ()));

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -291,7 +291,7 @@ TEST (rpc, send_work)
 TEST (rpc, send_work_disabled)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.work_threads = 0;
 	auto node = add_ipc_enabled_node (system, node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -1163,7 +1163,7 @@ TEST (rpc, history_count)
 TEST (rpc, history_pruning)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
@@ -1676,7 +1676,7 @@ TEST (rpc, keepalive)
 {
 	nano::test::system system;
 	auto node0 = add_ipc_enabled_node (system);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.logging, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);
 	auto const rpc_ctx = add_rpc (system, node0);
@@ -1702,7 +1702,7 @@ TEST (rpc, peers)
 {
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
-	auto const node2 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging));
+	auto const node2 = system.add_node ();
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "peers");
@@ -1717,7 +1717,7 @@ TEST (rpc, peers_node_id)
 {
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
-	auto const node2 = system.add_node (nano::node_config (nano::test::get_available_port (), system.logging));
+	auto const node2 = system.add_node ();
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "peers");
@@ -1800,7 +1800,7 @@ TEST (rpc, work_generate)
 TEST (rpc, work_generate_difficulty)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.max_work_generate_multiplier = 1000;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -1847,7 +1847,7 @@ TEST (rpc, work_generate_difficulty)
 TEST (rpc, work_generate_multiplier)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.max_work_generate_multiplier = 100;
 	auto node = add_ipc_enabled_node (system, node_config);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -2212,7 +2212,7 @@ TEST (rpc, block_count_pruning)
 {
 	nano::test::system system;
 	auto & node0 = *system.add_node ();
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
@@ -2420,7 +2420,7 @@ TEST (rpc, account_representative_set)
 TEST (rpc, account_representative_set_work_disabled)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.work_threads = 0;
 	auto node = add_ipc_enabled_node (system, node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -3199,7 +3199,7 @@ TEST (rpc, blocks)
 TEST (rpc, wallet_info)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = true;
 	auto node = add_ipc_enabled_node (system, node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -4258,10 +4258,10 @@ TEST (rpc, block_info_successor)
 TEST (rpc, block_info_pruning)
 {
 	nano::test::system system;
-	nano::node_config node_config0 (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config0 = system.default_config ();
 	node_config0.receive_minimum = nano::dev::constants.genesis_amount; // Prevent auto-receive & receive1 block conflicts
 	auto & node0 = *system.add_node (node_config0);
-	nano::node_config node_config1 (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config1 = system.default_config ();
 	node_config1.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
@@ -4324,10 +4324,10 @@ TEST (rpc, block_info_pruning)
 TEST (rpc, pruned_exists)
 {
 	nano::test::system system;
-	nano::node_config node_config0 (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config0 = system.default_config ();
 	node_config0.receive_minimum = nano::dev::constants.genesis_amount; // Prevent auto-receive & receive1 block conflicts
 	auto & node0 = *system.add_node (node_config0);
-	nano::node_config node_config1 (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config1 = system.default_config ();
 	node_config1.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
@@ -4410,7 +4410,7 @@ TEST (rpc, work_peers_all)
 TEST (rpc, populate_backlog)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	// Disable automatic backlog population
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = add_ipc_enabled_node (system, node_config);
@@ -5202,7 +5202,7 @@ TEST (rpc, confirmation_height_currently_processing)
 	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.force_use_write_database_queue = true;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
 	auto node = add_ipc_enabled_node (system, node_config, node_flags);
@@ -5371,9 +5371,9 @@ TEST (rpc, block_confirm_confirmed)
 	nano::test::system system (1);
 	auto path (nano::unique_path ());
 	nano::node_config config;
-	config.peering_port = nano::test::get_available_port ();
+	config.peering_port = system.get_available_port ();
 	config.callback_address = "localhost";
-	config.callback_port = nano::test::get_available_port ();
+	config.callback_port = system.get_available_port ();
 	config.callback_target = "/";
 	config.logging.init (path);
 	auto node = add_ipc_enabled_node (system, config);
@@ -5659,7 +5659,7 @@ TEST (rpc, uptime)
 TEST (rpc, DISABLED_wallet_history)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = false;
 	auto node = add_ipc_enabled_node (system, node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -5916,7 +5916,7 @@ TEST (rpc, database_txn_tracker)
 
 	// Now try enabling it but with invalid amounts
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.diagnostics_config.txn_tracking.enable = true;
 	auto node = add_ipc_enabled_node (system, node_config);
 	auto const rpc_ctx = add_rpc (system, node);
@@ -6042,7 +6042,7 @@ TEST (rpc, simultaneous_calls)
 	nano::thread_runner runner (system.io_ctx, node->config.io_threads);
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
-	nano::rpc_config rpc_config{ nano::dev::network_params.network, nano::test::get_available_port (), true };
+	nano::rpc_config rpc_config{ nano::dev::network_params.network, system.get_available_port (), true };
 	const auto ipc_tcp_port = ipc_server.listening_tcp_port ();
 	ASSERT_TRUE (ipc_tcp_port.has_value ());
 	rpc_config.rpc_process.num_ipc_connections = 8;
@@ -6292,7 +6292,7 @@ TEST (rpc, epoch_upgrade)
 TEST (rpc, epoch_upgrade_multithreaded)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.work_threads = 4;
 	auto node = add_ipc_enabled_node (system, node_config);
 	nano::keypair key1, key2, key3;
@@ -6484,9 +6484,9 @@ TEST (rpc, account_lazy_start)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
 
 	// Start lazy bootstrap with account
-	nano::node_config node_config{ nano::test::get_available_port (), system.logging };
+	nano::node_config node_config = system.default_config ();
 	node_config.ipc_config.transport_tcp.enabled = true;
-	node_config.ipc_config.transport_tcp.port = nano::test::get_available_port ();
+	node_config.ipc_config.transport_tcp.port = system.get_available_port ();
 	auto node2 = system.add_node (node_config, node_flags);
 	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	auto const rpc_ctx = add_rpc (system, node2);
@@ -6604,9 +6604,9 @@ TEST (rpc, receive_unopened)
 TEST (rpc, receive_work_disabled)
 {
 	nano::test::system system;
-	nano::node_config config (nano::test::get_available_port (), system.logging);
+	nano::node_config config = system.default_config ();
 	auto & worker_node = *system.add_node (config);
-	config.peering_port = nano::test::get_available_port ();
+	config.peering_port = system.get_available_port ();
 	config.work_threads = 0;
 	auto node = add_ipc_enabled_node (system, config);
 	auto wallet = system.wallet (1);
@@ -6637,7 +6637,7 @@ TEST (rpc, receive_pruned)
 {
 	nano::test::system system;
 	auto & node1 = *system.add_node ();
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
@@ -6857,7 +6857,7 @@ TEST (rpc, confirmation_active)
 	nano::test::system system;
 	nano::node_config node_config;
 	node_config.ipc_config.transport_tcp.enabled = true;
-	node_config.ipc_config.transport_tcp.port = nano::test::get_available_port ();
+	node_config.ipc_config.transport_tcp.port = system.get_available_port ();
 	nano::node_flags node_flags;
 	node_flags.disable_request_loop = true;
 	auto node1 (system.add_node (node_config, node_flags));

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -832,7 +832,7 @@ public:
 	virtual std::string vendor_get () const = 0;
 };
 
-std::unique_ptr<nano::store> make_store (nano::logger_mt & logger, boost::filesystem::path const & path, nano::ledger_constants & constants, bool open_read_only = false, bool add_db_postfix = false, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
+std::unique_ptr<nano::store> make_store (nano::logger_mt & logger, boost::filesystem::path const & path, nano::ledger_constants & constants, bool open_read_only = false, bool add_db_postfix = true, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
 }
 
 namespace std

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -38,7 +38,7 @@ size_t manually_count_pruned_blocks (nano::store & store)
 TEST (system, generate_mass_activity)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = false; // Prevent blocks cementing
 	auto node = system.add_node (node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -53,7 +53,7 @@ TEST (system, generate_mass_activity)
 TEST (system, generate_mass_activity_long)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = false; // Prevent blocks cementing
 	auto node = system.add_node (node_config);
 	nano::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
@@ -79,7 +79,7 @@ TEST (system, receive_while_synchronizing)
 	std::vector<boost::thread> threads;
 	{
 		nano::test::system system;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.enable_voting = false; // Prevent blocks cementing
 		auto node = system.add_node (node_config);
 		nano::thread_runner runner (system.io_ctx, system.nodes[0]->config.io_threads);
@@ -87,7 +87,7 @@ TEST (system, receive_while_synchronizing)
 		uint32_t count (1000);
 		system.generate_mass_activity (count, *system.nodes[0]);
 		nano::keypair key;
-		auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::test::get_available_port (), nano::unique_path (), system.logging, system.work));
+		auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.logging, system.work));
 		ASSERT_FALSE (node1->init_error ());
 		auto wallet (node1->wallets.create (1));
 		wallet->insert_adhoc (nano::dev::genesis_key.prv); // For voting
@@ -631,7 +631,7 @@ namespace nano
 TEST (confirmation_height, many_accounts_single_confirmation)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.online_weight_minimum = 100;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
@@ -716,7 +716,7 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 TEST (confirmation_height, many_accounts_many_confirmations)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.online_weight_minimum = 100;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
@@ -793,7 +793,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 TEST (confirmation_height, long_chains)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
 	nano::keypair key1;
@@ -940,7 +940,7 @@ TEST (confirmation_height, long_chains)
 TEST (confirmation_height, dynamic_algorithm)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node = system.add_node (node_config);
 	nano::keypair key;
@@ -1002,7 +1002,7 @@ TEST (confirmation_height, dynamic_algorithm_no_transition_while_pending)
 	for (auto _ = 0; _ < 3; ++_)
 	{
 		nano::test::system system;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		nano::node_flags node_flags;
 		node_flags.force_use_write_database_queue = true;
@@ -1080,7 +1080,7 @@ TEST (confirmation_height, dynamic_algorithm_no_transition_while_pending)
 TEST (confirmation_height, many_accounts_send_receive_self)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.online_weight_minimum = 100;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	node_config.active_elections_size = 400000;
@@ -1500,11 +1500,11 @@ namespace transport
 TEST (telemetry, under_load)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	auto node = system.add_node (node_config, node_flags);
-	node_config.peering_port = nano::test::get_available_port ();
+	node_config.peering_port = system.get_available_port ();
 	auto node1 = system.add_node (node_config, node_flags);
 	nano::keypair key;
 	nano::keypair key1;
@@ -1647,7 +1647,7 @@ TEST (telemetry, many_nodes)
 	auto const num_nodes = nano::memory_intensive_instrumentation () ? 4 : 10;
 	for (auto i = 0; i < num_nodes; ++i)
 	{
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		// Make a metric completely different for each node so we can check afterwards that there are no duplicates
 		node_config.bandwidth_limit = 100000 + i;
 
@@ -1824,7 +1824,7 @@ TEST (node, mass_epoch_upgrader)
 		std::vector<info> unopened (total_accounts / 2);
 
 		nano::test::system system;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		node_config.work_threads = 4;
 		// node_config.work_peers = { { "192.168.1.101", 7000 } };
 		auto & node = *system.add_node (node_config);
@@ -1928,7 +1928,7 @@ namespace nano
 TEST (node, mass_block_new)
 {
 	nano::test::system system;
-	nano::node_config node_config (nano::test::get_available_port (), system.logging);
+	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node = *system.add_node (node_config);
 	node.network_params.network.aec_loop_interval_ms = 500;
@@ -2074,7 +2074,7 @@ TEST (node, aggressive_flooding)
 	nodes_wallets.resize (!nano::memory_intensive_instrumentation () ? 5 : 3);
 
 	std::generate (nodes_wallets.begin (), nodes_wallets.end (), [&system, node_flags] () {
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config = system.default_config ();
 		auto node (system.add_node (node_config, node_flags));
 		return std::make_pair (node, system.wallet (system.nodes.size () - 1));
 	});
@@ -2188,7 +2188,7 @@ TEST (node, wallet_create_block_confirm_conflicts)
 	{
 		nano::test::system system;
 		nano::block_builder builder;
-		nano::node_config node_config (nano::test::get_available_port (), system.logging);
+		nano::node_config node_config (system.get_available_port (), system.logging);
 		node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 		auto node = system.add_node (node_config);
 		auto const num_blocks = 10000;
@@ -2257,7 +2257,7 @@ TEST (system, block_sequence)
 	system.ledger_initialization_set (reps, nano::Gxrb_ratio);
 	system.deadline_set (3600s);
 	nano::node_config config;
-	config.peering_port = nano::test::get_available_port ();
+	config.peering_port = system.get_available_port ();
 	// config.bandwidth_limit = 16 * 1024;
 	config.enable_voting = true;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
@@ -2270,11 +2270,11 @@ TEST (system, block_sequence)
 	for (auto rep : reps)
 	{
 		system.wallet (0);
-		config.peering_port = nano::test::get_available_port ();
+		config.peering_port = system.get_available_port ();
 		auto pr = system.add_node (config, flags, nano::transport::transport_type::tcp, rep);
 		for (auto j = 0; j < listeners_per_pr; ++j)
 		{
-			config.peering_port = nano::test::get_available_port ();
+			config.peering_port = system.get_available_port ();
 			system.add_node (config, flags);
 		}
 		std::cerr << rep.pub.to_account () << ' ' << pr->wallets.items.begin ()->second->exists (rep.pub) << pr->weight (rep.pub) << ' ' << '\n';

--- a/nano/test_common/network.cpp
+++ b/nano/test_common/network.cpp
@@ -24,9 +24,9 @@ std::shared_ptr<nano::transport::channel_tcp> nano::test::establish_tcp (nano::t
 	return result;
 }
 
-std::shared_ptr<nano::node> nano::test::add_outer_node (nano::test::system & system_a, uint16_t port_a, nano::node_flags flags_a)
+std::shared_ptr<nano::node> nano::test::add_outer_node (nano::test::system & system_a, nano::node_flags flags_a)
 {
-	auto outer_node = std::make_shared<nano::node> (system_a.io_ctx, port_a, nano::unique_path (), system_a.logging, system_a.work, flags_a);
+	auto outer_node = std::make_shared<nano::node> (system_a.io_ctx, system_a.get_available_port (), nano::unique_path (), system_a.logging, system_a.work, flags_a);
 	outer_node->start ();
 	system_a.nodes.push_back (outer_node);
 	return outer_node;

--- a/nano/test_common/network.hpp
+++ b/nano/test_common/network.hpp
@@ -19,6 +19,6 @@ namespace test
 	/** Waits until a TCP connection is established and returns the TCP channel on success*/
 	std::shared_ptr<nano::transport::channel_tcp> establish_tcp (nano::test::system &, nano::node &, nano::endpoint const &);
 	/** Adds a node to the system without establishing connections */
-	std::shared_ptr<nano::node> add_outer_node (nano::test::system & system, uint16_t port_a = nano::test::get_available_port (), nano::node_flags = nano::node_flags ());
+	std::shared_ptr<nano::node> add_outer_node (nano::test::system & system, nano::node_flags = nano::node_flags ());
 }
 }

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -567,7 +567,7 @@ nano::node_config nano::test::system::default_config ()
 	return config;
 }
 
-uint16_t nano::test::system::get_available_port ()
+uint16_t nano::test::system::get_available_port (bool can_be_zero)
 {
 	auto base_port_str = std::getenv ("NANO_TEST_BASE_PORT");
 	if (base_port_str)
@@ -590,25 +590,32 @@ uint16_t nano::test::system::get_available_port ()
 	}
 	else
 	{
-		/*
-		 * This works because the kernel doesn't seem to reuse port numbers until it absolutely has to.
-		 * Subsequent binds to port 0 will allocate a different port number.
-		 */
-		boost::asio::ip::tcp::acceptor acceptor{ io_ctx };
-		boost::asio::ip::tcp::tcp::endpoint endpoint{ boost::asio::ip::tcp::v4 (), 0 };
-		acceptor.open (endpoint.protocol ());
+		if (!can_be_zero)
+		{
+			/*
+			 * This works because the kernel doesn't seem to reuse port numbers until it absolutely has to.
+			 * Subsequent binds to port 0 will allocate a different port number.
+			 */
+			boost::asio::ip::tcp::acceptor acceptor{ io_ctx };
+			boost::asio::ip::tcp::tcp::endpoint endpoint{ boost::asio::ip::tcp::v4 (), 0 };
+			acceptor.open (endpoint.protocol ());
 
-		boost::asio::socket_base::reuse_address option{ true };
-		acceptor.set_option (option); // set SO_REUSEADDR option
+			boost::asio::socket_base::reuse_address option{ true };
+			acceptor.set_option (option); // set SO_REUSEADDR option
 
-		acceptor.bind (endpoint);
+			acceptor.bind (endpoint);
 
-		auto actual_endpoint = acceptor.local_endpoint ();
-		auto port = actual_endpoint.port ();
+			auto actual_endpoint = acceptor.local_endpoint ();
+			auto port = actual_endpoint.port ();
 
-		acceptor.close ();
+			acceptor.close ();
 
-		return port;
+			return port;
+		}
+		else
+		{
+			return 0;
+		}
 	}
 }
 

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -3,6 +3,7 @@
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
+#include <boost/asio.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <cstdlib>
@@ -562,11 +563,11 @@ void nano::test::system::stop ()
 
 nano::node_config nano::test::system::default_config ()
 {
-	nano::node_config config{ nano::test::get_available_port (), logging };
+	nano::node_config config{ get_available_port (), logging };
 	return config;
 }
 
-uint16_t nano::test::get_available_port ()
+uint16_t nano::test::system::get_available_port ()
 {
 	// Maximum possible sockets which may feasibly be used in 1 test
 	constexpr auto max = 200;

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -597,6 +597,10 @@ uint16_t nano::test::system::get_available_port ()
 		boost::asio::ip::tcp::acceptor acceptor{ io_ctx };
 		boost::asio::ip::tcp::tcp::endpoint endpoint{ boost::asio::ip::tcp::v4 (), 0 };
 		acceptor.open (endpoint.protocol ());
+
+		boost::asio::socket_base::reuse_address option{ true };
+		acceptor.set_option (option); // set SO_REUSEADDR option
+
 		acceptor.bind (endpoint);
 
 		auto actual_endpoint = acceptor.local_endpoint ();

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -61,6 +61,7 @@ namespace test
 		 * Returns default config for node running in test environment
 		 */
 		nano::node_config default_config ();
+		uint16_t get_available_port ();
 
 	public:
 		boost::asio::io_context io_ctx;
@@ -75,7 +76,6 @@ namespace test
 	};
 
 	std::unique_ptr<nano::state_block> upgrade_epoch (nano::work_pool &, nano::ledger &, nano::epoch);
-	uint16_t get_available_port ();
 	void cleanup_dev_directories_on_exit ();
 }
 }

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -61,7 +61,7 @@ namespace test
 		 * Returns default config for node running in test environment
 		 */
 		nano::node_config default_config ();
-		uint16_t get_available_port ();
+		uint16_t get_available_port (bool can_be_zero = true);
 
 	public:
 		boost::asio::io_context io_ctx;


### PR DESCRIPTION
This PR contains a set of fixes, which allow for running our core tests suite in parallel. This speeds up the execution time by an order of magnitude; on my device the time needed to run all tests dropped from 5 min+ to around 30 seconds. The tool that allows for parallel execution of gtest suites is https://github.com/google/gtest-parallel . Sample commands for getting it to work on macOS:
```
ulimit -n 1000000 # Needed to avoid 'too many open files' errors

./gtest-parallel "~/nano-node/cmake-build-debug/core_test"
```