### PR TITLE
Reduce mutex locked time in block scheduler

### DIFF
--- a/nano/node/scheduler/manual.cpp
+++ b/nano/node/scheduler/manual.cpp
@@ -51,36 +51,37 @@ bool nano::scheduler::manual::predicate () const
 
 void nano::scheduler::manual::run ()
 {
-	nano::unique_lock<nano::mutex> lock{ mutex };
-	while (!stopped)
+	while (true)
 	{
-		condition.wait (lock, [this] () {
-			return stopped || predicate ();
-		});
-		debug_assert ((std::this_thread::yield (), true)); // Introduce some random delay in debug builds
-		if (!stopped)
-		{
-			node.stats.inc (nano::stat::type::election_scheduler, nano::stat::detail::loop);
+		std::tuple<std::shared_ptr<nano::block>, boost::optional<nano::uint128_t>, nano::election_behavior> task;
 
-			if (predicate ())
+		{
+			nano::unique_lock<nano::mutex> lock{ mutex };
+			condition.wait (lock, [this] () {
+				return stopped || predicate ();
+			});
+			debug_assert ((std::this_thread::yield (), true)); // Introduce some random delay in debug builds
+			if (stopped)
 			{
-				auto const [block, previous_balance, election_behavior] = queue.front ();
-				queue.pop_front ();
-				lock.unlock ();
-				node.stats.inc (nano::stat::type::election_scheduler, nano::stat::detail::insert_manual);
-				auto result = node.active.insert (block, election_behavior);
-				if (result.election != nullptr)
-				{
-					result.election->transition_active ();
-				}
+				break;
 			}
-			else
-			{
-				lock.unlock ();
-			}
-			notify ();
-			lock.lock ();
+
+			task = queue.front ();
+			queue.pop_front ();
 		}
+
+		// Process outside of mutex lock
+		node.stats.inc (nano::stat::type::election_scheduler, nano::stat::detail::loop);
+		node.stats.inc (nano::stat::type::election_scheduler, nano::stat::detail::insert_manual);
+
+		auto [block, previous_balance, election_behavior] = task;
+		auto result = node.active.insert (block, election_behavior);
+		if (result.election != nullptr)
+		{
+			result.election->transition_active ();
+		}
+
+		notify ();
 	}
 }
 


### PR DESCRIPTION
Mutex is unlocked early by destroying the locked object it was created in and storing the block in a variable. The subsequent block processing is done outside the lock, reducing the total lock time.
Unit tests are successful.
Disclaimer: I'm no c++ expert. Chatgpt has helped me with parts of this. Review carefully, and feel free to dismiss it.