### PR TITLE
Limit max number of queued blocks from ascending bootstrap

### DIFF
--- a/nano/core_test/bootstrap_ascending.cpp
+++ b/nano/core_test/bootstrap_ascending.cpp
@@ -1,10 +1,13 @@
 #include <nano/lib/stats.hpp>
+#include <nano/lib/tomlconfig.hpp>
 #include <nano/node/bootstrap_ascending/service.hpp>
 #include <nano/node/make_store.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
+
+#include <sstream>
 
 using namespace std::chrono_literals;
 
@@ -250,4 +253,33 @@ TEST (bootstrap_ascending, trace_base)
 	//	std::cerr << "node0: " << node0.network.endpoint () << std::endl;
 	//	std::cerr << "node1: " << node1.network.endpoint () << std::endl;
 	ASSERT_TIMELY (10s, node1.block (receive1->hash ()) != nullptr);
+}
+
+TEST (bootstrap_ascending, config_serialization)
+{
+	nano::bootstrap_ascending_config config1;
+	config1.requests_limit = 0x101;
+	config1.database_requests_limit = 0x102;
+	config1.pull_count = 0x103;
+	config1.timeout = 0x104;
+	config1.throttle_coefficient = 0x105;
+	config1.throttle_wait = 0x106;
+	config1.block_wait_count = 0x107;
+	nano::tomlconfig toml1;
+	ASSERT_FALSE (config1.serialize (toml1));
+	std::stringstream stream1;
+	toml1.write (stream1);
+	auto string = stream1.str ();
+	std::stringstream stream2{ string };
+	nano::tomlconfig toml2;
+	toml2.read (stream2);
+	nano::bootstrap_ascending_config config2;
+	ASSERT_FALSE (config2.deserialize (toml2));
+	ASSERT_EQ (config1.requests_limit, config2.requests_limit);
+	ASSERT_EQ (config1.database_requests_limit, config2.database_requests_limit);
+	ASSERT_EQ (config1.pull_count, config2.pull_count);
+	ASSERT_EQ (config1.timeout, config2.timeout);
+	ASSERT_EQ (config1.throttle_coefficient, config2.throttle_coefficient);
+	ASSERT_EQ (config1.throttle_wait, config2.throttle_wait);
+	ASSERT_EQ (config1.block_wait_count, config2.block_wait_count);
 }

--- a/nano/node/bootstrap/bootstrap_config.cpp
+++ b/nano/node/bootstrap/bootstrap_config.cpp
@@ -35,6 +35,7 @@ nano::error nano::bootstrap_ascending_config::deserialize (nano::tomlconfig & to
 	toml.get ("timeout", timeout);
 	toml.get ("throttle_coefficient", throttle_coefficient);
 	toml.get ("throttle_wait", throttle_wait);
+	toml.get ("block_wait_count", block_wait_count);
 
 	if (toml.has_key ("account_sets"))
 	{
@@ -53,6 +54,7 @@ nano::error nano::bootstrap_ascending_config::serialize (nano::tomlconfig & toml
 	toml.put ("timeout", timeout, "Timeout in milliseconds for incoming ascending bootstrap messages to be processed.\ntype:milliseconds");
 	toml.put ("throttle_coefficient", throttle_coefficient, "Scales the number of samples to track for bootstrap throttling.\ntype:uint64");
 	toml.put ("throttle_wait", throttle_wait, "Length of time to wait between requests when throttled.\ntype:milliseconds");
+	toml.put ("block_wait_count", block_wait_count, "Asending bootstrap will wait while block processor has more than this many blocks queued.\ntype:uint64");
 
 	nano::tomlconfig account_sets_l;
 	account_sets.serialize (account_sets_l);

--- a/nano/node/bootstrap/bootstrap_config.hpp
+++ b/nano/node/bootstrap/bootstrap_config.hpp
@@ -33,6 +33,7 @@ public:
 	nano::millis_t timeout{ 1000 * 3 };
 	std::size_t throttle_coefficient{ 16 };
 	nano::millis_t throttle_wait{ 100 };
+	std::size_t block_wait_count{ 1000 };
 
 	nano::account_sets_config account_sets;
 };

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -194,7 +194,7 @@ void nano::bootstrap_ascending::service::inspect (store::transaction const & tx,
 void nano::bootstrap_ascending::service::wait_blockprocessor ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
-	while (!stopped && block_processor.size () > 1000)
+	while (!stopped && block_processor.size () > config.bootstrap_ascending.block_wait_count)
 	{
 		condition.wait_for (lock, std::chrono::milliseconds{ config.bootstrap_ascending.throttle_wait }, [this] () { return stopped; }); // Blockprocessor is relatively slow, sleeping here instead of using conditions
 	}

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -194,9 +194,9 @@ void nano::bootstrap_ascending::service::inspect (store::transaction const & tx,
 void nano::bootstrap_ascending::service::wait_blockprocessor ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
-	while (!stopped && block_processor.half_full ())
+	while (!stopped && block_processor.size () > 1000)
 	{
-		condition.wait_for (lock, 500ms, [this] () { return stopped; }); // Blockprocessor is relatively slow, sleeping here instead of using conditions
+		condition.wait_for (lock, std::chrono::milliseconds{ config.bootstrap_ascending.throttle_wait }, [this] () { return stopped; }); // Blockprocessor is relatively slow, sleeping here instead of using conditions
 	}
 }
 
@@ -206,7 +206,7 @@ std::shared_ptr<nano::transport::channel> nano::bootstrap_ascending::service::wa
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped && !(channel = scoring.channel ()))
 	{
-		condition.wait_for (lock, 100ms, [this] () { return stopped; });
+		condition.wait_for (lock, std::chrono::milliseconds{ config.bootstrap_ascending.throttle_wait }, [this] () { return stopped; });
 	}
 	return channel;
 }

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -506,6 +506,8 @@ std::unique_ptr<nano::container_info_component> nano::bootstrap_ascending::servi
 
 	auto composite = std::make_unique<container_info_composite> (name);
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "tags", tags.size (), sizeof (decltype (tags)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "throttle", throttle.size (), 0 }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "throttle_successes", throttle.successes (), 0 }));
 	composite->add_component (accounts.collect_container_info ("accounts"));
 	return composite;
 }


### PR DESCRIPTION
Previous behavior allowed ascending bootstrap to queue blocks until block processor was half full (~30k blocks). This wasn't working well on low performance nodes, where a block awaiting processing would be requested and queued multiple times.