### PR TITLE
Remove vote-by-block support for confirm req message

### DIFF
--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -128,35 +128,6 @@ TEST (message, confirm_ack_hash_serialization)
 	ASSERT_EQ (hashes, con2.vote->hashes);
 	// Check overflow with max hashes
 	ASSERT_EQ (header.count_get (), hashes.size ());
-	ASSERT_EQ (header.block_type (), nano::block_type::not_a_block);
-}
-
-TEST (message, confirm_req_serialization)
-{
-	nano::keypair key1;
-	nano::keypair key2;
-	nano::block_builder builder;
-	auto block = builder
-				 .send ()
-				 .previous (0)
-				 .destination (key2.pub)
-				 .balance (200)
-				 .sign (nano::keypair ().prv, 2)
-				 .work (3)
-				 .build_shared ();
-	nano::confirm_req req{ nano::dev::network_params.network, block };
-	std::vector<uint8_t> bytes;
-	{
-		nano::vectorstream stream (bytes);
-		req.serialize (stream);
-	}
-	auto error (false);
-	nano::bufferstream stream2 (bytes.data (), bytes.size ());
-	nano::message_header header (error, stream2);
-	nano::confirm_req req2 (error, stream2, header);
-	ASSERT_FALSE (error);
-	ASSERT_EQ (req, req2);
-	ASSERT_EQ (*req.block, *req2.block);
 }
 
 TEST (message, confirm_req_hash_serialization)
@@ -185,7 +156,6 @@ TEST (message, confirm_req_hash_serialization)
 	ASSERT_FALSE (error);
 	ASSERT_EQ (req, req2);
 	ASSERT_EQ (req.roots_hashes, req2.roots_hashes);
-	ASSERT_EQ (header.block_type (), nano::block_type::not_a_block);
 	ASSERT_EQ (header.count_get (), req.roots_hashes.size ());
 }
 
@@ -239,7 +209,6 @@ TEST (message, confirm_req_hash_batch_serialization)
 	ASSERT_EQ (req.roots_hashes, req2.roots_hashes);
 	ASSERT_EQ (req.roots_hashes, roots_hashes);
 	ASSERT_EQ (req2.roots_hashes, roots_hashes);
-	ASSERT_EQ (header.block_type (), nano::block_type::not_a_block);
 	ASSERT_EQ (header.count_get (), req.roots_hashes.size ());
 }
 

--- a/nano/core_test/message_deserializer.cpp
+++ b/nano/core_test/message_deserializer.cpp
@@ -74,23 +74,6 @@ TEST (message_deserializer, exact_confirm_ack)
 	message_deserializer_success_checker<decltype (message)> (message);
 }
 
-TEST (message_deserializer, exact_confirm_req)
-{
-	nano::test::system system{ 1 };
-	nano::block_builder builder;
-	auto block = builder
-				 .send ()
-				 .previous (1)
-				 .destination (1)
-				 .balance (2)
-				 .sign (nano::keypair ().prv, 4)
-				 .work (*system.work.generate (nano::root (1)))
-				 .build_shared ();
-	nano::confirm_req message{ nano::dev::network_params.network, block };
-
-	message_deserializer_success_checker<decltype (message)> (message);
-}
-
 TEST (message_deserializer, exact_confirm_req_hash)
 {
 	nano::test::system system{ 1 };

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2277,8 +2277,8 @@ TEST (node, local_votes_cache)
 	election->force_confirm ();
 	ASSERT_TIMELY (3s, node.ledger.cache.cemented_count == 3);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	nano::confirm_req message1{ nano::dev::network_params.network, send1 };
-	nano::confirm_req message2{ nano::dev::network_params.network, send2 };
+	nano::confirm_req message1{ nano::dev::network_params.network, send1->hash (), send1->root () };
+	nano::confirm_req message2{ nano::dev::network_params.network, send2->hash (), send2->root () };
 	auto channel = std::make_shared<nano::transport::fake::channel> (node);
 	node.network.inbound (message1, channel);
 	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 1);
@@ -2300,7 +2300,7 @@ TEST (node, local_votes_cache)
 		auto transaction (node.store.tx_begin_write ());
 		ASSERT_EQ (nano::process_result::progress, node.ledger.process (transaction, *send3).code);
 	}
-	nano::confirm_req message3{ nano::dev::network_params.network, send3 };
+	nano::confirm_req message3{ nano::dev::network_params.network, send3->hash (), send3->root () };
 	for (auto i (0); i < 100; ++i)
 	{
 		node.network.inbound (message3, channel);
@@ -2400,7 +2400,7 @@ TEST (node, local_votes_cache_generate_new_vote)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 
 	// Send a confirm req for genesis block to node
-	nano::confirm_req message1{ nano::dev::network_params.network, nano::dev::genesis };
+	nano::confirm_req message1{ nano::dev::network_params.network, nano::dev::genesis->hash (), nano::dev::genesis->root () };
 	auto channel = std::make_shared<nano::transport::fake::channel> (node);
 	node.network.inbound (message1, channel);
 

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -145,19 +145,20 @@ public:
 class confirm_req final : public message
 {
 public:
-	confirm_req (bool &, nano::stream &, nano::message_header const &, nano::block_uniquer * = nullptr);
-	confirm_req (nano::network_constants const & constants, std::shared_ptr<nano::block> const &);
+	confirm_req (bool & error, nano::stream &, nano::message_header const &, nano::block_uniquer * = nullptr);
 	confirm_req (nano::network_constants const & constants, std::vector<std::pair<nano::block_hash, nano::root>> const &);
 	confirm_req (nano::network_constants const & constants, nano::block_hash const &, nano::root const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
 	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::confirm_req const &) const;
-	std::shared_ptr<nano::block> block;
-	std::vector<std::pair<nano::block_hash, nano::root>> roots_hashes;
 	std::string roots_string () const;
-	static std::size_t size (nano::block_type, std::size_t = 0);
 	std::string to_string () const;
+
+	static std::size_t size (nano::message_header const &);
+
+public: // Payload
+	std::vector<std::pair<nano::block_hash, nano::root>> roots_hashes;
 };
 
 class confirm_ack final : public message

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -417,20 +417,12 @@ public:
 			{
 				node.logger.try_log (boost::str (boost::format ("Confirm_req message from %1% for hashes:roots %2%") % channel->to_string () % message_a.roots_string ()));
 			}
-			else
-			{
-				node.logger.try_log (boost::str (boost::format ("Confirm_req message from %1% for %2%") % channel->to_string () % message_a.block->hash ().to_string ()));
-			}
 		}
 
 		// Don't load nodes with disabled voting
 		if (node.config.enable_voting && node.wallets.reps ().voting > 0)
 		{
-			if (message_a.block != nullptr)
-			{
-				node.aggregator.add (channel, { { message_a.block->hash (), message_a.block->root () } });
-			}
-			else if (!message_a.roots_hashes.empty ())
+			if (!message_a.roots_hashes.empty ())
 			{
 				node.aggregator.add (channel, message_a.roots_hashes);
 			}

--- a/nano/node/transport/message_deserializer.cpp
+++ b/nano/node/transport/message_deserializer.cpp
@@ -236,14 +236,7 @@ std::unique_ptr<nano::confirm_req> nano::transport::message_deserializer::deseri
 	auto incoming = std::make_unique<nano::confirm_req> (error, stream, header, &block_uniquer_m);
 	if (!error && nano::at_end (stream))
 	{
-		if (incoming->block == nullptr || !network_constants_m.work.validate_entry (*incoming->block))
-		{
-			return incoming;
-		}
-		else
-		{
-			status = parse_status::insufficient_work;
-		}
+		return incoming;
 	}
 	else
 	{


### PR DESCRIPTION
Vote-by-block support was largely removed in https://github.com/nanocurrency/nano-node/pull/3813. This PR removes the remaining legacy part in confirm req message in order to free header fields for future upgrades. According to nanolooker there should be no pre V24 nodes on live network that could still rely on this functionality.