### PR TITLE
fixed bug in nano::rocksdb::store::clear()

### DIFF
--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -722,20 +722,20 @@ int nano::rocksdb::store::drop (nano::write_transaction const & transaction_a, t
 
 int nano::rocksdb::store::clear (::rocksdb::ColumnFamilyHandle * column_family)
 {
-	// Dropping completely removes the column
-	auto name = column_family->GetName ();
-	auto status = db->DropColumnFamily (column_family);
-	release_assert (status.ok ());
+	::rocksdb::ReadOptions read_options;
+  ::rocksdb::WriteOptions write_options;
+  ::rocksdb::WriteBatch write_batch;
+  std::unique_ptr<::rocksdb::Iterator> it(db->NewIterator(read_options, column_family));
 
-	// Need to add it back as we just want to clear the contents
-	auto handle_it = std::find_if (handles.begin (), handles.end (), [column_family] (auto & handle) {
-		return handle.get () == column_family;
-	});
-	debug_assert (handle_it != handles.cend ());
-	status = db->CreateColumnFamily (get_cf_options (name), name, &column_family);
-	release_assert (status.ok ());
-	handle_it->reset (column_family);
-	return status.code ();
+  for (it->SeekToFirst (); it->Valid (); it->Next ())
+  {
+    write_batch.Delete (column_family, it->key());
+  }
+
+  ::rocksdb::Status status = db->Write(write_options, &write_batch);
+  release_assert(status.ok());
+
+  return status.code();
 }
 
 void nano::rocksdb::store::construct_column_family_mutexes ()

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -723,19 +723,19 @@ int nano::rocksdb::store::drop (nano::write_transaction const & transaction_a, t
 int nano::rocksdb::store::clear (::rocksdb::ColumnFamilyHandle * column_family)
 {
 	::rocksdb::ReadOptions read_options;
-  ::rocksdb::WriteOptions write_options;
-  ::rocksdb::WriteBatch write_batch;
-  std::unique_ptr<::rocksdb::Iterator> it(db->NewIterator(read_options, column_family));
+	::rocksdb::WriteOptions write_options;
+	::rocksdb::WriteBatch write_batch;
+	std::unique_ptr<::rocksdb::Iterator> it (db->NewIterator (read_options, column_family));
 
-  for (it->SeekToFirst (); it->Valid (); it->Next ())
-  {
-    write_batch.Delete (column_family, it->key());
-  }
+	for (it->SeekToFirst (); it->Valid (); it->Next ())
+	{
+		write_batch.Delete (column_family, it->key ());
+	}
 
-  ::rocksdb::Status status = db->Write(write_options, &write_batch);
-  release_assert(status.ok());
+	::rocksdb::Status status = db->Write (write_options, &write_batch);
+	release_assert (status.ok ());
 
-  return status.code();
+	return status.code ();
 }
 
 void nano::rocksdb::store::construct_column_family_mutexes ()


### PR DESCRIPTION
Addresses #3911 - issue before was that the function was deleting the column entirely to clear the contents then adding it back. This solution makes use of the atomic update feature in RocksDB by creating a batch of delete operations for all keys in the column and applying them with a write operation. This approach ensures that either all operations are applied or none are, thus guaranteeing database consistency.
