### PR TITLE
Search for receivables as a wallet action, rather than a background node task.

### DIFF
--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -699,8 +699,9 @@ bool nano::wallet::enter_password (store::transaction const & transaction_a, std
 	auto result (store.attempt_password (transaction_a, password_a));
 	if (!result)
 	{
-		auto this_l (shared_from_this ());
-		wallets.node.background ([this_l] () {
+		auto this_l = shared_from_this ();
+		wallets.node.wallets.queue_wallet_action (nano::wallets::high_priority, this_l, [this_l] (nano::wallet & wallet) {
+			// Wallets must survive node lifetime
 			this_l->search_receivable (this_l->wallets.tx_begin_read ());
 		});
 		wallets.node.logger.try_log ("Wallet unlocked");

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -285,8 +285,11 @@ TEST (wallet, enter_password)
 	wallet->settings.new_password->setText ("");
 	QTest::keyClicks (wallet->settings.password, "abc");
 	QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
-	test_application->processEvents ();
-	ASSERT_NE (wallet->status->text ().toStdString ().rfind ("Status: Running", 0), std::string::npos);
+	auto is_running_status = [&wallet] () -> bool {
+		test_application->processEvents ();
+		return wallet->status->text ().toStdString ().rfind ("Status: Running", 0) != std::string::npos;
+	};
+	ASSERT_TIMELY (5s, is_running_status ());
 	ASSERT_EQ ("", wallet->settings.password->text ());
 }
 


### PR DESCRIPTION
While working on having a boost::asio::io_context for each nano::node instance rather than in nano::system instances, it uncovered a lifetime issue with background tasks queued by the wallet. nano::wallet::enter_password queues a background task on the node to search for receivable blocks when a wallet is unlocked.

Typically this is not an issue as wallet instances have the same lifetime as node objects. However, in unit tests, a standalone nano::wallets instance is created and destroyed before the node or io_context are destroyed. The body of nano::wallet::search_receivable could still be executing when nano::wallets and nano::wallet instances were destroyed yet the background task survived. This could cause wallet unit tests to fail intermittently if these race conditions ocurred. 

The tests could be rewritten to not create these standalone instances which matches how they're actually used within nano::node instances, however, the wallet already has a way to queue background tasks which is uses for work generation and generating blocks.

Queueing this search as a wallet action also feels like better encapsulation of wallet functionality and doesn't execute this potentially very slow task on an io_context which could affect io performance.