### PR TITLE
Round LRU time to nearest 32 seconds

### DIFF
--- a/nano/node/scheduler/bucket.cpp
+++ b/nano/node/scheduler/bucket.cpp
@@ -35,7 +35,10 @@ void nano::scheduler::bucket::pop ()
 
 void nano::scheduler::bucket::push (uint64_t time, std::shared_ptr<nano::block> block)
 {
-	queue.insert ({ time, block });
+	const uint64_t bitmask = ~0b11111;
+	uint64_t rounded_time = time & bitmask;
+
+	queue.insert ({ rounded_time, block });
 	if (queue.size () > maximum)
 	{
 		debug_assert (!queue.empty ());


### PR DESCRIPTION
By rounding LRU time we are more likely to get AEC aligned across the network because blocks that are published very fast are grouped in 32 seconds "slots" that are sorted by hash.
This pr uses a 5 bit mask for rounding for best performance.
60 seconds rounding has been suggested but I chose 32 seconds to err on the side of caution and because Piotr mentioned that down to 15 seconds might be enough