### PR TITLE
Fix linker warnings about duplicate libs

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -63,15 +63,7 @@ target_compile_definitions(
   core_test PRIVATE -DTAG_VERSION_STRING=${TAG_VERSION_STRING}
                     -DGIT_COMMIT_HASH=${GIT_COMMIT_HASH})
 
-target_link_libraries(
-  core_test
-  node
-  secure
-  test_common
-  gtest
-  libminiupnpc-static
-  Boost::log_setup
-  Boost::log)
+target_link_libraries(core_test test_common)
 
 include_directories(${CMAKE_SOURCE_DIR}/submodules)
 include_directories(${CMAKE_SOURCE_DIR}/submodules/cpptoml/include)

--- a/nano/crypto_lib/CMakeLists.txt
+++ b/nano/crypto_lib/CMakeLists.txt
@@ -1,5 +1,8 @@
-add_library(
-  crypto_lib interface.cpp random_pool.hpp random_pool.cpp
-             random_pool_shuffle.hpp secure_memory.hpp secure_memory.cpp)
+add_library(nano_ed25519 interface.cpp)
 
-target_link_libraries(crypto_lib blake2 ${CRYPTOPP_LIBRARY})
+target_link_libraries(ed25519 nano_ed25519)
+
+add_library(crypto_lib random_pool.hpp random_pool.cpp random_pool_shuffle.hpp
+                       secure_memory.hpp secure_memory.cpp)
+
+target_link_libraries(crypto_lib blake2 ed25519 ${CRYPTOPP_LIBRARY})

--- a/nano/ipc_flatbuffers_test/CMakeLists.txt
+++ b/nano/ipc_flatbuffers_test/CMakeLists.txt
@@ -1,11 +1,3 @@
 add_executable(ipc_flatbuffers_test_client entry.cpp)
 
-target_link_libraries(
-  ipc_flatbuffers_test_client
-  nano_lib
-  Boost::filesystem
-  Boost::log_setup
-  Boost::log
-  Boost::program_options
-  Boost::system
-  Boost::thread)
+target_link_libraries(ipc_flatbuffers_test_client node)

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -104,7 +104,6 @@ target_link_libraries(
   nano_lib
   ipc_flatbuffers_lib
   crypto_lib
-  ed25519
   blake2
   ${CRYPTOPP_LIBRARY}
   ${CMAKE_DL_LIBS}

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -102,13 +102,13 @@ include_directories(
 
 target_link_libraries(
   nano_lib
-  ed25519
-  crypto_lib
-  blake2
-  secure
   ipc_flatbuffers_lib
+  crypto_lib
+  ed25519
+  blake2
   ${CRYPTOPP_LIBRARY}
   ${CMAKE_DL_LIBS}
+  Boost::iostreams
   Boost::asio
   Boost::circular_buffer
   Boost::dll

--- a/nano/load_test/CMakeLists.txt
+++ b/nano/load_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(load_test entry.cpp)
 
-target_link_libraries(load_test boost_process node secure test_common gtest)
+target_link_libraries(load_test test_common Boost::process)
 
 include_directories(${CMAKE_SOURCE_DIR}/submodules)
 include_directories(${CMAKE_SOURCE_DIR}/submodules/cpptoml/include)

--- a/nano/nano_node/CMakeLists.txt
+++ b/nano/nano_node/CMakeLists.txt
@@ -1,13 +1,7 @@
 add_executable(nano_node daemon.cpp daemon.hpp entry.cpp)
 
-target_link_libraries(
-  nano_node
-  Boost::process
-  node
-  rpc
-  secure
-  argon2
-  ${PLATFORM_LIBS})
+target_link_libraries(nano_node node Boost::process ${PLATFORM_LIBS})
+
 include_directories(${CMAKE_SOURCE_DIR}/submodules)
 
 target_compile_definitions(

--- a/nano/nano_rpc/CMakeLists.txt
+++ b/nano/nano_rpc/CMakeLists.txt
@@ -1,16 +1,6 @@
 add_executable(nano_rpc entry.cpp)
 
-target_link_libraries(
-  nano_rpc
-  rpc
-  node
-  secure
-  Boost::filesystem
-  Boost::log_setup
-  Boost::log
-  Boost::program_options
-  Boost::system
-  Boost::thread)
+target_link_libraries(nano_rpc node)
 
 target_compile_definitions(
   nano_rpc

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -206,10 +206,10 @@ endif()
 
 target_link_libraries(
   node
-  nano_store
-  rpc
-  secure
   nano_lib
+  nano_store
+  secure
+  rpc
   libminiupnpc-static
   argon2
   lmdb

--- a/nano/rpc/CMakeLists.txt
+++ b/nano/rpc/CMakeLists.txt
@@ -15,4 +15,4 @@ add_library(
   rpc_request_processor.hpp
   rpc_request_processor.cpp)
 
-target_link_libraries(rpc Boost::beast nano_lib ${OPENSSL_LIBRARIES})
+target_link_libraries(rpc nano_lib Boost::beast ${OPENSSL_LIBRARIES})

--- a/nano/rpc_test/CMakeLists.txt
+++ b/nano/rpc_test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(rpc_test common.hpp common.cpp entry.cpp receivable.cpp rpc.cpp)
 
-target_link_libraries(rpc_test node secure rpc test_common gtest)
+target_link_libraries(rpc_test test_common)
 
 target_compile_definitions(
   rpc_test

--- a/nano/secure/CMakeLists.txt
+++ b/nano/secure/CMakeLists.txt
@@ -50,14 +50,8 @@ add_library(
   utility.cpp
   working.hpp)
 
-target_link_libraries(
-  secure
-  nano_lib
-  ed25519
-  crypto_lib
-  Boost::iostreams
-  Boost::system
-  Boost::filesystem)
+target_link_libraries(secure nano_lib ed25519 crypto_lib Boost::system
+                      Boost::filesystem)
 
 target_compile_definitions(secure PUBLIC -DQT_NO_KEYWORDS
                                          -DBOOST_ASIO_HAS_STD_ARRAY=1)

--- a/nano/slow_test/CMakeLists.txt
+++ b/nano/slow_test/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_executable(slow_test entry.cpp node.cpp vote_cache.cpp vote_processor.cpp
                          bootstrap.cpp)
 
-target_link_libraries(slow_test secure node test_common gtest
-                      libminiupnpc-static)
+target_link_libraries(slow_test test_common)
 
 include_directories(${CMAKE_SOURCE_DIR}/submodules)


### PR DESCRIPTION
After upgrading to XCode 15, linker started complaining about duplicate libraries being linked, glimpse of the warnings here:
```
[57/65] Linking CXX executable ipc_flatbuffers_test_client
ld: warning: ignoring duplicate libraries: 'nano/lib/libnano_lib.a', 'nano/secure/libsecure.a', 'submodules/boost/libs/filesystem/libboost_filesystem.a', 'submodules/boost/libs/log/libboost_log.a', 'submodules/boost/libs/log/libboost_log_setup.a', 'submodules/boost/libs/program_options/libboost_program_options.a', 'submodules/boost/libs/thread/libboost_thread.a'
[60/65] Linking CXX executable nano_rpc
ld: warning: ignoring duplicate libraries: 'nano/lib/libnano_lib.a', 'nano/rpc/librpc.a', 'nano/secure/libsecure.a', 'submodules/boost/libs/filesystem/libboost_filesystem.a', 'submodules/boost/libs/log/libboost_log.a', 'submodules/boost/libs/log/libboost_log_setup.a', 'submodules/boost/libs/program_options/libboost_program_options.a', 'submodules/boost/libs/thread/libboost_thread.a'
[61/65] Linking CXX executable slow_test
ld: warning: ignoring duplicate libraries: 'nano/lib/libnano_lib.a', 'nano/node/libnode.a', 'nano/secure/libsecure.a', 'submodules/miniupnp/miniupnpc/libminiupnpc.a'
[62/65] Linking CXX executable rpc_test
ld: warning: ignoring duplicate libraries: 'nano/lib/libnano_lib.a', 'nano/node/libnode.a', 'nano/rpc/librpc.a', 'nano/secure/libsecure.a'
[63/65] Linking CXX executable load_test
ld: warning: ignoring duplicate libraries: 'nano/lib/libnano_lib.a', 'nano/node/libnode.a', 'nano/secure/libsecure.a'
[64/65] Linking CXX executable core_test
ld: warning: ignoring duplicate libraries: 'nano/lib/libnano_lib.a', 'nano/node/libnode.a', 'nano/secure/libsecure.a', 'submodules/boost/libs/log/libboost_log.a', 'submodules/boost/libs/log/libboost_log_setup.a', 'submodules/miniupnp/miniupnpc/libminiupnpc.a'
[65/65] Linking CXX executable nano_node
ld: warning: ignoring duplicate libraries: 'nano/lib/libnano_lib.a', 'nano/secure/libsecure.a'
```
Our CMake linking definitions were a bit of a mess, there were a lot of duplications. This PR cleans that up, so warnings are no longer shown.