### PR TITLE
Fix active_transactions::completion_type

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -310,7 +310,7 @@ void nano::active_transactions::cleanup_election (nano::unique_lock<nano::mutex>
 
 nano::stat::type nano::active_transactions::completion_type (nano::election const & election) const
 {
-	if (election.confirmed ())
+	if (election.status_confirmed ())
 	{
 		return nano::stat::type::active_confirmed;
 	}


### PR DESCRIPTION
This fixes an issue introduced in https://github.com/nanocurrency/nano-node/pull/4200 which will erroneously report an election as dropped when it was confirmed in memory but not yet on disk. This causes active_transactions.limit_vote_hinted_elections to fail intermittently.