### PR TITLE
Encapsulate election mutex

### DIFF
--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -137,8 +137,7 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	// Add a vote for something else, not the winner
 	for (auto const & rep : representatives)
 	{
-		nano::lock_guard<nano::mutex> guard (election->mutex);
-		election->last_votes[rep.account] = { std::chrono::steady_clock::now (), 1, 1 };
+		election->set_last_vote (rep.account, { std::chrono::steady_clock::now (), 1, 1 });
 	}
 	ASSERT_FALSE (solicitor.add (*election));
 	ASSERT_FALSE (solicitor.broadcast (*election));

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -144,8 +144,9 @@ void nano::active_transactions::handle_confirmation (nano::store::read_transacti
 
 	handle_block_confirmation (transaction, block, hash, account, amount, is_state_send, is_state_epoch, pending_account);
 
-	election->set_status_type (status_type);
-	notify_observers (election, account, amount, is_state_send, is_state_epoch, pending_account);
+	auto status = election->set_status_type (status_type);
+	auto votes = election->votes_with_weight ();
+	notify_observers (status, votes, account, amount, is_state_send, is_state_epoch, pending_account);
 }
 
 void nano::active_transactions::handle_block_confirmation (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block, nano::block_hash const & hash, nano::account & account, nano::uint128_t & amount, bool & is_state_send, bool & is_state_epoch, nano::account & pending_account)
@@ -155,11 +156,8 @@ void nano::active_transactions::handle_block_confirmation (nano::store::read_tra
 	node.process_confirmed_data (transaction, block, hash, account, amount, is_state_send, is_state_epoch, pending_account);
 }
 
-void nano::active_transactions::notify_observers (std::shared_ptr<nano::election> const & election, nano::account const & account, nano::uint128_t amount, bool is_state_send, bool is_state_epoch, nano::account const & pending_account)
+void nano::active_transactions::notify_observers (nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes, nano::account const & account, nano::uint128_t amount, bool is_state_send, bool is_state_epoch, nano::account const & pending_account)
 {
-	auto status = election->get_status ();
-	auto votes = election->votes_with_weight ();
-
 	node.observers.blocks.notify (status, votes, account, amount, is_state_send, is_state_epoch);
 
 	if (amount > 0)

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -204,7 +204,7 @@ private:
 	void handle_confirmation (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block, std::shared_ptr<nano::election> election, nano::election_status_type status);
 	void activate_successors (const nano::account & account, std::shared_ptr<nano::block> const & block, nano::store::read_transaction const & transaction);
 	void handle_block_confirmation (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block, nano::block_hash const & hash, nano::account & account, nano::uint128_t & amount, bool & is_state_send, bool & is_state_epoch, nano::account & pending_account);
-	void notify_observers (std::shared_ptr<nano::election> const & election, nano::account const & account, nano::uint128_t amount, bool is_state_send, bool is_state_epoch, nano::account const & pending_account);
+	void notify_observers (nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes, nano::account const & account, nano::uint128_t amount, bool is_state_send, bool is_state_epoch, nano::account const & pending_account);
 
 private: // Dependencies
 	nano::confirmation_height_processor & confirmation_height_processor;

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -203,9 +203,7 @@ private:
 	void handle_final_votes_confirmation (std::shared_ptr<nano::block> const & block, nano::store::read_transaction const & transaction, nano::election_status_type status);
 	void handle_confirmation (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block, std::shared_ptr<nano::election> election, nano::election_status_type status);
 	void activate_successors (const nano::account & account, std::shared_ptr<nano::block> const & block, nano::store::read_transaction const & transaction);
-	void update_recently_cemented (std::shared_ptr<nano::election> const & election);
 	void handle_block_confirmation (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block, nano::block_hash const & hash, nano::account & account, nano::uint128_t & amount, bool & is_state_send, bool & is_state_epoch, nano::account & pending_account);
-	void update_election_status (std::shared_ptr<nano::election> election, nano::election_status_type status);
 	void notify_observers (std::shared_ptr<nano::election> const & election, nano::account const & account, nano::uint128_t amount, bool is_state_send, bool is_state_epoch, nano::account const & pending_account);
 
 private: // Dependencies

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -141,12 +141,17 @@ public: // Interface
 	bool publish (std::shared_ptr<nano::block> const & block_a);
 	// Confirm this block if quorum is met
 	void confirm_if_quorum (nano::unique_lock<nano::mutex> &);
+	boost::optional<nano::election_status_type> try_confirm (nano::block_hash const & hash);
+	nano::election_status set_status_type (nano::election_status_type status_type);
 
 	/**
 	 * Broadcasts vote for the current winner of this election
 	 * Checks if sufficient amount of time (`vote_generation_interval`) passed since the last vote generation
 	 */
 	void broadcast_vote ();
+	nano::vote_info get_last_vote (nano::account const & account);
+	void set_last_vote (nano::account const & account, nano::vote_info vote_info);
+	nano::election_status get_status () const;
 
 private: // Dependencies
 	nano::node & node;


### PR DESCRIPTION
This PR fixes an issue pointed out by @pwojcikdev  introduced in #4306  where in `notify_observers`,
`auto status = election->status;`was called  without holding the election lock.

It makes use of @simpago work of [encapsulating the mutex of election class ](https://github.com/simpago/rsnano-node/commit/ee1cd2dbee3671136da01af313850e1a00e00688) for rsnano.