### PR TITLE
Force use of windows.h instead of default winnt.h

### DIFF
--- a/nano/lib/plat/windows/thread_role.cpp
+++ b/nano/lib/plat/windows/thread_role.cpp
@@ -1,7 +1,6 @@
 #include <nano/lib/thread_roles.hpp>
 
 #include <windows.h>
-#include <processthreadsapi.h>
 
 void nano::thread_role::set_os_name (std::string const & thread_name)
 {

--- a/nano/lib/plat/windows/thread_role.cpp
+++ b/nano/lib/plat/windows/thread_role.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/thread_roles.hpp>
 
+#include <windows.h>
 #include <processthreadsapi.h>
 
 void nano::thread_role::set_os_name (std::string const & thread_name)


### PR DESCRIPTION
This fixes the "No target Architecture" error when building on windows.
Clang format will report an error but the windows.h include must be before processthreadapi.h to work properly.