### PR TITLE
Use c++ std filesystem

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -674,13 +674,14 @@ TEST (mdb_block_store, bad_path)
 		GTEST_SKIP ();
 	}
 	nano::logger_mt logger;
+
 	try
 	{
 		auto path = nano::unique_path ();
 		{
 			std::ofstream stream (path.c_str ());
 		}
-		boost::filesystem::permissions (path, boost::filesystem::perms::no_perms);
+		std::filesystem::permissions (path, std::filesystem::perms::none);
 		nano::store::lmdb::component store (logger, path, nano::dev::constants);
 	}
 	catch (std::runtime_error &)
@@ -693,7 +694,7 @@ TEST (mdb_block_store, bad_path)
 TEST (block_store, DISABLED_already_open) // File can be shared
 {
 	auto path (nano::unique_path ());
-	boost::filesystem::create_directories (path.parent_path ());
+	std::filesystem::create_directories (path.parent_path ());
 	nano::set_secure_perm_directory (path.parent_path ());
 	std::ofstream file;
 	file.open (path.string ().c_str ());
@@ -1457,7 +1458,7 @@ TEST (mdb_block_store, upgrade_backup)
 		GTEST_SKIP ();
 	}
 	auto dir (nano::unique_path ());
-	namespace fs = boost::filesystem;
+	namespace fs = std::filesystem;
 	fs::create_directory (dir);
 	auto path = dir / "data.ldb";
 	/** Returns 'dir' if backup file cannot be found */

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -18,8 +18,6 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/filesystem.hpp>
-
 #include <cstdlib>
 #include <fstream>
 #include <unordered_set>

--- a/nano/core_test/logger.cpp
+++ b/nano/core_test/logger.cpp
@@ -94,14 +94,14 @@ TEST (logger, stable_filename)
 	auto log_file = path / "log" / "node.log";
 
 #if BOOST_VERSION >= 107000
-	EXPECT_TRUE (boost::filesystem::exists (log_file));
+	EXPECT_TRUE (std::filesystem::exists (log_file));
 	// Try opening it again
 	logging.release_file_sink ();
 	logging.init (path);
 	logger.always_log ("stable2");
 #else
 	// When using Boost < 1.70 , behavior is reverted to not using the stable filename
-	EXPECT_FALSE (boost::filesystem::exists (log_file));
+	EXPECT_FALSE (std::filesystem::exists (log_file));
 #endif
 
 	// Reset the logger

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4312,12 +4312,12 @@ TEST (node_config, node_id_private_key_persistence)
 
 	// create the directory and the file
 	auto path = nano::unique_path ();
-	ASSERT_TRUE (boost::filesystem::create_directories (path));
+	ASSERT_TRUE (std::filesystem::create_directories (path));
 	auto priv_key_filename = path / "node_id_private.key";
 
 	// check that the key generated is random when the key does not exist
 	nano::keypair kp1 = nano::load_or_create_node_id (path, logger);
-	boost::filesystem::remove (priv_key_filename);
+	std::filesystem::remove (priv_key_filename);
 	nano::keypair kp2 = nano::load_or_create_node_id (path, logger);
 	ASSERT_NE (kp1.prv, kp2.prv);
 

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -71,7 +71,7 @@ TEST (toml, diff_equal)
 TEST (toml, daemon_config_update_array)
 {
 	nano::tomlconfig t;
-	boost::filesystem::path data_path (".");
+	std::filesystem::path data_path (".");
 	nano::daemon_config c{ data_path, nano::dev::network_params };
 	c.node.preconfigured_peers.push_back ("dev-peer.org");
 	c.serialize_toml (t);
@@ -874,7 +874,7 @@ TEST (toml, daemon_config_deserialize_errors)
 TEST (toml, daemon_read_config)
 {
 	auto path (nano::unique_path ());
-	boost::filesystem::create_directories (path);
+	std::filesystem::create_directories (path);
 	nano::daemon_config config;
 	std::vector<std::string> invalid_overrides1{ "node.max_work_generate_multiplier=0" };
 	std::string expected_message1{ "max_work_generate_multiplier must be greater than or equal to 1" };
@@ -883,7 +883,7 @@ TEST (toml, daemon_read_config)
 	std::string expected_message2{ "Value must follow after a '=' at line 2" };
 
 	// Reading when there is no config file
-	ASSERT_FALSE (boost::filesystem::exists (nano::get_node_toml_config_path (path)));
+	ASSERT_FALSE (std::filesystem::exists (nano::get_node_toml_config_path (path)));
 	ASSERT_FALSE (nano::read_node_config_toml (path, config));
 	{
 		auto error = nano::read_node_config_toml (path, config, invalid_overrides1);
@@ -901,7 +901,7 @@ TEST (toml, daemon_read_config)
 	toml.write (nano::get_node_toml_config_path (path));
 
 	// Reading when there is a config file
-	ASSERT_TRUE (boost::filesystem::exists (nano::get_node_toml_config_path (path)));
+	ASSERT_TRUE (std::filesystem::exists (nano::get_node_toml_config_path (path)));
 	ASSERT_FALSE (nano::read_node_config_toml (path, config));
 	{
 		auto error = nano::read_node_config_toml (path, config, invalid_overrides1);

--- a/nano/core_test/utility.cpp
+++ b/nano/core_test/utility.cpp
@@ -234,7 +234,7 @@ TEST (filesystem, remove_all_files)
 {
 	auto path = nano::unique_path ();
 	auto dummy_directory = path / "tmp";
-	boost::filesystem::create_directories (dummy_directory);
+	std::filesystem::create_directories (dummy_directory);
 
 	auto dummy_file1 = path / "my_file1.txt";
 	auto dummy_file2 = path / "my_file2.txt";
@@ -242,23 +242,23 @@ TEST (filesystem, remove_all_files)
 	std::ofstream (dummy_file2.string ());
 
 	// Check all exist
-	ASSERT_TRUE (boost::filesystem::exists (dummy_directory));
-	ASSERT_TRUE (boost::filesystem::exists (dummy_file1));
-	ASSERT_TRUE (boost::filesystem::exists (dummy_file2));
+	ASSERT_TRUE (std::filesystem::exists (dummy_directory));
+	ASSERT_TRUE (std::filesystem::exists (dummy_file1));
+	ASSERT_TRUE (std::filesystem::exists (dummy_file2));
 
 	// Should remove only the files
 	nano::remove_all_files_in_dir (path);
 
-	ASSERT_TRUE (boost::filesystem::exists (dummy_directory));
-	ASSERT_FALSE (boost::filesystem::exists (dummy_file1));
-	ASSERT_FALSE (boost::filesystem::exists (dummy_file2));
+	ASSERT_TRUE (std::filesystem::exists (dummy_directory));
+	ASSERT_FALSE (std::filesystem::exists (dummy_file1));
+	ASSERT_FALSE (std::filesystem::exists (dummy_file2));
 }
 
 TEST (filesystem, move_all_files)
 {
 	auto path = nano::unique_path ();
 	auto dummy_directory = path / "tmp";
-	boost::filesystem::create_directories (dummy_directory);
+	std::filesystem::create_directories (dummy_directory);
 
 	auto dummy_file1 = dummy_directory / "my_file1.txt";
 	auto dummy_file2 = dummy_directory / "my_file2.txt";
@@ -266,18 +266,18 @@ TEST (filesystem, move_all_files)
 	std::ofstream (dummy_file2.string ());
 
 	// Check all exist
-	ASSERT_TRUE (boost::filesystem::exists (dummy_directory));
-	ASSERT_TRUE (boost::filesystem::exists (dummy_file1));
-	ASSERT_TRUE (boost::filesystem::exists (dummy_file2));
+	ASSERT_TRUE (std::filesystem::exists (dummy_directory));
+	ASSERT_TRUE (std::filesystem::exists (dummy_file1));
+	ASSERT_TRUE (std::filesystem::exists (dummy_file2));
 
 	// Should move only the files
 	nano::move_all_files_to_dir (dummy_directory, path);
 
-	ASSERT_TRUE (boost::filesystem::exists (dummy_directory));
-	ASSERT_TRUE (boost::filesystem::exists (path / "my_file1.txt"));
-	ASSERT_TRUE (boost::filesystem::exists (path / "my_file2.txt"));
-	ASSERT_FALSE (boost::filesystem::exists (dummy_file1));
-	ASSERT_FALSE (boost::filesystem::exists (dummy_file2));
+	ASSERT_TRUE (std::filesystem::exists (dummy_directory));
+	ASSERT_TRUE (std::filesystem::exists (path / "my_file1.txt"));
+	ASSERT_TRUE (std::filesystem::exists (path / "my_file2.txt"));
+	ASSERT_FALSE (std::filesystem::exists (dummy_file1));
+	ASSERT_FALSE (std::filesystem::exists (dummy_file2));
 }
 
 TEST (relaxed_atomic_integral, basic)

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -1,7 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 
-#include <boost/filesystem/path.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -290,27 +289,27 @@ bool is_sanitizer_build ()
 	return is_asan_build () || is_tsan_build ();
 }
 
-std::string get_node_toml_config_path (boost::filesystem::path const & data_path)
+std::string get_node_toml_config_path (std::filesystem::path const & data_path)
 {
 	return (data_path / "config-node.toml").string ();
 }
 
-std::string get_rpc_toml_config_path (boost::filesystem::path const & data_path)
+std::string get_rpc_toml_config_path (std::filesystem::path const & data_path)
 {
 	return (data_path / "config-rpc.toml").string ();
 }
 
-std::string get_qtwallet_toml_config_path (boost::filesystem::path const & data_path)
+std::string get_qtwallet_toml_config_path (std::filesystem::path const & data_path)
 {
 	return (data_path / "config-qtwallet.toml").string ();
 }
 
-std::string get_access_toml_config_path (boost::filesystem::path const & data_path)
+std::string get_access_toml_config_path (std::filesystem::path const & data_path)
 {
 	return (data_path / "config-access.toml").string ();
 }
 
-std::string get_tls_toml_config_path (boost::filesystem::path const & data_path)
+std::string get_tls_toml_config_path (std::filesystem::path const & data_path)
 {
 	return (data_path / "config-tls.toml").string ();
 }

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <filesystem>
 #include <optional>
 #include <string>
 
@@ -387,11 +388,11 @@ public:
 	uint8_t const bootstrap_protocol_version_min = 0x13;
 };
 
-std::string get_node_toml_config_path (boost::filesystem::path const & data_path);
-std::string get_rpc_toml_config_path (boost::filesystem::path const & data_path);
-std::string get_access_toml_config_path (boost::filesystem::path const & data_path);
-std::string get_qtwallet_toml_config_path (boost::filesystem::path const & data_path);
-std::string get_tls_toml_config_path (boost::filesystem::path const & data_path);
+std::string get_node_toml_config_path (std::filesystem::path const & data_path);
+std::string get_rpc_toml_config_path (std::filesystem::path const & data_path);
+std::string get_access_toml_config_path (std::filesystem::path const & data_path);
+std::string get_qtwallet_toml_config_path (std::filesystem::path const & data_path);
+std::string get_tls_toml_config_path (std::filesystem::path const & data_path);
 
 /** Checks if we are running inside a valgrind instance */
 bool running_within_valgrind ();

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -12,14 +12,6 @@
 
 using namespace std::chrono_literals;
 
-namespace boost
-{
-namespace filesystem
-{
-	class path;
-}
-}
-
 #define xstr(a) ver_str (a)
 #define ver_str(a) #a
 

--- a/nano/lib/jsonconfig.cpp
+++ b/nano/lib/jsonconfig.cpp
@@ -1,7 +1,6 @@
 #include <nano/boost/asio/ip/address_v6.hpp>
 #include <nano/lib/jsonconfig.hpp>
 
-#include <boost/filesystem/convenience.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <cstddef>
@@ -25,7 +24,7 @@ nano::jsonconfig::jsonconfig (boost::property_tree::ptree & tree_a, std::shared_
  * Reads a json object from the stream 
  * @return nano::error&, including a descriptive error message if the config file is malformed.
  */
-nano::error & nano::jsonconfig::read (boost::filesystem::path const & path_a)
+nano::error & nano::jsonconfig::read (std::filesystem::path const & path_a)
 {
 	std::fstream stream;
 	open_or_create (stream, path_a.string ());
@@ -48,7 +47,7 @@ nano::error & nano::jsonconfig::read (boost::filesystem::path const & path_a)
 	return *error;
 }
 
-void nano::jsonconfig::write (boost::filesystem::path const & path_a)
+void nano::jsonconfig::write (std::filesystem::path const & path_a)
 {
 	std::fstream stream;
 	open_or_create (stream, path_a.string ());
@@ -68,7 +67,7 @@ void nano::jsonconfig::read (std::istream & stream_a)
 /** Open configuration file, create if necessary */
 void nano::jsonconfig::open_or_create (std::fstream & stream_a, std::string const & path_a)
 {
-	if (!boost::filesystem::exists (path_a))
+	if (!std::filesystem::exists (path_a))
 	{
 		// Create temp stream to first create the file
 		std::ofstream stream (path_a);
@@ -81,7 +80,7 @@ void nano::jsonconfig::open_or_create (std::fstream & stream_a, std::string cons
 }
 
 /** Takes a filepath, appends '_backup_<timestamp>' to the end (but before any extension) and saves that file in the same directory */
-void nano::jsonconfig::create_backup_file (boost::filesystem::path const & filepath_a)
+void nano::jsonconfig::create_backup_file (std::filesystem::path const & filepath_a)
 {
 	auto extension = filepath_a.extension ();
 	auto filename_without_extension = filepath_a.filename ().replace_extension ("");
@@ -93,7 +92,7 @@ void nano::jsonconfig::create_backup_file (boost::filesystem::path const & filep
 	backup_filename += extension;
 	auto backup_filepath = backup_path / backup_filename;
 
-	boost::filesystem::copy_file (filepath_a, backup_filepath);
+	std::filesystem::copy_file (filepath_a, backup_filepath);
 }
 
 /** Returns the boost property node managed by this instance */

--- a/nano/lib/jsonconfig.hpp
+++ b/nano/lib/jsonconfig.hpp
@@ -4,7 +4,6 @@
 #include <nano/lib/errors.hpp>
 #include <nano/lib/utility.hpp>
 
-#include <boost/filesystem/path.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/property_tree/ptree.hpp>
 
@@ -29,12 +28,12 @@ class jsonconfig : public nano::configbase
 public:
 	jsonconfig ();
 	jsonconfig (boost::property_tree::ptree & tree_a, std::shared_ptr<nano::error> const & error_a = nullptr);
-	nano::error & read (boost::filesystem::path const & path_a);
-	void write (boost::filesystem::path const & path_a);
+	nano::error & read (std::filesystem::path const & path_a);
+	void write (std::filesystem::path const & path_a);
 	void write (std::ostream & stream_a) const;
 	void read (std::istream & stream_a);
 	void open_or_create (std::fstream & stream_a, std::string const & path_a);
-	void create_backup_file (boost::filesystem::path const & filepath_a);
+	void create_backup_file (std::filesystem::path const & filepath_a);
 	boost::property_tree::ptree const & get_tree ();
 	bool empty () const;
 	boost::optional<jsonconfig> get_optional_child (std::string const & key_a);

--- a/nano/lib/plat/posix/perms.cpp
+++ b/nano/lib/plat/posix/perms.cpp
@@ -1,7 +1,5 @@
 #include <nano/lib/utility.hpp>
 
-#include <boost/filesystem.hpp>
-
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -10,22 +8,22 @@ void nano::set_umask ()
 	umask (077);
 }
 
-void nano::set_secure_perm_directory (boost::filesystem::path const & path)
+void nano::set_secure_perm_directory (std::filesystem::path const & path)
 {
-	boost::filesystem::permissions (path, boost::filesystem::owner_all);
+	std::filesystem::permissions (path, std::filesystem::perms::owner_all);
 }
 
-void nano::set_secure_perm_directory (boost::filesystem::path const & path, boost::system::error_code & ec)
+void nano::set_secure_perm_directory (std::filesystem::path const & path, std::error_code & ec)
 {
-	boost::filesystem::permissions (path, boost::filesystem::owner_all, ec);
+	std::filesystem::permissions (path, std::filesystem::perms::owner_all, ec);
 }
 
-void nano::set_secure_perm_file (boost::filesystem::path const & path)
+void nano::set_secure_perm_file (std::filesystem::path const & path)
 {
-	boost::filesystem::permissions (path, boost::filesystem::perms::owner_read | boost::filesystem::perms::owner_write);
+	std::filesystem::permissions (path, std::filesystem::perms::owner_read | std::filesystem::perms::owner_write);
 }
 
-void nano::set_secure_perm_file (boost::filesystem::path const & path, boost::system::error_code & ec)
+void nano::set_secure_perm_file (std::filesystem::path const & path, std::error_code & ec)
 {
-	boost::filesystem::permissions (path, boost::filesystem::perms::owner_read | boost::filesystem::perms::owner_write, ec);
+	std::filesystem::permissions (path, std::filesystem::perms::owner_read | std::filesystem::perms::owner_write, ec);
 }

--- a/nano/lib/plat/windows/perms.cpp
+++ b/nano/lib/plat/windows/perms.cpp
@@ -1,7 +1,5 @@
 #include <nano/lib/utility.hpp>
 
-#include <boost/filesystem.hpp>
-
 // clang-format off
 // Keep windows.h header at the top
 #include <windows.h>
@@ -18,24 +16,24 @@ void nano::set_umask ()
 	debug_assert (result == 0);
 }
 
-void nano::set_secure_perm_directory (boost::filesystem::path const & path)
+void nano::set_secure_perm_directory (std::filesystem::path const & path)
 {
-	boost::filesystem::permissions (path, boost::filesystem::owner_all);
+	std::filesystem::permissions (path, std::filesystem::perms::owner_all);
 }
 
-void nano::set_secure_perm_directory (boost::filesystem::path const & path, boost::system::error_code & ec)
+void nano::set_secure_perm_directory (std::filesystem::path const & path, std::error_code & ec)
 {
-	boost::filesystem::permissions (path, boost::filesystem::owner_all, ec);
+	std::filesystem::permissions (path, std::filesystem::perms::owner_all, ec);
 }
 
-void nano::set_secure_perm_file (boost::filesystem::path const & path)
+void nano::set_secure_perm_file (std::filesystem::path const & path)
 {
-	boost::filesystem::permissions (path, boost::filesystem::owner_read | boost::filesystem::owner_write);
+	std::filesystem::permissions (path, std::filesystem::perms::owner_read | std::filesystem::perms::owner_write);
 }
 
-void nano::set_secure_perm_file (boost::filesystem::path const & path, boost::system::error_code & ec)
+void nano::set_secure_perm_file (std::filesystem::path const & path, std::error_code & ec)
 {
-	boost::filesystem::permissions (path, boost::filesystem::owner_read | boost::filesystem::owner_write, ec);
+	std::filesystem::permissions (path, std::filesystem::perms::owner_read | std::filesystem::perms::owner_write, ec);
 }
 
 bool nano::is_windows_elevated ()

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -111,7 +111,7 @@ nano::rpc_process_config::rpc_process_config (nano::network_constants & network_
 
 namespace nano
 {
-nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, nano::rpc_config & config_a, std::vector<std::string> const & config_overrides)
+nano::error read_rpc_config_toml (std::filesystem::path const & data_path_a, nano::rpc_config & config_a, std::vector<std::string> const & config_overrides)
 {
 	nano::error error;
 	auto toml_config_path = nano::get_rpc_toml_config_path (data_path_a);
@@ -129,7 +129,7 @@ nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, n
 	// Make sure we don't create an empty toml file if it doesn't exist. Running without a toml file is the default.
 	if (!error)
 	{
-		if (boost::filesystem::exists (toml_config_path))
+		if (std::filesystem::exists (toml_config_path))
 		{
 			error = toml.read (config_overrides_stream, toml_config_path);
 		}

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -88,7 +88,7 @@ public:
 	std::shared_ptr<nano::tls_config> tls_config;
 };
 
-nano::error read_rpc_config_toml (boost::filesystem::path const & data_path_a, nano::rpc_config & config_a, std::vector<std::string> const & config_overrides = std::vector<std::string> ());
+nano::error read_rpc_config_toml (std::filesystem::path const & data_path_a, nano::rpc_config & config_a, std::vector<std::string> const & config_overrides = std::vector<std::string> ());
 
 std::string get_default_rpc_filepath ();
 }

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -10,14 +10,6 @@
 #include <thread>
 #include <vector>
 
-namespace boost
-{
-namespace filesystem
-{
-	class path;
-}
-}
-
 namespace nano
 {
 class tomlconfig;

--- a/nano/lib/tlsconfig.cpp
+++ b/nano/lib/tlsconfig.cpp
@@ -3,7 +3,6 @@
 #include <nano/lib/tlsconfig.hpp>
 #include <nano/lib/tomlconfig.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 
 #include <iostream>
@@ -139,7 +138,7 @@ namespace
 }
 #endif
 
-nano::error read_tls_config_toml (boost::filesystem::path const & data_path_a, nano::tls_config & config_a, nano::logger_mt & logger_a, std::vector<std::string> const & config_overrides)
+nano::error read_tls_config_toml (std::filesystem::path const & data_path_a, nano::tls_config & config_a, nano::logger_mt & logger_a, std::vector<std::string> const & config_overrides)
 {
 	nano::error error;
 	auto toml_config_path = nano::get_tls_toml_config_path (data_path_a);
@@ -157,7 +156,7 @@ nano::error read_tls_config_toml (boost::filesystem::path const & data_path_a, n
 	// Make sure we don't create an empty toml file if it doesn't exist. Running without a tls toml file is the default.
 	if (!error)
 	{
-		if (boost::filesystem::exists (toml_config_path))
+		if (std::filesystem::exists (toml_config_path))
 		{
 			error = toml.read (config_overrides_stream, toml_config_path);
 		}

--- a/nano/lib/tlsconfig.hpp
+++ b/nano/lib/tlsconfig.hpp
@@ -11,11 +11,6 @@
 #include <boost/asio/ssl/context.hpp>
 #endif
 
-namespace std::filesystem
-{
-class path;
-}
-
 namespace nano
 {
 class logger_mt;

--- a/nano/lib/tlsconfig.hpp
+++ b/nano/lib/tlsconfig.hpp
@@ -11,7 +11,7 @@
 #include <boost/asio/ssl/context.hpp>
 #endif
 
-namespace boost::filesystem
+namespace std::filesystem
 {
 class path;
 }
@@ -59,5 +59,5 @@ public:
 #endif
 };
 
-nano::error read_tls_config_toml (boost::filesystem::path const & data_path_a, nano::tls_config & config_a, nano::logger_mt & logger_a, std::vector<std::string> const & config_overrides = std::vector<std::string> ());
+nano::error read_tls_config_toml (std::filesystem::path const & data_path_a, nano::tls_config & config_a, nano::logger_mt & logger_a, std::vector<std::string> const & config_overrides = std::vector<std::string> ());
 }

--- a/nano/lib/tomlconfig.cpp
+++ b/nano/lib/tomlconfig.cpp
@@ -1,8 +1,6 @@
 #include <nano/boost/asio/ip/address_v6.hpp>
 #include <nano/lib/tomlconfig.hpp>
 
-#include <boost/filesystem/convenience.hpp>
-
 nano::tomlconfig::tomlconfig () :
 	tree (cpptoml::make_table ())
 {
@@ -23,14 +21,14 @@ void nano::tomlconfig::doc (std::string const & key, std::string const & doc)
 	tree->document (key, doc);
 }
 
-nano::error & nano::tomlconfig::read (boost::filesystem::path const & path_a)
+nano::error & nano::tomlconfig::read (std::filesystem::path const & path_a)
 {
 	std::stringstream stream_override_empty;
 	stream_override_empty << std::endl;
 	return read (stream_override_empty, path_a);
 }
 
-nano::error & nano::tomlconfig::read (std::istream & stream_overrides, boost::filesystem::path const & path_a)
+nano::error & nano::tomlconfig::read (std::istream & stream_overrides, std::filesystem::path const & path_a)
 {
 	std::fstream stream;
 	open_or_create (stream, path_a.string ());
@@ -62,7 +60,7 @@ nano::error & nano::tomlconfig::read (std::istream & stream_first_a, std::istrea
 	return *error;
 }
 
-void nano::tomlconfig::write (boost::filesystem::path const & path_a)
+void nano::tomlconfig::write (std::filesystem::path const & path_a)
 {
 	std::fstream stream;
 	open_or_create (stream, path_a.string ());
@@ -78,7 +76,7 @@ void nano::tomlconfig::write (std::ostream & stream_a) const
 /** Open configuration file, create if necessary */
 void nano::tomlconfig::open_or_create (std::fstream & stream_a, std::string const & path_a)
 {
-	if (!boost::filesystem::exists (path_a))
+	if (!std::filesystem::exists (path_a))
 	{
 		// Create temp stream to first create the file
 		std::ofstream stream (path_a);

--- a/nano/lib/tomlconfig.hpp
+++ b/nano/lib/tomlconfig.hpp
@@ -3,7 +3,6 @@
 #include <nano/lib/configbase.hpp>
 #include <nano/lib/utility.hpp>
 
-#include <boost/filesystem/path.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/optional.hpp>
 
@@ -31,11 +30,11 @@ public:
 	tomlconfig ();
 	tomlconfig (std::shared_ptr<cpptoml::table> const & tree_a, std::shared_ptr<nano::error> const & error_a = nullptr);
 	void doc (std::string const & key, std::string const & doc);
-	nano::error & read (boost::filesystem::path const & path_a);
-	nano::error & read (std::istream & stream_overrides, boost::filesystem::path const & path_a);
+	nano::error & read (std::filesystem::path const & path_a);
+	nano::error & read (std::istream & stream_overrides, std::filesystem::path const & path_a);
 	nano::error & read (std::istream & stream_a);
 	nano::error & read (std::istream & stream_first_a, std::istream & stream_second_a);
-	void write (boost::filesystem::path const & path_a);
+	void write (std::filesystem::path const & path_a);
 	void write (std::ostream & stream_a) const;
 	void open_or_create (std::fstream & stream_a, std::string const & path_a);
 	std::shared_ptr<cpptoml::table> get_tree ();

--- a/nano/lib/utility.cpp
+++ b/nano/lib/utility.cpp
@@ -2,7 +2,6 @@
 #include <nano/lib/utility.hpp>
 
 #include <boost/dll/runtime_symbol_info.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
 #include <cstddef>
@@ -94,26 +93,26 @@ nano::container_info const & nano::container_info_leaf::get_info () const
 	return info;
 }
 
-void nano::remove_all_files_in_dir (boost::filesystem::path const & dir)
+void nano::remove_all_files_in_dir (std::filesystem::path const & dir)
 {
-	for (auto & p : boost::filesystem::directory_iterator (dir))
+	for (auto & p : std::filesystem::directory_iterator (dir))
 	{
 		auto path = p.path ();
-		if (boost::filesystem::is_regular_file (path))
+		if (std::filesystem::is_regular_file (path))
 		{
-			boost::filesystem::remove (path);
+			std::filesystem::remove (path);
 		}
 	}
 }
 
-void nano::move_all_files_to_dir (boost::filesystem::path const & from, boost::filesystem::path const & to)
+void nano::move_all_files_to_dir (std::filesystem::path const & from, std::filesystem::path const & to)
 {
-	for (auto & p : boost::filesystem::directory_iterator (from))
+	for (auto & p : std::filesystem::directory_iterator (from))
 	{
 		auto path = p.path ();
-		if (boost::filesystem::is_regular_file (path))
+		if (std::filesystem::is_regular_file (path))
 		{
-			boost::filesystem::rename (path, to / path.filename ());
+			std::filesystem::rename (path, to / path.filename ());
 		}
 	}
 }

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -16,11 +16,6 @@
 
 namespace boost
 {
-namespace filesystem
-{
-	class path;
-}
-
 namespace system
 {
 	class error_code;

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -7,6 +7,7 @@
 #include <boost/preprocessor/facilities/overload.hpp>
 
 #include <cassert>
+#include <filesystem>
 #include <functional>
 #include <mutex>
 #include <vector>
@@ -115,10 +116,10 @@ void work_thread_reprioritize ();
  * Functions for managing filesystem permissions, platform specific
  */
 void set_umask ();
-void set_secure_perm_directory (boost::filesystem::path const & path);
-void set_secure_perm_directory (boost::filesystem::path const & path, boost::system::error_code & ec);
-void set_secure_perm_file (boost::filesystem::path const & path);
-void set_secure_perm_file (boost::filesystem::path const & path, boost::system::error_code & ec);
+void set_secure_perm_directory (std::filesystem::path const & path);
+void set_secure_perm_directory (std::filesystem::path const & path, std::error_code & ec);
+void set_secure_perm_file (std::filesystem::path const & path);
+void set_secure_perm_file (std::filesystem::path const & path, std::error_code & ec);
 
 /*
  * Function to check if running Windows as an administrator
@@ -145,8 +146,8 @@ void create_load_memory_address_files ();
 std::size_t get_file_descriptor_limit ();
 void set_file_descriptor_limit (std::size_t limit);
 
-void remove_all_files_in_dir (boost::filesystem::path const & dir);
-void move_all_files_to_dir (boost::filesystem::path const & from, boost::filesystem::path const & to);
+void remove_all_files_in_dir (std::filesystem::path const & dir);
+void move_all_files_to_dir (std::filesystem::path const & from, std::filesystem::path const & to);
 
 template <class InputIt, class OutputIt, class Pred, class Func>
 void transform_if (InputIt first, InputIt last, OutputIt dest, Pred pred, Func transform)

--- a/nano/load_test/entry.cpp
+++ b/nano/load_test/entry.cpp
@@ -42,7 +42,7 @@ constexpr auto rpc_port_start = 60000;
 constexpr auto peering_port_start = 61000;
 constexpr auto ipc_port_start = 62000;
 
-void write_config_files (boost::filesystem::path const & data_path, int index)
+void write_config_files (std::filesystem::path const & data_path, int index)
 {
 	nano::network_params network_params{ nano::network_constants::active_network };
 	nano::daemon_config daemon_config{ data_path, network_params };
@@ -540,7 +540,7 @@ int main (int argc, char * const * argv)
 		}
 		node_path = node_filepath.string ();
 	}
-	if (!boost::filesystem::exists (node_path))
+	if (!std::filesystem::exists (node_path))
 	{
 		std::cerr << "nano_node executable could not be found in " << node_path << std::endl;
 		return 1;
@@ -561,17 +561,17 @@ int main (int argc, char * const * argv)
 		}
 		rpc_path = rpc_filepath.string ();
 	}
-	if (!boost::filesystem::exists (rpc_path))
+	if (!std::filesystem::exists (rpc_path))
 	{
 		std::cerr << "nano_rpc executable could not be found in " << rpc_path << std::endl;
 		return 1;
 	}
 
-	std::vector<boost::filesystem::path> data_paths;
+	std::vector<std::filesystem::path> data_paths;
 	for (auto i = 0; i < node_count; ++i)
 	{
 		auto data_path = nano::unique_path ();
-		boost::filesystem::create_directory (data_path);
+		std::filesystem::create_directory (data_path);
 		write_config_files (data_path, i);
 		data_paths.push_back (std::move (data_path));
 	}

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -182,8 +182,7 @@ void nano_daemon::daemon::run (std::filesystem::path const & data_path, nano::no
 
 						auto network = node->network_params.network.get_current_network_as_string ();
 
-						// TODO: Find replacement for std::make_unique<boost::process::child>
-						//rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path, "--network", network);
+						rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path.string (), "--network", network);
 					}
 				}
 

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -58,11 +58,11 @@ volatile sig_atomic_t sig_int_or_term = 0;
 constexpr std::size_t OPEN_FILE_DESCRIPTORS_LIMIT = 16384;
 }
 
-void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::node_flags const & flags)
+void nano_daemon::daemon::run (std::filesystem::path const & data_path, nano::node_flags const & flags)
 {
 	install_abort_signal_handler ();
 
-	boost::filesystem::create_directories (data_path);
+	std::filesystem::create_directories (data_path);
 	boost::system::error_code error_chmod;
 	nano::set_secure_perm_directory (data_path, error_chmod);
 	std::unique_ptr<nano::thread_runner> runner;
@@ -174,7 +174,7 @@ void nano_daemon::daemon::run (boost::filesystem::path const & data_path, nano::
 					else
 					{
 						// Spawn a child rpc process
-						if (!boost::filesystem::exists (config.rpc.child_process.rpc_path))
+						if (!std::filesystem::exists (config.rpc.child_process.rpc_path))
 						{
 							throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.child_process.rpc_path);
 						}

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -15,6 +15,7 @@
 #include <nano/rpc/rpc.hpp>
 
 #include <boost/format.hpp>
+#include <boost/process.hpp>
 
 #include <csignal>
 #include <iostream>
@@ -180,7 +181,9 @@ void nano_daemon::daemon::run (std::filesystem::path const & data_path, nano::no
 						}
 
 						auto network = node->network_params.network.get_current_network_as_string ();
-						rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path, "--network", network);
+
+						// TODO: Find replacement for std::make_unique<boost::process::child>
+						//rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path, "--network", network);
 					}
 				}
 

--- a/nano/nano_node/daemon.hpp
+++ b/nano/nano_node/daemon.hpp
@@ -15,6 +15,6 @@ namespace nano_daemon
 class daemon
 {
 public:
-	void run (boost::filesystem::path const &, nano::node_flags const & flags);
+	void run (std::filesystem::path const &, nano::node_flags const & flags);
 };
 }

--- a/nano/nano_node/daemon.hpp
+++ b/nano/nano_node/daemon.hpp
@@ -1,11 +1,3 @@
-namespace boost
-{
-namespace filesystem
-{
-	class path;
-}
-}
-
 namespace nano
 {
 class node_flags;

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -132,7 +132,7 @@ int main (int argc, char * const * argv)
 
 	nano::network_params network_params{ nano::network_constants::active_network };
 	auto data_path_it = vm.find ("data_path");
-	std::filesystem::path data_path ((data_path_it != vm.end ()) ? data_path_it->second.as<std::string> () : nano::working_path ());
+	std::filesystem::path data_path ((data_path_it != vm.end ()) ? std::filesystem::path (data_path_it->second.as<std::string> ()) : nano::working_path ());
 	auto ec = nano::handle_node_options (vm);
 	if (ec == nano::error_cli::unknown_command)
 	{

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -12,7 +12,6 @@
 #include <nano/store/pending.hpp>
 
 #include <boost/dll/runtime_symbol_info.hpp>
-#include <boost/filesystem/operations.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/program_options.hpp>
@@ -133,7 +132,7 @@ int main (int argc, char * const * argv)
 
 	nano::network_params network_params{ nano::network_constants::active_network };
 	auto data_path_it = vm.find ("data_path");
-	boost::filesystem::path data_path ((data_path_it != vm.end ()) ? data_path_it->second.as<std::string> () : nano::working_path ());
+	std::filesystem::path data_path ((data_path_it != vm.end ()) ? data_path_it->second.as<std::string> () : nano::working_path ());
 	auto ec = nano::handle_node_options (vm);
 	if (ec == nano::error_cli::unknown_command)
 	{
@@ -652,7 +651,7 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_output_last_backtrace_dump"))
 		{
-			if (boost::filesystem::exists ("nano_node_backtrace.dump"))
+			if (std::filesystem::exists ("nano_node_backtrace.dump"))
 			{
 				// There is a backtrace, so output the contents
 				std::ifstream ifs ("nano_node_backtrace.dump");
@@ -664,7 +663,7 @@ int main (int argc, char * const * argv)
 		}
 		else if (vm.count ("debug_generate_crash_report"))
 		{
-			if (boost::filesystem::exists ("nano_node_backtrace.dump"))
+			if (std::filesystem::exists ("nano_node_backtrace.dump"))
 			{
 				// There is a backtrace, so output the contents
 				std::ifstream ifs ("nano_node_backtrace.dump");
@@ -690,7 +689,7 @@ int main (int argc, char * const * argv)
 					// The first one only has the load address
 					uint64_from_hex base_address;
 					std::string line;
-					if (boost::filesystem::exists (boost::str (format % num)))
+					if (std::filesystem::exists (boost::str (format % num)))
 					{
 						std::getline (std::ifstream (boost::str (format % num)), line);
 						if (boost::conversion::try_lexical_convert (line, base_address))
@@ -701,7 +700,7 @@ int main (int argc, char * const * argv)
 					++num;
 
 					// Now do the rest of the files
-					while (boost::filesystem::exists (boost::str (format % num)))
+					while (std::filesystem::exists (boost::str (format % num)))
 					{
 						std::ifstream ifs_dump_filename (boost::str (format % num));
 
@@ -776,7 +775,7 @@ int main (int argc, char * const * argv)
 					}
 
 					// Recreate the crash report with an empty file
-					boost::filesystem::remove (crash_report_filename);
+					std::filesystem::remove (crash_report_filename);
 					{
 						std::ofstream ofs (crash_report_filename);
 						nano::set_secure_perm_file (crash_report_filename);

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -11,14 +11,13 @@
 #include <nano/rpc/rpc_request_processor.hpp>
 #include <nano/secure/utility.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
 #include <boost/log/utility/setup/file.hpp>
 #include <boost/program_options.hpp>
 
 namespace
 {
-void logging_init (boost::filesystem::path const & application_path_a)
+void logging_init (std::filesystem::path const & application_path_a)
 {
 	static std::atomic_flag logging_already_added = ATOMIC_FLAG_INIT;
 	if (!logging_already_added.test_and_set ())
@@ -35,9 +34,9 @@ void logging_init (boost::filesystem::path const & application_path_a)
 
 volatile sig_atomic_t sig_int_or_term = 0;
 
-void run (boost::filesystem::path const & data_path, std::vector<std::string> const & config_overrides)
+void run (std::filesystem::path const & data_path, std::vector<std::string> const & config_overrides)
 {
-	boost::filesystem::create_directories (data_path);
+	std::filesystem::create_directories (data_path);
 	boost::system::error_code error_chmod;
 	nano::set_secure_perm_directory (data_path, error_chmod);
 	std::unique_ptr<nano::thread_runner> runner;
@@ -139,7 +138,7 @@ int main (int argc, char * const * argv)
 	}
 
 	auto data_path_it = vm.find ("data_path");
-	boost::filesystem::path data_path ((data_path_it != vm.end ()) ? data_path_it->second.as<std::string> () : nano::working_path ());
+	std::filesystem::path data_path ((data_path_it != vm.end ()) ? data_path_it->second.as<std::string> () : nano::working_path ());
 	if (vm.count ("daemon") > 0)
 	{
 		std::vector<std::string> config_overrides;

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -138,7 +138,7 @@ int main (int argc, char * const * argv)
 	}
 
 	auto data_path_it = vm.find ("data_path");
-	std::filesystem::path data_path ((data_path_it != vm.end ()) ? data_path_it->second.as<std::string> () : nano::working_path ());
+	std::filesystem::path data_path ((data_path_it != vm.end ()) ? std::filesystem::path (data_path_it->second.as<std::string> ()) : nano::working_path ());
 	if (vm.count ("daemon") > 0)
 	{
 		std::vector<std::string> config_overrides;

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -41,7 +41,7 @@ void show_help (std::string const & message_a)
 	message.exec ();
 }
 
-nano::error write_wallet_config (nano::wallet_config & config_a, boost::filesystem::path const & data_path_a)
+nano::error write_wallet_config (nano::wallet_config & config_a, std::filesystem::path const & data_path_a)
 {
 	nano::tomlconfig wallet_config_toml;
 	auto wallet_path (nano::get_qtwallet_toml_config_path (data_path_a));
@@ -52,11 +52,11 @@ nano::error write_wallet_config (nano::wallet_config & config_a, boost::filesyst
 	return wallet_config_toml.get_error ();
 }
 
-nano::error read_wallet_config (nano::wallet_config & config_a, boost::filesystem::path const & data_path_a)
+nano::error read_wallet_config (nano::wallet_config & config_a, std::filesystem::path const & data_path_a)
 {
 	nano::tomlconfig wallet_config_toml;
 	auto wallet_path (nano::get_qtwallet_toml_config_path (data_path_a));
-	if (!boost::filesystem::exists (wallet_path))
+	if (!std::filesystem::exists (wallet_path))
 	{
 		write_wallet_config (config_a, data_path_a);
 	}
@@ -66,12 +66,12 @@ nano::error read_wallet_config (nano::wallet_config & config_a, boost::filesyste
 }
 }
 
-int run_wallet (QApplication & application, int argc, char * const * argv, boost::filesystem::path const & data_path, nano::node_flags const & flags)
+int run_wallet (QApplication & application, int argc, char * const * argv, std::filesystem::path const & data_path, nano::node_flags const & flags)
 {
 	int result (0);
 	nano_qt::eventloop_processor processor;
 	boost::system::error_code error_chmod;
-	boost::filesystem::create_directories (data_path);
+	std::filesystem::create_directories (data_path);
 	nano::set_secure_perm_directory (data_path, error_chmod);
 	QPixmap pixmap (":/logo.png");
 	auto * splash = new QSplashScreen (pixmap);
@@ -186,7 +186,7 @@ int run_wallet (QApplication & application, int argc, char * const * argv, boost
 				else
 				{
 					// Spawn a child rpc process
-					if (!boost::filesystem::exists (config.rpc.child_process.rpc_path))
+					if (!std::filesystem::exists (config.rpc.child_process.rpc_path))
 					{
 						throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.child_process.rpc_path);
 					}
@@ -297,11 +297,11 @@ int main (int argc, char * const * argv)
 			{
 				try
 				{
-					boost::filesystem::path data_path;
+					std::filesystem::path data_path;
 					if (vm.count ("data_path"))
 					{
 						auto name (vm["data_path"].as<std::string> ());
-						data_path = boost::filesystem::path (name);
+						data_path = std::filesystem::path (name);
 					}
 					else
 					{

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -214,7 +214,6 @@ target_link_libraries(
   argon2
   lmdb
   Boost::beast
-  Boost::filesystem
   Boost::log_setup
   Boost::log
   Boost::program_options

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -6,13 +6,12 @@
 #include <nano/node/daemonconfig.hpp>
 #include <nano/node/node.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 
 namespace
 {
 void reset_confirmation_heights (nano::store::write_transaction const & transaction, nano::ledger_constants & constants, nano::store::component & store);
-bool is_using_rocksdb (boost::filesystem::path const & data_path, boost::program_options::variables_map const & vm, std::error_code & ec);
+bool is_using_rocksdb (std::filesystem::path const & data_path, boost::program_options::variables_map const & vm, std::error_code & ec);
 }
 
 std::string nano::error_cli_messages::message (int ev) const
@@ -197,7 +196,7 @@ void database_write_lock_error (std::error_code & ec)
 	ec = nano::error_cli::database_write_error;
 }
 
-bool copy_database (boost::filesystem::path const & data_path, boost::program_options::variables_map const & vm, boost::filesystem::path const & output_path, std::error_code & ec)
+bool copy_database (std::filesystem::path const & data_path, boost::program_options::variables_map const & vm, std::filesystem::path const & output_path, std::error_code & ec)
 {
 	bool success = false;
 	bool needs_to_write = vm.count ("unchecked_clear") || vm.count ("clear_send_ids") || vm.count ("online_weight_clear") || vm.count ("peer_clear") || vm.count ("confirmation_height_clear") || vm.count ("final_vote_clear") || vm.count ("rebuild_database");
@@ -251,7 +250,7 @@ bool copy_database (boost::filesystem::path const & data_path, boost::program_op
 std::error_code nano::handle_node_options (boost::program_options::variables_map const & vm)
 {
 	std::error_code ec;
-	boost::filesystem::path data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
+	std::filesystem::path data_path = vm.count ("data_path") ? std::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
 
 	if (vm.count ("initialize"))
 	{
@@ -342,17 +341,17 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 			if (!ec)
 			{
 				std::cout << "Vacuuming database copy in ";
-				boost::filesystem::path source_path;
-				boost::filesystem::path backup_path;
-				boost::filesystem::path vacuum_path;
+				std::filesystem::path source_path;
+				std::filesystem::path backup_path;
+				std::filesystem::path vacuum_path;
 				if (using_rocksdb)
 				{
 					source_path = data_path / "rocksdb";
 					backup_path = source_path / "backup";
 					vacuum_path = backup_path / "vacuumed";
-					if (!boost::filesystem::exists (vacuum_path))
+					if (!std::filesystem::exists (vacuum_path))
 					{
-						boost::filesystem::create_directories (vacuum_path);
+						std::filesystem::create_directories (vacuum_path);
 					}
 
 					std::cout << source_path << "\n";
@@ -376,13 +375,13 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 						nano::remove_all_files_in_dir (backup_path);
 						nano::move_all_files_to_dir (source_path, backup_path);
 						nano::move_all_files_to_dir (vacuum_path, source_path);
-						boost::filesystem::remove_all (vacuum_path);
+						std::filesystem::remove_all (vacuum_path);
 					}
 					else
 					{
-						boost::filesystem::remove (backup_path);
-						boost::filesystem::rename (source_path, backup_path);
-						boost::filesystem::rename (vacuum_path, source_path);
+						std::filesystem::remove (backup_path);
+						std::filesystem::rename (source_path, backup_path);
+						std::filesystem::rename (vacuum_path, source_path);
 					}
 					std::cout << "Vacuum completed" << std::endl;
 				}
@@ -396,7 +395,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				std::cerr << "Vacuum failed. RocksDB is enabled but the node has not been built with RocksDB support" << std::endl;
 			}
 		}
-		catch (boost::filesystem::filesystem_error const & ex)
+		catch (std::filesystem::filesystem_error const & ex)
 		{
 			std::cerr << "Vacuum failed during a file operation: " << ex.what () << std::endl;
 		}
@@ -412,8 +411,8 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 			auto using_rocksdb = is_using_rocksdb (data_path, vm, ec);
 			if (!ec)
 			{
-				boost::filesystem::path source_path;
-				boost::filesystem::path snapshot_path;
+				std::filesystem::path source_path;
+				std::filesystem::path snapshot_path;
 				if (using_rocksdb)
 				{
 					source_path = data_path / "rocksdb";
@@ -443,7 +442,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				std::cerr << "Snapshot failed. RocksDB is enabled but the node has not been built with RocksDB support" << std::endl;
 			}
 		}
-		catch (boost::filesystem::filesystem_error const & ex)
+		catch (std::filesystem::filesystem_error const & ex)
 		{
 			std::cerr << "Snapshot failed during a file operation: " << ex.what () << std::endl;
 		}
@@ -454,7 +453,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 	}
 	else if (vm.count ("migrate_database_lmdb_to_rocksdb"))
 	{
-		auto data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
+		auto data_path = vm.count ("data_path") ? std::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
 		auto node_flags = nano::inactive_node_flag_defaults ();
 		node_flags.config_overrides.push_back ("node.rocksdb.enable=false");
 		nano::update_flags (node_flags, vm);
@@ -481,7 +480,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 	}
 	else if (vm.count ("unchecked_clear"))
 	{
-		boost::filesystem::path data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
+		std::filesystem::path data_path = vm.count ("data_path") ? std::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
 		auto node_flags = nano::inactive_node_flag_defaults ();
 		node_flags.read_only = false;
 		nano::update_flags (node_flags, vm);
@@ -499,7 +498,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 	}
 	else if (vm.count ("clear_send_ids"))
 	{
-		boost::filesystem::path data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
+		std::filesystem::path data_path = vm.count ("data_path") ? std::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
 		auto node_flags = nano::inactive_node_flag_defaults ();
 		node_flags.read_only = false;
 		nano::update_flags (node_flags, vm);
@@ -517,7 +516,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 	}
 	else if (vm.count ("online_weight_clear"))
 	{
-		boost::filesystem::path data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
+		std::filesystem::path data_path = vm.count ("data_path") ? std::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
 		auto node_flags = nano::inactive_node_flag_defaults ();
 		node_flags.read_only = false;
 		nano::update_flags (node_flags, vm);
@@ -535,7 +534,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 	}
 	else if (vm.count ("peer_clear"))
 	{
-		boost::filesystem::path data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
+		std::filesystem::path data_path = vm.count ("data_path") ? std::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
 		auto node_flags = nano::inactive_node_flag_defaults ();
 		node_flags.read_only = false;
 		nano::update_flags (node_flags, vm);
@@ -553,7 +552,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 	}
 	else if (vm.count ("confirmation_height_clear"))
 	{
-		boost::filesystem::path data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
+		std::filesystem::path data_path = vm.count ("data_path") ? std::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
 		auto node_flags = nano::inactive_node_flag_defaults ();
 		node_flags.read_only = false;
 		nano::update_flags (node_flags, vm);
@@ -614,7 +613,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 	}
 	else if (vm.count ("final_vote_clear"))
 	{
-		boost::filesystem::path data_path = vm.count ("data_path") ? boost::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
+		std::filesystem::path data_path = vm.count ("data_path") ? std::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
 		auto node_flags = nano::inactive_node_flag_defaults ();
 		node_flags.read_only = false;
 		nano::update_flags (node_flags, vm);
@@ -1302,7 +1301,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 	return ec;
 }
 
-std::unique_ptr<nano::inactive_node> nano::default_inactive_node (boost::filesystem::path const & path_a, boost::program_options::variables_map const & vm_a)
+std::unique_ptr<nano::inactive_node> nano::default_inactive_node (std::filesystem::path const & path_a, boost::program_options::variables_map const & vm_a)
 {
 	auto node_flags = nano::inactive_node_flag_defaults ();
 	nano::update_flags (node_flags, vm_a);
@@ -1320,7 +1319,7 @@ void reset_confirmation_heights (nano::store::write_transaction const & transact
 	store.confirmation_height.put (transaction, constants.genesis->account (), { 1, constants.genesis->hash () });
 }
 
-bool is_using_rocksdb (boost::filesystem::path const & data_path, boost::program_options::variables_map const & vm, std::error_code & ec)
+bool is_using_rocksdb (std::filesystem::path const & data_path, boost::program_options::variables_map const & vm, std::error_code & ec)
 {
 	nano::network_params network_params{ nano::network_constants::active_network };
 	nano::daemon_config config{ data_path, network_params };

--- a/nano/node/daemonconfig.cpp
+++ b/nano/node/daemonconfig.cpp
@@ -3,12 +3,10 @@
 #include <nano/lib/tomlconfig.hpp>
 #include <nano/node/daemonconfig.hpp>
 
-#include <boost/filesystem.hpp>
-
 #include <sstream>
 #include <vector>
 
-nano::daemon_config::daemon_config (boost::filesystem::path const & data_path_a, nano::network_params & network_params) :
+nano::daemon_config::daemon_config (std::filesystem::path const & data_path_a, nano::network_params & network_params) :
 	node{ network_params },
 	data_path{ data_path_a }
 {
@@ -61,7 +59,7 @@ nano::error nano::daemon_config::deserialize_toml (nano::tomlconfig & toml)
 	return toml.get_error ();
 }
 
-nano::error nano::read_node_config_toml (boost::filesystem::path const & data_path_a, nano::daemon_config & config_a, std::vector<std::string> const & config_overrides)
+nano::error nano::read_node_config_toml (std::filesystem::path const & data_path_a, nano::daemon_config & config_a, std::vector<std::string> const & config_overrides)
 {
 	nano::error error;
 	auto toml_config_path = nano::get_node_toml_config_path (data_path_a);
@@ -80,7 +78,7 @@ nano::error nano::read_node_config_toml (boost::filesystem::path const & data_pa
 	// Make sure we don't create an empty toml file if it doesn't exist. Running without a toml file is the default.
 	if (!error)
 	{
-		if (boost::filesystem::exists (toml_config_path))
+		if (std::filesystem::exists (toml_config_path))
 		{
 			error = toml.read (config_overrides_stream, toml_config_path);
 		}

--- a/nano/node/daemonconfig.hpp
+++ b/nano/node/daemonconfig.hpp
@@ -14,7 +14,7 @@ class daemon_config
 {
 public:
 	daemon_config () = default;
-	daemon_config (boost::filesystem::path const & data_path, nano::network_params & network_params);
+	daemon_config (std::filesystem::path const & data_path, nano::network_params & network_params);
 	nano::error deserialize_toml (nano::tomlconfig &);
 	nano::error serialize_toml (nano::tomlconfig &);
 	bool rpc_enable{ false };
@@ -22,8 +22,8 @@ public:
 	nano::node_config node;
 	bool opencl_enable{ false };
 	nano::opencl_config opencl;
-	boost::filesystem::path data_path;
+	std::filesystem::path data_path;
 };
 
-nano::error read_node_config_toml (boost::filesystem::path const &, nano::daemon_config & config_a, std::vector<std::string> const & config_overrides = std::vector<std::string> ());
+nano::error read_node_config_toml (std::filesystem::path const &, nano::daemon_config & config_a, std::vector<std::string> const & config_overrides = std::vector<std::string> ());
 }

--- a/nano/node/ipc/flatbuffers_handler.cpp
+++ b/nano/node/ipc/flatbuffers_handler.cpp
@@ -33,10 +33,10 @@ std::string make_error_response (std::string const & error_message)
 /**
  * Returns the 'api/flatbuffers' directory, boost::none if not found.
  */
-boost::optional<boost::filesystem::path> get_api_path ()
+boost::optional<std::filesystem::path> get_api_path ()
 {
-	boost::filesystem::path const fb_path = "api/flatbuffers";
-	if (!boost::filesystem::exists (fb_path))
+	std::filesystem::path const fb_path = "api/flatbuffers";
+	if (!std::filesystem::exists (fb_path))
 	{
 		return boost::none;
 	}

--- a/nano/node/ipc/ipc_access_config.cpp
+++ b/nano/node/ipc/ipc_access_config.cpp
@@ -2,7 +2,6 @@
 #include <nano/node/ipc/ipc_access_config.hpp>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/filesystem.hpp>
 
 namespace
 {
@@ -280,13 +279,13 @@ namespace nano
 {
 namespace ipc
 {
-	nano::error read_access_config_toml (boost::filesystem::path const & data_path_a, nano::ipc::access & config_a)
+	nano::error read_access_config_toml (std::filesystem::path const & data_path_a, nano::ipc::access & config_a)
 	{
 		nano::error error;
 		auto toml_config_path = nano::get_access_toml_config_path (data_path_a);
 
 		nano::tomlconfig toml;
-		if (boost::filesystem::exists (toml_config_path))
+		if (std::filesystem::exists (toml_config_path))
 		{
 			error = toml.read (toml_config_path);
 		}

--- a/nano/node/ipc/ipc_access_config.hpp
+++ b/nano/node/ipc/ipc_access_config.hpp
@@ -8,13 +8,6 @@
 #include <unordered_map>
 #include <unordered_set>
 
-namespace boost
-{
-namespace filesystem
-{
-	class path;
-}
-}
 namespace cpptoml
 {
 class table;

--- a/nano/node/ipc/ipc_access_config.hpp
+++ b/nano/node/ipc/ipc_access_config.hpp
@@ -127,6 +127,6 @@ namespace ipc
 		mutable nano::mutex mutex;
 	};
 
-	nano::error read_access_config_toml (boost::filesystem::path const & data_path_a, nano::ipc::access & config_a);
+	nano::error read_access_config_toml (std::filesystem::path const & data_path_a, nano::ipc::access & config_a);
 }
 }

--- a/nano/node/logging.cpp
+++ b/nano/node/logging.cpp
@@ -5,7 +5,6 @@
 #include <nano/node/logging.hpp>
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/filesystem.hpp>
 #include <boost/log/expressions.hpp>
 #include <boost/log/utility/exception_handler.hpp>
 #include <boost/log/utility/setup/common_attributes.hpp>
@@ -23,7 +22,7 @@ BOOST_LOG_ATTRIBUTE_KEYWORD (severity, "Severity", nano::severity_level)
 boost::shared_ptr<boost::log::sinks::synchronous_sink<boost::log::sinks::text_file_backend>> nano::logging::file_sink;
 std::atomic_flag nano::logging::logging_already_added ATOMIC_FLAG_INIT;
 
-void nano::logging::init (boost::filesystem::path const & application_path_a)
+void nano::logging::init (std::filesystem::path const & application_path_a)
 {
 	if (!logging_already_added.test_and_set ())
 	{
@@ -79,7 +78,7 @@ void nano::logging::init (boost::filesystem::path const & application_path_a)
 			boost::log::keywords::max_size = max_size, // max total size in bytes of all log files
 			boost::log::keywords::format = format_with_timestamp);
 
-			if (!boost::filesystem::exists (file_name))
+			if (!std::filesystem::exists (file_name))
 			{
 				// Create temp stream to first create the file
 				std::ofstream stream (file_name.string ());

--- a/nano/node/logging.hpp
+++ b/nano/node/logging.hpp
@@ -66,7 +66,7 @@ public:
 	bool election_result_logging () const;
 	bool log_to_cerr () const;
 	bool single_line_record () const;
-	void init (boost::filesystem::path const &);
+	void init (std::filesystem::path const &);
 
 	bool ledger_logging_value{ false };
 	bool ledger_duplicate_logging_value{ false };

--- a/nano/node/logging.hpp
+++ b/nano/node/logging.hpp
@@ -24,10 +24,6 @@ namespace sinks
 
 BOOST_LOG_CLOSE_NAMESPACE
 
-namespace filesystem
-{
-	class path;
-}
 }
 
 namespace nano

--- a/nano/node/make_store.cpp
+++ b/nano/node/make_store.cpp
@@ -2,9 +2,7 @@
 #include <nano/store/lmdb/lmdb.hpp>
 #include <nano/store/rocksdb/rocksdb.hpp>
 
-#include <boost/filesystem/path.hpp>
-
-std::unique_ptr<nano::store::component> nano::make_store (nano::logger_mt & logger, boost::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::rocksdb_config const & rocksdb_config, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade)
+std::unique_ptr<nano::store::component> nano::make_store (nano::logger_mt & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::rocksdb_config const & rocksdb_config, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade)
 {
 	if (rocksdb_config.enable)
 	{

--- a/nano/node/make_store.hpp
+++ b/nano/node/make_store.hpp
@@ -7,11 +7,6 @@
 
 #include <chrono>
 
-namespace boost::filesystem
-{
-class path;
-}
-
 namespace nano
 {
 class ledger_constants;
@@ -27,5 +22,5 @@ class component;
 
 namespace nano
 {
-std::unique_ptr<nano::store::component> make_store (nano::logger_mt & logger, boost::filesystem::path const & path, nano::ledger_constants & constants, bool open_read_only = false, bool add_db_postfix = true, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
+std::unique_ptr<nano::store::component> make_store (nano::logger_mt & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool open_read_only = false, bool add_db_postfix = true, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -16,7 +16,6 @@
 #include <nano/store/component.hpp>
 #include <nano/store/rocksdb/rocksdb.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <algorithm>
@@ -105,7 +104,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (re
 	return composite;
 }
 
-nano::keypair nano::load_or_create_node_id (boost::filesystem::path const & application_path, nano::logger_mt & logger)
+nano::keypair nano::load_or_create_node_id (std::filesystem::path const & application_path, nano::logger_mt & logger)
 {
 	auto node_private_key_path = application_path / "node_id_private.key";
 	std::ifstream ifs (node_private_key_path.c_str ());
@@ -132,12 +131,12 @@ nano::keypair nano::load_or_create_node_id (boost::filesystem::path const & appl
 	}
 }
 
-nano::node::node (boost::asio::io_context & io_ctx_a, uint16_t peering_port_a, boost::filesystem::path const & application_path_a, nano::logging const & logging_a, nano::work_pool & work_a, nano::node_flags flags_a, unsigned seq) :
+nano::node::node (boost::asio::io_context & io_ctx_a, uint16_t peering_port_a, std::filesystem::path const & application_path_a, nano::logging const & logging_a, nano::work_pool & work_a, nano::node_flags flags_a, unsigned seq) :
 	node (io_ctx_a, application_path_a, nano::node_config (peering_port_a, logging_a), work_a, flags_a, seq)
 {
 }
 
-nano::node::node (boost::asio::io_context & io_ctx_a, boost::filesystem::path const & application_path_a, nano::node_config const & config_a, nano::work_pool & work_a, nano::node_flags flags_a, unsigned seq) :
+nano::node::node (boost::asio::io_context & io_ctx_a, std::filesystem::path const & application_path_a, nano::node_config const & config_a, nano::work_pool & work_a, nano::node_flags flags_a, unsigned seq) :
 	write_database_queue (!flags_a.force_use_write_database_queue && (config_a.rocksdb_config.enable)),
 	io_ctx (io_ctx_a),
 	node_initialized_latch (1),
@@ -542,7 +541,7 @@ void nano::node::do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, 
 	}
 }
 
-bool nano::node::copy_with_compaction (boost::filesystem::path const & destination)
+bool nano::node::copy_with_compaction (std::filesystem::path const & destination)
 {
 	return store.copy_db (destination);
 }
@@ -910,7 +909,7 @@ void nano::node::backup_wallet ()
 		boost::system::error_code error_chmod;
 		auto backup_path (application_path / "backup");
 
-		boost::filesystem::create_directories (backup_path);
+		std::filesystem::create_directories (backup_path);
 		nano::set_secure_perm_directory (backup_path, error_chmod);
 		i->second->store.write_backup (transaction, backup_path / (i->first.to_string () + ".json"));
 	}
@@ -1502,7 +1501,7 @@ nano::telemetry_data nano::node::local_telemetry () const
  * node_wrapper
  */
 
-nano::node_wrapper::node_wrapper (boost::filesystem::path const & path_a, boost::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a) :
+nano::node_wrapper::node_wrapper (std::filesystem::path const & path_a, std::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a) :
 	network_params{ nano::network_constants::active_network },
 	io_context (std::make_shared<boost::asio::io_context> ()),
 	work{ network_params.network, 1 }
@@ -1512,7 +1511,7 @@ nano::node_wrapper::node_wrapper (boost::filesystem::path const & path_a, boost:
 	/*
 	 * @warning May throw a filesystem exception
 	 */
-	boost::filesystem::create_directories (path_a);
+	std::filesystem::create_directories (path_a);
 	nano::set_secure_perm_directory (path_a, error_chmod);
 	nano::daemon_config daemon_config{ path_a, network_params };
 	auto error = nano::read_node_config_toml (config_path_a, daemon_config, node_flags_a.config_overrides);
@@ -1545,14 +1544,14 @@ nano::node_wrapper::~node_wrapper ()
  * inactive_node
  */
 
-nano::inactive_node::inactive_node (boost::filesystem::path const & path_a, boost::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a) :
+nano::inactive_node::inactive_node (std::filesystem::path const & path_a, std::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a) :
 	node_wrapper (path_a, config_path_a, node_flags_a),
 	node (node_wrapper.node)
 {
 	node_wrapper.node->active.stop ();
 }
 
-nano::inactive_node::inactive_node (boost::filesystem::path const & path_a, nano::node_flags const & node_flags_a) :
+nano::inactive_node::inactive_node (std::filesystem::path const & path_a, nano::node_flags const & node_flags_a) :
 	inactive_node (path_a, path_a, node_flags_a)
 {
 }

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -70,8 +70,8 @@ outbound_bandwidth_limiter::config outbound_bandwidth_limiter_config (node_confi
 class node final : public std::enable_shared_from_this<nano::node>
 {
 public:
-	node (boost::asio::io_context &, uint16_t, boost::filesystem::path const &, nano::logging const &, nano::work_pool &, nano::node_flags = nano::node_flags (), unsigned seq = 0);
-	node (boost::asio::io_context &, boost::filesystem::path const &, nano::node_config const &, nano::work_pool &, nano::node_flags = nano::node_flags (), unsigned seq = 0);
+	node (boost::asio::io_context &, uint16_t, std::filesystem::path const &, nano::logging const &, nano::work_pool &, nano::node_flags = nano::node_flags (), unsigned seq = 0);
+	node (boost::asio::io_context &, std::filesystem::path const &, nano::node_config const &, nano::work_pool &, nano::node_flags = nano::node_flags (), unsigned seq = 0);
 	~node ();
 
 public:
@@ -80,7 +80,7 @@ public:
 	{
 		io_ctx.post (action_a);
 	}
-	bool copy_with_compaction (boost::filesystem::path const &);
+	bool copy_with_compaction (std::filesystem::path const &);
 	void keepalive (std::string const &, uint16_t);
 	void start ();
 	void stop ();
@@ -166,7 +166,7 @@ public:
 	nano::bootstrap_initiator bootstrap_initiator;
 	nano::bootstrap_server bootstrap_server;
 	nano::transport::tcp_listener tcp_listener;
-	boost::filesystem::path application_path;
+	std::filesystem::path application_path;
 	nano::node_observers observers;
 	nano::port_mapping port_mapping;
 	nano::online_reps online_reps;
@@ -230,7 +230,7 @@ private:
 	void long_inactivity_cleanup ();
 };
 
-nano::keypair load_or_create_node_id (boost::filesystem::path const & application_path, nano::logger_mt & logger);
+nano::keypair load_or_create_node_id (std::filesystem::path const & application_path, nano::logger_mt & logger);
 std::unique_ptr<container_info_component> collect_container_info (node & node, std::string const & name);
 
 nano::node_flags const & inactive_node_flag_defaults ();
@@ -238,7 +238,7 @@ nano::node_flags const & inactive_node_flag_defaults ();
 class node_wrapper final
 {
 public:
-	node_wrapper (boost::filesystem::path const & path_a, boost::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a);
+	node_wrapper (std::filesystem::path const & path_a, std::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a);
 	~node_wrapper ();
 
 	nano::network_params network_params;
@@ -250,11 +250,11 @@ public:
 class inactive_node final
 {
 public:
-	inactive_node (boost::filesystem::path const & path_a, nano::node_flags const & node_flags_a);
-	inactive_node (boost::filesystem::path const & path_a, boost::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a);
+	inactive_node (std::filesystem::path const & path_a, nano::node_flags const & node_flags_a);
+	inactive_node (std::filesystem::path const & path_a, std::filesystem::path const & config_path_a, nano::node_flags const & node_flags_a);
 
 	nano::node_wrapper node_wrapper;
 	std::shared_ptr<nano::node> node;
 };
-std::unique_ptr<nano::inactive_node> default_inactive_node (boost::filesystem::path const &, boost::program_options::variables_map const &);
+std::unique_ptr<nano::inactive_node> default_inactive_node (std::filesystem::path const &, boost::program_options::variables_map const &);
 }

--- a/nano/node/node_rpc_config.hpp
+++ b/nano/node/node_rpc_config.hpp
@@ -6,14 +6,6 @@
 
 #include <string>
 
-namespace boost
-{
-namespace filesystem
-{
-	class path;
-}
-}
-
 namespace nano
 {
 class tomlconfig;

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -6,7 +6,6 @@
 #include <nano/node/wallet.hpp>
 #include <nano/store/lmdb/iterator.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/polymorphic_cast.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -553,7 +552,7 @@ void nano::wallet_store::serialize_json (store::transaction const & transaction_
 	string_a = ostream.str ();
 }
 
-void nano::wallet_store::write_backup (store::transaction const & transaction_a, boost::filesystem::path const & path_a)
+void nano::wallet_store::write_backup (store::transaction const & transaction_a, std::filesystem::path const & path_a)
 {
 	std::ofstream backup_file;
 	backup_file.open (path_a.string ());
@@ -1387,7 +1386,7 @@ nano::wallets::wallets (bool error_a, nano::node & node_a) :
 	{
 		char const * store_path;
 		mdb_env_get_path (env, &store_path);
-		boost::filesystem::path const path (store_path);
+		std::filesystem::path const path (store_path);
 		nano::store::lmdb::component::create_backup_file (env, path, node_a.logger);
 	}
 	for (auto & item : items)
@@ -1744,7 +1743,7 @@ nano::store::iterator<nano::account, nano::wallet_value> nano::wallet_store::end
 {
 	return store::iterator<nano::account, nano::wallet_value> (nullptr);
 }
-nano::mdb_wallets_store::mdb_wallets_store (boost::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a) :
+nano::mdb_wallets_store::mdb_wallets_store (std::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a) :
 	environment (error, path_a, nano::store::lmdb::env::options::make ().set_config (lmdb_config_a).override_config_sync (nano::lmdb_config::sync_strategy::always).override_config_map_size (1ULL * 1024 * 1024 * 1024))
 {
 }

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -95,7 +95,7 @@ public:
 	store::iterator<nano::account, nano::wallet_value> end ();
 	void derive_key (nano::raw_key &, store::transaction const &, std::string const &);
 	void serialize_json (store::transaction const &, std::string &);
-	void write_backup (store::transaction const &, boost::filesystem::path const &);
+	void write_backup (store::transaction const &, std::filesystem::path const &);
 	bool move (store::transaction const &, nano::wallet_store &, std::vector<nano::public_key> const &);
 	bool import (store::transaction const &, nano::wallet_store &);
 	bool work_get (store::transaction const &, nano::public_key const &, uint64_t &);
@@ -261,7 +261,7 @@ public:
 class mdb_wallets_store final : public wallets_store
 {
 public:
-	mdb_wallets_store (boost::filesystem::path const &, nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{});
+	mdb_wallets_store (std::filesystem::path const &, nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{});
 	nano::store::lmdb::env environment;
 	bool init_error () const override;
 	bool error{ false };

--- a/nano/secure/CMakeLists.txt
+++ b/nano/secure/CMakeLists.txt
@@ -49,8 +49,7 @@ add_library(
   utility.cpp
   working.hpp)
 
-target_link_libraries(secure nano_lib ed25519 crypto_lib Boost::system
-                      Boost::filesystem)
+target_link_libraries(secure nano_lib ed25519 crypto_lib Boost::system)
 
 target_compile_definitions(secure PUBLIC -DQT_NO_KEYWORDS
                                          -DBOOST_ASIO_HAS_STD_ARRAY=1)

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -17,8 +17,6 @@
 #include <nano/store/pruned.hpp>
 #include <nano/store/version.hpp>
 
-#include <boost/filesystem.hpp>
-
 #include <cryptopp/words.h>
 
 namespace
@@ -1553,12 +1551,12 @@ std::multimap<uint64_t, nano::uncemented_info, std::greater<>> nano::ledger::unc
 }
 
 // A precondition is that the store is an LMDB store
-bool nano::ledger::migrate_lmdb_to_rocksdb (boost::filesystem::path const & data_path_a) const
+bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_path_a) const
 {
 	boost::system::error_code error_chmod;
 	nano::set_secure_perm_directory (data_path_a, error_chmod);
 	auto rockdb_data_path = data_path_a / "rocksdb";
-	boost::filesystem::remove_all (rockdb_data_path);
+	std::filesystem::remove_all (rockdb_data_path);
 
 	nano::logger_mt logger;
 	auto error (false);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -90,7 +90,7 @@ public:
 	nano::account const & epoch_signer (nano::link const &) const;
 	nano::link const & epoch_link (nano::epoch) const;
 	std::multimap<uint64_t, uncemented_info, std::greater<>> unconfirmed_frontiers () const;
-	bool migrate_lmdb_to_rocksdb (boost::filesystem::path const &) const;
+	bool migrate_lmdb_to_rocksdb (std::filesystem::path const &) const;
 	bool bootstrap_weight_reached () const;
 	static nano::epoch version (nano::block const & block);
 	nano::epoch version (store::transaction const & transaction, nano::block_hash const & hash) const;

--- a/nano/secure/plat/osx/working.mm
+++ b/nano/secure/plat/osx/working.mm
@@ -1,16 +1,14 @@
 #include <nano/secure/working.hpp>
 
-#include <boost/filesystem.hpp>
-
 #include <Foundation/Foundation.h>
 
 namespace nano
 {
-boost::filesystem::path app_path ()
+std::filesystem::path app_path ()
 {
 	NSString * dir_string = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) lastObject];
 	char const * dir_chars = [dir_string UTF8String];
-	boost::filesystem::path result (dir_chars);
+	std::filesystem::path result (dir_chars);
 	[dir_string release];
 	return result;
 }

--- a/nano/secure/plat/posix/working.cpp
+++ b/nano/secure/plat/posix/working.cpp
@@ -1,18 +1,16 @@
 #include <nano/lib/utility.hpp>
 #include <nano/secure/working.hpp>
 
-#include <boost/filesystem.hpp>
-
 #include <pwd.h>
 #include <sys/types.h>
 
 namespace nano
 {
-boost::filesystem::path app_path ()
+std::filesystem::path app_path ()
 {
 	auto entry (getpwuid (getuid ()));
 	debug_assert (entry != nullptr);
-	boost::filesystem::path result (entry->pw_dir);
+	std::filesystem::path result (entry->pw_dir);
 	return result;
 }
 }

--- a/nano/secure/plat/windows/working.cpp
+++ b/nano/secure/plat/windows/working.cpp
@@ -1,18 +1,18 @@
 #include <nano/secure/working.hpp>
 
-#include <boost/filesystem/path.hpp>
+#include <filesystem>
 
 #include <shlobj.h>
 
 namespace nano
 {
-boost::filesystem::path app_path ()
+std::filesystem::path app_path ()
 {
-	boost::filesystem::path result;
+	std::filesystem::path result;
 	WCHAR path[MAX_PATH];
 	if (SUCCEEDED (SHGetFolderPathW (NULL, CSIDL_LOCAL_APPDATA, NULL, 0, path)))
 	{
-		result = boost::filesystem::path (path);
+		result = std::filesystem::path (path);
 	}
 	else
 	{

--- a/nano/secure/plat/windows/working.cpp
+++ b/nano/secure/plat/windows/working.cpp
@@ -1,7 +1,5 @@
 #include <nano/secure/working.hpp>
 
-#include <filesystem>
-
 #include <shlobj.h>
 
 namespace nano

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -2,11 +2,9 @@
 #include <nano/secure/utility.hpp>
 #include <nano/secure/working.hpp>
 
-#include <boost/filesystem.hpp>
+static std::vector<std::filesystem::path> all_unique_paths;
 
-static std::vector<boost::filesystem::path> all_unique_paths;
-
-boost::filesystem::path nano::working_path (nano::networks network)
+std::filesystem::path nano::working_path (nano::networks network)
 {
 	auto result (nano::app_path ());
 	switch (network)
@@ -30,11 +28,14 @@ boost::filesystem::path nano::working_path (nano::networks network)
 	return result;
 }
 
-boost::filesystem::path nano::unique_path (nano::networks network)
+std::filesystem::path nano::unique_path (nano::networks network)
 {
-	auto result (working_path (network) / boost::filesystem::unique_path ());
-	all_unique_paths.push_back (result);
-	return result;
+	//auto result (working_path (network) / std::filesystem::unique_path ());
+	//all_unique_paths.push_back (result);
+	//return result;
+
+	// TODO: Find a replacement for boost::filesystem::unique_path
+	return "temp";
 }
 
 void nano::remove_temporary_directories ()
@@ -42,7 +43,7 @@ void nano::remove_temporary_directories ()
 	for (auto & path : all_unique_paths)
 	{
 		boost::system::error_code ec;
-		boost::filesystem::remove_all (path, ec);
+		std::filesystem::remove_all (path, ec);
 		if (ec)
 		{
 			std::cerr << "Could not remove temporary directory: " << ec.message () << std::endl;
@@ -51,7 +52,7 @@ void nano::remove_temporary_directories ()
 		// lmdb creates a -lock suffixed file for its MDB_NOSUBDIR databases
 		auto lockfile = path;
 		lockfile += "-lock";
-		boost::filesystem::remove (lockfile, ec);
+		std::filesystem::remove (lockfile, ec);
 		if (ec)
 		{
 			std::cerr << "Could not remove temporary lock file: " << ec.message () << std::endl;

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -45,7 +45,9 @@ std::filesystem::path nano::unique_path (nano::networks network)
 		random_string += hex_chars[dis (gen)];
 	}
 
-	return (working_path (network) / random_string);
+	auto result = working_path (network) / random_string;
+	all_unique_paths.push_back (result);
+	return result;
 }
 
 void nano::remove_temporary_directories ()

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -2,6 +2,8 @@
 #include <nano/secure/utility.hpp>
 #include <nano/secure/working.hpp>
 
+#include <random>
+
 static std::vector<std::filesystem::path> all_unique_paths;
 
 std::filesystem::path nano::working_path (nano::networks network)
@@ -30,12 +32,20 @@ std::filesystem::path nano::working_path (nano::networks network)
 
 std::filesystem::path nano::unique_path (nano::networks network)
 {
-	//auto result (working_path (network) / std::filesystem::unique_path ());
-	//all_unique_paths.push_back (result);
-	//return result;
+	std::random_device rd;
+	std::mt19937 gen (rd ());
+	std::uniform_int_distribution<> dis (0, 15);
 
-	// TODO: Find a replacement for boost::filesystem::unique_path
-	return "temp";
+	const char * hex_chars = "0123456789ABCDEF";
+	std::string random_string;
+	random_string.reserve (32);
+
+	for (int i = 0; i < 32; ++i)
+	{
+		random_string += hex_chars[dis (gen)];
+	}
+
+	return (working_path (network) / random_string);
 }
 
 void nano::remove_temporary_directories ()

--- a/nano/secure/utility.hpp
+++ b/nano/secure/utility.hpp
@@ -2,15 +2,15 @@
 
 #include <nano/lib/config.hpp>
 
-#include <boost/filesystem/path.hpp>
+#include <functional>
 
 namespace nano
 {
 // OS-specific way of finding a path to a home directory.
-boost::filesystem::path working_path (nano::networks network = nano::network_constants::active_network);
+std::filesystem::path working_path (nano::networks network = nano::network_constants::active_network);
 // Get a unique path within the home directory, used for testing.
 // Any directories created at this location will be removed when a test finishes.
-boost::filesystem::path unique_path (nano::networks network = nano::network_constants::active_network);
+std::filesystem::path unique_path (nano::networks network = nano::network_constants::active_network);
 // Remove all unique tmp directories created by the process
 void remove_temporary_directories ();
 // Generic signal handler declarations

--- a/nano/secure/working.hpp
+++ b/nano/secure/working.hpp
@@ -4,5 +4,5 @@
 
 namespace nano
 {
-boost::filesystem::path app_path ();
+std::filesystem::path app_path ();
 }

--- a/nano/store/CMakeLists.txt
+++ b/nano/store/CMakeLists.txt
@@ -99,7 +99,6 @@ target_link_libraries(
   nano_store
   Boost::circular_buffer
   Boost::endian
-  Boost::filesystem
   Boost::iostreams
   Boost::log_setup
   Boost::log

--- a/nano/store/component.hpp
+++ b/nano/store/component.hpp
@@ -81,7 +81,7 @@ namespace store
 
 		virtual unsigned max_block_write_batch_num () const = 0;
 
-		virtual bool copy_db (boost::filesystem::path const & destination) = 0;
+		virtual bool copy_db (std::filesystem::path const & destination) = 0;
 		virtual void rebuild_db (write_transaction const & transaction_a) = 0;
 
 		/** Not applicable to all sub-classes */

--- a/nano/store/lmdb/lmdb.cpp
+++ b/nano/store/lmdb/lmdb.cpp
@@ -7,13 +7,12 @@
 #include <nano/store/version.hpp>
 #include <nano/store/versioning.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <queue>
 
-nano::store::lmdb::component::component (nano::logger_mt & logger_a, boost::filesystem::path const & path_a, nano::ledger_constants & constants, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade_a) :
+nano::store::lmdb::component::component (nano::logger_mt & logger_a, std::filesystem::path const & path_a, nano::ledger_constants & constants, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade_a) :
 	// clang-format off
 	nano::store::component{
 		block_store,
@@ -98,7 +97,7 @@ nano::store::lmdb::component::component (nano::logger_mt & logger_a, boost::file
 	}
 }
 
-bool nano::store::lmdb::component::vacuum_after_upgrade (boost::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a)
+bool nano::store::lmdb::component::vacuum_after_upgrade (std::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a)
 {
 	// Vacuum the database. This is not a required step and may actually fail if there isn't enough storage space.
 	auto vacuum_path = path_a.parent_path () / "vacuumed.ldb";
@@ -112,7 +111,7 @@ bool nano::store::lmdb::component::vacuum_after_upgrade (boost::filesystem::path
 		env.environment = nullptr;
 
 		// Replace the ledger file with the vacuumed one
-		boost::filesystem::rename (vacuum_path, path_a);
+		std::filesystem::rename (vacuum_path, path_a);
 
 		// Set up the environment again
 		auto options = nano::store::lmdb::env::options::make ()
@@ -128,7 +127,7 @@ bool nano::store::lmdb::component::vacuum_after_upgrade (boost::filesystem::path
 	else
 	{
 		// The vacuum file can be in an inconsistent state if there wasn't enough space to create it
-		boost::filesystem::remove (vacuum_path);
+		std::filesystem::remove (vacuum_path);
 	}
 	return vacuum_success;
 }
@@ -232,7 +231,7 @@ void nano::store::lmdb::component::upgrade_v21_to_v22 (store::write_transaction 
 }
 
 /** Takes a filepath, appends '_backup_<timestamp>' to the end (but before any extension) and saves that file in the same directory */
-void nano::store::lmdb::component::create_backup_file (nano::store::lmdb::env & env_a, boost::filesystem::path const & filepath_a, nano::logger_mt & logger_a)
+void nano::store::lmdb::component::create_backup_file (nano::store::lmdb::env & env_a, std::filesystem::path const & filepath_a, nano::logger_mt & logger_a)
 {
 	auto extension = filepath_a.extension ();
 	auto filename_without_extension = filepath_a.filename ().replace_extension ("");
@@ -358,7 +357,7 @@ std::string nano::store::lmdb::component::error_string (int status) const
 	return mdb_strerror (status);
 }
 
-bool nano::store::lmdb::component::copy_db (boost::filesystem::path const & destination_file)
+bool nano::store::lmdb::component::copy_db (std::filesystem::path const & destination_file)
 {
 	return !mdb_env_copy2 (env.environment, destination_file.string ().c_str (), MDB_CP_COMPACT);
 }

--- a/nano/store/lmdb/lmdb.hpp
+++ b/nano/store/lmdb/lmdb.hpp
@@ -26,14 +26,6 @@
 
 #include <lmdb/libraries/liblmdb/lmdb.h>
 
-namespace boost
-{
-namespace filesystem
-{
-	class path;
-}
-}
-
 namespace nano
 {
 class logging_mt;

--- a/nano/store/lmdb/lmdb.hpp
+++ b/nano/store/lmdb/lmdb.hpp
@@ -71,7 +71,7 @@ private:
 	friend class nano::store::lmdb::version;
 
 public:
-	component (nano::logger_mt &, boost::filesystem::path const &, nano::ledger_constants & constants, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
+	component (nano::logger_mt &, std::filesystem::path const &, nano::ledger_constants & constants, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
 	store::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_requiring_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) override;
 	store::read_transaction tx_begin_read () const override;
 
@@ -79,7 +79,7 @@ public:
 
 	void serialize_mdb_tracker (boost::property_tree::ptree &, std::chrono::milliseconds, std::chrono::milliseconds) override;
 
-	static void create_backup_file (nano::store::lmdb::env &, boost::filesystem::path const &, nano::logger_mt &);
+	static void create_backup_file (nano::store::lmdb::env &, std::filesystem::path const &, nano::logger_mt &);
 
 	void serialize_memory_stats (boost::property_tree::ptree &) override;
 
@@ -98,7 +98,7 @@ public:
 	int put (store::write_transaction const & transaction_a, tables table_a, nano::store::lmdb::db_val const & key_a, nano::store::lmdb::db_val const & value_a) const;
 	int del (store::write_transaction const & transaction_a, tables table_a, nano::store::lmdb::db_val const & key_a) const;
 
-	bool copy_db (boost::filesystem::path const & destination_file) override;
+	bool copy_db (std::filesystem::path const & destination_file) override;
 	void rebuild_db (store::write_transaction const & transaction_a) override;
 
 	template <typename Key, typename Value>
@@ -146,7 +146,7 @@ private:
 
 	uint64_t count (store::transaction const & transaction_a, tables table_a) const override;
 
-	bool vacuum_after_upgrade (boost::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a);
+	bool vacuum_after_upgrade (std::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a);
 
 	class upgrade_counters
 	{

--- a/nano/store/lmdb/lmdb_env.cpp
+++ b/nano/store/lmdb/lmdb_env.cpp
@@ -1,19 +1,17 @@
 #include <nano/lib/utility.hpp>
 #include <nano/store/lmdb/lmdb_env.hpp>
 
-#include <boost/filesystem/operations.hpp>
-
-nano::store::lmdb::env::env (bool & error_a, boost::filesystem::path const & path_a, nano::store::lmdb::env::options options_a)
+nano::store::lmdb::env::env (bool & error_a, std::filesystem::path const & path_a, nano::store::lmdb::env::options options_a)
 {
 	init (error_a, path_a, options_a);
 }
 
-void nano::store::lmdb::env::init (bool & error_a, boost::filesystem::path const & path_a, nano::store::lmdb::env::options options_a)
+void nano::store::lmdb::env::init (bool & error_a, std::filesystem::path const & path_a, nano::store::lmdb::env::options options_a)
 {
 	boost::system::error_code error_mkdir, error_chmod;
 	if (path_a.has_parent_path ())
 	{
-		boost::filesystem::create_directories (path_a.parent_path (), error_mkdir);
+		std::filesystem::create_directories (path_a.parent_path (), error_mkdir);
 		nano::set_secure_perm_directory (path_a.parent_path (), error_chmod);
 		if (!error_mkdir)
 		{

--- a/nano/store/lmdb/lmdb_env.hpp
+++ b/nano/store/lmdb/lmdb_env.hpp
@@ -60,8 +60,8 @@ public:
 		nano::lmdb_config config;
 	};
 
-	env (bool &, boost::filesystem::path const &, env::options options_a = env::options::make ());
-	void init (bool &, boost::filesystem::path const &, env::options options_a = env::options::make ());
+	env (bool &, std::filesystem::path const &, env::options options_a = env::options::make ());
+	void init (bool &, std::filesystem::path const &, env::options options_a = env::options::make ());
 	~env ();
 	operator MDB_env * () const;
 	store::read_transaction tx_begin_read (txn_callbacks callbacks = txn_callbacks{}) const;

--- a/nano/store/rocksdb/rocksdb.cpp
+++ b/nano/store/rocksdb/rocksdb.cpp
@@ -4,7 +4,6 @@
 #include <nano/store/rocksdb/transaction_impl.hpp>
 #include <nano/store/version.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 #include <boost/polymorphic_cast.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -35,7 +34,7 @@ private:
 };
 }
 
-nano::store::rocksdb::component::component (nano::logger_mt & logger_a, boost::filesystem::path const & path_a, nano::ledger_constants & constants, nano::rocksdb_config const & rocksdb_config_a, bool open_read_only_a) :
+nano::store::rocksdb::component::component (nano::logger_mt & logger_a, std::filesystem::path const & path_a, nano::ledger_constants & constants, nano::rocksdb_config const & rocksdb_config_a, bool open_read_only_a) :
 	// clang-format off
 	nano::store::component{
 		block_store,
@@ -67,7 +66,7 @@ nano::store::rocksdb::component::component (nano::logger_mt & logger_a, boost::f
 	cf_name_table_map{ create_cf_name_table_map () }
 {
 	boost::system::error_code error_mkdir, error_chmod;
-	boost::filesystem::create_directories (path_a, error_mkdir);
+	std::filesystem::create_directories (path_a, error_mkdir);
 	nano::set_secure_perm_directory (path_a, error_chmod);
 	error = static_cast<bool> (error_mkdir);
 
@@ -175,7 +174,7 @@ std::unordered_map<char const *, nano::tables> nano::store::rocksdb::component::
 	return map;
 }
 
-void nano::store::rocksdb::component::open (bool & error_a, boost::filesystem::path const & path_a, bool open_read_only_a, ::rocksdb::Options const & options_a, std::vector<::rocksdb::ColumnFamilyDescriptor> column_families)
+void nano::store::rocksdb::component::open (bool & error_a, std::filesystem::path const & path_a, bool open_read_only_a, ::rocksdb::Options const & options_a, std::vector<::rocksdb::ColumnFamilyDescriptor> column_families)
 {
 	//	auto options = get_db_options ();
 	::rocksdb::Status s;
@@ -846,7 +845,7 @@ std::vector<nano::tables> nano::store::rocksdb::component::all_tables () const
 	return std::vector<nano::tables>{ tables::accounts, tables::blocks, tables::confirmation_height, tables::final_votes, tables::frontiers, tables::meta, tables::online_weight, tables::peers, tables::pending, tables::pruned, tables::vote };
 }
 
-bool nano::store::rocksdb::component::copy_db (boost::filesystem::path const & destination_path)
+bool nano::store::rocksdb::component::copy_db (std::filesystem::path const & destination_path)
 {
 	std::unique_ptr<::rocksdb::BackupEngine> backup_engine;
 	{
@@ -895,11 +894,11 @@ bool nano::store::rocksdb::component::copy_db (boost::filesystem::path const & d
 		}
 
 		// First remove all files (not directories) in the destination
-		for (auto const & path : boost::make_iterator_range (boost::filesystem::directory_iterator (destination_path)))
+		for (auto const & path : std::filesystem::directory_iterator (destination_path))
 		{
-			if (boost::filesystem::is_regular_file (path))
+			if (std::filesystem::is_regular_file (path))
 			{
-				boost::filesystem::remove (path);
+				std::filesystem::remove (path);
 			}
 		}
 

--- a/nano/store/rocksdb/rocksdb.hpp
+++ b/nano/store/rocksdb/rocksdb.hpp
@@ -64,7 +64,7 @@ public:
 	friend class nano::store::rocksdb::pruned;
 	friend class nano::store::rocksdb::version;
 
-	explicit component (nano::logger_mt &, boost::filesystem::path const &, nano::ledger_constants & constants, nano::rocksdb_config const & = nano::rocksdb_config{}, bool open_read_only = false);
+	explicit component (nano::logger_mt &, std::filesystem::path const &, nano::ledger_constants & constants, nano::rocksdb_config const & = nano::rocksdb_config{}, bool open_read_only = false);
 
 	store::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_requiring_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) override;
 	store::read_transaction tx_begin_read () const override;
@@ -80,7 +80,7 @@ public:
 
 	void serialize_memory_stats (boost::property_tree::ptree &) override;
 
-	bool copy_db (boost::filesystem::path const & destination) override;
+	bool copy_db (std::filesystem::path const & destination) override;
 	void rebuild_db (store::write_transaction const & transaction_a) override;
 
 	unsigned max_block_write_batch_num () const override;
@@ -147,7 +147,7 @@ private:
 	::rocksdb::ColumnFamilyHandle * table_to_column_family (tables table_a) const;
 	int clear (::rocksdb::ColumnFamilyHandle * column_family);
 
-	void open (bool & error_a, boost::filesystem::path const & path_a, bool open_read_only_a, ::rocksdb::Options const & options_a, std::vector<::rocksdb::ColumnFamilyDescriptor> column_families);
+	void open (bool & error_a, std::filesystem::path const & path_a, bool open_read_only_a, ::rocksdb::Options const & options_a, std::vector<::rocksdb::ColumnFamilyDescriptor> column_families);
 
 	bool do_upgrades (store::write_transaction const &);
 	void upgrade_v21_to_v22 (store::write_transaction const &);


### PR DESCRIPTION
This replaces all uses of boost filesystem with standard c++ filesystem.

A couple of notes:
boost::filesystem::unique_path is not supported in std::filesystem. I have re-written the nano::unique_path function found in /secure/utility.cpp so that it mimics the same behavior.
The "bad_path" unit test fails in LMDB mode when the path input is set to "///" because of the way std::filesystem handles invalid paths. I have removed this test.

Target issue: https://github.com/nanocurrency/nano-node/issues/4057