### PR TITLE
Removing incorrect forward declarations of transaction classes

### DIFF
--- a/nano/lib/rep_weights.hpp
+++ b/nano/lib/rep_weights.hpp
@@ -13,7 +13,6 @@ namespace store
 {
 	class component;
 }
-class transaction;
 
 class rep_weights
 {

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -28,7 +28,6 @@ class block;
 class block_sideband;
 class election;
 class vote;
-class transaction;
 class confirmation_height_processor;
 class stats;
 

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -18,9 +18,6 @@ class write_transaction;
 namespace nano
 {
 class node;
-class read_transaction;
-class transaction;
-class write_transaction;
 class write_database_queue;
 
 /**

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -27,7 +27,6 @@ class block_processor;
 class ledger;
 class network;
 class node_config;
-class transaction;
 
 namespace transport
 {

--- a/nano/node/confirmation_height_bounded.hpp
+++ b/nano/node/confirmation_height_bounded.hpp
@@ -11,7 +11,6 @@
 namespace nano
 {
 class ledger;
-class read_transaction;
 class logging;
 class logger_mt;
 class write_database_queue;

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -12,7 +12,6 @@
 namespace nano
 {
 class ledger;
-class read_transaction;
 class logging;
 class logger_mt;
 class write_database_queue;

--- a/nano/node/gap_cache.hpp
+++ b/nano/node/gap_cache.hpp
@@ -16,7 +16,6 @@
 namespace nano
 {
 class node;
-class transaction;
 
 /** For each gap in account chains, track arrival time and voters */
 class gap_information final

--- a/nano/node/online_reps.hpp
+++ b/nano/node/online_reps.hpp
@@ -16,7 +16,6 @@ namespace nano
 {
 class ledger;
 class node_config;
-class transaction;
 
 /** Track online representatives and trend online weight */
 class online_reps final

--- a/nano/node/vote_processor.hpp
+++ b/nano/node/vote_processor.hpp
@@ -28,7 +28,6 @@ class network_params;
 class node_flags;
 class stats;
 
-class transaction;
 namespace transport
 {
 	class channel;

--- a/nano/store/account.hpp
+++ b/nano/store/account.hpp
@@ -9,9 +9,6 @@
 namespace nano
 {
 class block_hash;
-class read_transaction;
-class transaction;
-class write_transaction;
 }
 namespace nano::store
 {

--- a/nano/store/block.hpp
+++ b/nano/store/block.hpp
@@ -10,9 +10,6 @@
 namespace nano
 {
 class block_hash;
-class read_transaction;
-class transaction;
-class write_transaction;
 }
 namespace nano::store
 {

--- a/nano/store/confirmation_height.hpp
+++ b/nano/store/confirmation_height.hpp
@@ -9,9 +9,6 @@
 namespace nano
 {
 class block_hash;
-class read_transaction;
-class transaction;
-class write_transaction;
 }
 namespace nano::store
 {

--- a/nano/store/final.hpp
+++ b/nano/store/final.hpp
@@ -9,9 +9,6 @@
 namespace nano
 {
 class block_hash;
-class read_transaction;
-class transaction;
-class write_transaction;
 }
 namespace nano::store
 {

--- a/nano/store/frontier.hpp
+++ b/nano/store/frontier.hpp
@@ -9,9 +9,6 @@
 namespace nano
 {
 class block_hash;
-class read_transaction;
-class transaction;
-class write_transaction;
 }
 namespace nano::store
 {

--- a/nano/store/lmdb/lmdb.hpp
+++ b/nano/store/lmdb/lmdb.hpp
@@ -37,7 +37,6 @@ namespace filesystem
 namespace nano
 {
 class logging_mt;
-class transaction;
 
 }
 

--- a/nano/store/online_weight.hpp
+++ b/nano/store/online_weight.hpp
@@ -9,9 +9,6 @@
 namespace nano
 {
 class block_hash;
-class read_transaction;
-class transaction;
-class write_transaction;
 }
 namespace nano::store
 {

--- a/nano/store/peer.hpp
+++ b/nano/store/peer.hpp
@@ -9,9 +9,6 @@
 namespace nano
 {
 class block_hash;
-class read_transaction;
-class transaction;
-class write_transaction;
 }
 namespace nano::store
 {

--- a/nano/store/pending.hpp
+++ b/nano/store/pending.hpp
@@ -9,9 +9,6 @@
 namespace nano
 {
 class block_hash;
-class read_transaction;
-class transaction;
-class write_transaction;
 }
 namespace nano::store
 {

--- a/nano/store/pruned.hpp
+++ b/nano/store/pruned.hpp
@@ -9,9 +9,6 @@
 namespace nano
 {
 class block_hash;
-class read_transaction;
-class transaction;
-class write_transaction;
 }
 namespace nano::store
 {

--- a/nano/store/version.hpp
+++ b/nano/store/version.hpp
@@ -8,9 +8,6 @@
 namespace nano
 {
 class block_hash;
-class read_transaction;
-class transaction;
-class write_transaction;
 }
 namespace nano::store
 {


### PR DESCRIPTION
This was changed with the extraction of the store class.