### PR TITLE
Fixes for hinted scheduler & vote cache

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -275,6 +275,7 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.hinted_scheduler.hinting_threshold_percent, defaults.node.hinted_scheduler.hinting_threshold_percent);
 	ASSERT_EQ (conf.node.hinted_scheduler.check_interval.count (), defaults.node.hinted_scheduler.check_interval.count ());
 	ASSERT_EQ (conf.node.hinted_scheduler.block_cooldown.count (), defaults.node.hinted_scheduler.block_cooldown.count ());
+	ASSERT_EQ (conf.node.hinted_scheduler.vacancy_threshold_percent, defaults.node.hinted_scheduler.vacancy_threshold_percent);
 
 	ASSERT_EQ (conf.node.vote_cache.max_size, defaults.node.vote_cache.max_size);
 	ASSERT_EQ (conf.node.vote_cache.max_voters, defaults.node.vote_cache.max_voters);
@@ -543,6 +544,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	hinting_threshold = 99
 	check_interval = 999
 	block_cooldown = 999
+	vacancy_threshold = 99
 
 	[node.rocksdb]
 	enable = true
@@ -720,6 +722,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.hinted_scheduler.hinting_threshold_percent, defaults.node.hinted_scheduler.hinting_threshold_percent);
 	ASSERT_NE (conf.node.hinted_scheduler.check_interval.count (), defaults.node.hinted_scheduler.check_interval.count ());
 	ASSERT_NE (conf.node.hinted_scheduler.block_cooldown.count (), defaults.node.hinted_scheduler.block_cooldown.count ());
+	ASSERT_NE (conf.node.hinted_scheduler.vacancy_threshold_percent, defaults.node.hinted_scheduler.vacancy_threshold_percent);
 
 	ASSERT_NE (conf.node.vote_cache.max_size, defaults.node.vote_cache.max_size);
 	ASSERT_NE (conf.node.vote_cache.max_voters, defaults.node.vote_cache.max_voters);

--- a/nano/core_test/vote_cache.cpp
+++ b/nano/core_test/vote_cache.cpp
@@ -36,8 +36,9 @@ nano::keypair create_rep (nano::uint128_t weight)
 
 TEST (vote_cache, construction)
 {
+	nano::test::system system;
 	nano::vote_cache_config cfg;
-	nano::vote_cache vote_cache{ cfg };
+	nano::vote_cache vote_cache{ cfg, system.stats };
 	ASSERT_EQ (0, vote_cache.size ());
 	ASSERT_TRUE (vote_cache.empty ());
 	auto hash1 = nano::test::random_hash ();
@@ -49,8 +50,9 @@ TEST (vote_cache, construction)
  */
 TEST (vote_cache, insert_one_hash)
 {
+	nano::test::system system;
 	nano::vote_cache_config cfg;
-	nano::vote_cache vote_cache{ cfg };
+	nano::vote_cache vote_cache{ cfg, system.stats };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto rep1 = create_rep (7);
 	auto hash1 = nano::test::random_hash ();
@@ -79,8 +81,9 @@ TEST (vote_cache, insert_one_hash)
  */
 TEST (vote_cache, insert_one_hash_many_votes)
 {
+	nano::test::system system;
 	nano::vote_cache_config cfg;
-	nano::vote_cache vote_cache{ cfg };
+	nano::vote_cache vote_cache{ cfg, system.stats };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto hash1 = nano::test::random_hash ();
 	auto rep1 = create_rep (7);
@@ -114,8 +117,9 @@ TEST (vote_cache, insert_one_hash_many_votes)
  */
 TEST (vote_cache, insert_many_hashes_many_votes)
 {
+	nano::test::system system;
 	nano::vote_cache_config cfg;
-	nano::vote_cache vote_cache{ cfg };
+	nano::vote_cache vote_cache{ cfg, system.stats };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	// There will be 3 random hashes to vote for
 	auto hash1 = nano::test::random_hash ();
@@ -194,8 +198,9 @@ TEST (vote_cache, insert_many_hashes_many_votes)
  */
 TEST (vote_cache, insert_duplicate)
 {
+	nano::test::system system;
 	nano::vote_cache_config cfg;
-	nano::vote_cache vote_cache{ cfg };
+	nano::vote_cache vote_cache{ cfg, system.stats };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto hash1 = nano::test::random_hash ();
 	auto rep1 = create_rep (9);
@@ -211,8 +216,9 @@ TEST (vote_cache, insert_duplicate)
  */
 TEST (vote_cache, insert_newer)
 {
+	nano::test::system system;
 	nano::vote_cache_config cfg;
-	nano::vote_cache vote_cache{ cfg };
+	nano::vote_cache vote_cache{ cfg, system.stats };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto hash1 = nano::test::random_hash ();
 	auto rep1 = create_rep (9);
@@ -236,8 +242,9 @@ TEST (vote_cache, insert_newer)
  */
 TEST (vote_cache, insert_older)
 {
+	nano::test::system system;
 	nano::vote_cache_config cfg;
-	nano::vote_cache vote_cache{ cfg };
+	nano::vote_cache vote_cache{ cfg, system.stats };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto hash1 = nano::test::random_hash ();
 	auto rep1 = create_rep (9);
@@ -259,8 +266,9 @@ TEST (vote_cache, insert_older)
  */
 TEST (vote_cache, erase)
 {
+	nano::test::system system;
 	nano::vote_cache_config cfg;
-	nano::vote_cache vote_cache{ cfg };
+	nano::vote_cache vote_cache{ cfg, system.stats };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	auto hash1 = nano::test::random_hash ();
 	auto hash2 = nano::test::random_hash ();
@@ -298,10 +306,11 @@ TEST (vote_cache, erase)
  */
 TEST (vote_cache, overfill)
 {
+	nano::test::system system;
 	// Create a vote cache with max size set to 1024
 	nano::vote_cache_config cfg;
 	cfg.max_size = 1024;
-	nano::vote_cache vote_cache{ cfg };
+	nano::vote_cache vote_cache{ cfg, system.stats };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	const int count = 16 * 1024;
 	for (int n = 0; n < count; ++n)
@@ -324,8 +333,9 @@ TEST (vote_cache, overfill)
  */
 TEST (vote_cache, overfill_entry)
 {
+	nano::test::system system;
 	nano::vote_cache_config cfg;
-	nano::vote_cache vote_cache{ cfg };
+	nano::vote_cache vote_cache{ cfg, system.stats };
 	vote_cache.rep_weight_query = rep_weight_query ();
 	const int count = 1024;
 	auto hash1 = nano::test::random_hash ();
@@ -337,3 +347,5 @@ TEST (vote_cache, overfill_entry)
 	}
 	ASSERT_EQ (1, vote_cache.size ());
 }
+
+TEST (vote_cache, 

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(
   errors.hpp
   errors.cpp
   id_dispenser.hpp
+  interval.hpp
   ipc.hpp
   ipc.cpp
   ipc_client.hpp

--- a/nano/lib/interval.hpp
+++ b/nano/lib/interval.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <chrono>
+
+namespace nano
+{
+class interval
+{
+public:
+	explicit interval (std::chrono::milliseconds target) :
+		target{ target }
+	{
+	}
+
+	bool elapsed ()
+	{
+		auto const now = std::chrono::steady_clock::now ();
+		if (now - last >= target)
+		{
+			last = now;
+			return true;
+		}
+		return false;
+	}
+
+private:
+	std::chrono::milliseconds const target;
+	std::chrono::steady_clock::time_point last{ std::chrono::steady_clock::now () };
+};
+}

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -63,6 +63,8 @@ enum class detail : uint8_t
 	update,
 	request,
 	broadcast,
+	cleanup,
+	top,
 
 	// processing queue
 	queue,

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -182,7 +182,7 @@ nano::node::node (boost::asio::io_context & io_ctx_a, std::filesystem::path cons
 	history{ config.network_params.voting },
 	vote_uniquer (block_uniquer),
 	confirmation_height_processor (ledger, write_database_queue, config.conf_height_processor_batch_min_time, config.logging, logger, node_initialized_latch, flags.confirmation_height_processor_mode),
-	vote_cache{ config.vote_cache },
+	vote_cache{ config.vote_cache, stats },
 	generator{ config, ledger, wallets, vote_processor, history, network, stats, /* non-final */ false },
 	final_generator{ config, ledger, wallets, vote_processor, history, network, stats, /* final */ true },
 	active (*this, confirmation_height_processor),

--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -107,7 +107,8 @@ void nano::scheduler::hinted::activate (const nano::store::read_transaction & tr
 		else
 		{
 			stats.inc (nano::stat::type::hinting, nano::stat::detail::missing_block);
-			node.bootstrap_block (current_hash);
+
+			// TODO: Block is missing, bootstrap it
 		}
 	}
 }

--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -47,7 +47,7 @@ void nano::scheduler::hinted::notify ()
 {
 	// Avoid notifying when there is very little space inside AEC
 	auto const limit = active.limit (nano::election_behavior::hinted);
-	if (active.vacancy (nano::election_behavior::hinted) >= (limit / 5))
+	if (active.vacancy (nano::election_behavior::hinted) >= (limit * config.vaccancy_threshold_percent / 100))
 	{
 		condition.notify_all ();
 	}

--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -47,7 +47,7 @@ void nano::scheduler::hinted::notify ()
 {
 	// Avoid notifying when there is very little space inside AEC
 	auto const limit = active.limit (nano::election_behavior::hinted);
-	if (active.vacancy (nano::election_behavior::hinted) >= (limit * config.vaccancy_threshold_percent / 100))
+	if (active.vacancy (nano::election_behavior::hinted) >= (limit * config.vacancy_threshold_percent / 100))
 	{
 		condition.notify_all ();
 	}
@@ -230,6 +230,7 @@ nano::error nano::scheduler::hinted_config::serialize (nano::tomlconfig & toml) 
 	toml.put ("hinting_threshold", hinting_threshold_percent, "Percentage of online weight needed to start a hinted election. \ntype:uint32,[0,100]");
 	toml.put ("check_interval", check_interval.count (), "Interval between scans of the vote cache for possible hinted elections. \ntype:milliseconds");
 	toml.put ("block_cooldown", block_cooldown.count (), "Cooldown period for blocks that failed to start an election. \ntype:milliseconds");
+	toml.put ("vacancy_threshold", vacancy_threshold_percent, "Percentage of available space in the active elections container needed to trigger a scan for hinted elections (before the check interval elapses). \ntype:uint32,[0,100]");
 
 	return toml.get_error ();
 }
@@ -246,9 +247,15 @@ nano::error nano::scheduler::hinted_config::deserialize (nano::tomlconfig & toml
 	toml.get ("block_cooldown", block_cooldown_l);
 	block_cooldown = std::chrono::milliseconds{ block_cooldown_l };
 
+	toml.get ("vacancy_threshold", vacancy_threshold_percent);
+
 	if (hinting_threshold_percent > 100)
 	{
 		toml.get_error ().set ("hinting_threshold must be a number between 0 and 100");
+	}
+	if (vacancy_threshold_percent > 100)
+	{
+		toml.get_error ().set ("vacancy_threshold must be a number between 0 and 100");
 	}
 
 	return toml.get_error ();

--- a/nano/node/scheduler/hinted.hpp
+++ b/nano/node/scheduler/hinted.hpp
@@ -39,7 +39,7 @@ public:
 	std::chrono::milliseconds check_interval{ 1000 };
 	std::chrono::milliseconds block_cooldown{ 10000 };
 	unsigned hinting_threshold_percent{ 10 };
-	unsigned vaccancy_threshold_percent{ 20 };
+	unsigned vacancy_threshold_percent{ 20 };
 };
 
 /*

--- a/nano/node/scheduler/hinted.hpp
+++ b/nano/node/scheduler/hinted.hpp
@@ -39,6 +39,7 @@ public:
 	std::chrono::milliseconds check_interval{ 1000 };
 	std::chrono::milliseconds block_cooldown{ 10000 };
 	unsigned hinting_threshold_percent{ 10 };
+	unsigned vaccancy_threshold_percent{ 20 };
 };
 
 /*

--- a/nano/node/scheduler/hinted.hpp
+++ b/nano/node/scheduler/hinted.hpp
@@ -37,7 +37,7 @@ public:
 
 public:
 	std::chrono::milliseconds check_interval{ 1000 };
-	std::chrono::milliseconds block_cooldown{ 5000 };
+	std::chrono::milliseconds block_cooldown{ 10000 };
 	unsigned hinting_threshold_percent{ 10 };
 };
 

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -268,6 +268,7 @@ nano::error nano::vote_cache_config::serialize (nano::tomlconfig & toml) const
 {
 	toml.put ("max_size", max_size, "Maximum number of blocks to cache votes for. \ntype:uint64");
 	toml.put ("max_voters", max_voters, "Maximum number of voters to cache per block. \ntype:uint64");
+	toml.put ("age_cutoff", age_cutoff.count (), "Maximum age of votes to keep in cache. \ntype:seconds");
 
 	return toml.get_error ();
 }
@@ -276,6 +277,10 @@ nano::error nano::vote_cache_config::deserialize (nano::tomlconfig & toml)
 {
 	toml.get ("max_size", max_size);
 	toml.get ("max_voters", max_voters);
+
+	auto age_cutoff_l = age_cutoff.count ();
+	toml.get ("age_cutoff", age_cutoff_l);
+	age_cutoff = std::chrono::seconds{ age_cutoff_l };
 
 	return toml.get_error ();
 }

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -120,6 +120,9 @@ nano::vote_cache::vote_cache (vote_cache_config const & config_a, nano::stats & 
 
 void nano::vote_cache::vote (const nano::block_hash & hash, const std::shared_ptr<nano::vote> vote)
 {
+	// Assert that supplied hash corresponds to a one of the hashes stored in vote
+	debug_assert (std::find (vote->hashes.begin (), vote->hashes.end (), hash) != vote->hashes.end ());
+
 	auto const representative = vote->account;
 	auto const timestamp = vote->timestamp ();
 	auto const rep_weight = rep_weight_query (representative);

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/interval.hpp>
 #include <nano/lib/locks.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/utility.hpp>
@@ -38,6 +39,7 @@ public:
 public:
 	std::size_t max_size{ 1024 * 128 };
 	std::size_t max_voters{ 128 };
+	std::chrono::seconds age_cutoff{ 5 * 60 };
 };
 
 class vote_cache final
@@ -63,6 +65,7 @@ public:
 		 * @return true if current tally changed, false otherwise
 		 */
 		bool vote (nano::account const & representative, uint64_t const & timestamp, nano::uint128_t const & rep_weight, std::size_t max_voters);
+
 		/**
 		 * Inserts votes stored in this entry into an election
 		 */
@@ -73,13 +76,18 @@ public:
 		nano::uint128_t tally () const;
 		nano::uint128_t final_tally () const;
 		std::vector<voter_entry> voters () const;
+		std::chrono::steady_clock::time_point last_vote () const;
 
 	private:
+		bool vote_impl (nano::account const & representative, uint64_t const & timestamp, nano::uint128_t const & rep_weight, std::size_t max_voters);
+
 		nano::block_hash const hash_m;
 		std::vector<voter_entry> voters_m;
 
 		nano::uint128_t tally_m{ 0 };
 		nano::uint128_t final_tally_m{ 0 };
+
+		std::chrono::steady_clock::time_point last_vote_m{};
 	};
 
 public:
@@ -115,7 +123,7 @@ public:
 	 * The blocks are sorted in descending order by final tally, then by tally
 	 * @param min_tally minimum tally threshold, entries below with their voting weight below this will be ignored
 	 */
-	std::vector<top_entry> top (nano::uint128_t const & min_tally) const;
+	std::vector<top_entry> top (nano::uint128_t const & min_tally);
 
 public: // Container info
 	std::unique_ptr<nano::container_info_component> collect_container_info (std::string const & name);
@@ -126,8 +134,11 @@ public:
 	 */
 	std::function<nano::uint128_t (nano::account const &)> rep_weight_query{ [] (nano::account const & rep) { debug_assert (false); return 0; } };
 
-private:
+private: // Dependencies
 	vote_cache_config const & config;
+
+private:
+	void cleanup ();
 
 	// clang-format off
 	class tag_sequenced {};
@@ -148,5 +159,6 @@ private:
 	ordered_cache cache;
 
 	mutable nano::mutex mutex;
+	nano::interval cleanup_interval;
 };
 }

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -91,7 +91,7 @@ public:
 	};
 
 public:
-	explicit vote_cache (vote_cache_config const &);
+	explicit vote_cache (vote_cache_config const &, nano::stats &);
 
 	/**
 	 * Adds a new vote to cache
@@ -126,7 +126,7 @@ public:
 	std::vector<top_entry> top (nano::uint128_t const & min_tally);
 
 public: // Container info
-	std::unique_ptr<nano::container_info_component> collect_container_info (std::string const & name);
+	std::unique_ptr<nano::container_info_component> collect_container_info (std::string const & name) const;
 
 public:
 	/**
@@ -136,6 +136,7 @@ public:
 
 private: // Dependencies
 	vote_cache_config const & config;
+	nano::stats & stats;
 
 private:
 	void cleanup ();


### PR DESCRIPTION
There was a bug in hinted scheduler, when if node hardware was sufficiently slow background tasks related to bootstrapping missing blocks would queue up excessively:

<img width="1711" alt="Screenshot 2023-11-07 at 02 06 04" src="https://github.com/nanocurrency/nano-node/assets/3044353/5d005443-6d3b-4cf9-ae26-334f2a10b2c8">

This PR addresses this problem by:
- Removing the problematic call to `node.bootstrap_block (...)`. This in theory should be sufficient, but I wanted to eliminate other inefficiencies that made this bug possible.
- Cleanup vote cache periodically. The default punning age is 5 minutes - votes received earlier than this threshold will be removed.
- Adjust block check cooldown to avoid checking the same block too often.