### PR TITLE
Store pointer to boost::asio::signal_set and cancel when ipc_server::stop is called.

### DIFF
--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -14,7 +14,6 @@
 #include <nano/node/json_handler.hpp>
 #include <nano/node/node.hpp>
 
-#include <boost/asio/signal_set.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
@@ -614,7 +613,7 @@ nano::ipc::ipc_server::ipc_server (nano::node & node_a, nano::node_rpc_config co
 		}
 #ifndef _WIN32
 		// Hook up config reloading through the HUP signal
-		auto signals (std::make_shared<boost::asio::signal_set> (node.io_ctx, SIGHUP));
+		signals = std::make_shared<boost::asio::signal_set> (node.io_ctx, SIGHUP);
 		await_hup_signal (signals, *this);
 #endif
 		if (node_a.config.ipc_config.transport_domain.enabled)
@@ -658,6 +657,10 @@ void nano::ipc::ipc_server::stop ()
 	for (auto & transport : transports)
 	{
 		transport->stop ();
+	}
+	if (signals)
+	{
+		signals->cancel ();
 	}
 }
 

--- a/nano/node/ipc/ipc_server.hpp
+++ b/nano/node/ipc/ipc_server.hpp
@@ -6,6 +6,8 @@
 #include <nano/node/ipc/ipc_broker.hpp>
 #include <nano/node/node_rpc_config.hpp>
 
+#include <boost/asio/signal_set.hpp>
+
 #include <atomic>
 #include <memory>
 
@@ -41,6 +43,7 @@ namespace ipc
 		nano::ipc::access access;
 		std::unique_ptr<dsock_file_remover> file_remover;
 		std::vector<std::shared_ptr<nano::ipc::transport>> transports;
+		std::shared_ptr<boost::asio::signal_set> signals;
 	};
 }
 }


### PR DESCRIPTION
Previously the signals weren't cancelled on ipc_server and would remain running until the io_context was destroyed.