### PR TITLE
Periodically refresh read transaction inside hinted scheduler

### DIFF
--- a/nano/node/scheduler/hinted.hpp
+++ b/nano/node/scheduler/hinted.hpp
@@ -3,6 +3,7 @@
 #include <nano/lib/locks.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/secure/common.hpp>
+#include <nano/store/transaction.hpp>
 
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/ordered_index.hpp>
@@ -61,7 +62,7 @@ private:
 	bool predicate () const;
 	void run ();
 	void run_iterative ();
-	void activate (nano::store::transaction const &, nano::block_hash const & hash, bool check_dependents);
+	void activate (nano::store::read_transaction const &, nano::block_hash const & hash, bool check_dependents);
 
 	nano::uint128_t tally_threshold () const;
 	nano::uint128_t final_tally_threshold () const;

--- a/nano/store/transaction.hpp
+++ b/nano/store/transaction.hpp
@@ -56,9 +56,11 @@ public:
 	void reset () const;
 	void renew () const;
 	void refresh () const;
+	void refresh_if_needed (std::chrono::milliseconds max_age = std::chrono::milliseconds{ 500 }) const;
 
 private:
 	std::unique_ptr<read_transaction_impl> impl;
+	mutable std::chrono::steady_clock::time_point start;
 };
 
 /**
@@ -75,9 +77,11 @@ public:
 	void commit ();
 	void renew ();
 	void refresh ();
+	void refresh_if_needed (std::chrono::milliseconds max_age = std::chrono::milliseconds{ 500 });
 	bool contains (nano::tables table_a) const;
 
 private:
 	std::unique_ptr<write_transaction_impl> impl;
+	std::chrono::steady_clock::time_point start;
 };
 } // namespace nano::store


### PR DESCRIPTION
This fixes the issue of read transaction being held for prolonged periods of time causing ledger bloat.