### PR TITLE
 feat: Enhance GitHub Actions "Code Sanitizers" Workflow

### DIFF
--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -9,7 +9,7 @@ env:
 jobs:  
   google_sanitizers_linux:
     name: ${{ matrix.SANITIZER }} / ROCKSDB=${{ matrix.TEST_USE_ROCKSDB }} / ${{ matrix.COMPILER }}
-    timeout-minutes: 90
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           (
             issue_reported=false
-            reports=$(ls build/sanitizer_report*)
+            reports=$(ls build/sanitizer_report* 2>/dev/null)
             if [[ -n "${reports}" ]]; then
               echo "Report Output:"
               for report in ${reports}; do

--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -23,36 +23,44 @@ jobs:
       COMPILER: ${{ matrix.COMPILER }}
       TEST_USE_ROCKSDB: ${{ matrix.TEST_USE_ROCKSDB }}
       XSAN: ${{ endsWith(matrix.sanitizer, 'ASAN_INT') && 'ASAN' || matrix.SANITIZER }}
-      XSAN_SUPPRESSIONS: ${{ endsWith(matrix.SANITIZER, 'TSAN') && 'suppressions=../tsan_suppressions:' || '' }}
+      XSAN_SUPPRESSIONS: ${{ endsWith(matrix.SANITIZER, 'TSAN') && 'suppressions=../tsan_suppressions' || '' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
-          submodules: "true"
-      - name: Git Submodule Update
-        run: git submodule update --init --recursive
+          submodules: "recursive"
+
+      - name: Prepare
+        run: sudo -E ci/prepare/linux/prepare.sh
+
       - name: XSan variable values
         run: |
           (
             echo "XSAN: '${XSAN}'"
             echo "XSAN_SUPPRESSIONS: '${XSAN_SUPPRESSIONS}'"
           )
-      - name: Install Dependencies
-        run: ci/actions/linux/install_deps.sh
+
       - name: Build Tests
         id: build_tests
-        run: docker run -e TEST_USE_ROCKSDB -v ${PWD}:/workspace ghcr.io/${{ github.repository }}/nano-env:${{ matrix.COMPILER }} /bin/bash -c \
-          "cd /workspace && ${{ matrix.SANITIZER }}=1 ci/build-ci.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 'core_test rpc_test'"
+        run: ${{ matrix.SANITIZER }}=1 ci/build-ci.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5 'core_test rpc_test'
+
       - name: Run core_test
         id: core_test
         continue-on-error: true
-        run: docker run -v ${PWD}:/workspace ghcr.io/${{ github.repository }}/nano-env:${{ matrix.COMPILER }} /bin/bash -c \
-          "cd /workspace/build && ${XSAN}_OPTIONS=${XSAN_SUPPRESSIONS}log_exe_name=1:log_path=sanitizer_report ./core_test"
+        run: |
+          export ${XSAN}_OPTIONS="${XSAN_SUPPRESSIONS} log_exe_name=1 log_path=sanitizer_report"
+          timeout -sHUP 45m ./core_test
+        working-directory: build      
+      
       - name: Run rpc_test
         id: rpc_test
         continue-on-error: true
-        run: docker run -v ${PWD}:/workspace ghcr.io/${{ github.repository }}/nano-env:${{ matrix.COMPILER }} /bin/bash -c \
-          "cd /workspace/build && ${XSAN}_OPTIONS=${XSAN_SUPPRESSIONS}log_exe_name=1:log_path=sanitizer_report ./rpc_test"
+        run: |
+          export ${XSAN}_OPTIONS="${XSAN_SUPPRESSIONS} log_exe_name=1 log_path=sanitizer_report"
+          timeout -sHUP 20m ./rpc_test
+        working-directory: build       
+
       - name: Test Reports
         id: show_report
         run: |
@@ -63,7 +71,7 @@ jobs:
               echo "Report Output:"
               for report in ${reports}; do
                 echo "File: $report"
-                docker run -v ${PWD}:/workspace ghcr.io/${{ github.repository }}/nano-env:${{ matrix.COMPILER }} /bin/bash -c "cat /workspace/${report}"
+                cat ${report}
                 echo
               done
               issue_reported=true


### PR DESCRIPTION
This commit includes several improvements for our GitHub Actions workflows:

- Removed the need for 'nano-env' Docker images, and adjusted commands to be run directly.
- Increase the timeout limit from 90 to 120 minutes to accommodate longer running tests.
- Add inidividual timeouts fro core_test and rpc_test to always create a report, even in the case of a TSAN deadlock.
- Set submodules: "recursive" on checkout instead of having an special step to do this

These changes are intended to reduce the complexity of our CI/CD process.
