### PR TITLE
Beta testing without block gossip and 255votes/message

### DIFF
--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -119,10 +119,10 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 	std::error_code ec;
 	flags_a.disable_add_initial_peers = (vm.count ("disable_add_initial_peers") > 0);
 	flags_a.disable_backup = (vm.count ("disable_backup") > 0);
-	flags_a.disable_lazy_bootstrap = (vm.count ("disable_lazy_bootstrap") > 0);
-	flags_a.disable_legacy_bootstrap = (vm.count ("disable_legacy_bootstrap") > 0);
-	flags_a.disable_wallet_bootstrap = (vm.count ("disable_wallet_bootstrap") > 0);
-	flags_a.disable_ongoing_bootstrap = (vm.count ("disable_ongoing_bootstrap") > 0);
+	flags_a.disable_lazy_bootstrap = (vm.count ("disable_lazy_bootstrap") <= 0);
+	flags_a.disable_legacy_bootstrap = (vm.count ("disable_legacy_bootstrap") <= 0);
+	flags_a.disable_wallet_bootstrap = (vm.count ("disable_wallet_bootstrap") <= 0);
+	flags_a.disable_ongoing_bootstrap = (vm.count ("disable_ongoing_bootstrap") <= 0);
 	flags_a.disable_ascending_bootstrap = (vm.count ("disable_ascending_bootstrap") <= 0);
 	flags_a.disable_rep_crawler = (vm.count ("disable_rep_crawler") > 0);
 	flags_a.disable_request_loop = (vm.count ("disable_request_loop") > 0);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -123,7 +123,7 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 	flags_a.disable_legacy_bootstrap = (vm.count ("disable_legacy_bootstrap") > 0);
 	flags_a.disable_wallet_bootstrap = (vm.count ("disable_wallet_bootstrap") > 0);
 	flags_a.disable_ongoing_bootstrap = (vm.count ("disable_ongoing_bootstrap") > 0);
-	flags_a.disable_ascending_bootstrap = (vm.count ("disable_ascending_bootstrap") > 0);
+	flags_a.disable_ascending_bootstrap = (vm.count ("disable_ascending_bootstrap") <= 0);
 	flags_a.disable_rep_crawler = (vm.count ("disable_rep_crawler") > 0);
 	flags_a.disable_request_loop = (vm.count ("disable_request_loop") > 0);
 	if (!flags_a.inactive_node)

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -46,7 +46,7 @@ bool nano::confirmation_solicitor::broadcast (nano::election const & election_a)
 			}
 		}
 		// Random flood for block propagation
-		network.flood_message (winner, nano::transport::buffer_drop_policy::limiter, 0.5f);
+		// network.flood_message (winner, nano::transport::buffer_drop_policy::limiter, 0.5f);
 		error = false;
 	}
 	return error;

--- a/nano/node/messages.cpp
+++ b/nano/node/messages.cpp
@@ -192,17 +192,18 @@ void nano::message_header::block_type_set (nano::block_type type_a)
 	extensions |= std::bitset<16> (static_cast<unsigned long long> (type_a) << 8);
 }
 
-uint8_t nano::message_header::count_get () const
+uint8_t nano::message_header::count_get() const
 {
-	return static_cast<uint8_t> (((extensions & count_mask) >> 12).to_ullong ());
+    return static_cast<uint8_t>((extensions & count_mask).to_ullong());
 }
 
-void nano::message_header::count_set (uint8_t count_a)
+void nano::message_header::count_set(uint8_t count_a)
 {
-	debug_assert (count_a < 16);
-	extensions &= ~count_mask;
-	extensions |= std::bitset<16> (static_cast<unsigned long long> (count_a) << 12);
+    debug_assert(count_a < 256); // Because we're using 8 bits now
+    extensions &= ~count_mask;
+    extensions |= std::bitset<16>(static_cast<unsigned long long>(count_a));
 }
+
 
 void nano::message_header::flag_set (uint8_t flag_a, bool enable)
 {

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -92,7 +92,7 @@ public:
 	bool is_valid_message_type () const;
 
 	static std::bitset<16> constexpr block_type_mask{ 0x0f00 };
-	static std::bitset<16> constexpr count_mask{ 0xf000 };
+	static std::bitset<16> constexpr count_mask{ 0x00ff };
 	static std::bitset<16> constexpr telemetry_size_mask{ 0x3ff };
 };
 

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -164,7 +164,10 @@ void nano::network::flood_keepalive_self (float const scale_a)
 void nano::network::flood_block (std::shared_ptr<nano::block> const & block_a, nano::transport::buffer_drop_policy const drop_policy_a)
 {
 	nano::publish message (node.network_params.network, block_a);
-	flood_message (message, drop_policy_a);
+	// broadcast to `ceil(0.2 * √peer_count )`
+	// for beta: ~1 random peer instead 4
+	// for live: ~3 random peers instead 15
+	flood_message (message, drop_policy_a, 0.2);
 }
 
 void nano::network::flood_block_initial (std::shared_ptr<nano::block> const & block_a)

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -163,6 +163,8 @@ void nano::network::flood_keepalive_self (float const scale_a)
 
 void nano::network::flood_block (std::shared_ptr<nano::block> const & block_a, nano::transport::buffer_drop_policy const drop_policy_a)
 {
+	return ; // disable block gossip
+
 	nano::publish message (node.network_params.network, block_a);
 	// broadcast to `ceil(0.2 * √peer_count )`
 	// for beta: ~1 random peer instead 4
@@ -177,7 +179,7 @@ void nano::network::flood_block_initial (std::shared_ptr<nano::block> const & bl
 	{
 		i.channel->send (message, nullptr, nano::transport::buffer_drop_policy::no_limiter_drop);
 	}
-	for (auto & i : list_non_pr (fanout (1.0)))
+	for (auto & i : list_non_pr (size())) //send to all non prs
 	{
 		i->send (message, nullptr, nano::transport::buffer_drop_policy::no_limiter_drop);
 	}

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -155,7 +155,7 @@ public:
 	static unsigned const broadcast_interval_ms = 10;
 	static std::size_t const buffer_size = 512;
 	static std::size_t const confirm_req_hashes_max = 7;
-	static std::size_t const confirm_ack_hashes_max = 12;
+	static std::size_t const confirm_ack_hashes_max = 255;
 };
 std::unique_ptr<container_info_component> collect_container_info (network & network, std::string const & name);
 }

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -94,9 +94,9 @@ public:
 	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_dev_network () && !is_sanitizer_build ()) ? std::chrono::seconds (5) : std::chrono::seconds (15) };
 	std::chrono::nanoseconds pow_sleep_interval{ 0 };
 	// TODO: Move related settings to `active_transactions_config` class
-	std::size_t active_elections_size{ 5000 };
+	std::size_t active_elections_size{ 2000 };
 	/** Limit of hinted elections as percentage of `active_elections_size` */
-	std::size_t active_elections_hinted_limit_percentage{ 20 };
+	std::size_t active_elections_hinted_limit_percentage{ 50 };
 	/** Limit of optimistic elections as percentage of `active_elections_size` */
 	std::size_t active_elections_optimistic_limit_percentage{ 10 };
 	/** Default maximum incoming TCP connections, including realtime network & bootstrap */


### PR DESCRIPTION
A draft pull request for beta testing
- disable all bootstrapping
- disable all block gossip but publish new blocks to all peers
- 255 votes/confirm_ack
- modify AEC to 2000 with 50% hinted allocation