### PR TITLE
Bound depth of hinted scheduler block traversal

### DIFF
--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -61,10 +61,14 @@ bool nano::scheduler::hinted::predicate () const
 
 void nano::scheduler::hinted::activate (const nano::store::read_transaction & transaction, const nano::block_hash & hash, bool check_dependents)
 {
+	const int max_iterations = 64;
+
+	std::set<nano::block_hash> visited;
 	std::stack<nano::block_hash> stack;
 	stack.push (hash);
 
-	while (!stack.empty ())
+	int iterations = 0;
+	while (!stack.empty () && iterations++ < max_iterations)
 	{
 		transaction.refresh_if_needed ();
 
@@ -91,7 +95,7 @@ void nano::scheduler::hinted::activate (const nano::store::read_transaction & tr
 					auto dependents = node.ledger.dependent_blocks (transaction, *block);
 					for (const auto & dependent_hash : dependents)
 					{
-						if (!dependent_hash.is_zero ())
+						if (!dependent_hash.is_zero () && visited.insert (dependent_hash).second) // Avoid visiting the same block twice
 						{
 							stack.push (dependent_hash); // Add dependent block to the stack
 						}

--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -129,6 +129,11 @@ void nano::scheduler::hinted::run_iterative ()
 
 	for (auto const & entry : tops)
 	{
+		if (stopped)
+		{
+			return;
+		}
+
 		if (!predicate ())
 		{
 			return;

--- a/nano/node/scheduler/hinted.hpp
+++ b/nano/node/scheduler/hinted.hpp
@@ -9,6 +9,7 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index_container.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <thread>
@@ -79,7 +80,7 @@ private: // Dependencies
 private:
 	hinted_config const & config;
 
-	bool stopped{ false };
+	std::atomic<bool> stopped{ false };
 	nano::condition_variable condition;
 	mutable nano::mutex mutex;
 	std::thread thread;


### PR DESCRIPTION
This PR limits the depth of the hinted scheduler block traversal to a maximum of 64 iterations, which should be enough for live network activity where cemented block differences are small. This prevents potential infinite loops.