### PR TITLE
Prevent election winner from being immediately reinserted into AEC

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -326,11 +326,7 @@ void nano::active_transactions::cleanup_election (nano::unique_lock<nano::mutex>
 {
 	debug_assert (!mutex.try_lock ());
 	debug_assert (lock_a.owns_lock ());
-
-	if (election->confirmed ())
-	{
-		debug_assert (recently_confirmed.exists (election->qualified_root));
-	}
+	debug_assert (!election->confirmed () || recently_confirmed.exists (election->qualified_root));
 
 	node.stats.inc (completion_type (*election), nano::to_stat_detail (election->behavior ()));
 	// Keep track of election count by election type

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -327,6 +327,11 @@ void nano::active_transactions::cleanup_election (nano::unique_lock<nano::mutex>
 	debug_assert (!mutex.try_lock ());
 	debug_assert (lock_a.owns_lock ());
 
+	if (election->confirmed ())
+	{
+		debug_assert (recently_confirmed.exists (election->qualified_root));
+	}
+
 	node.stats.inc (completion_type (*election), nano::to_stat_detail (election->behavior ()));
 	// Keep track of election count by election type
 	debug_assert (count_by_behavior[election->behavior ()] > 0);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1386,7 +1386,6 @@ void nano::node::process_confirmed (nano::election_status const & status_a, uint
 	decltype (iteration_a) const num_iters = (config.block_processor_batch_max_time / network_params.node.process_confirmed_interval) * 4;
 	if (auto block_l = ledger.store.block.get (ledger.store.tx_begin_read (), hash))
 	{
-		active.recently_confirmed.put (block_l->qualified_root (), hash);
 		confirmation_height_processor.add (block_l);
 	}
 	else if (iteration_a < num_iters)


### PR DESCRIPTION
Test `active_transactions.inactive_votes_cache_fork` test is failing intermittently because of an AEC race condition. The problem is that is possible that a block that won an election will be immediately reinserted into the AEC. There is no way to atomically switch election to confirmed state and register it as recently confirmed, so this PR minimizes the chance of that happening. I think in this case the design tries to be too smart to the point of being impossible to implement with full correctness.