### PR TITLE
Add missing container info for hinted & optimistic schedulers

### DIFF
--- a/nano/node/scheduler/component.cpp
+++ b/nano/node/scheduler/component.cpp
@@ -39,12 +39,10 @@ void nano::scheduler::component::stop ()
 
 std::unique_ptr<nano::container_info_component> nano::scheduler::component::collect_container_info (std::string const & name)
 {
-	nano::unique_lock<nano::mutex> lock{ mutex };
-
 	auto composite = std::make_unique<container_info_composite> (name);
-	//composite->add_component (hinted.collect_container_info ("hinted"));
+	composite->add_component (hinted.collect_container_info ("hinted"));
 	composite->add_component (manual.collect_container_info ("manual"));
-	//composite->add_component (optimistic.collect_container_info ("optimistic"));
+	composite->add_component (optimistic.collect_container_info ("optimistic"));
 	composite->add_component (priority.collect_container_info ("priority"));
 	return composite;
 }

--- a/nano/node/scheduler/component.hpp
+++ b/nano/node/scheduler/component.hpp
@@ -23,7 +23,6 @@ class component final
 	std::unique_ptr<nano::scheduler::manual> manual_impl;
 	std::unique_ptr<nano::scheduler::optimistic> optimistic_impl;
 	std::unique_ptr<nano::scheduler::priority> priority_impl;
-	nano::mutex mutex;
 
 public:
 	explicit component (nano::node & node);

--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -163,10 +163,14 @@ void nano::scheduler::hinted::run ()
 
 		if (!stopped)
 		{
+			lock.unlock ();
+
 			if (predicate ())
 			{
 				run_iterative ();
 			}
+
+			lock.lock ();
 		}
 	}
 }
@@ -185,6 +189,8 @@ nano::uint128_t nano::scheduler::hinted::final_tally_threshold () const
 
 bool nano::scheduler::hinted::cooldown (const nano::block_hash & hash)
 {
+	nano::lock_guard<nano::mutex> guard{ mutex };
+
 	auto const now = std::chrono::steady_clock::now ();
 
 	// Check if the hash is still in the cooldown period using the hashed index
@@ -209,6 +215,15 @@ bool nano::scheduler::hinted::cooldown (const nano::block_hash & hash)
 	}
 
 	return false; // No need to cooldown
+}
+
+std::unique_ptr<nano::container_info_component> nano::scheduler::hinted::collect_container_info (const std::string & name) const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "cooldowns", cooldowns_m.size (), sizeof (decltype (cooldowns_m)::value_type) }));
+	return composite;
 }
 
 /*

--- a/nano/node/scheduler/hinted.hpp
+++ b/nano/node/scheduler/hinted.hpp
@@ -58,6 +58,8 @@ public:
 	 */
 	void notify ();
 
+	std::unique_ptr<container_info_component> collect_container_info (std::string const & name) const;
+
 private:
 	bool predicate () const;
 	void run ();

--- a/nano/node/scheduler/manual.cpp
+++ b/nano/node/scheduler/manual.cpp
@@ -84,7 +84,7 @@ void nano::scheduler::manual::run ()
 	}
 }
 
-std::unique_ptr<nano::container_info_component> nano::scheduler::manual::collect_container_info (std::string const & name)
+std::unique_ptr<nano::container_info_component> nano::scheduler::manual::collect_container_info (std::string const & name) const
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 

--- a/nano/node/scheduler/manual.hpp
+++ b/nano/node/scheduler/manual.hpp
@@ -22,7 +22,7 @@ class manual final
 {
 	std::deque<std::tuple<std::shared_ptr<nano::block>, boost::optional<nano::uint128_t>, nano::election_behavior>> queue;
 	nano::node & node;
-	nano::mutex mutex;
+	mutable nano::mutex mutex;
 	nano::condition_variable condition;
 	bool stopped{ false };
 	std::thread thread;
@@ -41,6 +41,6 @@ public:
 	// Call action with confirmed block, may be different than what we started with
 	void push (std::shared_ptr<nano::block> const &, boost::optional<nano::uint128_t> const & = boost::none, nano::election_behavior = nano::election_behavior::normal);
 
-	std::unique_ptr<container_info_component> collect_container_info (std::string const & name);
+	std::unique_ptr<container_info_component> collect_container_info (std::string const & name) const;
 }; // class manual
 } // nano::scheduler

--- a/nano/node/scheduler/optimistic.cpp
+++ b/nano/node/scheduler/optimistic.cpp
@@ -130,6 +130,7 @@ void nano::scheduler::optimistic::run ()
 				debug_assert (!candidates.empty ());
 				auto candidate = candidates.front ();
 				candidates.pop_front ();
+
 				lock.unlock ();
 
 				run_one (transaction, candidate);
@@ -159,6 +160,15 @@ void nano::scheduler::optimistic::run_one (store::transaction const & transactio
 			stats.inc (nano::stat::type::optimistic_scheduler, result.inserted ? nano::stat::detail::insert : nano::stat::detail::insert_failed);
 		}
 	}
+}
+
+std::unique_ptr<nano::container_info_component> nano::scheduler::optimistic::collect_container_info (const std::string & name) const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "candidates", candidates.size (), sizeof (decltype (candidates)::value_type) }));
+	return composite;
 }
 
 /*

--- a/nano/node/scheduler/optimistic.hpp
+++ b/nano/node/scheduler/optimistic.hpp
@@ -66,6 +66,8 @@ public:
 	 */
 	void notify ();
 
+	std::unique_ptr<container_info_component> collect_container_info (std::string const & name) const;
+
 private:
 	bool activate_predicate (nano::account_info const &, nano::confirmation_height_info const &) const;
 


### PR DESCRIPTION
Those schedulers were missing the ability to provide their info, which is a must have when debugging network problems.