### PR TITLE
Periodically refresh read transaction in `backlog_population`

### DIFF
--- a/nano/node/backlog_population.cpp
+++ b/nano/node/backlog_population.cpp
@@ -95,6 +95,8 @@ void nano::backlog_population::populate_backlog (nano::unique_lock<nano::mutex> 
 			auto const end = store.account.end ();
 			for (; i != end && count < chunk_size; ++i, ++count, ++total)
 			{
+				transaction.refresh_if_needed ();
+
 				stats.inc (nano::stat::type::backlog, nano::stat::detail::total);
 
 				auto const & account = i->first;


### PR DESCRIPTION
It is possible that with sufficiently slow IO the read lock will be held for prolonged periods of time, this PR avoids that.