### PR TITLE
Lazy steady clock sampling within nano::stats

### DIFF
--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -395,18 +395,17 @@ void nano::stats::update (uint32_t key_a, uint64_t value)
 	if (!stopped)
 	{
 		auto entry (get_entry_impl (key_a, config.interval, config.capacity));
-
-		// Counters
-		auto old (entry->counter.get_value ());
-		entry->counter.add (value);
-		entry->count_observers.notify (old, entry->counter.get_value ());
-
 		auto has_interval_counter = [&] () {
 			return config.log_interval_counters > 0;
 		};
 		auto has_sampling = [&] () {
 			return config.sampling_enabled && entry->sample_interval > 0;
 		};
+
+		// Counters
+		auto old (entry->counter.get_value ());
+		entry->counter.add (value, has_sampling ()); // Only update timestamp when sampling is enabled as this has a performance impact
+		entry->count_observers.notify (old, entry->counter.get_value ());
 		if (has_interval_counter () || has_sampling ())
 		{
 			auto now = std::chrono::steady_clock::now (); // Only sample clock if necessary as this impacts node performance due to frequent usage

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -9,10 +9,10 @@
 
 #include <chrono>
 #include <initializer_list>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 
 namespace nano
 {
@@ -440,7 +440,7 @@ private:
 	nano::stats_config config;
 
 	/** Stat entries are sorted by key to simplify processing of log output */
-	std::map<uint32_t, std::shared_ptr<nano::stat_entry>> entries;
+	std::unordered_map<uint32_t, std::shared_ptr<nano::stat_entry>> entries;
 	std::chrono::steady_clock::time_point log_last_count_writeout{ std::chrono::steady_clock::now () };
 	std::chrono::steady_clock::time_point log_last_sample_writeout{ std::chrono::steady_clock::now () };
 


### PR DESCRIPTION
This delays obtaining a sample from steady_clock unless it is configured to be needed. Excessive sampling of the steady_clock has an impact on node performance so should only be done when needed.