### PR TITLE
Larger votes preparation

### DIFF
--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -90,6 +90,59 @@ TEST (message, publish_serialization)
 	ASSERT_EQ (nano::message_type::publish, header.type);
 }
 
+TEST (message, confirm_header_flags)
+{
+	nano::message_header header_v2{ nano::dev::network_params.network, nano::message_type::confirm_req };
+	header_v2.confirm_set_v2 (true);
+
+	const uint8_t value = 0b0110'1001;
+
+	header_v2.count_v2_set (value); // Max count value
+
+	ASSERT_TRUE (header_v2.confirm_is_v2 ());
+	ASSERT_EQ (header_v2.count_v2_get (), value);
+
+	std::vector<uint8_t> bytes;
+	{
+		nano::vectorstream stream (bytes);
+		header_v2.serialize (stream);
+	}
+	nano::bufferstream stream (bytes.data (), bytes.size ());
+
+	bool error = false;
+	nano::message_header header (error, stream);
+	ASSERT_FALSE (error);
+	ASSERT_EQ (nano::message_type::confirm_req, header.type);
+
+	ASSERT_TRUE (header.confirm_is_v2 ());
+	ASSERT_EQ (header.count_v2_get (), value);
+}
+
+TEST (message, confirm_header_flags_max)
+{
+	nano::message_header header_v2{ nano::dev::network_params.network, nano::message_type::confirm_req };
+	header_v2.confirm_set_v2 (true);
+	header_v2.count_v2_set (255); // Max count value
+
+	ASSERT_TRUE (header_v2.confirm_is_v2 ());
+	ASSERT_EQ (header_v2.count_v2_get (), 255);
+
+	std::vector<uint8_t> bytes;
+	{
+		nano::vectorstream stream (bytes);
+		header_v2.serialize (stream);
+	}
+	nano::bufferstream stream (bytes.data (), bytes.size ());
+
+	bool error = false;
+	nano::message_header header (error, stream);
+	ASSERT_FALSE (error);
+	ASSERT_EQ (nano::message_type::confirm_req, header.type);
+
+	ASSERT_TRUE (header.confirm_is_v2 ());
+	ASSERT_EQ (header.count_v2_get (), 255);
+}
+
 TEST (message, confirm_ack_hash_serialization)
 {
 	std::vector<nano::block_hash> hashes;

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -327,6 +327,28 @@ TEST (vote_processor, no_broadcast_local_with_a_principal_representative)
 }
 
 /**
+ * Ensure that node behaves well with votes larger than 12 hashes, which was maximum before V26
+ */
+TEST (vote_processor, large_votes)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	const int count = 32;
+	auto blocks = nano::test::setup_chain (system, node, count, nano::dev::genesis_key, /* do not confirm */ false);
+
+	ASSERT_TRUE (nano::test::start_elections (system, node, blocks));
+	ASSERT_TIMELY (5s, nano::test::active (node, blocks));
+
+	auto vote = nano::test::make_final_vote (nano::dev::genesis_key, blocks);
+	ASSERT_TRUE (vote->hashes.size () == count);
+
+	node.vote_processor.vote (vote, nano::test::fake_channel (node));
+
+	ASSERT_TIMELY (5s, nano::test::confirmed (node, blocks));
+}
+
+/**
  * basic test to check that the timestamp mask is applied correctly on vote timestamp and duration fields
  */
 TEST (vote, timestamp_and_duration_masking)

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -25,8 +25,11 @@ TEST (vote_processor, codes)
 	// Hint of pre-validation
 	ASSERT_NE (nano::vote_code::invalid, node.vote_processor.vote_blocking (vote_invalid, channel, true));
 
-	// No ongoing election
+	// No ongoing election (vote goes to vote cache)
 	ASSERT_EQ (nano::vote_code::indeterminate, node.vote_processor.vote_blocking (vote, channel));
+
+	// Clear vote cache before starting election
+	node.vote_cache.clear ();
 
 	// First vote from an account for an ongoing election
 	node.start_election (blocks[0]);

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -154,6 +154,7 @@ public:
 	std::atomic<bool> stopped{ false };
 	static unsigned const broadcast_interval_ms = 10;
 	static std::size_t const buffer_size = 512;
+
 	static std::size_t const confirm_req_hashes_max = 7;
 	static std::size_t const confirm_ack_hashes_max = 12;
 };

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -34,6 +34,7 @@ nano::request_aggregator::request_aggregator (nano::node_config const & config_a
 	condition.wait (lock, [&started = started] { return started; });
 }
 
+// TODO: This is badly implemented, will prematurely drop large vote requests
 void nano::request_aggregator::add (std::shared_ptr<nano::transport::channel> const & channel_a, std::vector<std::pair<nano::block_hash, nano::root>> const & hashes_roots_a)
 {
 	debug_assert (wallets.reps ().voting > 0);

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -193,6 +193,12 @@ bool nano::vote_cache::erase (const nano::block_hash & hash)
 	return result;
 }
 
+void nano::vote_cache::clear ()
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	cache.clear ();
+}
+
 std::vector<nano::vote_cache::top_entry> nano::vote_cache::top (const nano::uint128_t & min_tally)
 {
 	stats.inc (nano::stat::type::vote_cache, nano::stat::detail::top);

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -97,15 +97,18 @@ public:
 	 * Adds a new vote to cache
 	 */
 	void vote (nano::block_hash const & hash, std::shared_ptr<nano::vote> vote);
+
 	/**
 	 * Tries to find an entry associated with block hash
 	 */
 	std::optional<entry> find (nano::block_hash const & hash) const;
+
 	/**
 	 * Removes an entry associated with block hash, does nothing if entry does not exist
 	 * @return true if hash existed and was erased, false otherwise
 	 */
 	bool erase (nano::block_hash const & hash);
+	void clear ();
 
 	std::size_t size () const;
 	bool empty () const;

--- a/nano/secure/vote.cpp
+++ b/nano/secure/vote.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/utility.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/vote.hpp>
 
@@ -13,11 +14,15 @@ nano::vote::vote (nano::account const & account_a, nano::raw_key const & prv_a, 
 	timestamp_m{ packed_timestamp (timestamp_a, duration) },
 	account{ account_a }
 {
+	debug_assert (hashes.size () <= max_hashes);
+
 	signature = nano::sign_message (prv_a, account_a, hash ());
 }
 
 void nano::vote::serialize (nano::stream & stream_a) const
 {
+	debug_assert (hashes.size () <= max_hashes);
+
 	write (stream_a, account);
 	write (stream_a, signature);
 	write (stream_a, boost::endian::native_to_little (timestamp_m));
@@ -36,7 +41,7 @@ bool nano::vote::deserialize (nano::stream & stream_a)
 		nano::read (stream_a, signature.bytes);
 		nano::read (stream_a, timestamp_m);
 
-		while (stream_a.in_avail () > 0)
+		while (stream_a.in_avail () > 0 && hashes.size () < max_hashes)
 		{
 			nano::block_hash block_hash;
 			nano::read (stream_a, block_hash);
@@ -48,6 +53,12 @@ bool nano::vote::deserialize (nano::stream & stream_a)
 		error = true;
 	}
 	return error;
+}
+
+std::size_t nano::vote::size (uint8_t count)
+{
+	debug_assert (count <= max_hashes);
+	return partial_size + count * sizeof (nano::block_hash);
 }
 
 std::string const nano::vote::hash_prefix = "vote ";

--- a/nano/secure/vote.hpp
+++ b/nano/secure/vote.hpp
@@ -34,6 +34,7 @@ public:
 	 * @returns true if there was an error
 	 */
 	bool deserialize (nano::stream &);
+	static std::size_t size (uint8_t count);
 
 	nano::block_hash hash () const;
 	nano::block_hash full_hash () const;
@@ -58,13 +59,10 @@ public:
 	static uint64_t constexpr timestamp_min = { 0x0000'0000'0000'0010ULL };
 	static uint8_t constexpr duration_max = { 0x0fu };
 
+	static std::size_t constexpr max_hashes = 255;
+
 	/* Check if timestamp represents a final vote */
 	static bool is_final_timestamp (uint64_t timestamp);
-
-private:
-	static std::string const hash_prefix;
-
-	static uint64_t packed_timestamp (uint64_t timestamp, uint8_t duration);
 
 public: // Payload
 	// The hashes for which this vote directly covers
@@ -77,6 +75,13 @@ public: // Payload
 private: // Payload
 	// Vote timestamp
 	uint64_t timestamp_m{ 0 };
+
+private:
+	// Size of vote payload without hashes
+	static std::size_t constexpr partial_size = sizeof (account) + sizeof (signature) + sizeof (timestamp_m);
+	static std::string const hash_prefix;
+
+	static uint64_t packed_timestamp (uint64_t timestamp, uint8_t duration);
 };
 
 using vote_uniquer = nano::uniquer<nano::block_hash, nano::vote>;

--- a/nano/test_common/chains.cpp
+++ b/nano/test_common/chains.cpp
@@ -18,7 +18,7 @@ nano::block_list_t nano::test::setup_chain (nano::test::system & system, nano::n
 					.state ()
 					.account (target.pub)
 					.previous (latest)
-					.representative (throwaway.pub)
+					.representative (target.pub)
 					.balance (balance)
 					.link (throwaway.pub)
 					.sign (target.prv, target.pub)


### PR DESCRIPTION
This allows nodes to handle `confirm_req` and `confirm_ack` messages with payload of more than 16 hashes, up to 255. During testing it was shown that fewer, larger messages provide considerable improvement in performance, especially on CPU limited hardware. This PR is one of the steps to better align our message formats with this philosophy.

What's important to note is that, even with ability to handle large votes, nodes will continue to generate vote requests & responses with legacy rules (<= 12 hashes per message) to keep compatibility with previous versions. Once majority of the network upgrades, switching to larger votes should be as simple as modifying two constants in code.

```
Header before:
+-------+-----------+--------+
|  1-4  |    5-8    |  9-16  |
+-------+-----------+--------+
| count | block type | unused |
+-------+-----------+--------+

Header after:
+---------------+-----------+---------------+--------+---------+
|      1-4      |    5-8    |     9-12      | 13-15  |   16    |
+---------------+-----------+---------------+--------+---------+
| count (upper) | block type | count (lower) | unused | v2 flag |
+---------------+-----------+---------------+--------+---------+
```