### PR TITLE
Block store cleanup

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1100,7 +1100,7 @@ TEST (mdb_block_store, sideband_height)
 				 .work (*pool.generate (state_open->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch).code);
-	ASSERT_EQ (nano::epoch::epoch_1, store.block.version (transaction, epoch->hash ()));
+	ASSERT_EQ (nano::epoch::epoch_1, ledger.version (*epoch));
 	auto epoch_open = builder
 					  .state ()
 					  .account (key2.pub)
@@ -1112,7 +1112,7 @@ TEST (mdb_block_store, sideband_height)
 					  .work (*pool.generate (key2.pub))
 					  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch_open).code);
-	ASSERT_EQ (nano::epoch::epoch_1, store.block.version (transaction, epoch_open->hash ()));
+	ASSERT_EQ (nano::epoch::epoch_1, ledger.version (*epoch_open));
 	auto state_receive = builder
 						 .state ()
 						 .account (key2.pub)

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -112,7 +112,7 @@ TEST (ledger, process_send)
 	ASSERT_TRUE (store.frontier.get (transaction, info1->head).is_zero ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, hash1));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	ASSERT_EQ (nano::dev::genesis_key.pub, store.block.account (*send));
+	ASSERT_EQ (nano::dev::genesis_key.pub, ledger.account (*send));
 	ASSERT_EQ (50, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_receivable (transaction, key2.pub));
 	auto info2 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
@@ -141,7 +141,7 @@ TEST (ledger, process_send)
 	ASSERT_EQ (1, open->sideband ().height);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash2));
 	ASSERT_EQ (nano::process_result::progress, return2.code);
-	ASSERT_EQ (key2.pub, store.block.account (*open));
+	ASSERT_EQ (key2.pub, ledger.account (*open));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash2));
 	ASSERT_EQ (key2.pub, store.frontier.get (transaction, hash2));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_balance (transaction, key2.pub));
@@ -225,7 +225,7 @@ TEST (ledger, process_receive)
 	nano::block_hash hash2 (open->hash ());
 	auto return1 = ledger.process (transaction, *open);
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	ASSERT_EQ (key2.pub, store.block.account (*open));
+	ASSERT_EQ (key2.pub, ledger.account (*open));
 	ASSERT_EQ (key2.pub, open->sideband ().account);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, open->sideband ().balance.number ());
 	ASSERT_EQ (1, open->sideband ().height);
@@ -258,7 +258,7 @@ TEST (ledger, process_receive)
 	ASSERT_TRUE (store.frontier.get (transaction, hash2).is_zero ());
 	ASSERT_EQ (key2.pub, store.frontier.get (transaction, hash4));
 	ASSERT_EQ (nano::process_result::progress, return2.code);
-	ASSERT_EQ (key2.pub, store.block.account (*receive));
+	ASSERT_EQ (key2.pub, ledger.account (*receive));
 	ASSERT_EQ (hash4, ledger.latest (transaction, key2.pub));
 	ASSERT_EQ (25, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.account_receivable (transaction, key2.pub));
@@ -525,7 +525,7 @@ TEST (ledger, representative_change)
 	ASSERT_TRUE (store.frontier.get (transaction, info1->head).is_zero ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, block->hash ()));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	ASSERT_EQ (nano::dev::genesis_key.pub, store.block.account (*block));
+	ASSERT_EQ (nano::dev::genesis_key.pub, ledger.account (*block));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key2.pub));
 	auto info2 = ledger.account_info (transaction, nano::dev::genesis_key.pub);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -112,7 +112,7 @@ TEST (ledger, process_send)
 	ASSERT_TRUE (store.frontier.get (transaction, info1->head).is_zero ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, hash1));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	ASSERT_EQ (nano::dev::genesis_key.pub, store.block.account_calculated (*send));
+	ASSERT_EQ (nano::dev::genesis_key.pub, store.block.account (*send));
 	ASSERT_EQ (50, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_receivable (transaction, key2.pub));
 	auto info2 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
@@ -141,7 +141,7 @@ TEST (ledger, process_send)
 	ASSERT_EQ (1, open->sideband ().height);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash2));
 	ASSERT_EQ (nano::process_result::progress, return2.code);
-	ASSERT_EQ (key2.pub, store.block.account_calculated (*open));
+	ASSERT_EQ (key2.pub, store.block.account (*open));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash2));
 	ASSERT_EQ (key2.pub, store.frontier.get (transaction, hash2));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_balance (transaction, key2.pub));
@@ -225,7 +225,7 @@ TEST (ledger, process_receive)
 	nano::block_hash hash2 (open->hash ());
 	auto return1 = ledger.process (transaction, *open);
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	ASSERT_EQ (key2.pub, store.block.account_calculated (*open));
+	ASSERT_EQ (key2.pub, store.block.account (*open));
 	ASSERT_EQ (key2.pub, open->sideband ().account);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, open->sideband ().balance.number ());
 	ASSERT_EQ (1, open->sideband ().height);
@@ -258,7 +258,7 @@ TEST (ledger, process_receive)
 	ASSERT_TRUE (store.frontier.get (transaction, hash2).is_zero ());
 	ASSERT_EQ (key2.pub, store.frontier.get (transaction, hash4));
 	ASSERT_EQ (nano::process_result::progress, return2.code);
-	ASSERT_EQ (key2.pub, store.block.account_calculated (*receive));
+	ASSERT_EQ (key2.pub, store.block.account (*receive));
 	ASSERT_EQ (hash4, ledger.latest (transaction, key2.pub));
 	ASSERT_EQ (25, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.account_receivable (transaction, key2.pub));
@@ -525,7 +525,7 @@ TEST (ledger, representative_change)
 	ASSERT_TRUE (store.frontier.get (transaction, info1->head).is_zero ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, block->hash ()));
 	ASSERT_EQ (nano::process_result::progress, return1.code);
-	ASSERT_EQ (nano::dev::genesis_key.pub, store.block.account_calculated (*block));
+	ASSERT_EQ (nano::dev::genesis_key.pub, store.block.account (*block));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key2.pub));
 	auto info2 = ledger.account_info (transaction, nano::dev::genesis_key.pub);

--- a/nano/core_test/ledger_walker.cpp
+++ b/nano/core_test/ledger_walker.cpp
@@ -111,11 +111,11 @@ TEST (ledger_walker, cross_account)
 	ASSERT_TRUE (account_info);
 
 	//    TODO: check issue with account head
-	//    auto const first = node->ledger.store.block.get_no_sideband(transaction, account_info.head);
-	//    auto const second = node->ledger.store.block.get_no_sideband(transaction, first->previous());
-	//    auto const third = node->ledger.store.block.get_no_sideband(transaction, second->previous());
-	//    auto const fourth = node->ledger.store.block.get_no_sideband(transaction, third->previous());
-	//    auto const fifth = node->ledger.store.block.get_no_sideband(transaction, fourth->previous());
+	//    auto const first = node->ledger.store.block.get(transaction, account_info.head);
+	//    auto const second = node->ledger.store.block.get(transaction, first->previous());
+	//    auto const third = node->ledger.store.block.get(transaction, second->previous());
+	//    auto const fourth = node->ledger.store.block.get(transaction, third->previous());
+	//    auto const fifth = node->ledger.store.block.get(transaction, fourth->previous());
 	//
 	//    auto const expected_blocks_to_walk = { first, second, third, fourth, fifth };
 	//    auto expected_blocks_to_walk_itr = expected_blocks_to_walk.begin();
@@ -193,7 +193,7 @@ TEST (ledger_walker, DISABLED_ladder_geometry)
 			nano::amount previous_balance{};
 			if (!block->previous ().is_zero ())
 			{
-				auto const previous_block = node->ledger.store.block.get_no_sideband (node->ledger.store.tx_begin_read (), block->previous ());
+				auto const previous_block = node->ledger.store.block.get (node->ledger.store.tx_begin_read (), block->previous ());
 				previous_balance = previous_block->balance ();
 			}
 
@@ -212,7 +212,7 @@ TEST (ledger_walker, DISABLED_ladder_geometry)
 			nano::amount previous_balance{};
 			if (!block->previous ().is_zero ())
 			{
-				auto const previous_block = node->ledger.store.block.get_no_sideband (node->ledger.store.tx_begin_read (), block->previous ());
+				auto const previous_block = node->ledger.store.block.get (node->ledger.store.tx_begin_read (), block->previous ());
 				previous_balance = previous_block->balance ();
 			}
 

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1072,7 +1072,7 @@ TEST (wallet, epoch_2_receive_propagation)
 		if (nano::dev::network_params.work.difficulty (*receive2) < node.network_params.work.base)
 		{
 			ASSERT_GE (nano::dev::network_params.work.difficulty (*receive2), node.network_params.work.epoch_2_receive);
-			ASSERT_EQ (nano::epoch::epoch_2, node.store.block.version (node.store.tx_begin_read (), receive2->hash ()));
+			ASSERT_EQ (nano::epoch::epoch_2, node.ledger.version (*receive2));
 			ASSERT_EQ (nano::epoch::epoch_2, receive2->sideband ().source_epoch);
 			break;
 		}
@@ -1125,7 +1125,7 @@ TEST (wallet, epoch_2_receive_unopened)
 		if (nano::dev::network_params.work.difficulty (*receive1) < node.network_params.work.base)
 		{
 			ASSERT_GE (nano::dev::network_params.work.difficulty (*receive1), node.network_params.work.epoch_2_receive);
-			ASSERT_EQ (nano::epoch::epoch_2, node.store.block.version (node.store.tx_begin_read (), receive1->hash ()));
+			ASSERT_EQ (nano::epoch::epoch_2, node.ledger.version (*receive1));
 			ASSERT_EQ (nano::epoch::epoch_1, receive1->sideband ().source_epoch);
 			break;
 		}

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1570,7 +1570,7 @@ int main (int argc, char * const * argv)
 					// Check link epoch version
 					if (sideband.details.is_receive && (!node->ledger.pruning || !node->store.pruned.exists (transaction, block->link ().as_block_hash ())))
 					{
-						if (sideband.source_epoch != node->store.block.version (transaction, block->link ().as_block_hash ()))
+						if (sideband.source_epoch != node->ledger.version (*block))
 						{
 							print_error_message (boost::str (boost::format ("Incorrect source epoch for block %1%\n") % hash.to_string ()));
 						}

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1687,7 +1687,7 @@ int main (int argc, char * const * argv)
 					std::cout << boost::str (boost::format ("%1% pending blocks validated\n") % count);
 				}
 				// Check block existance
-				auto block (node->store.block.get_no_sideband (transaction, key.hash));
+				auto block (node->store.block.get (transaction, key.hash));
 				bool pruned (false);
 				if (block == nullptr)
 				{
@@ -1811,7 +1811,7 @@ int main (int argc, char * const * argv)
 					while (!hash.is_zero ())
 					{
 						// Retrieving block data
-						auto block (source_node->store.block.get_no_sideband (transaction, hash));
+						auto block (source_node->store.block.get (transaction, hash));
 						if (block != nullptr)
 						{
 							++count;

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -307,7 +307,7 @@ void nano::confirmation_height_bounded::prepare_iterated_blocks_for_cementing (p
 	if (!preparation_data_a.already_cemented)
 	{
 		// Add the non-receive blocks iterated for this account
-		auto block_height = (ledger.store.block.account_height (preparation_data_a.transaction, preparation_data_a.top_most_non_receive_block_hash));
+		auto block_height = (ledger.height (preparation_data_a.transaction, preparation_data_a.top_most_non_receive_block_hash));
 		if (block_height > preparation_data_a.confirmation_height_info.height)
 		{
 			confirmed_info confirmed_info_l{ block_height, preparation_data_a.top_most_non_receive_block_hash };

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -5095,7 +5095,7 @@ void nano::json_handler::work_generate ()
 					auto transaction_l (node.store.tx_begin_read ());
 					if (node.store.block.exists (transaction_l, hash))
 					{
-						account = node.store.block.account (transaction_l, hash);
+						account = node.ledger.account (transaction_l, hash);
 					}
 				}
 				auto secondary_work_peers_l (request.get<bool> ("secondary_work_peers", false));

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -402,7 +402,7 @@ uint64_t nano::json_handler::difficulty_ledger (nano::block const & block_a)
 	// Send check
 	if (block_previous != nullptr)
 	{
-		details.is_send = node.store.block.balance (transaction, previous) > block_a.balance ().number ();
+		details.is_send = node.ledger.balance (transaction, previous) > block_a.balance ().number ();
 		details_found = true;
 	}
 	// Epoch check
@@ -1653,7 +1653,7 @@ void nano::json_handler::block_create ()
 			else if (previous_text.is_initialized () && balance_text.is_initialized () && type == "send")
 			{
 				auto transaction (node.store.tx_begin_read ());
-				if (node.store.block.exists (transaction, previous) && node.store.block.balance (transaction, previous) != balance.number ())
+				if (node.store.block.exists (transaction, previous) && node.ledger.balance (transaction, previous) != balance.number ())
 				{
 					ec = nano::error_rpc::block_create_balance_mismatch;
 				}

--- a/nano/node/lmdb/block_store.cpp
+++ b/nano/node/lmdb/block_store.cpp
@@ -147,17 +147,6 @@ nano::store_iterator<nano::block_hash, nano::block_w_sideband> nano::lmdb::block
 	return nano::store_iterator<nano::block_hash, nano::block_w_sideband> (nullptr);
 }
 
-nano::epoch nano::lmdb::block_store::version (nano::transaction const & transaction_a, nano::block_hash const & hash_a)
-{
-	auto block = get (transaction_a, hash_a);
-	if (block && block->type () == nano::block_type::state)
-	{
-		return block->sideband ().details.epoch;
-	}
-
-	return nano::epoch::epoch_0;
-}
-
 void nano::lmdb::block_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const
 {
 	parallel_traversal<nano::uint256_t> (

--- a/nano/node/lmdb/block_store.cpp
+++ b/nano/node/lmdb/block_store.cpp
@@ -101,20 +101,6 @@ std::shared_ptr<nano::block> nano::lmdb::block_store::get (nano::transaction con
 	return result;
 }
 
-std::shared_ptr<nano::block> nano::lmdb::block_store::get_no_sideband (nano::transaction const & transaction, nano::block_hash const & hash) const
-{
-	nano::mdb_val value;
-	block_raw_get (transaction, hash, value);
-	std::shared_ptr<nano::block> result;
-	if (value.size () != 0)
-	{
-		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()), value.size ());
-		result = nano::deserialize_block (stream);
-		debug_assert (result != nullptr);
-	}
-	return result;
-}
-
 std::shared_ptr<nano::block> nano::lmdb::block_store::random (nano::transaction const & transaction)
 {
 	nano::block_hash hash;

--- a/nano/node/lmdb/block_store.cpp
+++ b/nano/node/lmdb/block_store.cpp
@@ -146,25 +146,6 @@ uint64_t nano::lmdb::block_store::count (nano::transaction const & transaction_a
 	return store.count (transaction_a, tables::blocks);
 }
 
-nano::account nano::lmdb::block_store::account (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
-{
-	auto block (get (transaction_a, hash_a));
-	debug_assert (block != nullptr);
-	return account_calculated (*block);
-}
-
-nano::account nano::lmdb::block_store::account_calculated (nano::block const & block_a) const
-{
-	debug_assert (block_a.has_sideband ());
-	nano::account result (block_a.account ());
-	if (result.is_zero ())
-	{
-		result = block_a.sideband ().account;
-	}
-	debug_assert (!result.is_zero ());
-	return result;
-}
-
 nano::store_iterator<nano::block_hash, nano::block_w_sideband> nano::lmdb::block_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::block_hash, nano::block_w_sideband> (transaction, tables::blocks);

--- a/nano/node/lmdb/block_store.cpp
+++ b/nano/node/lmdb/block_store.cpp
@@ -156,13 +156,6 @@ void nano::lmdb::block_store::for_each_par (std::function<void (nano::read_trans
 	});
 }
 
-// Converts a block hash to a block height
-uint64_t nano::lmdb::block_store::account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
-{
-	auto block = get (transaction_a, hash_a);
-	return block->sideband ().height;
-}
-
 void nano::lmdb::block_store::block_raw_get (nano::transaction const & transaction, nano::block_hash const & hash, nano::mdb_val & value) const
 {
 	auto status = store.get (transaction, tables::blocks, hash, value);

--- a/nano/node/lmdb/block_store.cpp
+++ b/nano/node/lmdb/block_store.cpp
@@ -161,38 +161,6 @@ nano::store_iterator<nano::block_hash, nano::block_w_sideband> nano::lmdb::block
 	return nano::store_iterator<nano::block_hash, nano::block_w_sideband> (nullptr);
 }
 
-nano::uint128_t nano::lmdb::block_store::balance (nano::transaction const & transaction_a, nano::block_hash const & hash_a)
-{
-	auto block (get (transaction_a, hash_a));
-	release_assert (block);
-	nano::uint128_t result (balance_calculated (block));
-	return result;
-}
-
-nano::uint128_t nano::lmdb::block_store::balance_calculated (std::shared_ptr<nano::block> const & block_a) const
-{
-	nano::uint128_t result;
-	switch (block_a->type ())
-	{
-		case nano::block_type::open:
-		case nano::block_type::receive:
-		case nano::block_type::change:
-			result = block_a->sideband ().balance.number ();
-			break;
-		case nano::block_type::send:
-			result = boost::polymorphic_downcast<nano::send_block *> (block_a.get ())->hashables.balance.number ();
-			break;
-		case nano::block_type::state:
-			result = boost::polymorphic_downcast<nano::state_block *> (block_a.get ())->hashables.balance.number ();
-			break;
-		case nano::block_type::invalid:
-		case nano::block_type::not_a_block:
-			release_assert (false);
-			break;
-	}
-	return result;
-}
-
 nano::epoch nano::lmdb::block_store::version (nano::transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	auto block = get (transaction_a, hash_a);

--- a/nano/node/lmdb/block_store.hpp
+++ b/nano/node/lmdb/block_store.hpp
@@ -31,8 +31,6 @@ namespace lmdb
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const override;
-		// Converts a block hash to a block height
-		uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 
 		/**
 		 * Maps block hash to send block. (Removed)

--- a/nano/node/lmdb/block_store.hpp
+++ b/nano/node/lmdb/block_store.hpp
@@ -31,8 +31,6 @@ namespace lmdb
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;
-		nano::uint128_t balance (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
-		nano::uint128_t balance_calculated (std::shared_ptr<nano::block> const & block_a) const override;
 		nano::epoch version (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const override;
 		// Converts a block hash to a block height

--- a/nano/node/lmdb/block_store.hpp
+++ b/nano/node/lmdb/block_store.hpp
@@ -28,8 +28,6 @@ namespace lmdb
 		void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		uint64_t count (nano::transaction const & transaction_a) override;
-		nano::account account (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-		nano::account account_calculated (nano::block const & block_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;

--- a/nano/node/lmdb/block_store.hpp
+++ b/nano/node/lmdb/block_store.hpp
@@ -30,7 +30,6 @@ namespace lmdb
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;
-		nano::epoch version (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const override;
 		// Converts a block hash to a block height
 		uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;

--- a/nano/node/lmdb/block_store.hpp
+++ b/nano/node/lmdb/block_store.hpp
@@ -23,7 +23,6 @@ namespace lmdb
 		nano::block_hash successor (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		void successor_clear (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		std::shared_ptr<nano::block> get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-		std::shared_ptr<nano::block> get_no_sideband (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		std::shared_ptr<nano::block> random (nano::transaction const & transaction_a) override;
 		void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -4,6 +4,7 @@
 #include <nano/node/lmdb/lmdb_iterator.hpp>
 #include <nano/node/lmdb/wallet_value.hpp>
 #include <nano/secure/buffer.hpp>
+#include <nano/secure/ledger.hpp>
 #include <nano/secure/versioning.hpp>
 
 #include <boost/filesystem.hpp>
@@ -545,7 +546,8 @@ void nano::lmdb::store::upgrade_v17_to_v18 (nano::write_transaction const & tran
 		nano::amount prev_balance (0);
 		if (!block->hashables.previous.is_zero ())
 		{
-			prev_balance = block_balance_v18 (transaction_a, block->hashables.previous);
+			auto prev = block_get_v18 (transaction_a, block->hashables.previous);
+			prev_balance = nano::ledger::balance (*prev);
 		}
 		if (block->hashables.balance == prev_balance && constants.epochs.is_epoch_link (block->hashables.link))
 		{
@@ -1058,14 +1060,6 @@ boost::optional<nano::mdb_val> nano::lmdb::store::block_raw_get_by_type_v18 (nan
 	{
 		result = value;
 	}
-	return result;
-}
-
-nano::uint128_t nano::lmdb::store::block_balance_v18 (nano::transaction const & transaction, nano::block_hash const & hash) const
-{
-	auto block_l = block_get_v18 (transaction, hash);
-	release_assert (block_l);
-	nano::uint128_t result = block.balance (*block_l);
 	return result;
 }
 

--- a/nano/node/lmdb/lmdb.cpp
+++ b/nano/node/lmdb/lmdb.cpp
@@ -1061,11 +1061,11 @@ boost::optional<nano::mdb_val> nano::lmdb::store::block_raw_get_by_type_v18 (nan
 	return result;
 }
 
-nano::uint128_t nano::lmdb::store::block_balance_v18 (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
+nano::uint128_t nano::lmdb::store::block_balance_v18 (nano::transaction const & transaction, nano::block_hash const & hash) const
 {
-	auto block (block_get_v18 (transaction_a, hash_a));
-	release_assert (block);
-	nano::uint128_t result (this->block.balance_calculated (block));
+	auto block_l = block_get_v18 (transaction, hash);
+	release_assert (block_l);
+	nano::uint128_t result = block.balance (*block_l);
 	return result;
 }
 

--- a/nano/node/lmdb/lmdb.hpp
+++ b/nano/node/lmdb/lmdb.hpp
@@ -138,7 +138,6 @@ namespace lmdb
 		std::shared_ptr<nano::block> block_get_v18 (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const;
 		nano::mdb_val block_raw_get_v18 (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::block_type & type_a) const;
 		boost::optional<nano::mdb_val> block_raw_get_by_type_v18 (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::block_type & type_a) const;
-		nano::uint128_t block_balance_v18 (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const;
 
 		void open_databases (bool &, nano::transaction const &, unsigned);
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1344,7 +1344,7 @@ void nano::node::process_confirmed_data (nano::transaction const & transaction_a
 	auto previous (block_a->previous ());
 	bool error (false);
 	auto previous_balance (ledger.balance_safe (transaction_a, previous, error));
-	auto block_balance (store.block.balance_calculated (block_a));
+	auto block_balance = store.block.balance (*block_a);
 	if (hash_a != ledger.constants.genesis->account ())
 	{
 		if (!error)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1344,7 +1344,7 @@ void nano::node::process_confirmed_data (nano::transaction const & transaction_a
 	auto previous (block_a->previous ());
 	bool error (false);
 	auto previous_balance (ledger.balance_safe (transaction_a, previous, error));
-	auto block_balance = store.block.balance (*block_a);
+	auto block_balance = ledger.balance (*block_a);
 	if (hash_a != ledger.constants.genesis->account ())
 	{
 		if (!error)

--- a/nano/node/rocksdb/block_store.cpp
+++ b/nano/node/rocksdb/block_store.cpp
@@ -161,38 +161,6 @@ nano::store_iterator<nano::block_hash, nano::block_w_sideband> nano::rocksdb::bl
 	return nano::store_iterator<nano::block_hash, nano::block_w_sideband> (nullptr);
 }
 
-nano::uint128_t nano::rocksdb::block_store::balance (nano::transaction const & transaction_a, nano::block_hash const & hash_a)
-{
-	auto block (get (transaction_a, hash_a));
-	release_assert (block);
-	nano::uint128_t result (balance_calculated (block));
-	return result;
-}
-
-nano::uint128_t nano::rocksdb::block_store::balance_calculated (std::shared_ptr<nano::block> const & block_a) const
-{
-	nano::uint128_t result;
-	switch (block_a->type ())
-	{
-		case nano::block_type::open:
-		case nano::block_type::receive:
-		case nano::block_type::change:
-			result = block_a->sideband ().balance.number ();
-			break;
-		case nano::block_type::send:
-			result = boost::polymorphic_downcast<nano::send_block *> (block_a.get ())->hashables.balance.number ();
-			break;
-		case nano::block_type::state:
-			result = boost::polymorphic_downcast<nano::state_block *> (block_a.get ())->hashables.balance.number ();
-			break;
-		case nano::block_type::invalid:
-		case nano::block_type::not_a_block:
-			release_assert (false);
-			break;
-	}
-	return result;
-}
-
 nano::epoch nano::rocksdb::block_store::version (nano::transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	auto block = get (transaction_a, hash_a);

--- a/nano/node/rocksdb/block_store.cpp
+++ b/nano/node/rocksdb/block_store.cpp
@@ -147,17 +147,6 @@ nano::store_iterator<nano::block_hash, nano::block_w_sideband> nano::rocksdb::bl
 	return nano::store_iterator<nano::block_hash, nano::block_w_sideband> (nullptr);
 }
 
-nano::epoch nano::rocksdb::block_store::version (nano::transaction const & transaction_a, nano::block_hash const & hash_a)
-{
-	auto block = get (transaction_a, hash_a);
-	if (block && block->type () == nano::block_type::state)
-	{
-		return block->sideband ().details.epoch;
-	}
-
-	return nano::epoch::epoch_0;
-}
-
 void nano::rocksdb::block_store::for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const
 {
 	parallel_traversal<nano::uint256_t> (

--- a/nano/node/rocksdb/block_store.cpp
+++ b/nano/node/rocksdb/block_store.cpp
@@ -101,20 +101,6 @@ std::shared_ptr<nano::block> nano::rocksdb::block_store::get (nano::transaction 
 	return result;
 }
 
-std::shared_ptr<nano::block> nano::rocksdb::block_store::get_no_sideband (nano::transaction const & transaction, nano::block_hash const & hash) const
-{
-	nano::rocksdb_val value;
-	block_raw_get (transaction, hash, value);
-	std::shared_ptr<nano::block> result;
-	if (value.size () != 0)
-	{
-		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()), value.size ());
-		result = nano::deserialize_block (stream);
-		debug_assert (result != nullptr);
-	}
-	return result;
-}
-
 std::shared_ptr<nano::block> nano::rocksdb::block_store::random (nano::transaction const & transaction)
 {
 	nano::block_hash hash;

--- a/nano/node/rocksdb/block_store.cpp
+++ b/nano/node/rocksdb/block_store.cpp
@@ -156,13 +156,6 @@ void nano::rocksdb::block_store::for_each_par (std::function<void (nano::read_tr
 	});
 }
 
-// Converts a block hash to a block height
-uint64_t nano::rocksdb::block_store::account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
-{
-	auto block = get (transaction_a, hash_a);
-	return block->sideband ().height;
-}
-
 void nano::rocksdb::block_store::block_raw_get (nano::transaction const & transaction, nano::block_hash const & hash, nano::rocksdb_val & value) const
 {
 	auto status = store.get (transaction, tables::blocks, hash, value);

--- a/nano/node/rocksdb/block_store.cpp
+++ b/nano/node/rocksdb/block_store.cpp
@@ -146,25 +146,6 @@ uint64_t nano::rocksdb::block_store::count (nano::transaction const & transactio
 	return store.count (transaction_a, tables::blocks);
 }
 
-nano::account nano::rocksdb::block_store::account (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const
-{
-	auto block (get (transaction_a, hash_a));
-	debug_assert (block != nullptr);
-	return account_calculated (*block);
-}
-
-nano::account nano::rocksdb::block_store::account_calculated (nano::block const & block_a) const
-{
-	debug_assert (block_a.has_sideband ());
-	nano::account result (block_a.account ());
-	if (result.is_zero ())
-	{
-		result = block_a.sideband ().account;
-	}
-	debug_assert (!result.is_zero ());
-	return result;
-}
-
 nano::store_iterator<nano::block_hash, nano::block_w_sideband> nano::rocksdb::block_store::begin (nano::transaction const & transaction) const
 {
 	return store.make_iterator<nano::block_hash, nano::block_w_sideband> (transaction, tables::blocks);

--- a/nano/node/rocksdb/block_store.hpp
+++ b/nano/node/rocksdb/block_store.hpp
@@ -28,8 +28,6 @@ namespace rocksdb
 		void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		uint64_t count (nano::transaction const & transaction_a) override;
-		nano::account account (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-		nano::account account_calculated (nano::block const & block_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;

--- a/nano/node/rocksdb/block_store.hpp
+++ b/nano/node/rocksdb/block_store.hpp
@@ -23,7 +23,6 @@ namespace rocksdb
 		nano::block_hash successor (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		void successor_clear (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		std::shared_ptr<nano::block> get (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-		std::shared_ptr<nano::block> get_no_sideband (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		std::shared_ptr<nano::block> random (nano::transaction const & transaction_a) override;
 		void del (nano::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		bool exists (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;

--- a/nano/node/rocksdb/block_store.hpp
+++ b/nano/node/rocksdb/block_store.hpp
@@ -31,8 +31,6 @@ namespace rocksdb
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;
-		nano::uint128_t balance (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
-		nano::uint128_t balance_calculated (std::shared_ptr<nano::block> const & block_a) const override;
 		nano::epoch version (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const override;
 		// Converts a block hash to a block height

--- a/nano/node/rocksdb/block_store.hpp
+++ b/nano/node/rocksdb/block_store.hpp
@@ -30,7 +30,6 @@ namespace rocksdb
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;
-		nano::epoch version (nano::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const override;
 		// Converts a block hash to a block height
 		uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;

--- a/nano/node/rocksdb/block_store.hpp
+++ b/nano/node/rocksdb/block_store.hpp
@@ -31,8 +31,6 @@ namespace rocksdb
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> begin (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 		nano::store_iterator<nano::block_hash, nano::block_w_sideband> end () const override;
 		void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const override;
-		// Converts a block hash to a block height
-		uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 
 	protected:
 		void block_raw_get (nano::transaction const & transaction_a, nano::block_hash const & hash_a, nano::rocksdb_val & value) const;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1047,7 +1047,7 @@ nano::account nano::ledger::account_safe (nano::transaction const & transaction_
 		auto block (store.block.get (transaction_a, hash_a));
 		if (block != nullptr)
 		{
-			return store.block.account_calculated (*block);
+			return store.block.account (*block);
 		}
 		else
 		{
@@ -1057,12 +1057,12 @@ nano::account nano::ledger::account_safe (nano::transaction const & transaction_
 	}
 }
 
-nano::account nano::ledger::account_safe (const nano::transaction & transaction, const nano::block_hash & hash) const
+nano::account nano::ledger::account_safe (nano::transaction const & transaction, nano::block_hash const & hash) const
 {
 	auto block = store.block.get (transaction, hash);
 	if (block)
 	{
-		return store.block.account_calculated (*block);
+		return store.block.account (*block);
 	}
 	else
 	{

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1025,7 +1025,7 @@ bool nano::ledger::rollback (nano::write_transaction const & transaction_a, nano
 {
 	debug_assert (store.block.exists (transaction_a, block_a));
 	auto account_l (account (transaction_a, block_a));
-	auto block_account_height (store.block.account_height (transaction_a, block_a));
+	auto block_account_height (height (transaction_a, block_a));
 	rollback_visitor rollback (transaction_a, *this, list_a);
 	auto error (false);
 	while (!error && store.block.exists (transaction_a, block_a))
@@ -1631,6 +1631,12 @@ nano::epoch nano::ledger::version (nano::transaction const & transaction, nano::
 		return nano::epoch::epoch_0;
 	}
 	return version (*block);
+}
+
+uint64_t nano::ledger::height (nano::transaction const & transaction, nano::block_hash const & hash) const
+{
+	auto block = store.block.get (transaction, hash);
+	return block->sideband ().height;
 }
 
 nano::uncemented_info::uncemented_info (nano::block_hash const & cemented_frontier, nano::block_hash const & frontier, nano::account const & account) :

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -47,6 +47,7 @@ public:
 	nano::uint128_t amount (nano::transaction const &, nano::block_hash const &);
 	/** Safe for previous block, but block hash_a must exist */
 	nano::uint128_t amount_safe (nano::transaction const &, nano::block_hash const & hash_a, bool &) const;
+	static nano::uint128_t balance (nano::block const & block);
 	nano::uint128_t balance (nano::transaction const &, nano::block_hash const &) const;
 	nano::uint128_t balance_safe (nano::transaction const &, nano::block_hash const &, bool &) const;
 	nano::uint128_t account_balance (nano::transaction const &, nano::account const &, bool = false);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -89,6 +89,7 @@ public:
 	bool bootstrap_weight_reached () const;
 	static nano::epoch version (nano::block const & block);
 	nano::epoch version (nano::transaction const & transaction, nano::block_hash const & hash) const;
+	uint64_t height (nano::transaction const & transaction, nano::block_hash const & hash) const;
 	static nano::uint128_t const unit;
 	nano::ledger_constants & constants;
 	nano::store & store;

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -87,6 +87,8 @@ public:
 	std::multimap<uint64_t, uncemented_info, std::greater<>> unconfirmed_frontiers () const;
 	bool migrate_lmdb_to_rocksdb (boost::filesystem::path const &) const;
 	bool bootstrap_weight_reached () const;
+	static nano::epoch version (nano::block const & block);
+	nano::epoch version (nano::transaction const & transaction, nano::block_hash const & hash) const;
 	static nano::uint128_t const unit;
 	nano::ledger_constants & constants;
 	nano::store & store;

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -31,6 +31,7 @@ public:
 	/**
 	 * Return account containing hash, expects that block hash exists in ledger
 	 */
+	nano::account account (nano::block const & block) const;
 	nano::account account (nano::transaction const &, nano::block_hash const &) const;
 	std::optional<nano::account_info> account_info (nano::transaction const & transaction, nano::account const & account) const;
 	/**

--- a/nano/secure/store.cpp
+++ b/nano/secure/store.cpp
@@ -106,24 +106,6 @@ bool nano::write_transaction::contains (nano::tables table_a) const
 	return impl->contains (table_a);
 }
 
-nano::account nano::block_store::account (nano::block const & block) const
-{
-	debug_assert (block.has_sideband ());
-	nano::account result (block.account ());
-	if (result.is_zero ())
-	{
-		result = block.sideband ().account;
-	}
-	debug_assert (!result.is_zero ());
-	return result;
-}
-
-nano::account nano::block_store::account (nano::transaction const & transaction, nano::block_hash const & hash) const
-{
-	auto block = get (transaction, hash);
-	debug_assert (block != nullptr);
-	return account (*block);
-}
 
 nano::uint128_t nano::block_store::balance (nano::block const & block) const
 {

--- a/nano/secure/store.cpp
+++ b/nano/secure/store.cpp
@@ -125,6 +125,35 @@ nano::account nano::block_store::account (nano::transaction const & transaction,
 	return account (*block);
 }
 
+nano::uint128_t nano::block_store::balance (nano::block const & block) const
+{
+	nano::uint128_t result;
+	switch (block.type ())
+	{
+		case nano::block_type::open:
+		case nano::block_type::receive:
+		case nano::block_type::change:
+			result = block.sideband ().balance.number ();
+			break;
+		case nano::block_type::send:
+		case nano::block_type::state:
+			result = block.balance ().number ();
+			break;
+		case nano::block_type::invalid:
+		case nano::block_type::not_a_block:
+			release_assert (false);
+			break;
+	}
+	return result;
+}
+
+nano::uint128_t nano::block_store::balance (nano::transaction const & transaction, nano::block_hash const & hash) const
+{
+	auto block = get (transaction, hash);
+	debug_assert (block != nullptr);
+	return balance (*block);
+}
+
 // clang-format off
 nano::store::store (
 	nano::block_store & block_store_a,

--- a/nano/secure/store.cpp
+++ b/nano/secure/store.cpp
@@ -106,36 +106,6 @@ bool nano::write_transaction::contains (nano::tables table_a) const
 	return impl->contains (table_a);
 }
 
-
-nano::uint128_t nano::block_store::balance (nano::block const & block) const
-{
-	nano::uint128_t result;
-	switch (block.type ())
-	{
-		case nano::block_type::open:
-		case nano::block_type::receive:
-		case nano::block_type::change:
-			result = block.sideband ().balance.number ();
-			break;
-		case nano::block_type::send:
-		case nano::block_type::state:
-			result = block.balance ().number ();
-			break;
-		case nano::block_type::invalid:
-		case nano::block_type::not_a_block:
-			release_assert (false);
-			break;
-	}
-	return result;
-}
-
-nano::uint128_t nano::block_store::balance (nano::transaction const & transaction, nano::block_hash const & hash) const
-{
-	auto block = get (transaction, hash);
-	debug_assert (block != nullptr);
-	return balance (*block);
-}
-
 // clang-format off
 nano::store::store (
 	nano::block_store & block_store_a,

--- a/nano/secure/store.cpp
+++ b/nano/secure/store.cpp
@@ -106,6 +106,25 @@ bool nano::write_transaction::contains (nano::tables table_a) const
 	return impl->contains (table_a);
 }
 
+nano::account nano::block_store::account (nano::block const & block) const
+{
+	debug_assert (block.has_sideband ());
+	nano::account result (block.account ());
+	if (result.is_zero ())
+	{
+		result = block.sideband ().account;
+	}
+	debug_assert (!result.is_zero ());
+	return result;
+}
+
+nano::account nano::block_store::account (nano::transaction const & transaction, nano::block_hash const & hash) const
+{
+	auto block = get (transaction, hash);
+	debug_assert (block != nullptr);
+	return account (*block);
+}
+
 // clang-format off
 nano::store::store (
 	nano::block_store & block_store_a,

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -752,8 +752,6 @@ public:
 	virtual void del (nano::write_transaction const &, nano::block_hash const &) = 0;
 	virtual bool exists (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual uint64_t count (nano::transaction const &) = 0;
-	nano::account account (nano::block const & block) const;
-	nano::account account (nano::transaction const & transaction, nano::block_hash const & hash) const;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> begin (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> begin (nano::transaction const &) const = 0;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> end () const = 0;

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -755,8 +755,6 @@ public:
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> begin (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> begin (nano::transaction const &) const = 0;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> end () const = 0;
-	nano::uint128_t balance (nano::block const & block) const;
-	nano::uint128_t balance (nano::transaction const & transaction, nano::block_hash const & hash) const;
 	virtual nano::epoch version (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const = 0;
 	virtual uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -748,7 +748,6 @@ public:
 	virtual nano::block_hash successor (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual void successor_clear (nano::write_transaction const &, nano::block_hash const &) = 0;
 	virtual std::shared_ptr<nano::block> get (nano::transaction const &, nano::block_hash const &) const = 0;
-	virtual std::shared_ptr<nano::block> get_no_sideband (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual std::shared_ptr<nano::block> random (nano::transaction const &) = 0;
 	virtual void del (nano::write_transaction const &, nano::block_hash const &) = 0;
 	virtual bool exists (nano::transaction const &, nano::block_hash const &) = 0;

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -756,7 +756,6 @@ public:
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> begin (nano::transaction const &) const = 0;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> end () const = 0;
 	virtual void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const = 0;
-	virtual uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 };
 
 /**

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -755,7 +755,6 @@ public:
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> begin (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> begin (nano::transaction const &) const = 0;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> end () const = 0;
-	virtual nano::epoch version (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const = 0;
 	virtual uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;
 };

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -753,8 +753,8 @@ public:
 	virtual void del (nano::write_transaction const &, nano::block_hash const &) = 0;
 	virtual bool exists (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual uint64_t count (nano::transaction const &) = 0;
-	virtual nano::account account (nano::transaction const &, nano::block_hash const &) const = 0;
-	virtual nano::account account_calculated (nano::block const &) const = 0;
+	nano::account account (nano::block const & block) const;
+	nano::account account (nano::transaction const & transaction, nano::block_hash const & hash) const;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> begin (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> begin (nano::transaction const &) const = 0;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> end () const = 0;

--- a/nano/secure/store.hpp
+++ b/nano/secure/store.hpp
@@ -758,8 +758,8 @@ public:
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> begin (nano::transaction const &, nano::block_hash const &) const = 0;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> begin (nano::transaction const &) const = 0;
 	virtual nano::store_iterator<nano::block_hash, block_w_sideband> end () const = 0;
-	virtual nano::uint128_t balance (nano::transaction const &, nano::block_hash const &) = 0;
-	virtual nano::uint128_t balance_calculated (std::shared_ptr<nano::block> const &) const = 0;
+	nano::uint128_t balance (nano::block const & block) const;
+	nano::uint128_t balance (nano::transaction const & transaction, nano::block_hash const & hash) const;
 	virtual nano::epoch version (nano::transaction const &, nano::block_hash const &) = 0;
 	virtual void for_each_par (std::function<void (nano::read_transaction const &, nano::store_iterator<nano::block_hash, block_w_sideband>, nano::store_iterator<nano::block_hash, block_w_sideband>)> const & action_a) const = 0;
 	virtual uint64_t account_height (nano::transaction const & transaction_a, nano::block_hash const & hash_a) const = 0;


### PR DESCRIPTION
This patch cleans up several items in the nano::block_store class.
- Removes transaction parameters for functions that don't use it
- Removes *_calculated functions as they're no longer used with sideband
- Move several functions including ::balance, ::account, ::height from nano::block_store on to nano::ledger
- Remove block_store::get_no_sideband as it's effectively not used.