### PR TITLE
Removing references to boost from nano::error

### DIFF
--- a/nano/core_test/logger.cpp
+++ b/nano/core_test/logger.cpp
@@ -5,6 +5,8 @@
 
 #include <gtest/gtest.h>
 
+#include <boost/filesystem.hpp>
+
 #include <chrono>
 #include <regex>
 #include <thread>

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -8,6 +8,8 @@
 
 #include <gtest/gtest.h>
 
+#include <boost/filesystem.hpp>
+
 #include <numeric>
 #include <sstream>
 #include <string>

--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -282,47 +282,10 @@ std::string nano::error_config_messages::message (int ev) const
 	return "Invalid error code";
 }
 
-#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
-char const * nano::error_conversion::detail::generic_category::name () const noexcept
-{
-	return boost::system::generic_category ().name ();
-}
-
-std::string nano::error_conversion::detail::generic_category::message (int value) const
-{
-	return boost::system::generic_category ().message (value);
-}
-
-std::error_category const & nano::error_conversion::generic_category ()
-{
-	static detail::generic_category instance;
-	return instance;
-}
-
-std::error_code nano::error_conversion::convert (boost::system::error_code const & error)
-{
-	if (error.category () == boost::system::generic_category ())
-	{
-		return std::error_code (error.value (),
-		nano::error_conversion::generic_category ());
-	}
-
-	debug_assert (false);
-	return nano::error_common::invalid_type_conversion;
-}
-#endif
-
 nano::error::error (std::error_code code_a)
 {
 	code = code_a;
 }
-
-#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
-nano::error::error (boost::system::error_code const & code_a)
-{
-	code = std::make_error_code (static_cast<std::errc> (code_a.value ()));
-}
-#endif
 
 nano::error::error (std::string message_a)
 {
@@ -358,24 +321,6 @@ nano::error & nano::error::operator= (std::error_code const code_a)
 	return *this;
 }
 
-#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
-/** Assign boost error code (as converted to std::error_code) */
-nano::error & nano::error::operator= (boost::system::error_code const & code_a)
-{
-	code = nano::error_conversion::convert (code_a);
-	message.clear ();
-	return *this;
-}
-
-/** Assign boost error code (as converted to std::error_code) */
-nano::error & nano::error::operator= (boost::system::errc::errc_t const & code_a)
-{
-	code = nano::error_conversion::convert (boost::system::errc::make_error_code (code_a));
-	message.clear ();
-	return *this;
-}
-#endif
-
 /** Set the error to nano::error_common::generic and the error message to \p message_a */
 nano::error & nano::error::operator= (std::string message_a)
 {
@@ -397,14 +342,6 @@ bool nano::error::operator== (std::error_code const code_a) const
 {
 	return code == code_a;
 }
-
-#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
-/** Return true if this#error_code equals the parameter */
-bool nano::error::operator== (boost::system::error_code const code_a) const
-{
-	return code.value () == code_a.value ();
-}
-#endif
 
 /** Call the function iff the current error is zero */
 nano::error & nano::error::then (std::function<nano::error &()> next)
@@ -495,14 +432,3 @@ nano::error & nano::error::clear ()
 	message.clear ();
 	return *this;
 }
-
-#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
-// TODO: theoretically, nothing besides template (partial) specializations should ever be added inside std...
-namespace std
-{
-std::error_code make_error_code (boost::system::errc::errc_t const & e)
-{
-	return std::error_code (static_cast<int> (e), ::nano::error_conversion::generic_category ());
-}
-}
-#endif

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <boost/filesystem/operations.hpp>
-#include <boost/system/error_code.hpp>
-
 #include <algorithm>
 #include <functional>
 #include <memory>
@@ -197,51 +194,6 @@ REGISTER_ERROR_CODES (nano, error_rpc);
 REGISTER_ERROR_CODES (nano, error_process);
 REGISTER_ERROR_CODES (nano, error_config);
 
-#if BOOST_VERSION >= 107800
-/* no need for error_code bridge */
-#else
-#define NANO_USE_BOOST_TO_STD_ERROR_BRIDGE
-#endif
-
-#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
-/* boost->std error_code bridge */
-namespace nano
-{
-namespace error_conversion
-{
-	std::error_category const & generic_category ();
-}
-}
-
-namespace std
-{
-template <>
-struct is_error_code_enum<boost::system::errc::errc_t>
-	: public std::true_type
-{
-};
-
-std::error_code make_error_code (boost::system::errc::errc_t const & e);
-}
-namespace nano
-{
-namespace error_conversion
-{
-	namespace detail
-	{
-		class generic_category : public std::error_category
-		{
-		public:
-			char const * name () const noexcept override;
-			std::string message (int value) const override;
-		};
-	}
-	std::error_category const & generic_category ();
-	std::error_code convert (boost::system::error_code const & error);
-}
-}
-#endif
-
 namespace nano
 {
 /** Adapter for std/boost::error_code, std::exception and bool flags to facilitate unified error handling */
@@ -253,24 +205,14 @@ public:
 	error (nano::error && error_a) = default;
 
 	error (std::error_code code_a);
-#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
-	error (boost::system::error_code const & code_a);
-#endif
 	error (std::string message_a);
 	error (std::exception const & exception_a);
 	error & operator= (nano::error const & err_a);
 	error & operator= (nano::error && err_a);
 	error & operator= (std::error_code code_a);
-#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
-	error & operator= (boost::system::error_code const & code_a);
-	error & operator= (boost::system::errc::errc_t const & code_a);
-#endif
 	error & operator= (std::string message_a);
 	error & operator= (std::exception const & exception_a);
 	bool operator== (std::error_code code_a) const;
-#if defined(NANO_USE_BOOST_TO_STD_ERROR_BRIDGE)
-	bool operator== (boost::system::error_code code_a) const;
-#endif
 	error & then (std::function<nano::error &()> next);
 	template <typename... ErrorCode>
 	error & accept (ErrorCode... err)

--- a/nano/lib/tlsconfig.cpp
+++ b/nano/lib/tlsconfig.cpp
@@ -3,6 +3,7 @@
 #include <nano/lib/tlsconfig.hpp>
 #include <nano/lib/tomlconfig.hpp>
 
+#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 
 #include <iostream>

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -6,6 +6,7 @@
 #include <nano/node/daemonconfig.hpp>
 #include <nano/node/node.hpp>
 
+#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 
 namespace

--- a/nano/node/daemonconfig.cpp
+++ b/nano/node/daemonconfig.cpp
@@ -3,6 +3,8 @@
 #include <nano/lib/tomlconfig.hpp>
 #include <nano/node/daemonconfig.hpp>
 
+#include <boost/filesystem.hpp>
+
 #include <sstream>
 #include <vector>
 

--- a/nano/node/ipc/ipc_access_config.cpp
+++ b/nano/node/ipc/ipc_access_config.cpp
@@ -2,6 +2,7 @@
 #include <nano/node/ipc/ipc_access_config.hpp>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 
 namespace
 {

--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -5,6 +5,7 @@
 #include <nano/node/logging.hpp>
 
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/utility/exception_handler.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>

--- a/nano/node/rocksdb/rocksdb.cpp
+++ b/nano/node/rocksdb/rocksdb.cpp
@@ -3,6 +3,7 @@
 #include <nano/node/rocksdb/rocksdb_iterator.hpp>
 #include <nano/node/rocksdb/rocksdb_txn.hpp>
 
+#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/polymorphic_cast.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -6,6 +6,8 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/store.hpp>
 
+#include <boost/filesystem.hpp>
+
 #include <cryptopp/words.h>
 
 namespace

--- a/nano/secure/plat/osx/working.mm
+++ b/nano/secure/plat/osx/working.mm
@@ -1,5 +1,7 @@
 #include <nano/secure/working.hpp>
 
+#include <boost/filesystem.hpp>
+
 #include <Foundation/Foundation.h>
 
 namespace nano

--- a/nano/secure/plat/posix/working.cpp
+++ b/nano/secure/plat/posix/working.cpp
@@ -1,6 +1,8 @@
 #include <nano/lib/utility.hpp>
 #include <nano/secure/working.hpp>
 
+#include <boost/filesystem.hpp>
+
 #include <pwd.h>
 #include <sys/types.h>
 


### PR DESCRIPTION
Removes config variable NANO_USE_BOOST_TO_STD_ERROR_BRIDGE.
NANO_USE_BOOST_TO_STD_ERROR_BRIDGE appears to only be needed pre boost 1.78, we now use boost as a submodule at version 1.82
Fixes a number of ICWYU issues.