### PR TITLE
Rename the class nano::scheduler::buckets to nano::scheduler::priority.

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/election.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
@@ -418,7 +418,7 @@ TEST (active_transactions, inactive_votes_cache_multiple_votes)
 	ASSERT_TIMELY (5s, node.inactive_vote_cache.find (send1->hash ()));
 	ASSERT_TIMELY (5s, node.inactive_vote_cache.find (send1->hash ())->voters.size () == 2);
 	ASSERT_EQ (1, node.inactive_vote_cache.cache_size ());
-	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node.active.election (send1->qualified_root ()));
 	ASSERT_EQ (3, election->votes ().size ()); // 2 votes and 1 default not_an_acount
@@ -996,7 +996,7 @@ TEST (active_transactions, confirmation_consistency)
 		system.deadline_set (5s);
 		while (!node.ledger.block_confirmed (node.store.tx_begin_read (), block->hash ()))
 		{
-			node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+			node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 			ASSERT_NO_ERROR (system.poll (5ms));
 		}
 		ASSERT_NO_ERROR (system.poll_until_true (1s, [&node, &block, i] {
@@ -1140,19 +1140,19 @@ TEST (active_transactions, activate_account_chain)
 	ASSERT_EQ (nano::process_result::progress, node.process (*open).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*receive).code);
 
-	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node.active.election (send->qualified_root ()));
 	auto election1 = node.active.election (send->qualified_root ());
 	ASSERT_EQ (1, node.active.size ());
 	ASSERT_EQ (1, election1->blocks ().count (send->hash ()));
-	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	auto election2 = node.active.election (send->qualified_root ());
 	ASSERT_EQ (election2, election1);
 	election1->force_confirm ();
 	ASSERT_TIMELY (3s, node.block_confirmed (send->hash ()));
 	// On cementing, the next election is started
 	ASSERT_TIMELY (3s, node.active.active (send2->qualified_root ()));
-	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	auto election3 = node.active.election (send2->qualified_root ());
 	ASSERT_NE (nullptr, election3);
 	ASSERT_EQ (1, election3->blocks ().count (send2->hash ()));
@@ -1161,11 +1161,11 @@ TEST (active_transactions, activate_account_chain)
 	// On cementing, the next election is started
 	ASSERT_TIMELY (3s, node.active.active (open->qualified_root ()));
 	ASSERT_TIMELY (3s, node.active.active (send3->qualified_root ()));
-	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	auto election4 = node.active.election (send3->qualified_root ());
 	ASSERT_NE (nullptr, election4);
 	ASSERT_EQ (1, election4->blocks ().count (send3->hash ()));
-	node.scheduler.buckets.activate (key.pub, node.store.tx_begin_read ());
+	node.scheduler.priority.activate (key.pub, node.store.tx_begin_read ());
 	auto election5 = node.active.election (open->qualified_root ());
 	ASSERT_NE (nullptr, election5);
 	ASSERT_EQ (1, election5->blocks ().count (open->hash ()));
@@ -1173,7 +1173,7 @@ TEST (active_transactions, activate_account_chain)
 	ASSERT_TIMELY (3s, node.block_confirmed (open->hash ()));
 	// Until send3 is also confirmed, the receive block should not activate
 	std::this_thread::sleep_for (200ms);
-	node.scheduler.buckets.activate (key.pub, node.store.tx_begin_read ());
+	node.scheduler.priority.activate (key.pub, node.store.tx_begin_read ());
 	election4->force_confirm ();
 	ASSERT_TIMELY (3s, node.block_confirmed (send3->hash ()));
 	ASSERT_TIMELY (3s, node.active.active (receive->qualified_root ()));
@@ -1314,7 +1314,7 @@ TEST (active_transactions, vacancy)
 		ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
 		ASSERT_EQ (1, node.active.vacancy ());
 		ASSERT_EQ (0, node.active.size ());
-		node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+		node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 		ASSERT_TIMELY (1s, updated);
 		updated = false;
 		ASSERT_EQ (0, node.active.vacancy ());
@@ -1393,11 +1393,11 @@ TEST (active_transactions, fifo)
 	ASSERT_EQ (nano::process_result::progress, node.process (*receive2).code);
 
 	// Ensure first transaction becomes active
-	node.scheduler.buckets.manual (receive1);
+	node.scheduler.priority.manual (receive1);
 	ASSERT_TIMELY (5s, node.active.election (receive1->qualified_root ()) != nullptr);
 
 	// Ensure second transaction becomes active
-	node.scheduler.buckets.manual (receive2);
+	node.scheduler.priority.manual (receive2);
 	ASSERT_TIMELY (5s, node.active.election (receive2->qualified_root ()) != nullptr);
 
 	// Ensure excess transactions get trimmed
@@ -1503,7 +1503,7 @@ TEST (active_transactions, allow_limited_overflow)
 	// Insert the first part of the blocks into normal election scheduler
 	for (auto const & block : blocks1)
 	{
-		node.scheduler.buckets.activate (block->account (), node.store.tx_begin_read ());
+		node.scheduler.priority.activate (block->account (), node.store.tx_begin_read ());
 	}
 
 	// Ensure number of active elections reaches AEC limit and there is no overfill
@@ -1565,7 +1565,7 @@ TEST (active_transactions, allow_limited_overflow_adapt)
 	// Insert the first part of the blocks into normal election scheduler
 	for (auto const & block : blocks1)
 	{
-		node.scheduler.buckets.activate (block->account (), node.store.tx_begin_read ());
+		node.scheduler.priority.activate (block->account (), node.store.tx_begin_read ());
 	}
 
 	// Ensure number of active elections reaches AEC limit and there is no overfill

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -1,6 +1,6 @@
 #include <nano/node/election.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -27,7 +27,7 @@ TEST (conflicts, start_stop)
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
 	ASSERT_EQ (0, node1.active.size ());
-	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_EQ (1, node1.active.size ());
@@ -60,7 +60,7 @@ TEST (conflicts, add_existing)
 	ASSERT_TIMELY (5s, node1.block (send1->hash ()));
 
 	// instruct the election scheduler to trigger an election for send1
-	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 
 	// wait for election to be started before processing send2
 	ASSERT_TIMELY (5s, node1.active.active (*send1));
@@ -167,7 +167,7 @@ TEST (conflicts, add_two)
 
 	// activate elections for the previous two send blocks (to account3) that we did not forcefully confirm
 	//
-	node->scheduler.buckets.activate (account3.pub, node->store.tx_begin_read ());
+	node->scheduler.priority.activate (account3.pub, node->store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node->active.election ((*send3)->qualified_root ()) != nullptr);
 	ASSERT_TIMELY (5s, node->active.election ((*send4)->qualified_root ()) != nullptr);
 

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -1,6 +1,6 @@
 #include <nano/node/election.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -150,7 +150,7 @@ TEST (election, quorum_minimum_confirm_success)
 				 .build_shared ();
 	node1.work_generate_blocking (*send1);
 	node1.process_active (send1);
-	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election);

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -1,5 +1,5 @@
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -28,7 +28,7 @@ TEST (election_scheduler, activate_one_timely)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	system.nodes[0]->ledger.process (system.nodes[0]->store.tx_begin_write (), *send1);
-	system.nodes[0]->scheduler.buckets.activate (nano::dev::genesis_key.pub, system.nodes[0]->store.tx_begin_read ());
+	system.nodes[0]->scheduler.priority.activate (nano::dev::genesis_key.pub, system.nodes[0]->store.tx_begin_read ());
 	ASSERT_TIMELY (5s, system.nodes[0]->active.election (send1->qualified_root ()));
 }
 
@@ -46,7 +46,7 @@ TEST (election_scheduler, activate_one_flush)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	system.nodes[0]->ledger.process (system.nodes[0]->store.tx_begin_write (), *send1);
-	system.nodes[0]->scheduler.buckets.activate (nano::dev::genesis_key.pub, system.nodes[0]->store.tx_begin_read ());
+	system.nodes[0]->scheduler.priority.activate (nano::dev::genesis_key.pub, system.nodes[0]->store.tx_begin_read ());
 	ASSERT_TIMELY (5s, system.nodes[0]->active.election (send1->qualified_root ()));
 }
 
@@ -115,7 +115,7 @@ TEST (election_scheduler, no_vacancy)
 	ASSERT_EQ (nano::process_result::progress, node.process (*block1).code);
 
 	// There is vacancy so it should be inserted
-	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	std::shared_ptr<nano::election> election{};
 	ASSERT_TIMELY (5s, (election = node.active.election (block1->qualified_root ())) != nullptr);
 
@@ -131,14 +131,14 @@ TEST (election_scheduler, no_vacancy)
 	ASSERT_EQ (nano::process_result::progress, node.process (*block2).code);
 
 	// There is no vacancy so it should stay queued
-	node.scheduler.buckets.activate (key.pub, node.store.tx_begin_read ());
-	ASSERT_TIMELY (5s, node.scheduler.buckets.size () == 1);
+	node.scheduler.priority.activate (key.pub, node.store.tx_begin_read ());
+	ASSERT_TIMELY (5s, node.scheduler.priority.size () == 1);
 	ASSERT_TRUE (node.active.election (block2->qualified_root ()) == nullptr);
 
 	// Election confirmed, next in queue should begin
 	election->force_confirm ();
 	ASSERT_TIMELY (5s, node.active.election (block2->qualified_root ()) != nullptr);
-	ASSERT_TRUE (node.scheduler.buckets.empty ());
+	ASSERT_TRUE (node.scheduler.priority.empty ());
 }
 
 // Ensure that election_scheduler::flush terminates even if no elections can currently be queued e.g. shutdown or no active_transactions vacancy
@@ -162,9 +162,9 @@ TEST (election_scheduler, flush_vacancy)
 				.work (*system.work.generate (nano::dev::genesis->hash ()))
 				.build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
-	node.scheduler.buckets.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	// Ensure this call does not block, even though no elections can be activated.
-	node.scheduler.buckets.flush ();
+	node.scheduler.priority.flush ();
 	ASSERT_EQ (0, node.active.size ());
-	ASSERT_EQ (1, node.scheduler.buckets.size ());
+	ASSERT_EQ (1, node.scheduler.priority.size ());
 }

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -2,8 +2,8 @@
 #include <nano/lib/threading.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/test_common/ledger.hpp>
 #include <nano/test_common/system.hpp>
@@ -913,7 +913,7 @@ TEST (votes, check_signature)
 		auto transaction (node1.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
 	}
-	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_EQ (1, election1->votes ().size ());
@@ -984,7 +984,7 @@ TEST (votes, add_existing)
 										 .build ();
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (node1.store.tx_begin_write (), *send1).code);
-	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ send1->hash () }));

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1,7 +1,7 @@
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/transport/socket.hpp>
 #include <nano/test_common/network.hpp>
@@ -366,7 +366,7 @@ TEST (receivable_processor, confirm_insufficient_pos)
 				  .build_shared ();
 	node1.work_generate_blocking (*block1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*block1).code);
-	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	nano::keypair key1;
 	auto vote (std::make_shared<nano::vote> (key1.pub, key1.prv, 0, 0, std::vector<nano::block_hash>{ block1->hash () }));
 	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
@@ -389,7 +389,7 @@ TEST (receivable_processor, confirm_sufficient_pos)
 				  .build_shared ();
 	node1.work_generate_blocking (*block1);
 	ASSERT_EQ (nano::process_result::progress, node1.process (*block1).code);
-	node1.scheduler.buckets.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash>{ block1->hash () }));
 	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
 	auto channel1 = std::make_shared<nano::transport::inproc::channel> (node1, node1);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/config.hpp>
 #include <nano/node/election.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/test_common/network.hpp>
@@ -987,7 +987,7 @@ TEST (node, fork_open_flip)
 	// give block open1 to node1, manually trigger an election for open1 and ensure it is in the ledger
 	node1.process_active (open1);
 	ASSERT_TIMELY (5s, node1.block (open1->hash ()) != nullptr);
-	node1.scheduler.buckets.manual (open1);
+	node1.scheduler.priority.manual (open1);
 	ASSERT_TIMELY (5s, (election = node1.active.election (open1->qualified_root ())) != nullptr);
 	election->transition_active ();
 
@@ -1000,7 +1000,7 @@ TEST (node, fork_open_flip)
 
 	// ensure open2 is in node2 ledger (and therefore has sideband) and manually trigger an election for open2
 	ASSERT_TIMELY (5s, node2.block (open2->hash ()) != nullptr);
-	node2.scheduler.buckets.manual (open2);
+	node2.scheduler.priority.manual (open2);
 	ASSERT_TIMELY (5s, (election = node2.active.election (open2->qualified_root ())) != nullptr);
 	election->transition_active ();
 
@@ -1415,7 +1415,7 @@ TEST (node, rep_self_vote)
 	ASSERT_EQ (nano::process_result::progress, node0->process (*block0).code);
 	auto & active = node0->active;
 	auto & scheduler = node0->scheduler;
-	scheduler.buckets.activate (nano::dev::genesis_key.pub, node0->store.tx_begin_read ());
+	scheduler.priority.activate (nano::dev::genesis_key.pub, node0->store.tx_begin_read ());
 	ASSERT_TIMELY (5s, active.election (block0->qualified_root ()));
 	auto election1 = active.election (block0->qualified_root ());
 	ASSERT_NE (nullptr, election1);

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -196,14 +196,14 @@ add_library(
   rocksdb/rocksdb_iterator.hpp
   rocksdb/rocksdb_txn.hpp
   rocksdb/rocksdb_txn.cpp
-  scheduler/buckets.hpp
-  scheduler/buckets.cpp
   scheduler/component.hpp
   scheduler/component.cpp
   scheduler/hinted.hpp
   scheduler/hinted.cpp
   scheduler/optimistic.hpp
   scheduler/optimistic.cpp
+  scheduler/priority.hpp
+  scheduler/priority.cpp
   signatures.hpp
   signatures.cpp
   state_block_signature_verification.hpp

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -5,8 +5,8 @@
 #include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/repcrawler.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/secure/store.hpp>
 
 #include <boost/format.hpp>
@@ -151,13 +151,13 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 		if (cemented_bootstrap_count_reached && was_active)
 		{
 			// Start or vote for the next unconfirmed block
-			node.scheduler.buckets.activate (account, transaction);
+			node.scheduler.priority.activate (account, transaction);
 
 			// Start or vote for the next unconfirmed block in the destination account
 			auto const & destination (node.ledger.block_destination (transaction, *block_a));
 			if (!destination.is_zero () && destination != account)
 			{
-				node.scheduler.buckets.activate (destination, transaction);
+				node.scheduler.priority.activate (destination, transaction);
 			}
 		}
 	}

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -32,11 +32,6 @@ class transaction;
 class confirmation_height_processor;
 class stats;
 
-namespace scheduler
-{
-	class buckets;
-}
-
 class recently_confirmed_cache final
 {
 public:

--- a/nano/node/backlog_population.cpp
+++ b/nano/node/backlog_population.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/threading.hpp>
 #include <nano/node/backlog_population.hpp>
 #include <nano/node/nodeconfig.hpp>
-#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/secure/store.hpp>
 
 nano::backlog_population::backlog_population (const config & config_a, nano::store & store_a, nano::stats & stats_a) :

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -5,10 +5,10 @@
 #include <nano/node/daemonconfig.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/rocksdb/rocksdb.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/hinted.hpp>
 #include <nano/node/scheduler/optimistic.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/node/telemetry.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/secure/buffer.hpp>
@@ -205,7 +205,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	block_broadcast{ network, block_arrival, !flags.disable_block_processor_republishing },
 	block_publisher{ active },
 	gap_tracker{ gap_cache },
-	process_live_dispatcher{ ledger, scheduler.buckets, inactive_vote_cache, websocket }
+	process_live_dispatcher{ ledger, scheduler.priority, inactive_vote_cache, websocket }
 {
 	block_broadcast.connect (block_processor);
 	block_publisher.connect (block_processor);
@@ -220,7 +220,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	};
 
 	backlog.activate_callback.add ([this] (nano::transaction const & transaction, nano::account const & account, nano::account_info const & account_info, nano::confirmation_height_info const & conf_info) {
-		scheduler.buckets.activate (account, transaction);
+		scheduler.priority.activate (account, transaction);
 		scheduler.optimistic.activate (account, account_info, conf_info);
 	});
 
@@ -228,7 +228,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path co
 	{
 		// Notify election schedulers when AEC frees election slot
 		active.vacancy_update = [this] () {
-			scheduler.buckets.notify ();
+			scheduler.priority.notify ();
 			scheduler.hinted.notify ();
 			scheduler.optimistic.notify ();
 		};
@@ -576,7 +576,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (no
 	composite->add_component (collect_container_info (node.confirmation_height_processor, "confirmation_height_processor"));
 	composite->add_component (collect_container_info (node.distributed_work, "distributed_work"));
 	composite->add_component (collect_container_info (node.aggregator, "request_aggregator"));
-	composite->add_component (node.scheduler.buckets.collect_container_info ("election_scheduler"));
+	composite->add_component (node.scheduler.priority.collect_container_info ("priority_scheduler"));
 	composite->add_component (node.inactive_vote_cache.collect_container_info ("inactive_vote_cache"));
 	composite->add_component (collect_container_info (node.generator, "vote_generator"));
 	composite->add_component (collect_container_info (node.final_generator, "vote_generator_final"));
@@ -689,7 +689,7 @@ void nano::node::start ()
 	generator.start ();
 	final_generator.start ();
 	scheduler.optimistic.start ();
-	scheduler.buckets.start ();
+	scheduler.priority.start ();
 	backlog.start ();
 	scheduler.hinted.start ();
 	bootstrap_server.start ();
@@ -723,7 +723,7 @@ void nano::node::stop ()
 	block_processor.stop ();
 	aggregator.stop ();
 	vote_processor.stop ();
-	scheduler.buckets.stop ();
+	scheduler.priority.stop ();
 	scheduler.optimistic.stop ();
 	scheduler.hinted.stop ();
 	active.stop ();
@@ -1265,8 +1265,8 @@ void nano::node::add_initial_peers ()
 
 std::shared_ptr<nano::election> nano::node::block_confirm (std::shared_ptr<nano::block> const & block_a)
 {
-	scheduler.buckets.manual (block_a);
-	scheduler.buckets.flush ();
+	scheduler.priority.manual (block_a);
+	scheduler.priority.flush ();
 	auto election = active.election (block_a->qualified_root ());
 	if (election != nullptr)
 	{

--- a/nano/node/process_live_dispatcher.cpp
+++ b/nano/node/process_live_dispatcher.cpp
@@ -1,14 +1,14 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/blockprocessor.hpp>
 #include <nano/node/process_live_dispatcher.hpp>
-#include <nano/node/scheduler/buckets.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/node/vote_cache.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/store.hpp>
 
-nano::process_live_dispatcher::process_live_dispatcher (nano::ledger & ledger, nano::scheduler::buckets & scheduler, nano::vote_cache & inactive_vote_cache, nano::websocket_server & websocket) :
+nano::process_live_dispatcher::process_live_dispatcher (nano::ledger & ledger, nano::scheduler::priority & scheduler, nano::vote_cache & inactive_vote_cache, nano::websocket_server & websocket) :
 	ledger{ ledger },
 	scheduler{ scheduler },
 	inactive_vote_cache{ inactive_vote_cache },

--- a/nano/node/process_live_dispatcher.hpp
+++ b/nano/node/process_live_dispatcher.hpp
@@ -12,14 +12,14 @@ class transaction;
 
 namespace scheduler
 {
-	class buckets;
+	class priority;
 }
 
 // Observes confirmed blocks and dispatches the process_live function.
 class process_live_dispatcher
 {
 public:
-	process_live_dispatcher (nano::ledger & ledger, nano::scheduler::buckets & scheduler, nano::vote_cache & inactive_vote_cache, nano::websocket_server & websocket);
+	process_live_dispatcher (nano::ledger & ledger, nano::scheduler::priority & scheduler, nano::vote_cache & inactive_vote_cache, nano::websocket_server & websocket);
 	void connect (nano::block_processor & block_processor);
 
 private:
@@ -28,7 +28,7 @@ private:
 	void process_live (nano::block const & block, nano::transaction const & transaction);
 
 	nano::ledger & ledger;
-	nano::scheduler::buckets & scheduler;
+	nano::scheduler::priority & scheduler;
 	nano::vote_cache & inactive_vote_cache;
 	nano::websocket_server & websocket;
 };

--- a/nano/node/scheduler/component.cpp
+++ b/nano/node/scheduler/component.cpp
@@ -1,14 +1,14 @@
 #include <nano/node/node.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/hinted.hpp>
 #include <nano/node/scheduler/optimistic.hpp>
+#include <nano/node/scheduler/priority.hpp>
 
 nano::scheduler::component::component (nano::node & node) :
 	optimistic_impl{ std::make_unique<nano::scheduler::optimistic> (node.config.optimistic_scheduler, node, node.ledger, node.active, node.network_params.network, node.stats) },
-	buckets_impl{ std::make_unique<nano::scheduler::buckets> (node, node.stats) },
+	priority_impl{ std::make_unique<nano::scheduler::priority> (node, node.stats) },
 	hinted_impl{ std::make_unique<nano::scheduler::hinted> (nano::scheduler::hinted::config{ node.config }, node, node.inactive_vote_cache, node.active, node.online_reps, node.stats) },
-	buckets{ *buckets_impl },
+	priority{ *priority_impl },
 	hinted{ *hinted_impl },
 	optimistic{ *optimistic_impl }
 {

--- a/nano/node/scheduler/component.hpp
+++ b/nano/node/scheduler/component.hpp
@@ -2,23 +2,26 @@
 
 #include <memory>
 
+namespace nano
+{
+class node;
+}
 namespace nano::scheduler
 {
-class buckets;
 class hinted;
-class node;
 class optimistic;
+class priority;
 
 class component
 {
 	std::unique_ptr<nano::scheduler::optimistic> optimistic_impl;
-	std::unique_ptr<nano::scheduler::buckets> buckets_impl;
+	std::unique_ptr<nano::scheduler::priority> priority_impl;
 	std::unique_ptr<nano::scheduler::hinted> hinted_impl;
 
 public:
 	explicit component (nano::node & node);
 
-	nano::scheduler::buckets & buckets;
+	nano::scheduler::priority & priority;
 	nano::scheduler::hinted & hinted;
 	nano::scheduler::optimistic & optimistic;
 };

--- a/nano/node/scheduler/priority.hpp
+++ b/nano/node/scheduler/priority.hpp
@@ -19,11 +19,11 @@ class node;
 
 namespace nano::scheduler
 {
-class buckets final
+class priority final
 {
 public:
-	buckets (nano::node &, nano::stats &);
-	~buckets ();
+	priority (nano::node &, nano::stats &);
+	~priority ();
 
 	void start ();
 	void stop ();
@@ -54,7 +54,7 @@ private:
 	bool priority_queue_predicate () const;
 	bool manual_queue_predicate () const;
 
-	nano::prioritization priority;
+	nano::prioritization buckets;
 
 	std::deque<std::tuple<std::shared_ptr<nano::block>, boost::optional<nano::uint128_t>, nano::election_behavior>> manual_queue;
 	bool stopped{ false };

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5,8 +5,8 @@
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/json_handler.hpp>
 #include <nano/node/node_rpc_config.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
 #include <nano/rpc_test/common.hpp>
@@ -1559,7 +1559,7 @@ TEST (rpc, process_subtype_open)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
 	ASSERT_EQ (nano::process_result::progress, node2.process (*send).code);
 	auto const rpc_ctx = add_rpc (system, node1);
-	node1->scheduler.buckets.manual (send);
+	node1->scheduler.priority.manual (send);
 	auto open = builder
 				.state ()
 				.account (key.pub)
@@ -1608,7 +1608,7 @@ TEST (rpc, process_subtype_receive)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
 	ASSERT_EQ (nano::process_result::progress, node2.process (*send).code);
 	auto const rpc_ctx = add_rpc (system, node1);
-	node1->scheduler.buckets.manual (send);
+	node1->scheduler.priority.manual (send);
 	auto receive = builder
 				   .state ()
 				   .account (nano::dev::genesis_key.pub)
@@ -2448,7 +2448,7 @@ TEST (rpc, account_representative_set_epoch_2_insufficient_work)
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (*node, nano::epoch::epoch_2));
 
 	// speed up the cementing process, otherwise the node waits for frontiers confirmation to notice the unconfirmed epoch blocks, which takes time
-	node->scheduler.buckets.activate (nano::dev::genesis_key.pub, node->store.tx_begin_read ());
+	node->scheduler.priority.activate (nano::dev::genesis_key.pub, node->store.tx_begin_read ());
 
 	// wait for the epoch blocks to be cemented
 	ASSERT_TIMELY (5s, node->get_confirmation_height (node->store.tx_begin_read (), nano::dev::genesis_key.pub) == 3);
@@ -6964,12 +6964,12 @@ TEST (node, election_scheduler_container_info)
 
 	// process the block and wait for it to show up in the election scheduler
 	node->process_active (send1);
-	ASSERT_TIMELY (10s, node->scheduler.buckets.size () == 1);
+	ASSERT_TIMELY (10s, node->scheduler.priority.size () == 1);
 
 	// now check the RPC call
 	boost::property_tree::ptree request;
 	request.put ("action", "stats");
 	request.put ("type", "objects");
 	auto response = wait_response (system, rpc_ctx, request);
-	auto es = response.get_child ("node").get_child ("election_scheduler");
+	auto es = response.get_child ("node").get_child ("priority_scheduler");
 }

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1,8 +1,8 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/node/election.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/unchecked_map.hpp>
 #include <nano/test_common/network.hpp>
@@ -677,7 +677,7 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	{
 		auto block = node->block (last_open_hash);
 		ASSERT_NE (nullptr, block);
-		node->scheduler.buckets.manual (block);
+		node->scheduler.priority.manual (block);
 		std::shared_ptr<nano::election> election;
 		ASSERT_TIMELY (10s, (election = node->active.election (block->qualified_root ())) != nullptr);
 		election->force_confirm ();
@@ -760,7 +760,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	// Confirm all of the accounts
 	for (auto & open_block : open_blocks)
 	{
-		node->scheduler.buckets.manual (open_block);
+		node->scheduler.priority.manual (open_block);
 		std::shared_ptr<nano::election> election;
 		ASSERT_TIMELY (10s, (election = node->active.election (open_block->qualified_root ())) != nullptr);
 		election->force_confirm ();
@@ -900,7 +900,7 @@ TEST (confirmation_height, long_chains)
 
 	// Call block confirm on the existing receive block on the genesis account which will confirm everything underneath on both accounts
 	{
-		node->scheduler.buckets.manual (receive1);
+		node->scheduler.priority.manual (receive1);
 		std::shared_ptr<nano::election> election;
 		ASSERT_TIMELY (10s, (election = node->active.election (receive1->qualified_root ())) != nullptr);
 		election->force_confirm ();
@@ -2225,7 +2225,7 @@ TEST (node, wallet_create_block_confirm_conflicts)
 		// Call block confirm on the top level send block which will confirm everything underneath on both accounts.
 		{
 			auto block = node->store.block.get (node->store.tx_begin_read (), latest);
-			node->scheduler.buckets.manual (block);
+			node->scheduler.priority.manual (block);
 			std::shared_ptr<nano::election> election;
 			ASSERT_TIMELY (10s, (election = node->active.election (block->qualified_root ())) != nullptr);
 			election->force_confirm ();
@@ -2319,7 +2319,7 @@ TEST (system, block_sequence)
 			std::string message;
 			for (auto i : system.nodes)
 			{
-				message += boost::str (boost::format ("N:%1% b:%2% c:%3% a:%4% s:%5% p:%6%\n") % std::to_string (i->network.port) % std::to_string (i->ledger.cache.block_count) % std::to_string (i->ledger.cache.cemented_count) % std::to_string (i->active.size ()) % std::to_string (i->scheduler.buckets.size ()) % std::to_string (i->network.size ()));
+				message += boost::str (boost::format ("N:%1% b:%2% c:%3% a:%4% s:%5% p:%6%\n") % std::to_string (i->network.port) % std::to_string (i->ledger.cache.block_count) % std::to_string (i->ledger.cache.cemented_count) % std::to_string (i->active.size ()) % std::to_string (i->scheduler.priority.size ()) % std::to_string (i->network.size ()));
 				nano::lock_guard<nano::mutex> lock{ i->active.mutex };
 				for (auto const & j : i->active.roots)
 				{

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -1,6 +1,6 @@
 #include <nano/crypto_lib/random_pool.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/component.hpp>
+#include <nano/node/scheduler/priority.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -156,7 +156,7 @@ bool nano::test::activate (nano::node & node, std::vector<nano::block_hash> hash
 			// Block does not exist in the ledger yet
 			return false;
 		}
-		node.scheduler.buckets.manual (disk_block);
+		node.scheduler.priority.manual (disk_block);
 	}
 	return true;
 }
@@ -237,7 +237,7 @@ std::shared_ptr<nano::election> nano::test::start_election (nano::test::system &
 		block_l = node_a.block (hash_a);
 	}
 
-	node_a.scheduler.buckets.manual (block_l);
+	node_a.scheduler.priority.manual (block_l);
 
 	// wait for the election to appear
 	std::shared_ptr<nano::election> election = node_a.active.election (block_l->qualified_root ());


### PR DESCRIPTION
Naming it "priority scheduler" matches the naming of other scheduler strategies like hinted scheduler and optimistic scheduler.