### PR TITLE
Convert unit test make_shared<nano::node> to system.add_node.

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -585,11 +585,11 @@ TEST (bootstrap_processor, DISABLED_push_diamond_pruning)
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 = system.add_node (config);
 	nano::keypair key;
-	config.peering_port = system.get_available_port ();
 	config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
-	auto node1 = system.add_node (config, node_flags);
+	// create a node manually to avoid making automatic network connections
+	auto node1 = std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags, 1);
 	ASSERT_FALSE (node1->init_error ());
 	auto latest (node0->latest (nano::dev::genesis_key.pub));
 	nano::block_builder builder;
@@ -648,8 +648,8 @@ TEST (bootstrap_processor, DISABLED_push_diamond_pruning)
 	}
 	// 2nd bootstrap
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node0->balance (nano::dev::genesis_key.pub) == 100);
-	ASSERT_EQ (100, node0->balance (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (5s, node0->balance (nano::dev::genesis_key.pub), 100);
+	node1->stop ();
 }
 
 TEST (bootstrap_processor, push_one)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -735,7 +735,7 @@ TEST (bootstrap_processor, lazy_hash)
 	node0->block_processor.add (receive1);
 	node0->block_processor.add (send2);
 	node0->block_processor.add (receive2);
-	ASSERT_TIMELY(5s, nano::test::exists (*node0, {send1, receive1, send2, receive2}));
+	ASSERT_TIMELY (5s, nano::test::exists (*node0, { send1, receive1, send2, receive2 }));
 
 	// Start lazy bootstrap with last block in chain known
 	// create a node manually to avoid making automatic network connections

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -465,11 +465,13 @@ TEST (bootstrap_processor, pull_diamond)
 				   .work (*system.work.generate (send1->hash ()))
 				   .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node0->process (*receive).code);
-	auto node1 = system.add_node ();
+
+	// create a node manually to avoid making automatic network connections
+	auto node1 = std::make_shared<nano::node> (system.io_ctx, 0, nano::unique_path (), system.logging, system.work);
 	ASSERT_FALSE (node1->init_error ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node1->balance (nano::dev::genesis_key.pub) == 100);
-	ASSERT_EQ (100, node1->balance (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (5s, node1->balance (nano::dev::genesis_key.pub), 100);
+	node1->stop ();
 }
 
 TEST (bootstrap_processor, DISABLED_pull_requeue_network_error)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -527,7 +527,7 @@ TEST (bootstrap_processor, DISABLED_push_diamond)
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 = system.add_node (config);
 	nano::keypair key;
-	auto node1 = system.add_node ();
+	auto node1 = std::make_shared<nano::node> (system.io_ctx, 0, nano::unique_path (), system.logging, system.work);
 	ASSERT_FALSE (node1->init_error ());
 	auto wallet1 (node1->wallets.create (100));
 	wallet1->insert_adhoc (nano::dev::genesis_key.prv);
@@ -569,8 +569,9 @@ TEST (bootstrap_processor, DISABLED_push_diamond)
 				   .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node0->balance (nano::dev::genesis_key.pub) == 100);
-	ASSERT_EQ (100, node0->balance (nano::dev::genesis_key.pub));
+	// create a node manually to avoid making automatic network connections
+	ASSERT_TIMELY_EQ (5s, node0->balance (nano::dev::genesis_key.pub), 100);
+	node1->stop ();
 }
 
 // Check that an outgoing bootstrap request can push blocks

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -809,7 +809,7 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 	node0->block_processor.add (receive1);
 	node0->block_processor.add (send2);
 	node0->block_processor.add (receive2);
-	ASSERT_TIMELY(5s, nano::test::exists (*node0, {send1, receive1, send2, receive2}));
+	ASSERT_TIMELY (5s, nano::test::exists (*node0, { send1, receive1, send2, receive2 }));
 
 	// Start lazy bootstrap with last block in chain known
 	// create a node manually to avoid making automatic network connections

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -390,26 +390,34 @@ TEST (bootstrap_processor, process_new)
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
-	auto node1 = system.add_node (config, node_flags);
-	config.peering_port = system.get_available_port ();
-	auto node2 = system.add_node (config, node_flags);
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key2;
-	system.wallet (1)->insert_adhoc (key2.prv);
-	auto send (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node1->config.receive_minimum.number ()));
-	ASSERT_NE (nullptr, send);
-	ASSERT_TIMELY (10s, !node1->balance (key2.pub).is_zero ());
-	auto receive (node2->block (node2->latest (key2.pub)));
-	ASSERT_NE (nullptr, receive);
-	nano::uint128_t balance1 (node1->balance (nano::dev::genesis_key.pub));
-	nano::uint128_t balance2 (node1->balance (key2.pub));
-	ASSERT_TIMELY (10s, node1->block_confirmed (send->hash ()) && node1->block_confirmed (receive->hash ()) && node1->active.empty () && node2->active.empty ()); // All blocks should be propagated & confirmed
 
-	auto node3 = system.add_node ();
+	auto node1 = system.add_node (config, node_flags);
+	auto node2 = system.add_node (config, node_flags);
+
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	system.wallet (1)->insert_adhoc (key2.prv);
+
+	// send amount raw from genesis to key2, the wallet will autoreceive
+	auto amount = node1->config.receive_minimum.number ();
+	auto send = system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, amount);
+	ASSERT_NE (nullptr, send);
+	ASSERT_TIMELY (5s, !node1->balance (key2.pub).is_zero ());
+	auto receive = node2->block (node2->latest (key2.pub));
+	ASSERT_NE (nullptr, receive);
+
+	// All blocks should be propagated & confirmed
+	ASSERT_TIMELY (5s, nano::test::confirmed (*node1, { send, receive }));
+	ASSERT_TIMELY (5s, nano::test::confirmed (*node2, { send, receive }));
+	ASSERT_TIMELY (5s, node1->active.empty ());
+	ASSERT_TIMELY (5s, node2->active.empty ());
+
+	// create a node manually to avoid making automatic network connections
+	auto node3 = std::make_shared<nano::node> (system.io_ctx, 0, nano::unique_path (), system.logging, system.work);
 	ASSERT_FALSE (node3->init_error ());
 	node3->bootstrap_initiator.bootstrap (node1->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node3->balance (key2.pub) == balance2);
-	ASSERT_EQ (balance1, node3->balance (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (5s, node3->balance (key2.pub), amount);
+	node3->stop ();
 }
 
 TEST (bootstrap_processor, pull_diamond)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -657,18 +657,25 @@ TEST (bootstrap_processor, push_one)
 	nano::test::system system;
 	nano::node_config config = system.default_config ();
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
+
 	auto node0 = system.add_node (config);
+
 	nano::keypair key1;
-	auto node1 = system.add_node ();
-	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
+	// create a node manually to avoid making automatic network connections
+	auto node1 = std::make_shared<nano::node> (system.io_ctx, 0, nano::unique_path (), system.logging, system.work);
+	auto wallet = node1->wallets.create (nano::random_wallet_id ());
 	ASSERT_NE (nullptr, wallet);
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
-	nano::uint128_t balance1 (node1->balance (nano::dev::genesis_key.pub));
-	auto send (wallet->send_action (nano::dev::genesis_key.pub, key1.pub, 100));
+
+	// send 100 raw from genesis to key1
+	nano::uint128_t genesis_balance = node1->balance (nano::dev::genesis_key.pub);
+	auto send = wallet->send_action (nano::dev::genesis_key.pub, key1.pub, 100);
 	ASSERT_NE (nullptr, send);
-	ASSERT_NE (balance1, node1->balance (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (5s, genesis_balance - 100, node1->balance (nano::dev::genesis_key.pub));
+
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node0->balance (nano::dev::genesis_key.pub) != balance1);
+	ASSERT_TIMELY_EQ (5s, node0->balance (nano::dev::genesis_key.pub), genesis_balance - 100);
+	node1->stop ();
 }
 
 TEST (bootstrap_processor, lazy_hash)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -762,7 +762,6 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 	auto node0 = system.add_node (config, node_flags);
 	nano::keypair key1;
 	nano::keypair key2;
-	// Generating test chain
 
 	nano::state_block_builder builder;
 
@@ -806,14 +805,15 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 					.work (*node0->work_generate_blocking (key2.pub))
 					.build_shared ();
 
-	// Processing test chain
 	node0->block_processor.add (send1);
 	node0->block_processor.add (receive1);
 	node0->block_processor.add (send2);
 	node0->block_processor.add (receive2);
-	node0->block_processor.flush ();
+	ASSERT_TIMELY(5s, nano::test::exists (*node0, {send1, receive1, send2, receive2}));
+
 	// Start lazy bootstrap with last block in chain known
-	auto node1 = system.add_node ();
+	// create a node manually to avoid making automatic network connections
+	auto node1 = std::make_shared<nano::node> (system.io_ctx, 0, nano::unique_path (), system.logging, system.work);
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true, "123456");
 	{
@@ -822,7 +822,8 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 		ASSERT_EQ ("123456", lazy_attempt->id);
 	}
 	// Check processed blocks
-	ASSERT_TIMELY (10s, node1->balance (key2.pub) != 0);
+	ASSERT_TIMELY (5s, node1->balance (key2.pub) != 0);
+	node1->stop ();
 }
 
 TEST (bootstrap_processor, lazy_hash_pruning)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -280,16 +280,14 @@ TEST (bulk_pull, count_limit)
 	ASSERT_EQ (nullptr, block);
 }
 
-TEST (bootstrap_processor, DISABLED_process_none)
+TEST (bootstrap_processor, process_none)
 {
 	nano::test::system system (1);
+	auto node0 = system.nodes[0];
 	auto node1 = system.add_node ();
-	auto done (false);
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint (), false);
-	while (!done)
-	{
-		system.io_ctx.run_one ();
-	}
+	ASSERT_TIMELY (5s, !node1->network.empty ());
+	ASSERT_TIMELY (5s, !node0->network.empty ());
 }
 
 // Bootstrap can pull one basic block

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -2014,7 +2014,10 @@ TEST (bulk, DISABLED_genesis_pruning)
 	auto node1 = system.add_node (config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	node_flags.enable_pruning = false;
-	auto node2 = system.add_node (system.default_config (), node_flags);
+
+	// create a node manually so that it is not connected to the other node automatically
+	auto node2 = std::make_shared<nano::node> (system.io_ctx, 0, nano::unique_path (), system.logging, system.work, node_flags);
+	ASSERT_FALSE (node2->init_error ());
 	nano::block_hash latest1 (node1->latest (nano::dev::genesis_key.pub));
 	nano::block_hash latest2 (node2->latest (nano::dev::genesis_key.pub));
 	ASSERT_EQ (latest1, latest2);
@@ -2079,6 +2082,7 @@ TEST (bulk, DISABLED_genesis_pruning)
 	node2->bootstrap_initiator.bootstrap (node1->network.endpoint (), false);
 	ASSERT_TIMELY (10s, node2->latest (nano::dev::genesis_key.pub) == node1->latest (nano::dev::genesis_key.pub));
 	ASSERT_EQ (node2->latest (nano::dev::genesis_key.pub), node1->latest (nano::dev::genesis_key.pub));
+	node2->stop ();
 }
 
 TEST (bulk_pull_account, basics)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -323,19 +323,17 @@ TEST (bootstrap_processor, process_two)
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	auto node0 = system.add_node (config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	nano::block_hash hash1 (node0->latest (nano::dev::genesis_key.pub));
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub, 50));
-	nano::block_hash hash2 (node0->latest (nano::dev::genesis_key.pub));
-	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub, 50));
-	nano::block_hash hash3 (node0->latest (nano::dev::genesis_key.pub));
-	ASSERT_NE (hash1, hash2);
-	ASSERT_NE (hash1, hash3);
-	ASSERT_NE (hash2, hash3);
+	ASSERT_TRUE (system.wallet (0)->send_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub, 50));
+	ASSERT_TRUE (system.wallet (0)->send_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub, 50));
+	ASSERT_TIMELY_EQ (5s, nano::test::account_info (*node0, nano::dev::genesis_key.pub).block_count, 3);
 
-	auto node1 = system.add_node ();
-	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_NE (node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
-	ASSERT_TIMELY (10s, node1->latest (nano::dev::genesis_key.pub) == node0->latest (nano::dev::genesis_key.pub));
+	// create a node manually to avoid making automatic network connections
+	auto node1 = std::make_shared<nano::node> (system.io_ctx, 0, nano::unique_path (), system.logging, system.work);
+	ASSERT_FALSE (node1->init_error ());
+	ASSERT_NE (node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub)); // nodes should be out of sync here
+	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false); // bootstrap triggered
+	ASSERT_TIMELY (5s, node1->latest (nano::dev::genesis_key.pub) == node0->latest (nano::dev::genesis_key.pub)); // nodes should sync up
+	node1->stop ();
 }
 
 // Bootstrap can pull universal blocks

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1864,9 +1864,7 @@ TEST (node, rep_remove)
 	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 1);
 
 	// Start a node for Rep2 and wait until it is connected
-	auto node_rep2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), nano::node_config (system.get_available_port (), system.logging), system.work));
-	node_rep2->start ();
-	searching_node.network.tcp_channels.start_tcp (node_rep2->network.endpoint ());
+	auto node_rep2 = system.add_node ();
 	std::shared_ptr<nano::transport::channel> channel_rep2;
 	ASSERT_TIMELY (10s, (channel_rep2 = searching_node.network.tcp_channels.find_node_id (node_rep2->get_node_id ())) != nullptr);
 

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -563,7 +563,7 @@ void nano::test::system::stop ()
 
 nano::node_config nano::test::system::default_config ()
 {
-	nano::node_config config{ get_available_port (), logging };
+	nano::node_config config{ std::nullopt, logging };
 	return config;
 }
 

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -245,6 +245,28 @@ bool nano::test::start_elections (nano::test::system & system_a, nano::node & no
 	return nano::test::start_elections (system_a, node_a, blocks_to_hashes (blocks_a), forced_a);
 }
 
+nano::account_info nano::test::account_info (nano::node const & node, nano::account const & acc)
+{
+	auto const tx = node.ledger.store.tx_begin_read ();
+	auto opt = node.ledger.account_info (tx, acc);
+	if (opt.has_value ())
+	{
+		return opt.value ();
+	}
+	return {};
+}
+
+uint64_t nano::test::account_height (nano::node const & node, nano::account const & acc)
+{
+	auto const tx = node.ledger.store.tx_begin_read ();
+	nano::confirmation_height_info height_info;
+	if (!node.ledger.store.confirmation_height.get (tx, acc, height_info))
+	{
+		return 0;
+	}
+	return height_info.height;
+}
+
 void nano::test::print_all_account_info (nano::node & node)
 {
 	auto const tx = node.ledger.store.tx_begin_read ();

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -418,10 +418,19 @@ namespace test
 	[[nodiscard]] bool start_elections (nano::test::system &, nano::node &, std::vector<std::shared_ptr<nano::block>> const &, bool const forced_a = false);
 
 	/**
+	 *  Return account_info for account "acc", if account is not found, a default initialised object is returned
+	 */
+	nano::account_info account_info (nano::node const & node, nano::account const & acc);
+
+	/**
+	 * Return the account height, returns 0 on error
+	 */
+	uint64_t account_height (nano::node const & node, nano::account const & acc);
+
+	/**
 	 * \brief Debugging function to print all accounts in a ledger. Intented to be used to debug unit tests.
 	 * \param ledger
 	 */
 	void print_all_account_info (nano::node & node);
-
 }
 }


### PR DESCRIPTION
When changing the lifetime of io_context it ocurred that a lot of unit tests constructed nodes manually via make_shored.

This change converts many usages to system.add_node. Some usages like the networking tests are not upgraded as they're testing specific operations on how nodes connect which system::add_node assumes.