### PR TITLE
Make hinted and optimistic AEC allocation configurable

### DIFF
--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -117,6 +117,8 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("use_memory_pools", use_memory_pools, "If true, allocate memory from memory pools. Enabling this may improve performance. Memory is never released to the OS.\ntype:bool");
 	toml.put ("confirmation_history_size", confirmation_history_size, "Maximum confirmation history size. If tracking the rate of block confirmations, the websocket feature is recommended instead.\ntype:uint64");
 	toml.put ("active_elections_size", active_elections_size, "Number of active elections. Elections beyond this limit have limited survival time.\nWarning: modifying this value may result in a lower confirmation rate.\ntype:uint64,[250..]");
+	toml.put ("active_elections_hinted_limit_percentage", active_elections_hinted_limit_percentage, "Limit of hinted elections as percentage of `active_elections_size`. \ntype:uint64");
+	toml.put ("active_elections_optimistic_limit_percentage", active_elections_optimistic_limit_percentage, "Limit of optimistic elections as percentage of `active_elections_size`. \ntype:uint64");
 
 	toml.put ("bandwidth_limit", bandwidth_limit, "Outbound traffic limit in bytes/sec after which messages will be dropped.\nNote: changing to unlimited bandwidth (0) is not recommended for limited connections.\ntype:uint64");
 	toml.put ("bandwidth_limit_burst_ratio", bandwidth_limit_burst_ratio, "Burst ratio for outbound traffic shaping.\ntype:double");
@@ -409,6 +411,8 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		toml.get<bool> ("use_memory_pools", use_memory_pools);
 		toml.get<std::size_t> ("confirmation_history_size", confirmation_history_size);
 		toml.get<std::size_t> ("active_elections_size", active_elections_size);
+		toml.get<std::size_t> ("active_elections_hinted_limit_percentage", active_elections_hinted_limit_percentage);
+		toml.get<std::size_t> ("active_elections_optimistic_limit_percentage", active_elections_optimistic_limit_percentage);
 
 		toml.get<std::size_t> ("bandwidth_limit", bandwidth_limit);
 		toml.get<double> ("bandwidth_limit_burst_ratio", bandwidth_limit_burst_ratio);


### PR DESCRIPTION
During the beta tests I noticed that modifying `active_elections_hinted_limit_percentage` in the config-node.toml isn't applied correctly.

This PR adds
- active_elections_hinted_limit_percentage
- active_elections_optimistic_limit_percentage
to nodeconfig.cpp