### PR TITLE
Add utility to get values for maps and multi_index containers

### DIFF
--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -162,6 +162,17 @@ void transform_if (InputIt first, InputIt last, OutputIt dest, Pred pred, Func t
 	}
 }
 
+template <typename MapType, typename KeyType>
+auto get_value (const MapType & map, const KeyType & key) -> std::optional<typename MapType::mapped_type>
+{
+	auto it = map.find (key);
+	if (it != map.end ())
+	{
+		return it->second;
+	}
+	return std::nullopt;
+}
+
 /**
  * Erase elements from container when predicate returns true
  * TODO: Use `std::erase_if` in c++20

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -173,6 +173,17 @@ auto get_value (const MapType & map, const KeyType & key) -> std::optional<typen
 	return std::nullopt;
 }
 
+template <typename MultiIndex, typename KeyType>
+auto get_value_multi_index (const MultiIndex & mi, const KeyType & key) -> std::optional<typename MultiIndex::value_type>
+{
+	auto it = mi.find (key);
+	if (it != mi.end ())
+	{
+		return *it;
+	}
+	return std::nullopt;
+}
+
 /**
  * Erase elements from container when predicate returns true
  * TODO: Use `std::erase_if` in c++20


### PR DESCRIPTION
I personally have a hard time know if  
`if (existing == roots.get<tag_root> ().end ())`
means existing is true or false.

I added an utility `get_value` and `get_value_multi_index`to make it more obvious
`if (!existing_entry)`

I made the changes for one active_transactions class to seee what it would look like and marked the PR as draft.