### PR TITLE
Cleanup scheduler::buckets class

### DIFF
--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -194,6 +194,8 @@ add_library(
   rocksdb/rocksdb_iterator.hpp
   rocksdb/rocksdb_txn.hpp
   rocksdb/rocksdb_txn.cpp
+  scheduler/bucket.cpp
+  scheduler/bucket.hpp
   scheduler/buckets.cpp
   scheduler/buckets.hpp
   scheduler/component.hpp

--- a/nano/node/scheduler/bucket.cpp
+++ b/nano/node/scheduler/bucket.cpp
@@ -1,0 +1,62 @@
+#include <nano/lib/blocks.hpp>
+#include <nano/node/scheduler/bucket.hpp>
+
+bool nano::scheduler::bucket::value_type::operator< (value_type const & other_a) const
+{
+	return time < other_a.time || (time == other_a.time && block->hash () < other_a.block->hash ());
+}
+
+bool nano::scheduler::bucket::value_type::operator== (value_type const & other_a) const
+{
+	return time == other_a.time && block->hash () == other_a.block->hash ();
+}
+
+nano::scheduler::bucket::bucket (size_t maximum) :
+	maximum{ maximum }
+{
+	debug_assert (maximum > 0);
+}
+
+nano::scheduler::bucket::~bucket ()
+{
+}
+
+std::shared_ptr<nano::block> nano::scheduler::bucket::top () const
+{
+	debug_assert (!queue.empty ());
+	return queue.begin ()->block;
+}
+
+void nano::scheduler::bucket::pop ()
+{
+	debug_assert (!queue.empty ());
+	queue.erase (queue.begin ());
+}
+
+void nano::scheduler::bucket::push (uint64_t time, std::shared_ptr<nano::block> block)
+{
+	queue.insert ({ time, block });
+	if (queue.size () > maximum)
+	{
+		debug_assert (!queue.empty ());
+		queue.erase (--queue.end ());
+	}
+}
+
+size_t nano::scheduler::bucket::size () const
+{
+	return queue.size ();
+}
+
+bool nano::scheduler::bucket::empty () const
+{
+	return queue.empty ();
+}
+
+void nano::scheduler::bucket::dump () const
+{
+	for (auto const & item : queue)
+	{
+		std::cerr << item.time << ' ' << item.block->hash ().to_string () << '\n';
+	}
+}

--- a/nano/node/scheduler/bucket.hpp
+++ b/nano/node/scheduler/bucket.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <set>
+
+namespace nano
+{
+class block;
+}
+namespace nano::scheduler
+{
+/** A class which holds an ordered set of blocks to be scheduled, ordered by their block arrival time
+ */
+class bucket final
+{
+	class value_type
+	{
+	public:
+		uint64_t time;
+		std::shared_ptr<nano::block> block;
+		bool operator< (value_type const & other_a) const;
+		bool operator== (value_type const & other_a) const;
+	};
+	std::set<value_type> queue;
+	size_t const maximum;
+
+public:
+	bucket (size_t maximum);
+	~bucket ();
+	std::shared_ptr<nano::block> top () const;
+	void pop ();
+	void push (uint64_t time, std::shared_ptr<nano::block> block);
+	size_t size () const;
+	bool empty () const;
+	void dump () const;
+};
+} // namespace nano::scheduler

--- a/nano/node/scheduler/buckets.cpp
+++ b/nano/node/scheduler/buckets.cpp
@@ -9,9 +9,9 @@
 void nano::scheduler::buckets::next ()
 {
 	++current;
-	if (current == schedule.end ())
+	if (current == buckets_m.end ())
 	{
-		current = schedule.begin ();
+		current = buckets_m.begin ();
 	}
 }
 
@@ -19,18 +19,9 @@ void nano::scheduler::buckets::next ()
 void nano::scheduler::buckets::seek ()
 {
 	next ();
-	for (std::size_t i = 0, n = schedule.size (); buckets_m[*current]->empty () && i < n; ++i)
+	for (std::size_t i = 0, n = buckets_m.size (); (*current)->empty () && i < n; ++i)
 	{
 		next ();
-	}
-}
-
-/** Initialise the schedule vector */
-void nano::scheduler::buckets::populate_schedule ()
-{
-	for (auto i = 0; i < buckets_m.size (); ++i)
-	{
-		schedule.push_back (i);
 	}
 }
 
@@ -63,8 +54,7 @@ nano::scheduler::buckets::buckets (uint64_t maximum) :
 	{
 		buckets_m.push_back (std::make_unique<scheduler::bucket> (bucket_max));
 	}
-	populate_schedule ();
-	current = schedule.begin ();
+	current = buckets_m.begin ();
 }
 
 nano::scheduler::buckets::~buckets ()
@@ -96,7 +86,7 @@ void nano::scheduler::buckets::push (uint64_t time, std::shared_ptr<nano::block>
 std::shared_ptr<nano::block> nano::scheduler::buckets::top () const
 {
 	debug_assert (!empty ());
-	auto result = buckets_m[*current]->top ();
+	auto result = (*current)->top ();
 	return result;
 }
 
@@ -104,7 +94,7 @@ std::shared_ptr<nano::block> nano::scheduler::buckets::top () const
 void nano::scheduler::buckets::pop ()
 {
 	debug_assert (!empty ());
-	auto & bucket = buckets_m[*current];
+	auto & bucket = *current;
 	bucket->pop ();
 	seek ();
 }
@@ -145,7 +135,7 @@ void nano::scheduler::buckets::dump () const
 	{
 		bucket->dump ();
 	}
-	std::cerr << "current: " << std::to_string (*current) << '\n';
+	std::cerr << "current: " << current - buckets_m.begin () << '\n';
 }
 
 std::unique_ptr<nano::container_info_component> nano::scheduler::buckets::collect_container_info (std::string const & name)

--- a/nano/node/scheduler/buckets.hpp
+++ b/nano/node/scheduler/buckets.hpp
@@ -33,18 +33,14 @@ class buckets final
 	 *  the container writes a block to the lowest indexed bucket that has balance larger than the bucket's minimum value */
 	std::deque<nano::uint128_t> minimums;
 
-	/** Contains bucket indicies to iterate over when making the next scheduling decision */
-	std::deque<uint8_t> schedule;
-
 	/** index of bucket to read next */
-	decltype (schedule)::const_iterator current;
+	decltype (buckets_m)::const_iterator current;
 
 	/** maximum number of blocks in whole container, each bucket's maximum is maximum / bucket_number */
 	uint64_t const maximum;
 
 	void next ();
 	void seek ();
-	void populate_schedule ();
 
 public:
 	buckets (uint64_t maximum = 250000u);

--- a/nano/node/scheduler/buckets.hpp
+++ b/nano/node/scheduler/buckets.hpp
@@ -4,7 +4,7 @@
 
 #include <cstddef>
 #include <set>
-#include <vector>
+#include <deque>
 
 namespace nano
 {
@@ -36,14 +36,14 @@ class buckets final
 	using priority = std::set<value_type>;
 
 	/** container for the buckets to be read in round robin fashion */
-	std::vector<priority> buckets_m;
+	std::deque<priority> buckets_m;
 
 	/** thresholds that define the bands for each bucket, the minimum balance an account must have to enter a bucket,
 	 *  the container writes a block to the lowest indexed bucket that has balance larger than the bucket's minimum value */
-	std::vector<nano::uint128_t> minimums;
+	std::deque<nano::uint128_t> minimums;
 
 	/** Contains bucket indicies to iterate over when making the next scheduling decision */
-	std::vector<uint8_t> schedule;
+	std::deque<uint8_t> schedule;
 
 	/** index of bucket to read next */
 	decltype (schedule)::const_iterator current;

--- a/nano/node/scheduler/buckets.hpp
+++ b/nano/node/scheduler/buckets.hpp
@@ -3,8 +3,9 @@
 #include <nano/lib/utility.hpp>
 
 #include <cstddef>
-#include <set>
+#include <cstdint>
 #include <deque>
+#include <memory>
 
 namespace nano
 {
@@ -12,6 +13,7 @@ class block;
 }
 namespace nano::scheduler
 {
+class bucket;
 /** A container for holding blocks and their arrival/creation time.
  *
  *  The container consists of a number of buckets. Each bucket holds an ordered set of 'value_type' items.
@@ -24,19 +26,8 @@ namespace nano::scheduler
  */
 class buckets final
 {
-	class value_type
-	{
-	public:
-		uint64_t time;
-		std::shared_ptr<nano::block> block;
-		bool operator< (value_type const & other_a) const;
-		bool operator== (value_type const & other_a) const;
-	};
-
-	using priority = std::set<value_type>;
-
 	/** container for the buckets to be read in round robin fashion */
-	std::deque<priority> buckets_m;
+	std::deque<std::unique_ptr<bucket>> buckets_m;
 
 	/** thresholds that define the bands for each bucket, the minimum balance an account must have to enter a bucket,
 	 *  the container writes a block to the lowest indexed bucket that has balance larger than the bucket's minimum value */
@@ -57,6 +48,7 @@ class buckets final
 
 public:
 	buckets (uint64_t maximum = 250000u);
+	~buckets ();
 	void push (uint64_t time, std::shared_ptr<nano::block> block, nano::amount const & priority);
 	std::shared_ptr<nano::block> top () const;
 	void pop ();

--- a/nano/node/scheduler/priority.hpp
+++ b/nano/node/scheduler/priority.hpp
@@ -2,7 +2,6 @@
 
 #include <nano/lib/numbers.hpp>
 #include <nano/node/active_transactions.hpp>
-#include <nano/node/scheduler/buckets.hpp>
 
 #include <boost/optional.hpp>
 
@@ -19,6 +18,7 @@ class node;
 
 namespace nano::scheduler
 {
+class buckets;
 class priority final
 {
 public:
@@ -52,7 +52,7 @@ private:
 	bool priority_queue_predicate () const;
 	bool manual_queue_predicate () const;
 
-	nano::scheduler::buckets buckets;
+	std::unique_ptr<nano::scheduler::buckets> buckets;
 
 	std::deque<std::tuple<std::shared_ptr<nano::block>, boost::optional<nano::uint128_t>, nano::election_behavior>> manual_queue;
 	bool stopped{ false };


### PR DESCRIPTION
This patch does a number of cleanups to the scheduler::buckets class.
- Extracts a previously nested class into its own file scheduler::bucket.
- Replaces usages of vectors with deques as only indexing is needed, not contiguous allocation.
- Removed buckets::schedule as it's confusing and not needed
- Using more unique_ptr to reduce class definition inclusion requirements