### PR TITLE
Remove priority::flush and rename node::block_confirm to node::start_election

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1118,7 +1118,7 @@ TEST (confirmation_height, conflict_rollback_cemented)
 					  .work (*system.work.generate (genesis_hash))
 					  .build_shared ();
 		ASSERT_EQ (nano::process_result::progress, node1->process (*fork1a).code);
-		ASSERT_TRUE (nano::test::confirm (*node1, { fork1a }));
+		nano::test::start_elections (system, *node1, { fork1a }, true);
 		ASSERT_TIMELY (5s, nano::test::confirmed (*node1, { fork1a }));
 
 		// create the other side of the fork on node2

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -13,7 +13,7 @@ TEST (election, construction)
 {
 	nano::test::system system (1);
 	auto & node = *system.nodes[0];
-	node.block_confirm (nano::dev::genesis);
+	node.start_election (nano::dev::genesis);
 	ASSERT_TIMELY (5s, node.active.election (nano::dev::genesis->qualified_root ()));
 	auto election = node.active.election (nano::dev::genesis->qualified_root ());
 	election->transition_active ();

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -13,10 +13,8 @@ TEST (election, construction)
 {
 	nano::test::system system (1);
 	auto & node = *system.nodes[0];
-	node.start_election (nano::dev::genesis);
-	ASSERT_TIMELY (5s, node.active.election (nano::dev::genesis->qualified_root ()));
-	auto election = node.active.election (nano::dev::genesis->qualified_root ());
-	election->transition_active ();
+	auto election = std::make_shared<nano::election> (
+	node, nano::dev::genesis, [] (auto const &) {}, [] (auto const &) {}, nano::election_behavior::normal);
 }
 
 TEST (election, behavior)

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -288,7 +288,7 @@ TEST (election, continuous_voting)
 				 .build_shared ();
 
 	ASSERT_TRUE (nano::test::process (node1, { send1 }));
-	ASSERT_TIMELY (5s, nano::test::confirm (node1, { send1 }));
+	nano::test::start_elections (system, node1, { send1 }, true);
 	ASSERT_TIMELY (5s, nano::test::confirmed (node1, { send1 }));
 
 	node1.stats.clear ();

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -942,7 +942,7 @@ TEST (votes, add_one)
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
-	node1.block_confirm (send1);
+	node1.start_election (send1);
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_EQ (1, election1->votes ().size ());
@@ -1043,7 +1043,7 @@ TEST (votes, add_old)
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
-	node1.block_confirm (send1);
+	node1.start_election (send1);
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 2, 0, std::vector<nano::block_hash>{ send1->hash () }));
@@ -1149,7 +1149,7 @@ TEST (votes, add_cooldown)
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
-	node1.block_confirm (send1);
+	node1.start_election (send1);
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	auto vote1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash>{ send1->hash () }));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2573,7 +2573,7 @@ TEST (node, vote_by_hash_bundle)
 	}
 
 	// Confirming last block will confirm whole chain and allow us to generate votes for those blocks later
-	ASSERT_TIMELY (5s, nano::test::confirm (node, { blocks.back () }));
+	nano::test::start_elections (system, node, { blocks.back () }, true);
 	ASSERT_TIMELY (5s, nano::test::confirmed (node, { blocks.back () }));
 
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -2752,7 +2752,7 @@ TEST (node, epoch_conflict_confirm)
 	ASSERT_TRUE (nano::test::process (node1, { send, send2, open }));
 
 	// Confirm open block in node1 to allow generating votes
-	ASSERT_TIMELY (5s, nano::test::confirm (node1, { open }));
+	nano::test::start_elections (system, node1, { open }, true);
 	ASSERT_TIMELY (5s, nano::test::confirmed (node1, { open }));
 
 	// Process initial blocks on node0
@@ -2766,7 +2766,7 @@ TEST (node, epoch_conflict_confirm)
 	ASSERT_TIMELY (5s, nano::test::exists (node1, { change, epoch_open }));
 
 	// Confirm initial blocks in node1 to allow generating votes later
-	ASSERT_TIMELY (5s, nano::test::confirm (node1, { change, epoch_open, send2 }));
+	nano::test::start_elections (system, node1, { change, epoch_open, send2 }, true);
 	ASSERT_TIMELY (5s, nano::test::confirmed (node1, { change, epoch_open, send2 }));
 
 	// Start elections for node0 for conflicting change and epoch_open blocks (those two blocks have the same root)
@@ -3481,7 +3481,7 @@ TEST (node, rollback_vote_self)
 
 	// Process and mark the first 2 blocks as confirmed to allow voting
 	ASSERT_TRUE (nano::test::process (node, { send1, open }));
-	ASSERT_TIMELY (5s, nano::test::confirm (node, { send1, open }));
+	nano::test::start_elections (system, node, { send1, open }, true);
 	ASSERT_TIMELY (5s, node.ledger.cache.cemented_count == 3);
 
 	// wait until the rep weights have caught up with the weight transfer

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1329,7 +1329,7 @@ TEST (node, DISABLED_broadcast_elected)
 	{
 		auto block (node->block (node->latest (nano::dev::genesis_key.pub)));
 		ASSERT_NE (nullptr, block);
-		node->block_confirm (block);
+		node->start_election (block);
 		auto election (node->active.election (block->qualified_root ()));
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
@@ -1397,9 +1397,9 @@ TEST (node, rep_self_vote)
 	ASSERT_EQ (nano::process_result::progress, node0->process (fund_big).code);
 	ASSERT_EQ (nano::process_result::progress, node0->process (open_big).code);
 	// Confirm both blocks, allowing voting on the upcoming block
-	node0->block_confirm (node0->block (open_big.hash ()));
-	auto election = node0->active.election (open_big.qualified_root ());
-	ASSERT_NE (nullptr, election);
+	node0->start_election (node0->block (open_big.hash ()));
+	std::shared_ptr<nano::election> election;
+	ASSERT_TIMELY (5s, election = node0->active.election (open_big.qualified_root ()));
 	election->force_confirm ();
 
 	system.wallet (0)->insert_adhoc (rep_big.prv);
@@ -1545,7 +1545,7 @@ TEST (node, bootstrap_fork_open)
 	// Confirm send0 to allow starting and voting on the following blocks
 	for (auto node : system.nodes)
 	{
-		node->block_confirm (node->block (node->latest (nano::dev::genesis_key.pub)));
+		node->start_election (node->block (node->latest (nano::dev::genesis_key.pub)));
 		ASSERT_TIMELY (1s, node->active.election (send0.qualified_root ()));
 		auto election = node->active.election (send0.qualified_root ());
 		ASSERT_NE (nullptr, election);
@@ -2147,9 +2147,9 @@ TEST (node, block_confirm)
 	ASSERT_TRUE (node1.ledger.block_or_pruned_exists (send1->hash ()));
 	ASSERT_TRUE (node2.ledger.block_or_pruned_exists (send1_copy->hash ()));
 	// Confirm send1 on node2 so it can vote for send2
-	node2.block_confirm (send1_copy);
-	auto election = node2.active.election (send1_copy->qualified_root ());
-	ASSERT_NE (nullptr, election);
+	node2.start_election (send1_copy);
+	std::shared_ptr<nano::election> election;
+	ASSERT_TIMELY (5s, election = node2.active.election (send1_copy->qualified_root ()));
 	ASSERT_TIMELY (10s, node1.active.recently_cemented.list ().size () == 1);
 }
 
@@ -2267,9 +2267,9 @@ TEST (node, local_votes_cache)
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *send2).code);
 	}
 	// Confirm blocks to allow voting
-	node.block_confirm (send2);
-	auto election = node.active.election (send2->qualified_root ());
-	ASSERT_NE (nullptr, election);
+	node.start_election (send2);
+	std::shared_ptr<nano::election> election;
+	ASSERT_TIMELY (5s, election = node.active.election (send2->qualified_root ()));
 	election->force_confirm ();
 	ASSERT_TIMELY (3s, node.ledger.cache.cemented_count == 3);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -3768,7 +3768,7 @@ TEST (node, dependency_graph)
 
 	// Start an election for the first block of the dependency graph, and ensure all blocks are eventually confirmed
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	node.block_confirm (gen_send1);
+	node.start_election (gen_send1);
 
 	ASSERT_NO_ERROR (system.poll_until_true (15s, [&] {
 		// Not many blocks should be active simultaneously
@@ -3957,7 +3957,7 @@ TEST (node, dependency_graph_frontier)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 
 	ASSERT_TIMELY (10s, node2.active.active (gen_send1->qualified_root ()));
-	node1.block_confirm (gen_send1);
+	node1.start_election (gen_send1);
 
 	ASSERT_TIMELY (15s, node1.ledger.cache.cemented_count == node1.ledger.cache.block_count);
 	ASSERT_TIMELY (15s, node2.ledger.cache.cemented_count == node2.ledger.cache.block_count);

--- a/nano/core_test/optimistic_scheduler.cpp
+++ b/nano/core_test/optimistic_scheduler.cpp
@@ -24,7 +24,7 @@ TEST (optimistic_scheduler, activate_one)
 	auto & [account, blocks] = chains.front ();
 
 	// Confirm block towards at the beginning the chain, so gap between confirmation and account frontier is larger than `gap_threshold`
-	ASSERT_TRUE (nano::test::confirm (node, { blocks.at (11) }));
+	nano::test::start_elections (system, node, { blocks.at (11) }, true);
 	ASSERT_TIMELY (5s, nano::test::confirmed (node, { blocks.at (11) }));
 
 	// Ensure unconfirmed account head block gets activated
@@ -93,7 +93,7 @@ TEST (optimistic_scheduler, under_gap_threshold)
 	auto & [account, blocks] = chains.front ();
 
 	// Confirm block towards the end of the chain, so gap between confirmation and account frontier is less than `gap_threshold`
-	ASSERT_TRUE (nano::test::confirm (node, { blocks.at (55) }));
+	nano::test::start_elections (system, node, { blocks.at (55) }, true);
 	ASSERT_TIMELY (5s, nano::test::confirmed (node, { blocks.at (55) }));
 
 	// Manually trigger backlog scan

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1182,8 +1182,8 @@ TEST (wallet, search_receivable)
 	// Pending search should start an election
 	ASSERT_TRUE (node.active.empty ());
 	ASSERT_FALSE (wallet.search_receivable (wallet.wallets.tx_begin_read ()));
-	auto election = node.active.election (send->qualified_root ());
-	ASSERT_NE (nullptr, election);
+	std::shared_ptr<nano::election> election;
+	ASSERT_TIMELY (5s, election = node.active.election (send->qualified_root ()));
 
 	// Erase the key so the confirmation does not trigger an automatic receive
 	wallet.store.erase (node.wallets.tx_begin_write (), nano::dev::genesis->account ());

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -222,8 +222,8 @@ TEST (wallets, search_receivable)
 		{
 			node.wallets.search_receivable (wallet_id);
 		}
-		auto election = node.active.election (send->qualified_root ());
-		ASSERT_NE (nullptr, election);
+		std::shared_ptr<nano::election> election;
+		ASSERT_TIMELY (5s, election = node.active.election (send->qualified_root ()));
 
 		// Erase the key so the confirmation does not trigger an automatic receive
 		wallet->store.erase (node.wallets.tx_begin_write (), nano::dev::genesis->account ());

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1205,7 +1205,7 @@ void nano::json_handler::block_confirm ()
 				// Start new confirmation for unconfirmed (or not being confirmed) block
 				if (!node.confirmation_height_processor.is_processing_block (hash))
 				{
-					node.block_confirm (std::move (block_l));
+					node.start_election (std::move (block_l));
 				}
 			}
 			else

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1266,7 +1266,6 @@ void nano::node::add_initial_peers ()
 void nano::node::start_election (std::shared_ptr<nano::block> const & block)
 {
 	scheduler.priority.manual (block);
-	scheduler.priority.flush ();
 }
 
 bool nano::node::block_confirmed (nano::block_hash const & hash_a)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1263,17 +1263,10 @@ void nano::node::add_initial_peers ()
 	}
 }
 
-std::shared_ptr<nano::election> nano::node::block_confirm (std::shared_ptr<nano::block> const & block_a)
+void nano::node::start_election (std::shared_ptr<nano::block> const & block)
 {
-	scheduler.priority.manual (block_a);
+	scheduler.priority.manual (block);
 	scheduler.priority.flush ();
-	auto election = active.election (block_a->qualified_root ());
-	if (election != nullptr)
-	{
-		election->transition_active ();
-		return election;
-	}
-	return {};
 }
 
 bool nano::node::block_confirmed (nano::block_hash const & hash_a)

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -121,11 +121,7 @@ public:
 	boost::optional<uint64_t> work_generate_blocking (nano::work_version const, nano::root const &, uint64_t, boost::optional<nano::account> const & = boost::none);
 	void work_generate (nano::work_version const, nano::root const &, uint64_t, std::function<void (boost::optional<uint64_t>)>, boost::optional<nano::account> const & = boost::none, bool const = false);
 	void add_initial_peers ();
-	/*
-	 * Starts an election for the block, DOES NOT confirm it
-	 * TODO: Rename to `start_election`
-	 */
-	std::shared_ptr<nano::election> block_confirm (std::shared_ptr<nano::block> const &);
+	void start_election (std::shared_ptr<nano::block> const & block);
 	bool block_confirmed (nano::block_hash const &);
 	bool block_confirmed_or_being_confirmed (nano::block_hash const &);
 	void do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -133,7 +133,11 @@ void nano::scheduler::priority::run ()
 				manual_queue.pop_front ();
 				lock.unlock ();
 				stats.inc (nano::stat::type::election_scheduler, nano::stat::detail::insert_manual);
-				node.active.insert (block, election_behavior);
+				auto result = node.active.insert (block, election_behavior);
+				if (result.election != nullptr)
+				{
+					result.election->transition_active ();
+				}
 			}
 			else if (priority_queue_predicate ())
 			{

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -69,14 +69,6 @@ bool nano::scheduler::priority::activate (nano::account const & account_a, nano:
 	return false; // Not activated
 }
 
-void nano::scheduler::priority::flush ()
-{
-	nano::unique_lock<nano::mutex> lock{ mutex };
-	condition.wait (lock, [this] () {
-		return stopped || empty_locked () || node.active.vacancy () <= 0;
-	});
-}
-
 void nano::scheduler::priority::notify ()
 {
 	condition.notify_all ();

--- a/nano/node/scheduler/priority.hpp
+++ b/nano/node/scheduler/priority.hpp
@@ -36,8 +36,6 @@ public:
 	 * @return true if account was activated
 	 */
 	bool activate (nano::account const &, nano::transaction const &);
-	// Blocks until no more elections can be activated or there are no more elections to activate
-	void flush ();
 	void notify ();
 	std::size_t size () const;
 	bool empty () const;

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1195,7 +1195,7 @@ bool nano::wallet::search_receivable (nano::transaction const & wallet_transacti
 							if (block)
 							{
 								// Request confirmation for block which is not being processed yet
-								wallets.node.block_confirm (block);
+								wallets.node.start_election (block);
 							}
 						}
 					}

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -144,7 +144,7 @@ TEST (rpc, receivable_unconfirmed)
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
-	nano::test::confirm (*node, { block1->hash () });
+	nano::test::start_elections (system, *node, { block1->hash () }, true);
 	ASSERT_TIMELY (5s, !node->active.active (*block1));
 	request.put ("include_only_confirmed", "true");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
@@ -548,7 +548,7 @@ TEST (rpc, accounts_receivable_confirmed)
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
-	nano::test::confirm (*node, { block1->hash () });
+	nano::test::start_elections (system, *node, { block1->hash () }, true);
 	ASSERT_TIMELY (5s, !node->active.active (*block1));
 	request.put ("include_only_confirmed", "true");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1246,10 +1246,7 @@ TEST (rpc, history_pruning)
 	ASSERT_TIMELY (5s, nano::test::exists (*node0, blocks));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 
-	// WORKAROUND: this is called repeatedly inside an assert timely because nano::test::confirm()
-	// uses block_processor.flush internally which can fail to flush
-	ASSERT_TIMELY (5s, nano::test::confirm (*node0, blocks));
-
+	nano::test::start_elections (system, *node0, blocks, true);
 	ASSERT_TIMELY (5s, node0->block_confirmed (uchange->hash ()));
 	nano::confirmation_height_info confirmation_height_info;
 	node0->store.confirmation_height.get (node0->store.tx_begin_read (), nano::dev::genesis_key.pub, confirmation_height_info);
@@ -5880,7 +5877,7 @@ TEST (rpc, block_confirmed)
 				.work (*system.work.generate (latest))
 				.build_shared ();
 	node->process_active (send);
-	ASSERT_TIMELY (5s, nano::test::confirm (*node, { send }));
+	nano::test::start_elections (system, *node, { send }, true);
 
 	// Wait until the confirmation height has been set
 	ASSERT_TIMELY (5s, node->ledger.block_confirmed (node->store.tx_begin_read (), send->hash ()) && !node->confirmation_height_processor.is_processing_block (send->hash ()));

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1132,7 +1132,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 	// Confirm all of the accounts
 	for (auto & open_block : open_blocks)
 	{
-		node->block_confirm (open_block);
+		node->start_election (open_block);
 		std::shared_ptr<nano::election> election;
 		ASSERT_TIMELY (10s, (election = node->active.election (open_block->qualified_root ())) != nullptr);
 		election->force_confirm ();

--- a/nano/slow_test/vote_cache.cpp
+++ b/nano/slow_test/vote_cache.cpp
@@ -38,7 +38,7 @@ nano::keypair setup_rep (nano::test::system & system, nano::node & node, nano::u
 				.build_shared ();
 
 	EXPECT_TRUE (nano::test::process (node, { send, open }));
-	EXPECT_TIMELY (5s, nano::test::confirm (node, { send, open }));
+	nano::test::start_elections (system, node, { send, open }, true);
 	EXPECT_TIMELY (5s, nano::test::confirmed (node, { send, open }));
 
 	return key;
@@ -104,7 +104,7 @@ std::vector<std::shared_ptr<nano::block>> setup_blocks (nano::test::system & sys
 	EXPECT_TRUE (nano::test::process (node, receives));
 
 	// Confirm whole genesis chain at once
-	EXPECT_TIMELY (5s, nano::test::confirm (node, { sends.back () }));
+	nano::test::start_elections (system, node, { sends.back () }, true);
 	EXPECT_TIMELY (5s, nano::test::confirmed (node, { sends }));
 
 	std::cout << "setup_blocks done" << std::endl;

--- a/nano/test_common/chains.cpp
+++ b/nano/test_common/chains.cpp
@@ -35,7 +35,7 @@ nano::block_list_t nano::test::setup_chain (nano::test::system & system, nano::n
 	if (confirm)
 	{
 		// Confirm whole chain at once
-		EXPECT_TIMELY (5s, nano::test::confirm (node, { blocks.back () }));
+		nano::test::start_elections (system, node, { blocks.back () }, true);
 		EXPECT_TIMELY (5s, nano::test::confirmed (node, blocks));
 	}
 
@@ -83,7 +83,7 @@ std::vector<std::pair<nano::account, nano::block_list_t>> nano::test::setup_chai
 		if (confirm)
 		{
 			// Ensure blocks are in the ledger and confirmed
-			EXPECT_TIMELY (5s, nano::test::confirm (node, { send, open }));
+			nano::test::start_elections (system, node, { send, open }, true);
 			EXPECT_TIMELY (5s, nano::test::confirmed (node, { send, open }));
 		}
 
@@ -142,7 +142,7 @@ nano::block_list_t nano::test::setup_independent_blocks (nano::test::system & sy
 	}
 
 	// Confirm whole genesis chain at once
-	EXPECT_TIMELY (5s, nano::test::confirm (node, { latest }));
+	nano::test::start_elections (system, node, { latest }, true);
 	EXPECT_TIMELY (5s, nano::test::confirmed (node, { latest }));
 
 	return blocks;
@@ -179,7 +179,7 @@ nano::keypair nano::test::setup_rep (nano::test::system & system, nano::node & n
 				.build_shared ();
 
 	EXPECT_TRUE (nano::test::process (node, { send, open }));
-	EXPECT_TIMELY (5s, nano::test::confirm (node, { send, open }));
+	nano::test::start_elections (system, node, { send, open }, true);
 	EXPECT_TIMELY (5s, nano::test::confirmed (node, { send, open }));
 
 	return key;

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -80,38 +80,6 @@ bool nano::test::process_live (nano::node & node, std::vector<std::shared_ptr<na
 	return true;
 }
 
-bool nano::test::confirm (nano::node & node, std::vector<nano::block_hash> hashes)
-{
-	// Finish processing all blocks - FIXME: block processor flush is broken and should be removed
-	node.block_processor.flush ();
-	for (auto & hash : hashes)
-	{
-		if (node.block_confirmed (hash))
-		{
-			continue;
-		}
-
-		auto disk_block = node.block (hash);
-		// A sideband is required to start an election
-		release_assert (disk_block != nullptr);
-		release_assert (disk_block->has_sideband ());
-		// This only starts election
-		auto election = node.block_confirm (disk_block);
-		if (election == nullptr)
-		{
-			return false;
-		}
-		// Here we actually confirm the block
-		election->force_confirm ();
-	}
-	return true;
-}
-
-bool nano::test::confirm (nano::node & node, std::vector<std::shared_ptr<nano::block>> blocks)
-{
-	return confirm (node, blocks_to_hashes (blocks));
-}
-
 bool nano::test::confirmed (nano::node & node, std::vector<nano::block_hash> hashes)
 {
 	for (auto & hash : hashes)

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -333,18 +333,6 @@ namespace test
 	 */
 	bool process_live (nano::node & node, std::vector<std::shared_ptr<nano::block>> blocks);
 	/*
-	 * Convenience function to confirm a list of blocks
-	 * The actual confirmation will happen asynchronously, check for that with `nano::test::confirmed (..)` function
-	 * @return true if successfully scheduled blocks to be confirmed
-	 */
-	bool confirm (nano::node & node, std::vector<std::shared_ptr<nano::block>> blocks);
-	/*
-	 * Convenience function to confirm a list of hashes
-	 * The actual confirmation will happen asynchronously, check for that with `nano::test::confirmed (..)` function
-	 * @return true if successfully scheduled blocks to be confirmed
-	 */
-	bool confirm (nano::node & node, std::vector<nano::block_hash> hashes);
-	/*
 	 * Convenience function to check whether a list of blocks is confirmed.
 	 * @return true if all blocks are confirmed, false otherwise
 	 */


### PR DESCRIPTION
This PR contains 3 commits that:
- Removes blocking nano::test::confirm functions which have functionality superceded by nano::test::start_elections which polls a nano::system rather than using a thread wait
- Renames nano::block_confirm to node::start_election. This adresses a TODO item to better name this function and make it not block
- Removes priority::flush function as flush functions are being removed from the codebase.