### PR TITLE
Fix Docker build type

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
           - ${{ startsWith(github.ref, 'refs/tags/') }}
     env:
       BACKEND: ${{ matrix.BACKEND }}
-      RELEASE: ${{ matrix.RELEASE }}
+      BUILD_TYPE: ${{ matrix.RELEASE && 'RelWithDebInfo' || 'Debug' }}
       TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}
       DEADLINE_SCALE_FACTOR: ${{ matrix.BACKEND == 'rocksdb' && '2' || '1' }}
     runs-on: macos-12
@@ -78,7 +78,7 @@ jobs:
     env:
       COMPILER: ${{ matrix.COMPILER }}
       BACKEND: ${{ matrix.BACKEND }}
-      RELEASE: ${{ matrix.RELEASE }}
+      BUILD_TYPE: ${{ matrix.RELEASE && 'RelWithDebInfo' || 'Debug' }}
       TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}
       DEADLINE_SCALE_FACTOR: ${{ matrix.BACKEND == 'rocksdb' && '2' || '1' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
@@ -144,8 +144,9 @@ jobs:
     runs-on: windows-latest
     env:
       BACKEND: ${{ matrix.BACKEND }}
-      RELEASE: ${{ matrix.RELEASE }}
+      BUILD_TYPE: ${{ matrix.RELEASE && 'RelWithDebInfo' || 'Debug' }}
       TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}
+      DEADLINE_SCALE_FACTOR: ${{ matrix.BACKEND == 'rocksdb' && '2' || '1' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout

--- a/ci/build-tests.sh
+++ b/ci/build-tests.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -euox pipefail
 
-BUILD_TYPE="Debug"
-if [[ "${RELEASE:-false}" == "true" ]]; then
-    BUILD_TYPE="RelWithDebInfo"
-fi
-
-BUILD_TYPE=$BUILD_TYPE \
 NANO_TEST=ON \
 NANO_NETWORK=dev \
 NANO_GUI=ON \

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:22.04 as builder
 
 ARG COMPILER=gcc
+ARG BUILD_TYPE=RelWithDebInfo
+ARG SANITIZER
 ARG NANO_NETWORK=live
 ARG CI_TAG=DEV_BUILD
 ARG CI_BUILD=OFF
@@ -20,7 +22,7 @@ RUN echo ${NANO_NETWORK} >/etc/nano-network
 FROM ubuntu:22.04
 
 RUN groupadd --gid 1000 nanocurrency && \
-useradd --uid 1000 --gid nanocurrency --shell /bin/bash --create-home nanocurrency
+    useradd --uid 1000 --gid nanocurrency --shell /bin/bash --create-home nanocurrency
 
 COPY --from=builder /tmp/src/build/nano_node /usr/bin
 COPY --from=builder /tmp/src/build/nano_rpc /usr/bin


### PR DESCRIPTION
I forgot to declare a `BUILD_TYPE` environment variable inside the Dockerfile in a recent PR. It meant that Docker builds would always happen in `Debug` mode. This PR changes that to `RelWithDebInfo` by default with a possibility of overriding it by passing the variable manually.