### PR TITLE
Use assert_eq and assert_timely_eq

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -219,7 +219,7 @@ TEST (active_transactions, keep_local)
 	node.process_active (receive3);
 
 	/// bound elections, should drop after one loop
-	ASSERT_TIMELY (5s, node.active.size () == node_config.active_elections_size);
+	ASSERT_TIMELY_EQ (5s, node.active.size (), node_config.active_elections_size);
 	// ASSERT_EQ (1, node.scheduler.size ());
 }
 
@@ -238,7 +238,7 @@ TEST (active_transactions, inactive_votes_cache)
 				.build_shared ();
 	auto vote (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash> (1, send->hash ())));
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::inproc::channel> (node, node));
-	ASSERT_TIMELY (5s, node.vote_cache.size () == 1);
+	ASSERT_TIMELY_EQ (5s, node.vote_cache.size (), 1);
 	node.process_active (send);
 	node.block_processor.flush ();
 	ASSERT_TIMELY (5s, node.ledger.block_confirmed (node.store.tx_begin_read (), send->hash ()));
@@ -264,7 +264,7 @@ TEST (active_transactions, inactive_votes_cache_non_final)
 	// Non-final vote
 	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash> (1, send->hash ()));
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::inproc::channel> (node, node));
-	ASSERT_TIMELY (5s, node.vote_cache.size () == 1);
+	ASSERT_TIMELY_EQ (5s, node.vote_cache.size (), 1);
 
 	node.process_active (send);
 	std::shared_ptr<nano::election> election;
@@ -301,7 +301,7 @@ TEST (active_transactions, inactive_votes_cache_fork)
 
 	auto const vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash> (1, send1->hash ()));
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::inproc::channel> (node, node));
-	ASSERT_TIMELY (5s, node.vote_cache.size () == 1);
+	ASSERT_TIMELY_EQ (5s, node.vote_cache.size (), 1);
 
 	node.process_active (send2);
 
@@ -309,7 +309,7 @@ TEST (active_transactions, inactive_votes_cache_fork)
 	ASSERT_TIMELY (5s, (election = node.active.election (send1->qualified_root ())) != nullptr);
 
 	node.process_active (send1);
-	ASSERT_TIMELY (5s, election->blocks ().size () == 2);
+	ASSERT_TIMELY_EQ (5s, election->blocks ().size (), 2);
 	ASSERT_TIMELY (5s, node.block_confirmed (send1->hash ()));
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
 }
@@ -342,14 +342,14 @@ TEST (active_transactions, inactive_votes_cache_existing_vote)
 	node.process_active (send);
 	node.block_processor.add (open);
 	node.block_processor.flush ();
-	ASSERT_TIMELY (5s, node.active.size () == 1);
+	ASSERT_TIMELY_EQ (5s, node.active.size (), 1);
 	auto election (node.active.election (send->qualified_root ()));
 	ASSERT_NE (nullptr, election);
 	ASSERT_GT (node.weight (key.pub), node.minimum_principal_weight ());
 	// Insert vote
 	auto vote1 (std::make_shared<nano::vote> (key.pub, key.prv, nano::vote::timestamp_min * 1, 0, std::vector<nano::block_hash> (1, send->hash ())));
 	node.vote_processor.vote (vote1, std::make_shared<nano::transport::inproc::channel> (node, node));
-	ASSERT_TIMELY (5s, election->votes ().size () == 2);
+	ASSERT_TIMELY_EQ (5s, election->votes ().size (), 2);
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_new));
 	auto last_vote1 (election->votes ()[key.pub]);
 	ASSERT_EQ (send->hash (), last_vote1.hash);
@@ -417,7 +417,7 @@ TEST (active_transactions, inactive_votes_cache_multiple_votes)
 	node.vote_processor.vote (vote2, std::make_shared<nano::transport::inproc::channel> (node, node));
 
 	ASSERT_TIMELY (5s, node.vote_cache.find (send1->hash ()));
-	ASSERT_TIMELY (5s, node.vote_cache.find (send1->hash ())->voters ().size () == 2);
+	ASSERT_TIMELY_EQ (5s, node.vote_cache.find (send1->hash ())->voters ().size (), 2);
 	ASSERT_EQ (1, node.vote_cache.size ());
 	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	std::shared_ptr<nano::election> election;
@@ -475,7 +475,7 @@ TEST (active_transactions, inactive_votes_cache_election_start)
 	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*open1).code);
 	ASSERT_EQ (nano::process_result::progress, node.process (*open2).code);
-	ASSERT_TIMELY (5s, 5 == node.ledger.cache.block_count);
+	ASSERT_TIMELY_EQ (5s, 5, node.ledger.cache.block_count);
 	ASSERT_TRUE (node.active.empty ());
 	ASSERT_EQ (1, node.ledger.cache.cemented_count);
 	// These blocks will be processed later
@@ -497,7 +497,7 @@ TEST (active_transactions, inactive_votes_cache_election_start)
 	// Inactive votes
 	auto vote1 = nano::test::make_vote (key1, { open1, open2, send4 });
 	node.vote_processor.vote (vote1, std::make_shared<nano::transport::inproc::channel> (node, node));
-	ASSERT_TIMELY (5s, node.vote_cache.size () == 3);
+	ASSERT_TIMELY_EQ (5s, node.vote_cache.size (), 3);
 	ASSERT_TRUE (node.active.empty ());
 	ASSERT_EQ (1, node.ledger.cache.cemented_count);
 
@@ -512,7 +512,7 @@ TEST (active_transactions, inactive_votes_cache_election_start)
 	auto vote0 = nano::test::make_final_vote (nano::dev::genesis_key, { open1, open2, send4 });
 	node.vote_processor.vote (vote0, std::make_shared<nano::transport::inproc::channel> (node, node));
 	ASSERT_TIMELY_EQ (5s, 0, node.active.size ());
-	ASSERT_TIMELY (5s, 5 == node.ledger.cache.cemented_count);
+	ASSERT_TIMELY_EQ (5s, 5, node.ledger.cache.cemented_count);
 	ASSERT_TRUE (nano::test::confirmed (node, { send1, send2, open1, open2 }));
 
 	// A late block arrival also checks the inactive votes cache
@@ -526,7 +526,7 @@ TEST (active_transactions, inactive_votes_cache_election_start)
 	// send7 cannot be voted on but an election should be started from inactive votes
 	ASSERT_FALSE (node.ledger.dependents_confirmed (node.store.tx_begin_read (), *send4));
 	node.process_active (send4);
-	ASSERT_TIMELY (5s, 7 == node.ledger.cache.cemented_count);
+	ASSERT_TIMELY_EQ (5s, 7, node.ledger.cache.cemented_count);
 }
 
 namespace nano
@@ -570,7 +570,7 @@ TEST (active_transactions, vote_replays)
 	ASSERT_EQ (2, node.active.size ());
 	ASSERT_EQ (nano::vote_code::replay, node.active.vote (vote_send1));
 	// Wait until the election is removed, at which point the vote is still a replay since it's been recently confirmed
-	ASSERT_TIMELY (3s, node.active.size () == 1);
+	ASSERT_TIMELY_EQ (3s, node.active.size (), 1);
 	ASSERT_EQ (nano::vote_code::replay, node.active.vote (vote_send1));
 	// Open new account
 	auto vote_open1 (std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::vote::timestamp_max, nano::vote::duration_max, std::vector<nano::block_hash>{ open1->hash () }));
@@ -700,7 +700,7 @@ TEST (active_transactions, republish_winner)
 
 	node1.process_active (send1);
 	node1.block_processor.flush ();
-	ASSERT_TIMELY (3s, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) == 1);
+	ASSERT_TIMELY_EQ (3s, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in), 1);
 
 	// Several forks
 	for (auto i (0); i < 5; i++)
@@ -792,7 +792,7 @@ TEST (active_transactions, fork_filter_cleanup)
 	// All forks were merged into the same election
 	std::shared_ptr<nano::election> election{};
 	ASSERT_TIMELY (5s, (election = node1.active.election (send1->qualified_root ())) != nullptr);
-	ASSERT_TIMELY (5s, election->blocks ().size () == 10);
+	ASSERT_TIMELY_EQ (5s, election->blocks ().size (), 10);
 	ASSERT_EQ (1, node1.active.size ());
 
 	// Instantiate a new node
@@ -809,8 +809,8 @@ TEST (active_transactions, fork_filter_cleanup)
 	//                  how about node1 picking up "send1" from node2? we know it does because we assert at
 	//                  the end that it is within node1's AEC, but why node1.block_count doesn't increase?
 	//
-	ASSERT_TIMELY (5s, node2.ledger.cache.block_count == 2);
-	ASSERT_TIMELY (5s, node1.ledger.cache.block_count == 2);
+	ASSERT_TIMELY_EQ (5s, node2.ledger.cache.block_count, 2);
+	ASSERT_TIMELY_EQ (5s, node1.ledger.cache.block_count, 2);
 
 	// Block is erased from the duplicate filter
 	ASSERT_TIMELY (5s, node1.network.publish_filter.apply (send_block_bytes.data (), send_block_bytes.size ()));
@@ -1407,7 +1407,7 @@ TEST (active_transactions, fifo)
 	ASSERT_TIMELY (5s, node.active.election (receive2->qualified_root ()) != nullptr);
 
 	// Ensure excess transactions get trimmed
-	ASSERT_TIMELY (5s, node.active.size () == 1);
+	ASSERT_TIMELY_EQ (5s, node.active.size (), 1);
 
 	// Ensure overflow stats have been incremented
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::active_dropped, nano::stat::detail::normal));
@@ -1449,7 +1449,7 @@ TEST (active_transactions, limit_vote_hinted_elections)
 	auto vote1 = nano::test::make_vote (rep1, { open0, open1 });
 	node.vote_processor.vote (vote1, nano::test::fake_channel (node));
 	// Ensure new inactive vote cache entries were created
-	ASSERT_TIMELY (5s, node.vote_cache.size () == 2);
+	ASSERT_TIMELY_EQ (5s, node.vote_cache.size (), 2);
 	// And no elections are getting started yet
 	ASSERT_ALWAYS (1s, node.active.empty ());
 	// And nothing got confirmed yet
@@ -1459,7 +1459,7 @@ TEST (active_transactions, limit_vote_hinted_elections)
 	auto vote2 = nano::test::make_vote (rep2, { open0 });
 	node.vote_processor.vote (vote2, nano::test::fake_channel (node));
 	// Ensure an election got started for open0 block
-	ASSERT_TIMELY (5s, node.active.size () == 1);
+	ASSERT_TIMELY_EQ (5s, node.active.size (), 1);
 	ASSERT_TIMELY (5s, nano::test::active (node, { open0 }));
 
 	// This vote should trigger election hinting but not become active due to limit of active hinted elections

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -142,7 +142,8 @@ TEST (active_transactions, confirm_frontier)
 	// Save election to check request count afterwards
 	auto election2 = node2.active.election (send->qualified_root ());
 	ASSERT_NE (nullptr, election2);
-	ASSERT_TIMELY (5s, node2.ledger.cache.cemented_count == 2 && node2.active.empty ());
+	ASSERT_TIMELY_EQ (5s, node2.ledger.cache.cemented_count, 2);
+	ASSERT_TIMELY (5s, node2.active.empty ());
 	ASSERT_GT (election2->confirmation_request_count, 0u);
 }
 }

--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -638,7 +638,7 @@ TEST (block_builder, zeroed_state_block)
 							 .work (0)
 							 .build_shared ();
 	auto zero_block_build = builder.state ().zero ().sign (key.prv, key.pub).build ();
-	ASSERT_TRUE (zero_block_manual->hash () == zero_block_build->hash ());
+	ASSERT_EQ (zero_block_manual->hash (), zero_block_build->hash ());
 	ASSERT_FALSE (nano::validate_message (key.pub, zero_block_build->hash (), zero_block_build->signature));
 }
 

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1683,6 +1683,6 @@ TEST (rocksdb_block_store, tombstone_count)
 	ASSERT_EQ (store->tombstone_map.at (nano::tables::accounts).num_since_last_flush.load (), 0);
 	// Performs a delete operation and checks for the tombstone counter
 	store->account.del (store->tx_begin_write (), account);
-	ASSERT_TIMELY (5s, store->tombstone_map.at (nano::tables::accounts).num_since_last_flush.load () == 1);
+	ASSERT_TIMELY_EQ (5s, store->tombstone_map.at (nano::tables::accounts).num_since_last_flush.load (), 1);
 }
 }

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -316,7 +316,7 @@ TEST (bootstrap_processor, process_one)
 	ASSERT_NE (hash1, hash2);
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
 	ASSERT_NE (node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
-	ASSERT_TIMELY (10s, node1->latest (nano::dev::genesis_key.pub) == node0->latest (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (10s, node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
 	node1->stop ();
 }
 
@@ -342,7 +342,7 @@ TEST (bootstrap_processor, process_two)
 	ASSERT_FALSE (node1->init_error ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
 	ASSERT_NE (node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
-	ASSERT_TIMELY (10s, node1->latest (nano::dev::genesis_key.pub) == node0->latest (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (10s, node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
 	node1->stop ();
 }
 
@@ -389,7 +389,7 @@ TEST (bootstrap_processor, process_state)
 	ASSERT_NE (node1->latest (nano::dev::genesis_key.pub), block2->hash ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
 	ASSERT_NE (node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
-	ASSERT_TIMELY (10s, node1->latest (nano::dev::genesis_key.pub) == node0->latest (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (10s, node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
 	node1->stop ();
 }
 
@@ -418,7 +418,7 @@ TEST (bootstrap_processor, process_new)
 	auto node3 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.logging, system.work));
 	ASSERT_FALSE (node3->init_error ());
 	node3->bootstrap_initiator.bootstrap (node1->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node3->balance (key2.pub) == balance2);
+	ASSERT_TIMELY_EQ (10s, node3->balance (key2.pub), balance2);
 	ASSERT_EQ (balance1, node3->balance (nano::dev::genesis_key.pub));
 	node3->stop ();
 }
@@ -471,7 +471,7 @@ TEST (bootstrap_processor, pull_diamond)
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.logging, system.work));
 	ASSERT_FALSE (node1->init_error ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node1->balance (nano::dev::genesis_key.pub) == 100);
+	ASSERT_TIMELY_EQ (10s, node1->balance (nano::dev::genesis_key.pub), 100);
 	ASSERT_EQ (100, node1->balance (nano::dev::genesis_key.pub));
 	node1->stop ();
 }
@@ -571,7 +571,7 @@ TEST (bootstrap_processor, DISABLED_push_diamond)
 				   .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node0->balance (nano::dev::genesis_key.pub) == 100);
+	ASSERT_TIMELY_EQ (10s, node0->balance (nano::dev::genesis_key.pub), 100);
 	ASSERT_EQ (100, node0->balance (nano::dev::genesis_key.pub));
 	node1->stop ();
 }
@@ -615,7 +615,7 @@ TEST (bootstrap_processor, DISABLED_push_diamond_pruning)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
 	// 1st bootstrap
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node0->balance (key.pub) == nano::dev::constants.genesis_amount);
+	ASSERT_TIMELY_EQ (10s, node0->balance (key.pub), nano::dev::constants.genesis_amount);
 	// Process more blocks & prune old
 	auto send2 = builder
 				 .send ()
@@ -650,7 +650,7 @@ TEST (bootstrap_processor, DISABLED_push_diamond_pruning)
 	}
 	// 2nd bootstrap
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node0->balance (nano::dev::genesis_key.pub) == 100);
+	ASSERT_TIMELY_EQ (10s, node0->balance (nano::dev::genesis_key.pub), 100);
 	ASSERT_EQ (100, node0->balance (nano::dev::genesis_key.pub));
 	node1->stop ();
 }
@@ -953,7 +953,7 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive3->hash (), true);
 	// Check processed blocks
-	ASSERT_TIMELY (5s, node1->ledger.cache.block_count == 9);
+	ASSERT_TIMELY_EQ (5s, node1->ledger.cache.block_count, 9);
 	ASSERT_TIMELY (5s, node1->balance (key2.pub) != 0);
 	ASSERT_TIMELY (5s, !node1->bootstrap_initiator.in_progress ());
 	node1->stop ();
@@ -1619,7 +1619,7 @@ TEST (bootstrap_processor, multiple_attempts)
 	// Check processed blocks
 	ASSERT_TIMELY (10s, node2->balance (key2.pub) != 0);
 	// Check attempts finish
-	ASSERT_TIMELY (5s, node2->bootstrap_initiator.attempts.size () == 0);
+	ASSERT_TIMELY_EQ (5s, node2->bootstrap_initiator.attempts.size (), 0);
 	node2->stop ();
 }
 
@@ -1930,7 +1930,7 @@ TEST (bulk, genesis)
 	ASSERT_NE (latest1, latest3);
 
 	node2->bootstrap_initiator.bootstrap (node1->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node2->latest (nano::dev::genesis_key.pub) == node1->latest (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (10s, node2->latest (nano::dev::genesis_key.pub), node1->latest (nano::dev::genesis_key.pub));
 	ASSERT_EQ (node2->latest (nano::dev::genesis_key.pub), node1->latest (nano::dev::genesis_key.pub));
 	node2->stop ();
 }
@@ -1970,7 +1970,7 @@ TEST (bulk, offline_send)
 	// Send block arrival via bootstrap
 	ASSERT_TIMELY (10s, node2->balance (nano::dev::genesis_key.pub) != std::numeric_limits<nano::uint256_t>::max ());
 	// Receiving send block
-	ASSERT_TIMELY (20s, node2->balance (key2.pub) == node1->config.receive_minimum.number ());
+	ASSERT_TIMELY_EQ (20s, node2->balance (key2.pub), node1->config.receive_minimum.number ());
 	node2->stop ();
 }
 
@@ -2053,9 +2053,9 @@ TEST (bulk, DISABLED_genesis_pruning)
 	node2->block_processor.flush ();
 	ASSERT_EQ (3, node2->ledger.cache.block_count);
 	// New bootstrap
-	ASSERT_TIMELY (5s, node2->bootstrap_initiator.connections->connections_count == 0);
+	ASSERT_TIMELY_EQ (5s, node2->bootstrap_initiator.connections->connections_count, 0);
 	node2->bootstrap_initiator.bootstrap (node1->network.endpoint (), false);
-	ASSERT_TIMELY (10s, node2->latest (nano::dev::genesis_key.pub) == node1->latest (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (10s, node2->latest (nano::dev::genesis_key.pub), node1->latest (nano::dev::genesis_key.pub));
 	ASSERT_EQ (node2->latest (nano::dev::genesis_key.pub), node1->latest (nano::dev::genesis_key.pub));
 	node2->stop ();
 }
@@ -2070,7 +2070,7 @@ TEST (bulk_pull_account, basics)
 	auto send1 (system.wallet (0)->send_action (nano::dev::genesis->account (), key1.pub, 25));
 	auto send2 (system.wallet (0)->send_action (nano::dev::genesis->account (), key1.pub, 10));
 	auto send3 (system.wallet (0)->send_action (nano::dev::genesis->account (), key1.pub, 2));
-	ASSERT_TIMELY (5s, system.nodes[0]->balance (key1.pub) == 25);
+	ASSERT_TIMELY_EQ (5s, system.nodes[0]->balance (key1.pub), 25);
 	auto connection (std::make_shared<nano::transport::tcp_server> (std::make_shared<nano::transport::socket> (*system.nodes[0], nano::transport::socket::endpoint_type_t::server), system.nodes[0]));
 
 	{

--- a/nano/core_test/bootstrap_server.cpp
+++ b/nano/core_test/bootstrap_server.cpp
@@ -93,7 +93,7 @@ TEST (bootstrap_server, serve_account_blocks)
 
 	node.network.inbound (request, nano::test::fake_channel (node));
 
-	ASSERT_TIMELY (5s, responses.size () == 1);
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
@@ -138,7 +138,7 @@ TEST (bootstrap_server, serve_hash)
 
 	node.network.inbound (request, nano::test::fake_channel (node));
 
-	ASSERT_TIMELY (5s, responses.size () == 1);
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
@@ -183,7 +183,7 @@ TEST (bootstrap_server, serve_hash_one)
 
 	node.network.inbound (request, nano::test::fake_channel (node));
 
-	ASSERT_TIMELY (5s, responses.size () == 1);
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
@@ -193,7 +193,7 @@ TEST (bootstrap_server, serve_hash_one)
 	nano::asc_pull_ack::blocks_payload response_payload;
 	ASSERT_NO_THROW (response_payload = std::get<nano::asc_pull_ack::blocks_payload> (response.payload));
 	ASSERT_EQ (response_payload.blocks.size (), 1);
-	ASSERT_TRUE (response_payload.blocks.front ()->hash () == request_payload.start.as_block_hash ());
+	ASSERT_EQ (response_payload.blocks.front ()->hash (), request_payload.start.as_block_hash ());
 }
 
 TEST (bootstrap_server, serve_end_of_chain)
@@ -222,7 +222,7 @@ TEST (bootstrap_server, serve_end_of_chain)
 
 	node.network.inbound (request, nano::test::fake_channel (node));
 
-	ASSERT_TIMELY (5s, responses.size () == 1);
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
@@ -261,7 +261,7 @@ TEST (bootstrap_server, serve_missing)
 
 	node.network.inbound (request, nano::test::fake_channel (node));
 
-	ASSERT_TIMELY (5s, responses.size () == 1);
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
@@ -306,7 +306,7 @@ TEST (bootstrap_server, serve_multiple)
 		}
 	}
 
-	ASSERT_TIMELY (15s, responses.size () == chains.size ());
+	ASSERT_TIMELY_EQ (15s, responses.size (), chains.size ());
 
 	auto all_responses = responses.get ();
 	{
@@ -360,7 +360,7 @@ TEST (bootstrap_server, serve_account_info)
 
 	node.network.inbound (request, nano::test::fake_channel (node));
 
-	ASSERT_TIMELY (5s, responses.size () == 1);
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
@@ -406,7 +406,7 @@ TEST (bootstrap_server, serve_account_info_missing)
 
 	node.network.inbound (request, nano::test::fake_channel (node));
 
-	ASSERT_TIMELY (5s, responses.size () == 1);
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
@@ -451,7 +451,7 @@ TEST (bootstrap_server, serve_frontiers)
 
 	node.network.inbound (request, nano::test::fake_channel (node));
 
-	ASSERT_TIMELY (5s, responses.size () == 1);
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -62,7 +62,7 @@ TEST (confirmation_height, single)
 		node->process_active (send1);
 		node->block_processor.flush ();
 
-		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 1);
+		ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 1);
 
 		{
 			auto transaction = node->store.tx_begin_write ();
@@ -244,7 +244,7 @@ TEST (confirmation_height, multiple_accounts)
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 
-		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 10);
+		ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 10);
 
 		nano::confirmation_height_info confirmation_height_info;
 		auto & store = node->store;
@@ -409,7 +409,7 @@ TEST (confirmation_height, gap_bootstrap)
 		// Now complete the chain where the block comes in on the bootstrap network.
 		node1.block_processor.add (open1);
 
-		ASSERT_TIMELY (5s, node1.unchecked.count () == 0);
+		ASSERT_TIMELY_EQ (5s, node1.unchecked.count (), 0);
 		// Confirmation height should be unchanged and unchecked should now be 0
 		{
 			auto transaction = node1.store.tx_begin_read ();
@@ -533,13 +533,13 @@ TEST (confirmation_height, gap_live)
 
 		// Vote and confirm all existing blocks
 		nano::test::start_election (system, *node, send1->hash ());
-		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 3);
+		ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 3);
 
 		// Now complete the chain where the block comes in on the live network
 		node->process_active (open1);
 		node->block_processor.flush ();
 
-		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 6);
+		ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 6);
 
 		// This should confirm the open block and the source of the receive blocks
 		auto transaction = node->store.tx_begin_read ();
@@ -691,7 +691,7 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 
-		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 10);
+		ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 10);
 
 		auto transaction (node->store.tx_begin_read ());
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive4->hash ()));
@@ -808,7 +808,7 @@ TEST (confirmation_height, send_receive_self)
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 
-		ASSERT_TIMELY (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 6);
+		ASSERT_TIMELY_EQ (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 6);
 
 		auto transaction (node->store.tx_begin_read ());
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive3->hash ()));
@@ -1053,7 +1053,7 @@ TEST (confirmation_height, all_block_types)
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 
-		ASSERT_TIMELY (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 15);
+		ASSERT_TIMELY_EQ (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 15);
 
 		auto transaction (node->store.tx_begin_read ());
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, state_send2->hash ()));
@@ -1136,7 +1136,7 @@ TEST (confirmation_height, conflict_rollback_cemented)
 		// node2 already has send2 forced confirmed whilst node1 should have confirmed send1 and therefore we have a cemented fork on node2
 		// and node2 should print an error message on the log that it cannot rollback send2 because it is already cemented
 		[[maybe_unused]] size_t count = 0;
-		ASSERT_TIMELY (5s, 1 == (count = node1->stats.count (nano::stat::type::ledger, nano::stat::detail::rollback_failed)));
+		ASSERT_TIMELY_EQ (5s, 1, (count = node1->stats.count (nano::stat::type::ledger, nano::stat::detail::rollback_failed)));
 		ASSERT_TRUE (nano::test::confirmed (*node1, { fork1a->hash () })); // fork1a should still remain after the rollback failed event
 	};
 
@@ -1221,7 +1221,7 @@ TEST (confirmation_height, observers)
 
 		node1->process_active (send1);
 		node1->block_processor.flush ();
-		ASSERT_TIMELY (10s, node1->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 1);
+		ASSERT_TIMELY_EQ (10s, node1->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 1);
 		auto transaction = node1->store.tx_begin_read ();
 		ASSERT_TRUE (node1->ledger.block_confirmed (transaction, send1->hash ()));
 		ASSERT_EQ (1, node1->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
@@ -1512,7 +1512,7 @@ TEST (confirmation_height, callback_confirmed_history)
 			auto election = node->active.election (send1->qualified_root ());
 			ASSERT_NE (nullptr, election);
 			election->force_confirm ();
-			ASSERT_TIMELY (10s, node->active.size () == 0);
+			ASSERT_TIMELY_EQ (10s, node->active.size (), 0);
 			ASSERT_EQ (0, node->active.recently_cemented.list ().size ());
 			ASSERT_TRUE (node->active.empty ());
 
@@ -1530,8 +1530,8 @@ TEST (confirmation_height, callback_confirmed_history)
 		auto transaction = node->store.tx_begin_read ();
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, send->hash ()));
 
-		ASSERT_TIMELY (10s, node->active.size () == 0);
-		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out) == 1);
+		ASSERT_TIMELY_EQ (10s, node->active.size (), 0);
+		ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out), 1);
 
 		ASSERT_EQ (1, node->active.recently_cemented.list ().size ());
 		ASSERT_TRUE (node->active.empty ());
@@ -1607,7 +1607,7 @@ TEST (confirmation_height, dependent_election)
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
 
-		ASSERT_TIMELY (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 3);
+		ASSERT_TIMELY_EQ (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 3);
 
 		ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out));
 		ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_conf_height, nano::stat::dir::out));
@@ -1760,7 +1760,7 @@ TEST (confirmation_height, cemented_gap_below_receive)
 		auto election = nano::test::start_election (system, *node, open1->hash ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
-		ASSERT_TIMELY (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 10);
+		ASSERT_TIMELY_EQ (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 10);
 
 		auto transaction = node->store.tx_begin_read ();
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, open1->hash ()));
@@ -1925,7 +1925,7 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 		auto election = nano::test::start_election (system, *node, open1->hash ());
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
-		ASSERT_TIMELY (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 6);
+		ASSERT_TIMELY_EQ (5s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 6);
 
 		auto transaction = node->store.tx_begin_read ();
 		ASSERT_TRUE (node->ledger.block_confirmed (transaction, open1->hash ()));
@@ -1988,7 +1988,7 @@ TEST (confirmation_height, election_winner_details_clearing)
 
 		node->process_confirmed (nano::election_status{ send2 });
 		ASSERT_TIMELY (5s, node->block_confirmed (send2->hash ()));
-		ASSERT_TIMELY (5s, 1 == node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out));
+		ASSERT_TIMELY_EQ (5s, 1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out));
 
 		node->process_confirmed (nano::election_status{ send3 });
 		ASSERT_TIMELY (5s, node->block_confirmed (send3->hash ()));
@@ -1996,7 +1996,7 @@ TEST (confirmation_height, election_winner_details_clearing)
 		// Add an already cemented block with fake election details. It should get removed
 		node->active.add_election_winner_details (send3->hash (), nullptr);
 		node->confirmation_height_processor.add (send3);
-		ASSERT_TIMELY (10s, node->active.election_winner_details_size () == 0);
+		ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 		ASSERT_EQ (4, node->ledger.cache.cemented_count);
 
 		EXPECT_EQ (1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out));

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -28,7 +28,7 @@ TEST (confirmation_solicitor, batches)
 	ASSERT_EQ (1, representatives.size ());
 	ASSERT_EQ (channel1, representatives.front ().channel);
 	ASSERT_EQ (nano::dev::genesis_key.pub, representatives.front ().account);
-	ASSERT_TIMELY (3s, node2.network.size () == 1);
+	ASSERT_TIMELY_EQ (3s, node2.network.size (), 1);
 	nano::block_builder builder;
 	auto send = builder
 				.send ()
@@ -78,7 +78,7 @@ TEST (confirmation_solicitor, different_hash)
 	ASSERT_EQ (1, representatives.size ());
 	ASSERT_EQ (channel1, representatives.front ().channel);
 	ASSERT_EQ (nano::dev::genesis_key.pub, representatives.front ().account);
-	ASSERT_TIMELY (3s, node2.network.size () == 1);
+	ASSERT_TIMELY_EQ (3s, node2.network.size (), 1);
 	nano::block_builder builder;
 	auto send = builder
 				.send ()
@@ -122,7 +122,7 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	}
 	ASSERT_EQ (max_representatives + 1, representatives.size ());
 	solicitor.prepare (representatives);
-	ASSERT_TIMELY (3s, node2.network.size () == 1);
+	ASSERT_TIMELY_EQ (3s, node2.network.size (), 1);
 	nano::block_builder builder;
 	auto send = builder
 				.send ()
@@ -143,7 +143,7 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	ASSERT_FALSE (solicitor.broadcast (*election));
 	solicitor.flush ();
 	// All requests went through, the last one would normally not go through due to the cap but a vote for a different hash does not count towards the cap
-	ASSERT_TIMELY (6s, max_representatives + 1 == node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (6s, max_representatives + 1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
 
 	solicitor.prepare (representatives);
 	auto election2 (std::make_shared<nano::election> (node2, send, nullptr, nullptr, nano::election_behavior::normal));

--- a/nano/core_test/distributed_work.cpp
+++ b/nano/core_test/distributed_work.cpp
@@ -92,7 +92,7 @@ TEST (distributed_work, no_peers_multi)
 	{
 		ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, node->config.work_peers, nano::difficulty::from_multiplier (10, node->network_params.work.base), callback));
 	}
-	ASSERT_TIMELY (5s, count == total);
+	ASSERT_TIMELY_EQ (5s, count, total);
 	system.deadline_set (5s);
 	while (node->distributed_work.size () > 0)
 	{
@@ -106,7 +106,7 @@ TEST (distributed_work, no_peers_multi)
 		nano::block_hash hash_i (i + 1);
 		ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash_i, node->config.work_peers, node->network_params.work.base, callback));
 	}
-	ASSERT_TIMELY (5s, count == total);
+	ASSERT_TIMELY_EQ (5s, count, total);
 	system.deadline_set (5s);
 	while (node->distributed_work.size () > 0)
 	{
@@ -214,7 +214,7 @@ TEST (distributed_work, DISABLED_peer_multi)
 	ASSERT_FALSE (node->distributed_work.make (nano::work_version::work_1, hash, peers, node->network_params.work.base, callback, nano::account ()));
 	ASSERT_TIMELY (5s, done);
 	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, *work), node->network_params.work.base);
-	ASSERT_TIMELY (5s, slow_peer->cancels == 1);
+	ASSERT_TIMELY_EQ (5s, slow_peer->cancels, 1);
 	ASSERT_EQ (0, malicious_peer->generations_good);
 	ASSERT_EQ (1, malicious_peer->generations_bad);
 	ASSERT_EQ (0, malicious_peer->cancels);

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -66,7 +66,7 @@ TEST (election, quorum_minimum_flip_success)
 	node1.process_active (send2);
 	std::shared_ptr<nano::election> election{};
 	ASSERT_TIMELY (5s, (election = node1.active.election (send2->qualified_root ())) != nullptr)
-	ASSERT_TIMELY (5s, election->blocks ().size () == 2);
+	ASSERT_TIMELY_EQ (5s, election->blocks ().size (), 2);
 
 	auto vote = nano::test::make_final_vote (nano::dev::genesis_key, { send2->hash () });
 	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote));
@@ -114,7 +114,7 @@ TEST (election, quorum_minimum_flip_fail)
 	node.process_active (send2);
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node.active.election (send2->qualified_root ()))
-	ASSERT_TIMELY (5s, election->blocks ().size () == 2);
+	ASSERT_TIMELY_EQ (5s, election->blocks ().size (), 2);
 
 	// genesis generates a final vote for send2 but it should not be enough to reach quorum due to the online_weight_minimum being so high
 	auto vote = nano::test::make_final_vote (nano::dev::genesis_key, { send2->hash () });
@@ -235,13 +235,13 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 					   .work (*system.work.generate (open1->hash ()))
 					   .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
-	ASSERT_TIMELY (5s, node1.ledger.cache.block_count == 4);
+	ASSERT_TIMELY_EQ (5s, node1.ledger.cache.block_count, 4);
 
 	node_config.peering_port = system.get_available_port ();
 	auto & node2 = *system.add_node (node_config);
 
 	system.wallet (1)->insert_adhoc (key1.prv);
-	ASSERT_TIMELY (10s, node2.ledger.cache.block_count == 4);
+	ASSERT_TIMELY_EQ (10s, node2.ledger.cache.block_count, 4);
 
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, (election = node1.active.election (send1->qualified_root ())) != nullptr);

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -132,8 +132,8 @@ TEST (election_scheduler, no_vacancy)
 
 	// There is no vacancy so it should stay queued
 	node.scheduler.priority.activate (key.pub, node.store.tx_begin_read ());
-	ASSERT_TIMELY (5s, node.scheduler.priority.size () == 1);
-	ASSERT_TRUE (node.active.election (block2->qualified_root ()) == nullptr);
+	ASSERT_TIMELY_EQ (5s, node.scheduler.priority.size (), 1);
+	ASSERT_EQ (node.active.election (block2->qualified_root ()), nullptr);
 
 	// Election confirmed, next in queue should begin
 	election->force_confirm ();

--- a/nano/core_test/frontiers_confirmation.cpp
+++ b/nano/core_test/frontiers_confirmation.cpp
@@ -31,7 +31,7 @@ TEST (frontiers_confirmation, mode)
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
 		}
-		ASSERT_TIMELY (5s, node->active.size () == 1);
+		ASSERT_TIMELY_EQ (5s, node->active.size (), 1);
 	}
 	// Auto mode
 	{
@@ -53,7 +53,7 @@ TEST (frontiers_confirmation, mode)
 			auto transaction = node->store.tx_begin_write ();
 			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
 		}
-		ASSERT_TIMELY (5s, node->active.size () == 1);
+		ASSERT_TIMELY_EQ (5s, node->active.size (), 1);
 	}
 	// Disabled mode
 	{

--- a/nano/core_test/gap_cache.cpp
+++ b/nano/core_test/gap_cache.cpp
@@ -120,9 +120,9 @@ TEST (gap_cache, gap_bootstrap)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto latest_block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, 100));
 	ASSERT_NE (nullptr, latest_block);
-	ASSERT_TIMELY (5s, nano::dev::constants.genesis_amount - 200 == node1.balance (nano::dev::genesis->account ()));
-	ASSERT_TIMELY (5s, nano::dev::constants.genesis_amount == node2.balance (nano::dev::genesis->account ()));
-	ASSERT_TIMELY (5s, node2.balance (nano::dev::genesis->account ()) == nano::dev::constants.genesis_amount - 200);
+	ASSERT_TIMELY_EQ (5s, nano::dev::constants.genesis_amount - 200, node1.balance (nano::dev::genesis->account ()));
+	ASSERT_TIMELY_EQ (5s, nano::dev::constants.genesis_amount, node2.balance (nano::dev::genesis->account ()));
+	ASSERT_TIMELY_EQ (5s, node2.balance (nano::dev::genesis->account ()), nano::dev::constants.genesis_amount - 200);
 }
 
 TEST (gap_cache, two_dependencies)
@@ -164,7 +164,7 @@ TEST (gap_cache, two_dependencies)
 	ASSERT_EQ (2, node1.gap_cache.size ());
 	node1.block_processor.add (send1);
 	node1.block_processor.flush ();
-	ASSERT_TIMELY (5s, node1.gap_cache.size () == 0);
+	ASSERT_TIMELY_EQ (5s, node1.gap_cache.size (), 0);
 	ASSERT_TIMELY (5s, node1.store.block.exists (node1.store.tx_begin_read (), send1->hash ()));
 	ASSERT_TIMELY (5s, node1.store.block.exists (node1.store.tx_begin_read (), send2->hash ()));
 	ASSERT_TIMELY (5s, node1.store.block.exists (node1.store.tx_begin_read (), open->hash ()));

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -2332,13 +2332,13 @@ TEST (ledger, block_destination_source)
 	ASSERT_TRUE (ledger.block_source (transaction, *block1).is_zero ());
 	ASSERT_EQ (nano::dev::genesis->account (), ledger.block_destination (transaction, *block2));
 	ASSERT_TRUE (ledger.block_source (transaction, *block2).is_zero ());
-	ASSERT_TRUE (ledger.block_destination (transaction, *block3) == nullptr);
+	ASSERT_EQ (ledger.block_destination (transaction, *block3), nullptr);
 	ASSERT_EQ (block2->hash (), ledger.block_source (transaction, *block3));
 	ASSERT_EQ (dest.pub, ledger.block_destination (transaction, *block4));
 	ASSERT_TRUE (ledger.block_source (transaction, *block4).is_zero ());
 	ASSERT_EQ (nano::dev::genesis->account (), ledger.block_destination (transaction, *block5));
 	ASSERT_TRUE (ledger.block_source (transaction, *block5).is_zero ());
-	ASSERT_TRUE (ledger.block_destination (transaction, *block6) == nullptr);
+	ASSERT_EQ (ledger.block_destination (transaction, *block6), nullptr);
 	ASSERT_EQ (block5->hash (), ledger.block_source (transaction, *block6));
 }
 
@@ -4049,7 +4049,7 @@ TEST (ledger, epoch_open_pending)
 	ASSERT_EQ (nano::process_result::gap_epoch_open_pending, process_result.code);
 	node1.block_processor.add (epoch_open);
 	// Waits for the block to get saved in the database
-	ASSERT_TIMELY (10s, 1 == node1.unchecked.count ());
+	ASSERT_TIMELY_EQ (10s, 1, node1.unchecked.count ());
 	ASSERT_FALSE (node1.ledger.block_or_pruned_exists (epoch_open->hash ()));
 	// Open block should be inserted into unchecked
 	auto blocks = node1.unchecked.get (nano::hash_or_account (epoch_open->account ()).hash);
@@ -4343,7 +4343,7 @@ TEST (ledger, unchecked_epoch)
 	node1.block_processor.add (epoch1);
 	{
 		// Waits for the epoch1 block to pass through block_processor and unchecked.put queues
-		ASSERT_TIMELY (10s, 1 == node1.unchecked.count ());
+		ASSERT_TIMELY_EQ (10s, 1, node1.unchecked.count ());
 		auto blocks = node1.unchecked.get (epoch1->previous ());
 		ASSERT_EQ (blocks.size (), 1);
 	}
@@ -4352,7 +4352,7 @@ TEST (ledger, unchecked_epoch)
 	ASSERT_TIMELY (5s, node1.store.block.exists (node1.store.tx_begin_read (), epoch1->hash ()));
 	{
 		// Waits for the last blocks to pass through block_processor and unchecked.put queues
-		ASSERT_TIMELY (10s, 0 == node1.unchecked.count ());
+		ASSERT_TIMELY_EQ (10s, 0, node1.unchecked.count ());
 		auto info = node1.ledger.account_info (node1.store.tx_begin_read (), destination.pub);
 		ASSERT_TRUE (info);
 		ASSERT_EQ (info->epoch (), nano::epoch::epoch_1);
@@ -4417,7 +4417,7 @@ TEST (ledger, unchecked_epoch_invalid)
 	node1.block_processor.add (epoch2);
 	{
 		// Waits for the last blocks to pass through block_processor and unchecked.put queues
-		ASSERT_TIMELY (10s, 2 == node1.unchecked.count ());
+		ASSERT_TIMELY_EQ (10s, 2, node1.unchecked.count ());
 		auto blocks = node1.unchecked.get (epoch1->previous ());
 		ASSERT_EQ (blocks.size (), 2);
 	}
@@ -4484,7 +4484,7 @@ TEST (ledger, unchecked_open)
 	node1.block_processor.add (open1);
 	{
 		// Waits for the last blocks to pass through block_processor and unchecked.put queues
-		ASSERT_TIMELY (10s, 1 == node1.unchecked.count ());
+		ASSERT_TIMELY_EQ (10s, 1, node1.unchecked.count ());
 		// Get the next peer for attempting a tcp bootstrap connection
 		auto blocks = node1.unchecked.get (open1->source ());
 		ASSERT_EQ (blocks.size (), 1);
@@ -5654,7 +5654,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	ASSERT_FALSE (rocksdb_store.confirmation_height.get (rocksdb_transaction, nano::dev::genesis->account (), confirmation_height_info));
 	ASSERT_EQ (confirmation_height_info.height, 2);
 	ASSERT_EQ (confirmation_height_info.frontier, send->hash ());
-	ASSERT_TRUE (rocksdb_store.final_vote.get (rocksdb_transaction, nano::root (send->previous ())).size () == 1);
+	ASSERT_EQ (rocksdb_store.final_vote.get (rocksdb_transaction, nano::root (send->previous ())).size (), 1);
 	ASSERT_EQ (rocksdb_store.final_vote.get (rocksdb_transaction, nano::root (send->previous ()))[0], nano::block_hash (2));
 }
 

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -119,7 +119,7 @@ TEST (network, last_contacted)
 
 	auto channel1 = nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	ASSERT_NE (nullptr, channel1);
-	ASSERT_TIMELY (3s, node0->network.size () == 1);
+	ASSERT_TIMELY_EQ (3s, node0->network.size (), 1);
 
 	// channel0 is the other side of channel1, same connection different endpoint
 	auto channel0 = node0->network.tcp_channels.find_node_id (node1->node_id.pub);
@@ -129,8 +129,8 @@ TEST (network, last_contacted)
 		// check that the endpoints are part of the same connection
 		std::shared_ptr<nano::transport::socket> sock0 = channel0->socket.lock ();
 		std::shared_ptr<nano::transport::socket> sock1 = channel1->socket.lock ();
-		ASSERT_TRUE (sock0->local_endpoint () == sock1->remote_endpoint ());
-		ASSERT_TRUE (sock1->local_endpoint () == sock0->remote_endpoint ());
+		ASSERT_EQ (sock0->local_endpoint (), sock1->remote_endpoint ());
+		ASSERT_EQ (sock1->local_endpoint (), sock0->remote_endpoint ());
 	}
 
 	// capture the state before and ensure the clock ticks at least once
@@ -570,7 +570,7 @@ TEST (network, endpoint_bad_fd)
 	auto endpoint (system.nodes[0]->network.endpoint ());
 	ASSERT_TRUE (endpoint.address ().is_loopback ());
 	// The endpoint is invalidated asynchronously
-	ASSERT_TIMELY (10s, system.nodes[0]->network.endpoint ().port () == 0);
+	ASSERT_TIMELY_EQ (10s, system.nodes[0]->network.endpoint ().port (), 0);
 }
 
 TEST (network, reserved_address)
@@ -802,9 +802,9 @@ TEST (network, duplicate_detection)
 	ASSERT_NE (nullptr, tcp_channel);
 	ASSERT_EQ (0, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish));
 	tcp_channel->send (publish);
-	ASSERT_TIMELY (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish) == 0);
+	ASSERT_TIMELY_EQ (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish), 0);
 	tcp_channel->send (publish);
-	ASSERT_TIMELY (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish) == 1);
+	ASSERT_TIMELY_EQ (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish), 1);
 }
 
 TEST (network, duplicate_revert_publish)
@@ -859,15 +859,15 @@ TEST (network, bandwidth_limiter_4_messages)
 		channel2.send (message);
 	}
 	// Only sent messages below limit, so we don't expect any drops
-	ASSERT_TIMELY (1s, 0 == node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (1s, 0, node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 
 	// Send droppable message; drop stats should increase by one now
 	channel1.send (message);
-	ASSERT_TIMELY (1s, 1 == node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (1s, 1, node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 
 	// Send non-droppable message, i.e. drop stats should not increase
 	channel2.send (message, nullptr, nano::transport::buffer_drop_policy::no_limiter_drop);
-	ASSERT_TIMELY (1s, 1 == node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (1s, 1, node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 }
 
 TEST (network, bandwidth_limiter_2_messages)
@@ -887,7 +887,7 @@ TEST (network, bandwidth_limiter_2_messages)
 	channel2.send (message);
 	channel1.send (message);
 	channel2.send (message);
-	ASSERT_TIMELY (1s, 2 == node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (1s, 2, node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 }
 
 TEST (network, bandwidth_limiter_with_burst)
@@ -907,7 +907,7 @@ TEST (network, bandwidth_limiter_with_burst)
 	channel2.send (message);
 	channel1.send (message);
 	channel2.send (message);
-	ASSERT_TIMELY (1s, 0 == node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (1s, 0, node.stats.count (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::out));
 }
 
 namespace nano
@@ -987,7 +987,7 @@ TEST (network, tcp_no_connect_excluded_peers)
 	// Ensure a successful connection
 	ASSERT_EQ (0, node0->network.size ());
 	node1->network.merge_peer (node0->network.endpoint ());
-	ASSERT_TIMELY (5s, node0->network.size () == 1);
+	ASSERT_TIMELY_EQ (5s, node0->network.size (), 1);
 }
 
 namespace nano
@@ -1072,7 +1072,7 @@ TEST (network, cleanup_purge)
 	std::weak_ptr<nano::node> node_w = node1.shared ();
 	node1.network.tcp_channels.start_tcp (node2->network.endpoint ());
 
-	ASSERT_TIMELY (3s, node1.network.size () == 1);
+	ASSERT_TIMELY_EQ (3s, node1.network.size (), 1);
 	node1.network.cleanup (test_start);
 	ASSERT_EQ (1, node1.network.size ());
 
@@ -1093,7 +1093,7 @@ TEST (network, loopback_channel)
 	ASSERT_EQ (channel1.get_node_id (), node1.node_id.pub);
 	ASSERT_EQ (channel1.get_node_id_optional ().value_or (0), node1.node_id.pub);
 	nano::transport::inproc::channel channel2 (node2, node2);
-	ASSERT_TRUE (channel1 == channel1);
+	ASSERT_EQ (channel1, channel1);
 	ASSERT_FALSE (channel1 == channel2);
 	++node1.network.port;
 	ASSERT_NE (channel1.get_endpoint (), node1.network.endpoint ());
@@ -1115,7 +1115,7 @@ TEST (network, filter_invalid_network_bytes)
 	const_cast<nano::networks &> (keepalive.header.network) = nano::networks::invalid;
 	channel->send (keepalive);
 
-	ASSERT_TIMELY (5s, 1 == node1.stats.count (nano::stat::type::error, nano::stat::detail::invalid_network));
+	ASSERT_TIMELY_EQ (5s, 1, node1.stats.count (nano::stat::type::error, nano::stat::detail::invalid_network));
 }
 
 // Ensure the network filters messages with the incorrect minimum version
@@ -1134,7 +1134,7 @@ TEST (network, filter_invalid_version_using)
 	const_cast<uint8_t &> (keepalive.header.version_using) = nano::dev::network_params.network.protocol_version_min - 1;
 	channel->send (keepalive);
 
-	ASSERT_TIMELY (5s, 1 == node1.stats.count (nano::stat::type::error, nano::stat::detail::outdated_version));
+	ASSERT_TIMELY_EQ (5s, 1, node1.stats.count (nano::stat::type::error, nano::stat::detail::outdated_version));
 }
 
 TEST (network, fill_keepalive_self)
@@ -1142,7 +1142,7 @@ TEST (network, fill_keepalive_self)
 	nano::test::system system{ 2 };
 	std::array<nano::endpoint, 8> target;
 	system.nodes[0]->network.fill_keepalive_self (target);
-	ASSERT_TRUE (target[2].port () == system.nodes[1]->network.port);
+	ASSERT_EQ (target[2].port (), system.nodes[1]->network.port);
 }
 
 /*

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -20,7 +20,7 @@ using namespace std::chrono_literals;
 TEST (node, null_account)
 {
 	auto const & null_account = nano::account::null ();
-	ASSERT_TRUE (null_account == nullptr);
+	ASSERT_EQ (null_account, nullptr);
 	ASSERT_FALSE (null_account != nullptr);
 
 	nano::account default_account{};
@@ -277,20 +277,20 @@ TEST (node, auto_bootstrap)
 	system.wallet (0)->insert_adhoc (key2.prv);
 	auto send1 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node0->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send1);
-	ASSERT_TIMELY (10s, node0->balance (key2.pub) == node0->config.receive_minimum.number ());
+	ASSERT_TIMELY_EQ (10s, node0->balance (key2.pub), node0->config.receive_minimum.number ());
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.logging, system.work, node_flags));
 	ASSERT_FALSE (node1->init_error ());
 	node1->start ();
 	system.nodes.push_back (node1);
 	ASSERT_NE (nullptr, nano::test::establish_tcp (system, *node1, node0->network.endpoint ()));
 	ASSERT_TIMELY (10s, node1->bootstrap_initiator.in_progress ());
-	ASSERT_TIMELY (10s, node1->balance (key2.pub) == node0->config.receive_minimum.number ());
+	ASSERT_TIMELY_EQ (10s, node1->balance (key2.pub), node0->config.receive_minimum.number ());
 	ASSERT_TIMELY (10s, !node1->bootstrap_initiator.in_progress ());
 	ASSERT_TRUE (node1->ledger.block_or_pruned_exists (send1->hash ()));
 	// Wait block receive
-	ASSERT_TIMELY (5s, node1->ledger.cache.block_count == 3);
+	ASSERT_TIMELY_EQ (5s, node1->ledger.cache.block_count, 3);
 	// Confirmation for all blocks
-	ASSERT_TIMELY (5s, node1->ledger.cache.cemented_count == 3);
+	ASSERT_TIMELY_EQ (5s, node1->ledger.cache.cemented_count, 3);
 
 	node1->stop ();
 }
@@ -313,7 +313,7 @@ TEST (node, auto_bootstrap_reverse)
 	node1->start ();
 	system.nodes.push_back (node1);
 	ASSERT_NE (nullptr, nano::test::establish_tcp (system, *node0, node1->network.endpoint ()));
-	ASSERT_TIMELY (10s, node1->balance (key2.pub) == node0->config.receive_minimum.number ());
+	ASSERT_TIMELY_EQ (10s, node1->balance (key2.pub), node0->config.receive_minimum.number ());
 }
 
 TEST (node, auto_bootstrap_age)
@@ -393,7 +393,7 @@ TEST (node, search_receivable_same)
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	system.wallet (0)->insert_adhoc (key2.prv);
 	ASSERT_FALSE (system.wallet (0)->search_receivable (system.wallet (0)->wallets.tx_begin_read ()));
-	ASSERT_TIMELY (10s, node->balance (key2.pub) == 2 * node->config.receive_minimum.number ());
+	ASSERT_TIMELY_EQ (10s, node->balance (key2.pub), 2 * node->config.receive_minimum.number ());
 }
 
 TEST (node, search_receivable_multiple)
@@ -410,7 +410,7 @@ TEST (node, search_receivable_multiple)
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (key3.pub, key2.pub, node->config.receive_minimum.number ()));
 	system.wallet (0)->insert_adhoc (key2.prv);
 	ASSERT_FALSE (system.wallet (0)->search_receivable (system.wallet (0)->wallets.tx_begin_read ()));
-	ASSERT_TIMELY (10s, node->balance (key2.pub) == 2 * node->config.receive_minimum.number ());
+	ASSERT_TIMELY_EQ (10s, node->balance (key2.pub), 2 * node->config.receive_minimum.number ());
 }
 
 TEST (node, search_receivable_confirmed)
@@ -444,7 +444,7 @@ TEST (node, search_receivable_confirmed)
 		ASSERT_FALSE (node->active.active (send1->hash ()));
 		ASSERT_FALSE (node->active.active (send2->hash ()));
 	}
-	ASSERT_TIMELY (10s, node->balance (key2.pub) == 2 * node->config.receive_minimum.number ());
+	ASSERT_TIMELY_EQ (10s, node->balance (key2.pub), 2 * node->config.receive_minimum.number ());
 }
 
 TEST (node, search_receivable_pruned)
@@ -468,7 +468,7 @@ TEST (node, search_receivable_pruned)
 	// Confirmation
 	ASSERT_TIMELY (10s, node1->active.empty () && node2->active.empty ());
 	ASSERT_TIMELY (5s, node1->ledger.block_confirmed (node1->store.tx_begin_read (), send2->hash ()));
-	ASSERT_TIMELY (5s, node2->ledger.cache.cemented_count == 3);
+	ASSERT_TIMELY_EQ (5s, node2->ledger.cache.cemented_count, 3);
 	system.wallet (0)->store.erase (node1->wallets.tx_begin_write (), nano::dev::genesis_key.pub);
 
 	// Pruning
@@ -482,7 +482,7 @@ TEST (node, search_receivable_pruned)
 	// Receive pruned block
 	system.wallet (1)->insert_adhoc (key2.prv);
 	ASSERT_FALSE (system.wallet (1)->search_receivable (system.wallet (1)->wallets.tx_begin_read ()));
-	ASSERT_TIMELY (10s, node2->balance (key2.pub) == 2 * node2->config.receive_minimum.number ());
+	ASSERT_TIMELY_EQ (10s, node2->balance (key2.pub), 2 * node2->config.receive_minimum.number ());
 }
 
 TEST (node, unlock_search)
@@ -589,7 +589,7 @@ TEST (node, fork_publish)
 		auto election (node1.active.election (send1->qualified_root ()));
 		ASSERT_NE (nullptr, election);
 		// Wait until the genesis rep activated & makes vote
-		ASSERT_TIMELY (1s, election->votes ().size () == 2);
+		ASSERT_TIMELY_EQ (1s, election->votes ().size (), 2);
 		node1.process_active (send2);
 		node1.block_processor.flush ();
 		auto votes1 (election->votes ());
@@ -915,7 +915,7 @@ TEST (node, fork_open)
 				 .build_shared ();
 	nano::publish publish2{ nano::dev::network_params.network, open1 };
 	node.network.inbound (publish2, channel1);
-	ASSERT_TIMELY (5s, 1 == node.active.size ());
+	ASSERT_TIMELY_EQ (5s, 1, node.active.size ());
 
 	// create 2nd open block, which is a fork of open1 block
 	auto open2 = builder.make_block ()
@@ -930,7 +930,7 @@ TEST (node, fork_open)
 	ASSERT_TIMELY (5s, (election = node.active.election (publish3.block->qualified_root ())) != nullptr);
 
 	// we expect to find 2 blocks in the election and we expect the first block to be the winner just because it was first
-	ASSERT_TIMELY (5s, 2 == election->blocks ().size ());
+	ASSERT_TIMELY_EQ (5s, 2, election->blocks ().size ());
 	ASSERT_EQ (publish2.block->hash (), election->winner ()->hash ());
 
 	// wait for a second and check that the election did not get confirmed
@@ -1002,8 +1002,8 @@ TEST (node, fork_open_flip)
 	ASSERT_TIMELY (5s, (election = node2.active.election (open2->qualified_root ())) != nullptr);
 	election->transition_active ();
 
-	ASSERT_TIMELY (5s, 2 == node1.active.size ());
-	ASSERT_TIMELY (5s, 2 == node2.active.size ());
+	ASSERT_TIMELY_EQ (5s, 2, node1.active.size ());
+	ASSERT_TIMELY_EQ (5s, 2, node2.active.size ());
 
 	// allow node1 to vote and wait for open1 to be confirmed on node1
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -1013,7 +1013,7 @@ TEST (node, fork_open_flip)
 	node1.process_active (open2);
 	node2.process_active (open1);
 
-	ASSERT_TIMELY (5s, 2 == election->votes ().size ()); // one more than expected due to elections having dummy votes
+	ASSERT_TIMELY_EQ (5s, 2, election->votes ().size ()); // one more than expected due to elections having dummy votes
 
 	// Node2 should eventually settle on open1
 	ASSERT_TIMELY (10s, node2.block (open1->hash ()));
@@ -1099,9 +1099,9 @@ TEST (node, fork_no_vote_quorum)
 	ASSERT_NE (nullptr, channel);
 	channel->send_buffer (nano::shared_const_buffer (std::move (buffer)));
 	ASSERT_TIMELY (10s, node3.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::in) >= 3);
-	ASSERT_TRUE (node1.latest (nano::dev::genesis_key.pub) == send1->hash ());
-	ASSERT_TRUE (node2.latest (nano::dev::genesis_key.pub) == send1->hash ());
-	ASSERT_TRUE (node3.latest (nano::dev::genesis_key.pub) == send1->hash ());
+	ASSERT_EQ (node1.latest (nano::dev::genesis_key.pub), send1->hash ());
+	ASSERT_EQ (node2.latest (nano::dev::genesis_key.pub), send1->hash ());
+	ASSERT_EQ (node3.latest (nano::dev::genesis_key.pub), send1->hash ());
 }
 
 // Disabled because it sometimes takes way too long (but still eventually finishes)
@@ -1331,7 +1331,7 @@ TEST (node, DISABLED_broadcast_elected)
 		auto election (node->active.election (block->qualified_root ()));
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
-		ASSERT_TIMELY (5s, 4 == node->ledger.cache.cemented_count)
+		ASSERT_TIMELY_EQ (5s, 4, node->ledger.cache.cemented_count)
 	}
 
 	system.wallet (0)->insert_adhoc (rep_big.prv);
@@ -1418,7 +1418,7 @@ TEST (node, rep_self_vote)
 	auto election1 = active.election (block0->qualified_root ());
 	ASSERT_NE (nullptr, election1);
 	// Wait until representatives are activated & make vote
-	ASSERT_TIMELY (1s, election1->votes ().size () == 3);
+	ASSERT_TIMELY_EQ (1s, election1->votes ().size (), 3);
 	auto rep_votes (election1->votes ());
 	ASSERT_NE (rep_votes.end (), rep_votes.find (nano::dev::genesis_key.pub));
 	ASSERT_NE (rep_votes.end (), rep_votes.find (rep_big.pub));
@@ -1624,7 +1624,7 @@ TEST (node, unconfirmed_send)
 	ASSERT_TIMELY (5s, node2.block_confirmed (send1->hash ()));
 
 	// wait until receive1 (auto-receive created by wallet) is cemented
-	ASSERT_TIMELY (5s, node2.get_confirmation_height (node2.store.tx_begin_read (), key2.pub) == 1);
+	ASSERT_TIMELY_EQ (5s, node2.get_confirmation_height (node2.store.tx_begin_read (), key2.pub), 1);
 	ASSERT_EQ (node2.balance (key2.pub), 2 * nano::Mxrb_ratio);
 	auto recv1 = node2.ledger.find_receive_block_by_send_hash (node2.store.tx_begin_read (), key2.pub, send1->hash ());
 
@@ -1646,8 +1646,8 @@ TEST (node, unconfirmed_send)
 	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
 	ASSERT_TIMELY (5s, node2.block_confirmed (send3->hash ()));
 	ASSERT_TIMELY (5s, node1.block_confirmed (send3->hash ()));
-	ASSERT_TIMELY (5s, node2.ledger.cache.cemented_count == 7);
-	ASSERT_TIMELY (5s, node1.balance (nano::dev::genesis->account ()) == nano::dev::constants.genesis_amount);
+	ASSERT_TIMELY_EQ (5s, node2.ledger.cache.cemented_count, 7);
+	ASSERT_TIMELY_EQ (5s, node1.balance (nano::dev::genesis->account ()), nano::dev::constants.genesis_amount);
 }
 
 // Test that nodes can track nodes that have rep weight for priority broadcasting
@@ -1757,7 +1757,7 @@ TEST (node, rep_weight)
 	node.rep_crawler.response (channel1, vote0);
 	node.rep_crawler.response (channel2, vote1);
 	node.rep_crawler.response (channel3, vote2);
-	ASSERT_TIMELY (5s, node.rep_crawler.representative_count () == 2);
+	ASSERT_TIMELY_EQ (5s, node.rep_crawler.representative_count (), 2);
 	// Make sure we get the rep with the most weight first
 	auto reps = node.rep_crawler.representatives (1);
 	ASSERT_EQ (1, reps.size ());
@@ -1841,7 +1841,7 @@ TEST (node, rep_remove)
 	// Ensure Rep1 is found by the rep_crawler after receiving a vote from it
 	auto vote_rep1 = std::make_shared<nano::vote> (keys_rep1.pub, keys_rep1.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
 	ASSERT_FALSE (searching_node.rep_crawler.response (channel_rep1, vote_rep1, true));
-	ASSERT_TIMELY (5s, searching_node.rep_crawler.representative_count () == 1);
+	ASSERT_TIMELY_EQ (5s, searching_node.rep_crawler.representative_count (), 1);
 	auto reps (searching_node.rep_crawler.representatives (1));
 	ASSERT_EQ (1, reps.size ());
 	ASSERT_EQ (searching_node.minimum_principal_weight () * 2, searching_node.ledger.weight (reps[0].account));
@@ -1850,7 +1850,7 @@ TEST (node, rep_remove)
 
 	// When rep1 disconnects then rep1 should not be found anymore
 	channel_rep1->close ();
-	ASSERT_TIMELY (5s, searching_node.rep_crawler.representative_count () == 0);
+	ASSERT_TIMELY_EQ (5s, searching_node.rep_crawler.representative_count (), 0);
 
 	// Add working node for genesis representative
 	auto node_genesis_rep = system.add_node (nano::node_config (system.get_available_port (), system.logging));
@@ -1861,7 +1861,7 @@ TEST (node, rep_remove)
 	// genesis_rep should be found as principal representative after receiving a vote from it
 	auto vote_genesis_rep = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
 	searching_node.rep_crawler.response (channel_genesis_rep, vote_genesis_rep, true);
-	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 1);
+	ASSERT_TIMELY_EQ (10s, searching_node.rep_crawler.representative_count (), 1);
 
 	// Start a node for Rep2 and wait until it is connected
 	auto node_rep2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), nano::node_config (system.get_available_port (), system.logging), system.work));
@@ -1873,11 +1873,11 @@ TEST (node, rep_remove)
 	// Rep2 should be found as a principal representative after receiving a vote from it
 	auto vote_rep2 = std::make_shared<nano::vote> (keys_rep2.pub, keys_rep2.prv, 0, 0, std::vector<nano::block_hash>{ nano::dev::genesis->hash () });
 	ASSERT_FALSE (searching_node.rep_crawler.response (channel_rep2, vote_rep2, true));
-	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 2);
+	ASSERT_TIMELY_EQ (10s, searching_node.rep_crawler.representative_count (), 2);
 
 	// When Rep2 is stopped, it should not be found as principal representative anymore
 	node_rep2->stop ();
-	ASSERT_TIMELY (10s, searching_node.rep_crawler.representative_count () == 1);
+	ASSERT_TIMELY_EQ (10s, searching_node.rep_crawler.representative_count (), 1);
 
 	// Now only genesisRep should be found:
 	reps = searching_node.rep_crawler.representatives (1);
@@ -1894,10 +1894,10 @@ TEST (node, rep_connection_close)
 	auto & node2 (*system.nodes[1]);
 	// Add working representative (node 2)
 	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
-	ASSERT_TIMELY (10s, node1.rep_crawler.representative_count () == 1);
+	ASSERT_TIMELY_EQ (10s, node1.rep_crawler.representative_count (), 1);
 	node2.stop ();
 	// Remove representative with closed channel
-	ASSERT_TIMELY (10s, node1.rep_crawler.representative_count () == 0);
+	ASSERT_TIMELY_EQ (10s, node1.rep_crawler.representative_count (), 0);
 }
 
 // Test that nodes can disable representative voting
@@ -2150,7 +2150,7 @@ TEST (node, block_confirm)
 	node2.start_election (send1_copy);
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node2.active.election (send1_copy->qualified_root ()));
-	ASSERT_TIMELY (10s, node1.active.recently_cemented.list ().size () == 1);
+	ASSERT_TIMELY_EQ (10s, node1.active.recently_cemented.list ().size (), 1);
 }
 
 TEST (node, block_arrival)
@@ -2271,15 +2271,15 @@ TEST (node, local_votes_cache)
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node.active.election (send2->qualified_root ()));
 	election->force_confirm ();
-	ASSERT_TIMELY (3s, node.ledger.cache.cemented_count == 3);
+	ASSERT_TIMELY_EQ (3s, node.ledger.cache.cemented_count, 3);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::confirm_req message1{ nano::dev::network_params.network, send1->hash (), send1->root () };
 	nano::confirm_req message2{ nano::dev::network_params.network, send2->hash (), send2->root () };
 	auto channel = std::make_shared<nano::transport::fake::channel> (node);
 	node.network.inbound (message1, channel);
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 1);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes), 1);
 	node.network.inbound (message2, channel);
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 2);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes), 2);
 	for (auto i (0); i < 100; ++i)
 	{
 		node.network.inbound (message1, channel);
@@ -2290,7 +2290,7 @@ TEST (node, local_votes_cache)
 		ASSERT_NO_ERROR (system.poll (node.aggregator.max_delay));
 	}
 	// Make sure a new vote was not generated
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 2);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes), 2);
 	// Max cache
 	{
 		auto transaction (node.store.tx_begin_write ());
@@ -2305,7 +2305,7 @@ TEST (node, local_votes_cache)
 	{
 		ASSERT_NO_ERROR (system.poll (node.aggregator.max_delay));
 	}
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 3);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes), 3);
 	ASSERT_TIMELY (3s, !node.history.votes (send1->root (), send1->hash ()).empty ());
 	ASSERT_TIMELY (3s, !node.history.votes (send2->root (), send2->hash ()).empty ());
 	ASSERT_TIMELY (3s, !node.history.votes (send3->root (), send3->hash ()).empty ());
@@ -2360,26 +2360,26 @@ TEST (node, DISABLED_local_votes_cache_batch)
 	auto channel = std::make_shared<nano::transport::fake::channel> (node);
 	// Generates and sends one vote for both hashes which is then cached
 	node.network.inbound (message, channel);
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out) == 1);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out), 1);
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 	ASSERT_FALSE (node.history.votes (send2->root (), send2->hash ()).empty ());
 	ASSERT_FALSE (node.history.votes (receive1->root (), receive1->hash ()).empty ());
 	// Only one confirm_ack should be sent if all hashes are part of the same vote
 	node.network.inbound (message, channel);
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out) == 2);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out), 2);
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 	// Test when votes are different
 	node.history.erase (send2->root ());
 	node.history.erase (receive1->root ());
 	node.network.inbound (nano::confirm_req{ nano::dev::network_params.network, send2->hash (), send2->root () }, channel);
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out) == 3);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out), 3);
 	ASSERT_EQ (3, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 	node.network.inbound (nano::confirm_req{ nano::dev::network_params.network, receive1->hash (), receive1->root () }, channel);
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out) == 4);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out), 4);
 	ASSERT_EQ (4, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 	// There are two different votes, so both should be sent in response
 	node.network.inbound (message, channel);
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out) == 6);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out), 6);
 	ASSERT_EQ (6, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 }
 
@@ -2406,7 +2406,7 @@ TEST (node, local_votes_cache_generate_new_vote)
 	ASSERT_EQ (1, votes1.size ());
 	ASSERT_EQ (1, votes1[0]->hashes.size ());
 	ASSERT_EQ (nano::dev::genesis->hash (), votes1[0]->hashes[0]);
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 1);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes), 1);
 
 	auto send1 = nano::state_block_builder ()
 				 .account (nano::dev::genesis_key.pub)
@@ -2426,11 +2426,11 @@ TEST (node, local_votes_cache_generate_new_vote)
 	auto votes2 (node.history.votes (send1->root (), send1->hash ()));
 	ASSERT_EQ (1, votes2.size ());
 	ASSERT_EQ (1, votes2[0]->hashes.size ());
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 2);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes), 2);
 	ASSERT_FALSE (node.history.votes (nano::dev::genesis->root (), nano::dev::genesis->hash ()).empty ());
 	ASSERT_FALSE (node.history.votes (send1->root (), send1->hash ()).empty ());
 	// First generated + again cached + new generated
-	ASSERT_TIMELY (3s, 3 == node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (3s, 3, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 }
 
 TEST (node, local_votes_cache_fork)
@@ -2536,8 +2536,8 @@ TEST (node, vote_republish)
 	// check that send1 is deleted from the ledger on nodes
 	ASSERT_FALSE (node1.block (send1->hash ()));
 	ASSERT_FALSE (node2.block (send1->hash ()));
-	ASSERT_TIMELY (5s, node2.balance (key2.pub) == node1.config.receive_minimum.number () * 2);
-	ASSERT_TIMELY (5s, node1.balance (key2.pub) == node1.config.receive_minimum.number () * 2);
+	ASSERT_TIMELY_EQ (5s, node2.balance (key2.pub), node1.config.receive_minimum.number () * 2);
+	ASSERT_TIMELY_EQ (5s, node1.balance (key2.pub), node1.config.receive_minimum.number () * 2);
 }
 
 TEST (node, vote_by_hash_bundle)
@@ -2646,8 +2646,8 @@ TEST (node, vote_by_hash_republish)
 	ASSERT_TIMELY (5s, node2.block_confirmed (send2->hash ()));
 	ASSERT_FALSE (node1.block (send1->hash ()));
 	ASSERT_FALSE (node2.block (send1->hash ()));
-	ASSERT_TIMELY (5s, node2.balance (key2.pub) == node1.config.receive_minimum.number () * 2);
-	ASSERT_TIMELY (5s, node1.balance (key2.pub) == node1.config.receive_minimum.number () * 2);
+	ASSERT_TIMELY_EQ (5s, node2.balance (key2.pub), node1.config.receive_minimum.number () * 2);
+	ASSERT_TIMELY_EQ (5s, node1.balance (key2.pub), node1.config.receive_minimum.number () * 2);
 }
 
 // Test disabled because it's failing intermittently.
@@ -2974,7 +2974,7 @@ TEST (node, block_processor_signatures)
 	node1.process_active (receive2);
 	node1.process_active (receive3);
 	ASSERT_TIMELY (5s, node1.block (receive2->hash ()) != nullptr); // Implies send1, send2, send3, receive1.
-	ASSERT_TIMELY (5s, node1.unchecked.count () == 0);
+	ASSERT_TIMELY_EQ (5s, node1.unchecked.count (), 0);
 	ASSERT_EQ (nullptr, node1.block (receive3->hash ())); // Invalid signer
 	ASSERT_EQ (nullptr, node1.block (send4->hash ())); // Invalid signature via process_active
 	ASSERT_EQ (nullptr, node1.block (send5->hash ())); // Invalid signature via unchecked
@@ -3279,7 +3279,7 @@ TEST (node, unchecked_cleanup)
 	ASSERT_FALSE (node.network.publish_filter.apply (bytes.data (), bytes.size ()));
 	node.process_active (open);
 	// Waits for the open block to get saved in the database
-	ASSERT_TIMELY (15s, 1 == node.unchecked.count ());
+	ASSERT_TIMELY_EQ (15s, 1, node.unchecked.count ());
 	node.config.unchecked_cutoff_time = std::chrono::seconds (2);
 	ASSERT_EQ (1, node.unchecked.count ());
 	std::this_thread::sleep_for (std::chrono::seconds (1));
@@ -3482,7 +3482,7 @@ TEST (node, rollback_vote_self)
 	// Process and mark the first 2 blocks as confirmed to allow voting
 	ASSERT_TRUE (nano::test::process (node, { send1, open }));
 	ASSERT_TRUE (nano::test::start_elections (system, node, { send1, open }, true));
-	ASSERT_TIMELY (5s, node.ledger.cache.cemented_count == 3);
+	ASSERT_TIMELY_EQ (5s, node.ledger.cache.cemented_count, 3);
 
 	// wait until the rep weights have caught up with the weight transfer
 	ASSERT_TIMELY_EQ (5s, nano::dev::constants.genesis_amount / 2, node.weight (key.pub));
@@ -3581,9 +3581,9 @@ TEST (node, rollback_gap_source)
 	// Node has 'fork1a' & doesn't have source 'send2' for winning 'fork1b' block
 	ASSERT_EQ (nullptr, node.block (send2->hash ()));
 	node.block_processor.force (fork1b);
-	ASSERT_TIMELY (5s, node.block (fork1a->hash ()) == nullptr);
+	ASSERT_TIMELY_EQ (5s, node.block (fork1a->hash ()), nullptr);
 	// Wait for the rollback (attempt to replace fork with open)
-	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::rollback, nano::stat::detail::open) == 1);
+	ASSERT_TIMELY_EQ (5s, node.stats.count (nano::stat::type::rollback, nano::stat::detail::open), 1);
 	// But replacing is not possible (missing source block - send2)
 	ASSERT_EQ (nullptr, node.block (fork1b->hash ()));
 	// Fork can be returned by some other forked node
@@ -3593,7 +3593,7 @@ TEST (node, rollback_gap_source)
 	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
 	node.block_processor.force (fork1b);
 	// Wait for new rollback
-	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::rollback, nano::stat::detail::open) == 2);
+	ASSERT_TIMELY_EQ (5s, node.stats.count (nano::stat::type::rollback, nano::stat::detail::open), 2);
 	// Now fork block should be replaced with open
 	ASSERT_TIMELY (5s, node.block (fork1b->hash ()) != nullptr);
 	ASSERT_EQ (nullptr, node.block (fork1a->hash ()));
@@ -3959,8 +3959,8 @@ TEST (node, dependency_graph_frontier)
 	ASSERT_TIMELY (10s, node2.active.active (gen_send1->qualified_root ()));
 	node1.start_election (gen_send1);
 
-	ASSERT_TIMELY (15s, node1.ledger.cache.cemented_count == node1.ledger.cache.block_count);
-	ASSERT_TIMELY (15s, node2.ledger.cache.cemented_count == node2.ledger.cache.block_count);
+	ASSERT_TIMELY_EQ (15s, node1.ledger.cache.cemented_count, node1.ledger.cache.block_count);
+	ASSERT_TIMELY_EQ (15s, node2.ledger.cache.cemented_count, node2.ledger.cache.block_count);
 }
 
 namespace nano
@@ -4174,8 +4174,8 @@ TEST (node, pruning_automatic)
 
 	// Check pruning result
 	ASSERT_EQ (3, node1.ledger.cache.block_count);
-	ASSERT_TIMELY (5s, node1.ledger.cache.pruned_count == 1);
-	ASSERT_TIMELY (5s, node1.store.pruned.count (node1.store.tx_begin_read ()) == 1);
+	ASSERT_TIMELY_EQ (5s, node1.ledger.cache.pruned_count, 1);
+	ASSERT_TIMELY_EQ (5s, node1.store.pruned.count (node1.store.tx_begin_read ()), 1);
 	ASSERT_EQ (1, node1.ledger.cache.pruned_count);
 	ASSERT_EQ (3, node1.ledger.cache.block_count);
 

--- a/nano/core_test/optimistic_scheduler.cpp
+++ b/nano/core_test/optimistic_scheduler.cpp
@@ -30,7 +30,7 @@ TEST (optimistic_scheduler, activate_one)
 	// Ensure unconfirmed account head block gets activated
 	auto const & block = blocks.back ();
 	ASSERT_TIMELY (5s, node.active.active (block->hash ()));
-	ASSERT_TRUE (node.active.election (block->qualified_root ())->behavior () == nano::election_behavior::optimistic);
+	ASSERT_EQ (node.active.election (block->qualified_root ())->behavior (), nano::election_behavior::optimistic);
 }
 
 /*
@@ -51,7 +51,7 @@ TEST (optimistic_scheduler, activate_one_zero_conf)
 	// Ensure unconfirmed account head block gets activated
 	auto const & block = blocks.back ();
 	ASSERT_TIMELY (5s, node.active.active (block->hash ()));
-	ASSERT_TRUE (node.active.election (block->qualified_root ())->behavior () == nano::election_behavior::optimistic);
+	ASSERT_EQ (node.active.election (block->qualified_root ())->behavior (), nano::election_behavior::optimistic);
 }
 
 /*

--- a/nano/core_test/processing_queue.cpp
+++ b/nano/core_test/processing_queue.cpp
@@ -27,7 +27,7 @@ TEST (processing_queue, process_one)
 
 	queue.add (1);
 
-	ASSERT_TIMELY (5s, processed == 1);
+	ASSERT_TIMELY_EQ (5s, processed, 1);
 	ASSERT_ALWAYS (1s, processed == 1);
 	ASSERT_EQ (queue.size (), 0);
 }
@@ -49,7 +49,7 @@ TEST (processing_queue, process_many)
 		queue.add (1);
 	}
 
-	ASSERT_TIMELY (5s, processed == count);
+	ASSERT_TIMELY_EQ (5s, processed, count);
 	ASSERT_ALWAYS (1s, processed == count);
 	ASSERT_EQ (queue.size (), 0);
 }
@@ -89,7 +89,7 @@ TEST (processing_queue, max_batch_size)
 	};
 	nano::test::start_stop_guard queue_guard{ queue };
 
-	ASSERT_TIMELY (5s, max_batch == 128);
+	ASSERT_TIMELY_EQ (5s, max_batch, 128);
 	ASSERT_ALWAYS (1s, max_batch == 128);
 	ASSERT_EQ (queue.size (), 0);
 }
@@ -114,6 +114,6 @@ TEST (processing_queue, parallel)
 
 	// There are 16 threads and 16 items, each thread is waiting 1 second inside processing callback
 	// If processing is done in parallel it should take ~2 seconds to process every item, but keep some margin for slow machines
-	ASSERT_TIMELY (3s, processed == count);
+	ASSERT_TIMELY_EQ (3s, processed, count);
 	ASSERT_EQ (queue.size (), 0);
 }

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -35,7 +35,7 @@ TEST (request_aggregator, one)
 	ASSERT_EQ (1, node.aggregator.size ());
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	// Not yet in the ledger
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
@@ -46,13 +46,13 @@ TEST (request_aggregator, one)
 	ASSERT_EQ (1, node.aggregator.size ());
 	// Already cached
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
-	ASSERT_TIMELY (3s, 3 == node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
-	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (3s, 3, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
+	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 }
 
 TEST (request_aggregator, one_update)
@@ -109,16 +109,16 @@ TEST (request_aggregator, one_update)
 	// In the ledger but no vote generated yet
 	ASSERT_TIMELY (3s, 0 < node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes))
 	ASSERT_TRUE (node.aggregator.empty ());
-	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
-	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
+	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
+	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
 	size_t count = 0;
-	ASSERT_TIMELY (3s, 1 == (count = node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes)));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (3s, 1, (count = node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes)));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 }
 
 TEST (request_aggregator, two)
@@ -179,13 +179,13 @@ TEST (request_aggregator, two)
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
-	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
-	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes));
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
-	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
+	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
+	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
+	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 	// Make sure the cached vote is for both hashes
 	auto vote1 (node.history.votes (send2->root (), send2->hash ()));
 	auto vote2 (node.history.votes (receive1->root (), receive1->hash ()));
@@ -287,24 +287,24 @@ TEST (request_aggregator, split)
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node.active.election (blocks.back ()->qualified_root ()));
 	election->force_confirm ();
-	ASSERT_TIMELY (5s, max_vbh + 2 == node.ledger.cache.cemented_count);
+	ASSERT_TIMELY_EQ (5s, max_vbh + 2, node.ledger.cache.cemented_count);
 	ASSERT_EQ (max_vbh + 1, request.size ());
 	auto client = std::make_shared<nano::transport::socket> (node);
 	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
 	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	// In the ledger but no vote generated yet
-	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
+	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
 	ASSERT_TRUE (node.aggregator.empty ());
 	// Two votes were sent, the first one for 12 hashes and the second one for 1 hash
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_TIMELY (3s, 13 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
-	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes));
-	ASSERT_TIMELY (3s, 0 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
-	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (3s, 13, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
+	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes));
+	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
+	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 }
 
 TEST (request_aggregator, channel_lifetime)
@@ -374,7 +374,7 @@ TEST (request_aggregator, channel_update)
 	ASSERT_EQ (1, node.aggregator.size ());
 	// channel1 is not being held anymore
 	ASSERT_EQ (nullptr, channel1_w.lock ());
-	ASSERT_TIMELY (3s, 0 < node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes) == 0);
+	ASSERT_TIMELY_EQ (3s, 0 < node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes), 0);
 }
 
 TEST (request_aggregator, channel_max_queue)
@@ -403,7 +403,7 @@ TEST (request_aggregator, channel_max_queue)
 	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
 	node.aggregator.add (dummy_channel, request);
 	node.aggregator.add (dummy_channel, request);
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
 }
 
 TEST (request_aggregator, unique)
@@ -433,8 +433,8 @@ TEST (request_aggregator, unique)
 	node.aggregator.add (dummy_channel, request);
 	node.aggregator.add (dummy_channel, request);
 	node.aggregator.add (dummy_channel, request);
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
 }
 
 namespace nano
@@ -481,7 +481,7 @@ TEST (request_aggregator, cannot_vote)
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_TIMELY (3s, 2 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
+	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
@@ -494,7 +494,7 @@ TEST (request_aggregator, cannot_vote)
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_TIMELY (3s, 4 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
+	ASSERT_TIMELY_EQ (3s, 4, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_votes));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
@@ -512,8 +512,8 @@ TEST (request_aggregator, cannot_vote)
 	ASSERT_EQ (3, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
 	ASSERT_EQ (4, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cannot_vote));
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
 	ASSERT_TIMELY (3s, 1 <= node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 }

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -156,9 +156,9 @@ TEST (socket, max_connections_per_ip)
 		return node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_accept_success, nano::stat::dir::in);
 	};
 
-	ASSERT_TIMELY (5s, get_tcp_accept_successes () == max_ip_connections);
-	ASSERT_TIMELY (5s, get_tcp_max_per_ip () == 1);
-	ASSERT_TIMELY (5s, connection_attempts == max_ip_connections + 1);
+	ASSERT_TIMELY_EQ (5s, get_tcp_accept_successes (), max_ip_connections);
+	ASSERT_TIMELY_EQ (5s, get_tcp_max_per_ip (), 1);
+	ASSERT_TIMELY_EQ (5s, connection_attempts, max_ip_connections + 1);
 
 	node->stop ();
 }
@@ -276,9 +276,9 @@ TEST (socket, max_connections_per_subnetwork)
 		return node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_accept_success, nano::stat::dir::in);
 	};
 
-	ASSERT_TIMELY (5s, get_tcp_accept_successes () == max_subnetwork_connections);
-	ASSERT_TIMELY (5s, get_tcp_max_per_subnetwork () == 1);
-	ASSERT_TIMELY (5s, connection_attempts == max_subnetwork_connections + 1);
+	ASSERT_TIMELY_EQ (5s, get_tcp_accept_successes (), max_subnetwork_connections);
+	ASSERT_TIMELY_EQ (5s, get_tcp_max_per_subnetwork (), 1);
+	ASSERT_TIMELY_EQ (5s, connection_attempts, max_subnetwork_connections + 1);
 
 	node->stop ();
 }
@@ -336,9 +336,9 @@ TEST (socket, disabled_max_peers_per_ip)
 		return node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_accept_success, nano::stat::dir::in);
 	};
 
-	ASSERT_TIMELY (5s, get_tcp_accept_successes () == max_ip_connections + 1);
-	ASSERT_TIMELY (5s, get_tcp_max_per_ip () == 0);
-	ASSERT_TIMELY (5s, connection_attempts == max_ip_connections + 1);
+	ASSERT_TIMELY_EQ (5s, get_tcp_accept_successes (), max_ip_connections + 1);
+	ASSERT_TIMELY_EQ (5s, get_tcp_max_per_ip (), 0);
+	ASSERT_TIMELY_EQ (5s, connection_attempts, max_ip_connections + 1);
 
 	node->stop ();
 }
@@ -598,7 +598,7 @@ TEST (socket_timeout, connect)
 	});
 
 	// check that the callback was called and we got an error
-	ASSERT_TIMELY (6s, done == true);
+	ASSERT_TIMELY_EQ (6s, done, true);
 	ASSERT_TRUE (ec);
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_connect_error, nano::stat::dir::in));
 
@@ -644,7 +644,7 @@ TEST (socket_timeout, read)
 	});
 
 	// check that the callback was called and we got an error
-	ASSERT_TIMELY (10s, done == true);
+	ASSERT_TIMELY_EQ (10s, done, true);
 	ASSERT_TRUE (ec);
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_read_error, nano::stat::dir::in));
 
@@ -695,7 +695,7 @@ TEST (socket_timeout, write)
 	});
 
 	// check that the callback was called and we got an error
-	ASSERT_TIMELY (10s, done == true);
+	ASSERT_TIMELY_EQ (10s, done, true);
 	ASSERT_TRUE (ec);
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_write_error, nano::stat::dir::in));
 
@@ -753,7 +753,7 @@ TEST (socket_timeout, read_overlapped)
 	});
 
 	// check that the callback was called and we got an error
-	ASSERT_TIMELY (10s, done == true);
+	ASSERT_TIMELY_EQ (10s, done, true);
 	ASSERT_TRUE (ec);
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_read_error, nano::stat::dir::in));
 
@@ -813,7 +813,7 @@ TEST (socket_timeout, write_overlapped)
 	});
 
 	// check that the callback was called and we got an error
-	ASSERT_TIMELY (10s, done == true);
+	ASSERT_TIMELY_EQ (10s, done, true);
 	ASSERT_TRUE (ec);
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_write_error, nano::stat::dir::in));
 

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -368,7 +368,7 @@ TEST (telemetry, dos_tcp)
 		ASSERT_FALSE (ec);
 	});
 
-	ASSERT_TIMELY (5s, 1 == node_server->stats.count (nano::stat::type::message, nano::stat::detail::telemetry_req, nano::stat::dir::in));
+	ASSERT_TIMELY_EQ (5s, 1, node_server->stats.count (nano::stat::type::message, nano::stat::detail::telemetry_req, nano::stat::dir::in));
 
 	auto orig = std::chrono::steady_clock::now ();
 	for (int i = 0; i < 10; ++i)
@@ -440,7 +440,7 @@ TEST (telemetry, max_possible_size)
 		ASSERT_FALSE (ec);
 	});
 
-	ASSERT_TIMELY (5s, 1 == node_server->stats.count (nano::stat::type::message, nano::stat::detail::telemetry_ack, nano::stat::dir::in));
+	ASSERT_TIMELY_EQ (5s, 1, node_server->stats.count (nano::stat::type::message, nano::stat::detail::telemetry_ack, nano::stat::dir::in));
 }
 
 TEST (telemetry, maker_pruning)

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -362,13 +362,13 @@ TEST (toml, base_override)
 	t.get_required<uint16_t> ("node.peering_port_not_existent", port);
 	ASSERT_EQ (port, 65535);
 	ASSERT_TRUE (t.get_error ());
-	ASSERT_TRUE (t.get_error () == nano::error_config::missing_value);
+	ASSERT_EQ (t.get_error (), nano::error_config::missing_value);
 	t.get_error ().clear ();
 
 	// Query uint16 that's too big, make sure we have an error
 	t.get_required<uint16_t> ("node.too_big", port);
 	ASSERT_TRUE (t.get_error ());
-	ASSERT_TRUE (t.get_error () == nano::error_config::invalid_value);
+	ASSERT_EQ (t.get_error (), nano::error_config::invalid_value);
 }
 
 TEST (toml, put)
@@ -394,7 +394,7 @@ TEST (toml, array)
 	config_node.push<std::string> ("items", "item 2");
 	int i = 1;
 	config_node.array_entries_required<std::string> ("items", [&i] (std::string item) {
-		ASSERT_TRUE (item == std::string ("item ") + std::to_string (i));
+		ASSERT_EQ (item, std::string ("item ") + std::to_string (i));
 		i++;
 	});
 }

--- a/nano/core_test/unchecked_map.cpp
+++ b/nano/core_test/unchecked_map.cpp
@@ -238,7 +238,7 @@ TEST (unchecked, multiple_get)
 	};
 
 	// Waits for the blocks to get saved in the database
-	ASSERT_TIMELY (5s, 8 == count_unchecked_blocks_one_by_one ());
+	ASSERT_TIMELY_EQ (5s, 8, count_unchecked_blocks_one_by_one ());
 
 	std::vector<nano::block_hash> unchecked1;
 	// Asserts the entries will be found for the provided key

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -78,9 +78,9 @@ TEST (vote_processor, invalid_signature)
 	ASSERT_EQ (1, election->votes ().size ());
 
 	node.vote_processor.vote (vote_invalid, channel);
-	ASSERT_TIMELY (5s, 1 == election->votes ().size ());
+	ASSERT_TIMELY_EQ (5s, 1, election->votes ().size ());
 	node.vote_processor.vote (vote, channel);
-	ASSERT_TIMELY (5s, 2 == election->votes ().size ());
+	ASSERT_TIMELY_EQ (5s, 2, election->votes ().size ());
 }
 
 TEST (vote_processor, no_capacity)
@@ -154,7 +154,7 @@ TEST (vote_processor, weights)
 	system.wallet (0)->send_sync (nano::dev::genesis_key.pub, key2.pub, level2);
 
 	// Wait for representatives
-	ASSERT_TIMELY (10s, node.ledger.cache.rep_weights.get_rep_amounts ().size () == 4);
+	ASSERT_TIMELY_EQ (10s, node.ledger.cache.rep_weights.get_rep_amounts ().size (), 4);
 	node.vote_processor.calculate_weights ();
 
 	ASSERT_EQ (node.vote_processor.representatives_1.end (), node.vote_processor.representatives_1.find (key0.pub));
@@ -344,7 +344,7 @@ TEST (vote_processor, large_votes)
 	ASSERT_TIMELY (5s, nano::test::active (node, blocks));
 
 	auto vote = nano::test::make_final_vote (nano::dev::genesis_key, blocks);
-	ASSERT_TRUE (vote->hashes.size () == count);
+	ASSERT_EQ (vote->hashes.size (), count);
 
 	node.vote_processor.vote (vote, nano::test::fake_channel (node));
 

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -51,7 +51,7 @@ TEST (local_vote_history, basic)
 	ASSERT_EQ (1, history.size ());
 	auto votes3 (history.votes (1));
 	ASSERT_EQ (1, votes3.size ());
-	ASSERT_TRUE (vote3 == votes3[0]);
+	ASSERT_EQ (vote3, votes3[0]);
 }
 }
 
@@ -92,7 +92,7 @@ TEST (vote_generator, multiple_representatives)
 	auto hash = wallet.send_sync (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub, 1);
 	auto send = node.block (hash);
 	ASSERT_NE (nullptr, send);
-	ASSERT_TIMELY (5s, node.history.votes (send->root (), send->hash ()).size () == 4);
+	ASSERT_TIMELY_EQ (5s, node.history.votes (send->root (), send->hash ()).size (), 4);
 	auto votes (node.history.votes (send->root (), send->hash ()));
 	for (auto const & account : { key1.pub, key2.pub, key3.pub, nano::dev::genesis_key.pub })
 	{
@@ -169,15 +169,15 @@ TEST (vote_spacing, vote_generator)
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts));
 	node.generator.add (nano::dev::genesis->hash (), send1->hash ());
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts) == 1);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts), 1);
 	ASSERT_FALSE (node.ledger.rollback (node.store.tx_begin_write (), send1->hash ()));
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send2).code);
 	node.generator.add (nano::dev::genesis->hash (), send2->hash ());
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_spacing) == 1);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_spacing), 1);
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts));
 	std::this_thread::sleep_for (config.network_params.voting.delay);
 	node.generator.add (nano::dev::genesis->hash (), send2->hash ());
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts) == 2);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts), 2);
 }
 
 TEST (vote_spacing, rapid)
@@ -212,13 +212,13 @@ TEST (vote_spacing, rapid)
 				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
 	node.generator.add (nano::dev::genesis->hash (), send1->hash ());
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts) == 1);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts), 1);
 	ASSERT_FALSE (node.ledger.rollback (node.store.tx_begin_write (), send1->hash ()));
 	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send2).code);
 	node.generator.add (nano::dev::genesis->hash (), send2->hash ());
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_spacing) == 1);
-	ASSERT_TIMELY (3s, 1 == node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts));
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_spacing), 1);
+	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts));
 	std::this_thread::sleep_for (config.network_params.voting.delay);
 	node.generator.add (nano::dev::genesis->hash (), send2->hash ());
-	ASSERT_TIMELY (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts) == 2);
+	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts), 2);
 }

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -86,7 +86,9 @@ TEST (vote_generator, multiple_representatives)
 	wallet.change_sync (key1.pub, key1.pub);
 	wallet.change_sync (key2.pub, key2.pub);
 	wallet.change_sync (key3.pub, key3.pub);
-	ASSERT_TRUE (node.weight (key1.pub) == amount && node.weight (key2.pub) == amount && node.weight (key3.pub) == amount);
+	ASSERT_EQ (node.weight (key1.pub), amount);
+	ASSERT_EQ (node.weight (key2.pub), amount);
+	ASSERT_EQ (node.weight (key3.pub), amount);
 	node.wallets.compute_reps ();
 	ASSERT_EQ (4, node.wallets.reps ().voting);
 	auto hash = wallet.send_sync (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub, 1);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -911,19 +911,19 @@ TEST (wallet, password_race_corrupt_seed)
 		{
 			nano::raw_key seed_now;
 			wallet->store.seed (seed_now, transaction);
-			ASSERT_TRUE (seed_now == seed);
+			ASSERT_EQ (seed_now, seed);
 		}
 		else if (!wallet->store.attempt_password (transaction, "0000"))
 		{
 			nano::raw_key seed_now;
 			wallet->store.seed (seed_now, transaction);
-			ASSERT_TRUE (seed_now == seed);
+			ASSERT_EQ (seed_now, seed);
 		}
 		else if (!wallet->store.attempt_password (transaction, "4567"))
 		{
 			nano::raw_key seed_now;
 			wallet->store.seed (seed_now, transaction);
-			ASSERT_TRUE (seed_now == seed);
+			ASSERT_EQ (seed_now, seed);
 		}
 		else
 		{
@@ -1145,7 +1145,7 @@ TEST (wallet, foreach_representative_deadlock)
 	bool set = false;
 	node.wallets.foreach_representative ([&node, &set, &system] (nano::public_key const & pub, nano::raw_key const & prv) {
 		node.wallets.foreach_representative ([&node, &set, &system] (nano::public_key const & pub, nano::raw_key const & prv) {
-			ASSERT_TIMELY (5s, node.wallets.mutex.try_lock () == 1);
+			ASSERT_TIMELY_EQ (5s, node.wallets.mutex.try_lock (), 1);
 			node.wallets.mutex.unlock ();
 			set = true;
 		});
@@ -1197,7 +1197,7 @@ TEST (wallet, search_receivable)
 	// Pending search should create the receive block
 	ASSERT_EQ (2, node.ledger.cache.block_count);
 	ASSERT_FALSE (wallet.search_receivable (wallet.wallets.tx_begin_read ()));
-	ASSERT_TIMELY (3s, node.balance (nano::dev::genesis->account ()) == nano::dev::constants.genesis_amount);
+	ASSERT_TIMELY_EQ (3s, node.balance (nano::dev::genesis->account ()), nano::dev::constants.genesis_amount);
 	auto receive_hash = node.ledger.latest (node.store.tx_begin_read (), nano::dev::genesis->account ());
 	auto receive = node.block (receive_hash);
 	ASSERT_NE (nullptr, receive);
@@ -1229,7 +1229,7 @@ TEST (wallet, receive_pruned)
 	auto send2 = wallet1.send_action (nano::dev::genesis_key.pub, key.pub, 1, 1);
 
 	// Pruning
-	ASSERT_TIMELY (5s, node2.ledger.cache.cemented_count == 3);
+	ASSERT_TIMELY_EQ (5s, node2.ledger.cache.cemented_count, 3);
 	{
 		auto transaction = node2.store.tx_begin_write ();
 		ASSERT_EQ (1, node2.ledger.pruning_action (transaction, send1->hash (), 2));
@@ -1243,5 +1243,5 @@ TEST (wallet, receive_pruned)
 	auto open1 = wallet2.receive_action (send1->hash (), key.pub, amount, send1->link ().as_account (), 1);
 	ASSERT_NE (nullptr, open1);
 	ASSERT_EQ (amount, node2.ledger.balance (node2.store.tx_begin_read (), open1->hash ()));
-	ASSERT_TIMELY (5s, node2.ledger.cache.cemented_count == 4);
+	ASSERT_TIMELY_EQ (5s, node2.ledger.cache.cemented_count, 4);
 }

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1145,7 +1145,7 @@ TEST (wallet, foreach_representative_deadlock)
 	bool set = false;
 	node.wallets.foreach_representative ([&node, &set, &system] (nano::public_key const & pub, nano::raw_key const & prv) {
 		node.wallets.foreach_representative ([&node, &set, &system] (nano::public_key const & pub, nano::raw_key const & prv) {
-			ASSERT_TIMELY_EQ (5s, node.wallets.mutex.try_lock (), 1);
+			ASSERT_TIMELY_EQ (5s, node.wallets.mutex.try_lock (), true);
 			node.wallets.mutex.unlock ();
 			set = true;
 		});

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1145,7 +1145,7 @@ TEST (wallet, foreach_representative_deadlock)
 	bool set = false;
 	node.wallets.foreach_representative ([&node, &set, &system] (nano::public_key const & pub, nano::raw_key const & prv) {
 		node.wallets.foreach_representative ([&node, &set, &system] (nano::public_key const & pub, nano::raw_key const & prv) {
-			ASSERT_TIMELY_EQ (5s, node.wallets.mutex.try_lock (), true);
+			ASSERT_TIMELY (5s, node.wallets.mutex.try_lock () == 1);
 			node.wallets.mutex.unlock ();
 			set = true;
 		});

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -248,7 +248,7 @@ TEST (wallets, search_receivable)
 		{
 			node.wallets.search_receivable (wallet_id);
 		}
-		ASSERT_TIMELY (3s, node.balance (nano::dev::genesis->account ()) == nano::dev::constants.genesis_amount);
+		ASSERT_TIMELY_EQ (3s, node.balance (nano::dev::genesis->account ()), nano::dev::constants.genesis_amount);
 		auto receive_hash = node.ledger.latest (node.store.tx_begin_read (), nano::dev::genesis->account ());
 		auto receive = node.block (receive_hash);
 		ASSERT_NE (nullptr, receive);

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -47,7 +47,7 @@ TEST (websocket, subscription_edge)
 	});
 	auto future = std::async (std::launch::async, task);
 
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 }
 
 // Subscribes to block confirmations, confirms a block and then awaits websocket notification
@@ -123,7 +123,7 @@ TEST (websocket, confirmation)
 		node1->process_active (send);
 	}
 
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 }
 
 // Tests getting notification of a started election
@@ -163,7 +163,7 @@ TEST (websocket, started_election)
 	auto channel1 = std::make_shared<nano::transport::fake::channel> (*node1);
 	node1->network.inbound (publish1, channel1);
 	ASSERT_TIMELY (1s, node1->active.election (send1->qualified_root ()));
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 
 	auto response = future.get ();
 	ASSERT_TRUE (response);
@@ -214,7 +214,7 @@ TEST (websocket, stopped_election)
 	ASSERT_TIMELY (1s, node1->active.election (send1->qualified_root ()));
 	node1->active.erase (*send1);
 
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 
 	auto response = future.get ();
 	ASSERT_TRUE (response);
@@ -271,7 +271,7 @@ TEST (websocket, confirmation_options)
 		previous = send->hash ();
 	}
 
-	ASSERT_TIMELY (5s, future1.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future1.wait_for (0s), std::future_status::ready);
 
 	ack_ready = false;
 	auto task2 = ([&ack_ready, config, &node1] () {
@@ -304,7 +304,7 @@ TEST (websocket, confirmation_options)
 		previous = send->hash ();
 	}
 
-	ASSERT_TIMELY (5s, future2.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future2.wait_for (0s), std::future_status::ready);
 
 	auto response2 = future2.get ();
 	ASSERT_TRUE (response2);
@@ -366,7 +366,7 @@ TEST (websocket, confirmation_options)
 		previous = send->hash ();
 	}
 
-	ASSERT_TIMELY (5s, future3.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future3.wait_for (0s), std::future_status::ready);
 }
 
 TEST (websocket, confirmation_options_votes)
@@ -413,7 +413,7 @@ TEST (websocket, confirmation_options_votes)
 		previous = send->hash ();
 	}
 
-	ASSERT_TIMELY (5s, future1.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future1.wait_for (0s), std::future_status::ready);
 
 	auto response1 = future1.get ();
 	ASSERT_TRUE (response1);
@@ -500,7 +500,7 @@ TEST (websocket, confirmation_options_sideband)
 		previous = send->hash ();
 	}
 
-	ASSERT_TIMELY (5s, future1.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future1.wait_for (0s), std::future_status::ready);
 
 	auto response1 = future1.get ();
 	ASSERT_TRUE (response1);
@@ -597,7 +597,7 @@ TEST (websocket, confirmation_options_update)
 
 	node1->process_active (send2);
 
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 }
 
 // Subscribes to votes, sends a block and awaits websocket notification of a vote arrival
@@ -639,7 +639,7 @@ TEST (websocket, vote)
 
 	node1->process_active (send);
 
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 
 	auto response = future.get ();
 	ASSERT_TRUE (response);
@@ -678,7 +678,7 @@ TEST (websocket, vote_options_type)
 	auto msg (builder.vote_received (vote, nano::vote_code::replay));
 	node1->websocket.server->broadcast (msg);
 
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 
 	auto response = future.get ();
 	ASSERT_TRUE (response);
@@ -742,7 +742,7 @@ TEST (websocket, vote_options_representatives)
 	};
 	confirm_block ();
 
-	ASSERT_TIMELY (5s, future1.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future1.wait_for (0s), std::future_status::ready);
 
 	ack_ready = false;
 	auto task2 = ([&ack_ready, config, &node1] () {
@@ -763,7 +763,7 @@ TEST (websocket, vote_options_representatives)
 	// Confirm another block
 	confirm_block ();
 
-	ASSERT_TIMELY (5s, future2.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future2.wait_for (0s), std::future_status::ready);
 }
 
 // Test client subscribing to notifications for work generation
@@ -799,7 +799,7 @@ TEST (websocket, work)
 	ASSERT_TRUE (work.is_initialized ());
 
 	// Wait for the work notification
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 
 	// Check the work notification message
 	auto response = future.get ();
@@ -864,10 +864,10 @@ TEST (websocket, bootstrap)
 
 	// Start bootstrap attempt
 	node1->bootstrap_initiator.bootstrap (true, "123abc");
-	ASSERT_TIMELY (5s, nullptr == node1->bootstrap_initiator.current_attempt ());
+	ASSERT_TIMELY_EQ (5s, nullptr, node1->bootstrap_initiator.current_attempt ());
 
 	// Wait for the bootstrap notification
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 
 	// Check the bootstrap notification message
 	auto response = future.get ();
@@ -932,7 +932,7 @@ TEST (websocket, bootstrap_exited)
 	// Wait for the bootstrap notification
 	subscribed_completion.increment ();
 	bootstrap_thread.join ();
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 
 	// Check the bootstrap notification message
 	auto response = future.get ();
@@ -967,7 +967,7 @@ TEST (websocket, ws_keepalive)
 	});
 	auto future = std::async (std::launch::async, task);
 
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 }
 
 // Tests sending telemetry
@@ -1004,7 +1004,7 @@ TEST (websocket, telemetry)
 	ASSERT_NE (channel, nullptr);
 	ASSERT_TIMELY (5s, node1->telemetry.get_telemetry (channel->get_endpoint ()));
 
-	ASSERT_TIMELY (10s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (10s, future.wait_for (0s), std::future_status::ready);
 
 	// Check the telemetry notification message
 	auto response = future.get ();
@@ -1064,7 +1064,7 @@ TEST (websocket, new_unconfirmed_block)
 
 	ASSERT_EQ (nano::process_result::progress, node1->process_local (send1).value ().code);
 
-	ASSERT_TIMELY (5s, future.wait_for (0s) == std::future_status::ready);
+	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 
 	// Check the response
 	boost::optional<std::string> response = future.get ();

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -157,7 +157,7 @@ TEST (rpc, receivable_unconfirmed)
 	auto block4 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1.pub, 400));
 	rpc_ctx.io_scope->renew ();
 
-	ASSERT_TIMELY (10s, node->ledger.account_receivable (node->store.tx_begin_read (), key1.pub) == 1000);
+	ASSERT_TIMELY_EQ (10s, node->ledger.account_receivable (node->store.tx_begin_read (), key1.pub), 1000);
 	ASSERT_TIMELY (5s, !node->active.active (*block4));
 	ASSERT_TIMELY (5s, node->block_confirmed (block4->hash ()));
 
@@ -191,7 +191,7 @@ TEST (rpc, receivable_offset_and_sorting)
 	auto block6 = system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1.pub, 300);
 
 	// check that all blocks got confirmed
-	ASSERT_TIMELY (5s, node->ledger.account_receivable (node->store.tx_begin_read (), key1.pub, true) == 1600);
+	ASSERT_TIMELY_EQ (5s, node->ledger.account_receivable (node->store.tx_begin_read (), key1.pub, true), 1600);
 
 	// check confirmation height is as expected, there is no perfect clarity yet when confirmation height updates after a block get confirmed
 	nano::confirmation_height_info confirmation_height_info;
@@ -376,7 +376,7 @@ TEST (rpc, search_receivable)
 	request.put ("action", "search_receivable");
 	request.put ("wallet", wallet);
 	auto response (wait_response (system, rpc_ctx, request));
-	ASSERT_TIMELY (10s, node->balance (nano::dev::genesis_key.pub) == nano::dev::constants.genesis_amount);
+	ASSERT_TIMELY_EQ (10s, node->balance (nano::dev::genesis_key.pub), nano::dev::constants.genesis_amount);
 }
 
 TEST (rpc, accounts_pending_deprecated)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -49,7 +49,7 @@ TEST (rpc, wrapped_task)
 		throw std::runtime_error ("");
 	}));
 	system.nodes[0]->workers.push_task (task);
-	ASSERT_TIMELY (5s, response == true);
+	ASSERT_TIMELY_EQ (5s, response, true);
 }
 
 TEST (rpc, account_balance)
@@ -1345,7 +1345,7 @@ TEST (rpc, process_block)
 	request.put ("block", json);
 	{
 		auto response (wait_response (system, rpc_ctx, request));
-		ASSERT_TIMELY (10s, node1->latest (nano::dev::genesis_key.pub) == send->hash ());
+		ASSERT_TIMELY_EQ (10s, node1->latest (nano::dev::genesis_key.pub), send->hash ());
 		std::string send_hash (response.get<std::string> ("hash"));
 		ASSERT_EQ (send->hash ().to_string (), send_hash);
 	}
@@ -1386,7 +1386,7 @@ TEST (rpc, process_json_block)
 	request.put ("json_block", true);
 	{
 		auto response (wait_response (system, rpc_ctx, request));
-		ASSERT_TIMELY (10s, node1->latest (nano::dev::genesis_key.pub) == send->hash ());
+		ASSERT_TIMELY_EQ (10s, node1->latest (nano::dev::genesis_key.pub), send->hash ());
 		std::string send_hash (response.get<std::string> ("hash"));
 		ASSERT_EQ (send->hash ().to_string (), send_hash);
 	}
@@ -1443,7 +1443,7 @@ TEST (rpc, process_block_async)
 	{
 		auto response (wait_response (system, rpc_ctx, request));
 		ASSERT_EQ ("1", response.get<std::string> ("started"));
-		ASSERT_TIMELY (10s, node1->latest (nano::dev::genesis_key.pub) == state_send->hash ());
+		ASSERT_TIMELY_EQ (10s, node1->latest (nano::dev::genesis_key.pub), state_send->hash ());
 	}
 }
 
@@ -1497,7 +1497,7 @@ TEST (rpc, process_republish)
 	send->serialize_json (json);
 	request.put ("block", json);
 	auto response (wait_response (system, rpc_ctx, request));
-	ASSERT_TIMELY (10s, node2.latest (nano::dev::genesis_key.pub) == send->hash ());
+	ASSERT_TIMELY_EQ (10s, node2.latest (nano::dev::genesis_key.pub), send->hash ());
 }
 
 TEST (rpc, process_subtype_send)
@@ -1534,7 +1534,7 @@ TEST (rpc, process_subtype_send)
 	request.put ("subtype", "send");
 	auto response3 (wait_response (system, rpc_ctx, request));
 	ASSERT_EQ (send->hash ().to_string (), response3.get<std::string> ("hash"));
-	ASSERT_TIMELY (10s, system.nodes[1]->latest (nano::dev::genesis_key.pub) == send->hash ());
+	ASSERT_TIMELY_EQ (10s, system.nodes[1]->latest (nano::dev::genesis_key.pub), send->hash ());
 }
 
 TEST (rpc, process_subtype_open)
@@ -1584,7 +1584,7 @@ TEST (rpc, process_subtype_open)
 	request.put ("subtype", "open");
 	auto response3 (wait_response (system, rpc_ctx, request));
 	ASSERT_EQ (open->hash ().to_string (), response3.get<std::string> ("hash"));
-	ASSERT_TIMELY (10s, node2.latest (key.pub) == open->hash ());
+	ASSERT_TIMELY_EQ (10s, node2.latest (key.pub), open->hash ());
 }
 
 TEST (rpc, process_subtype_receive)
@@ -1634,7 +1634,7 @@ TEST (rpc, process_subtype_receive)
 	request.put ("subtype", "receive");
 	auto response3 (wait_response (system, rpc_ctx, request));
 	ASSERT_EQ (receive->hash ().to_string (), response3.get<std::string> ("hash"));
-	ASSERT_TIMELY (10s, node2.latest (nano::dev::genesis_key.pub) == receive->hash ());
+	ASSERT_TIMELY_EQ (10s, node2.latest (nano::dev::genesis_key.pub), receive->hash ());
 }
 
 TEST (rpc, process_ledger_insufficient_work)
@@ -2450,7 +2450,7 @@ TEST (rpc, account_representative_set_epoch_2_insufficient_work)
 	node->scheduler.priority.activate (nano::dev::genesis_key.pub, node->store.tx_begin_read ());
 
 	// wait for the epoch blocks to be cemented
-	ASSERT_TIMELY (5s, node->get_confirmation_height (node->store.tx_begin_read (), nano::dev::genesis_key.pub) == 3);
+	ASSERT_TIMELY_EQ (5s, node->get_confirmation_height (node->store.tx_begin_read (), nano::dev::genesis_key.pub), 3);
 
 	auto target_difficulty = nano::dev::network_params.work.threshold (nano::work_version::work_1, nano::block_details (nano::epoch::epoch_2, false, false, false));
 	ASSERT_LT (node->network_params.work.entry, target_difficulty);
@@ -3325,7 +3325,7 @@ TEST (rpc, wallet_pending)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key1.prv);
 	auto block1 = system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1.pub, 100);
-	ASSERT_TIMELY (5s, node->get_confirmation_height (node->store.tx_begin_read (), nano::dev::genesis_key.pub) == 2);
+	ASSERT_TIMELY_EQ (5s, node->get_confirmation_height (node->store.tx_begin_read (), nano::dev::genesis_key.pub), 2);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_pending");
@@ -3535,7 +3535,7 @@ TEST (rpc, search_receivable_all)
 	boost::property_tree::ptree request;
 	request.put ("action", "search_receivable_all");
 	auto response (wait_response (system, rpc_ctx, request));
-	ASSERT_TIMELY (10s, node->balance (nano::dev::genesis_key.pub) == nano::dev::constants.genesis_amount);
+	ASSERT_TIMELY_EQ (10s, node->balance (nano::dev::genesis_key.pub), nano::dev::constants.genesis_amount);
 }
 
 TEST (rpc, wallet_republish)
@@ -5181,7 +5181,7 @@ TEST (rpc, online_reps)
 	auto change (system.wallet (0)->change_action (nano::dev::genesis_key.pub, new_rep));
 	ASSERT_NE (nullptr, change);
 	ASSERT_TIMELY (5s, node2->block (change->hash ()));
-	ASSERT_TIMELY (5s, node2->online_reps.list ().size () == 2);
+	ASSERT_TIMELY_EQ (5s, node2->online_reps.list ().size (), 2);
 	boost::property_tree::ptree child_rep;
 	child_rep.put ("", new_rep.to_account ());
 	boost::property_tree::ptree filtered_accounts;
@@ -5241,7 +5241,7 @@ TEST (rpc, confirmation_height_currently_processing)
 		auto write_guard = node->write_database_queue.wait (nano::writer::testing);
 		nano::test::start_election (system, *node, frontier->hash ());
 
-		ASSERT_TIMELY (5s, node->confirmation_height_processor.current () == frontier->hash ());
+		ASSERT_TIMELY_EQ (5s, node->confirmation_height_processor.current (), frontier->hash ());
 
 		// Make the request
 		{
@@ -5303,7 +5303,7 @@ TEST (rpc, confirmation_history_hash)
 	auto send1 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	auto send2 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	auto send3 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, nano::Gxrb_ratio));
-	ASSERT_TIMELY (10s, node->active.recently_cemented.list ().size () == 3);
+	ASSERT_TIMELY_EQ (10s, node->active.recently_cemented.list ().size (), 3);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "confirmation_history");
@@ -5459,7 +5459,7 @@ TEST (rpc, unchecked)
 	node->process_active (open);
 	node->process_active (open2);
 	// Waits for the last block of the queue to get saved in the database
-	ASSERT_TIMELY (10s, 2 == node->unchecked.count ());
+	ASSERT_TIMELY_EQ (10s, 2, node->unchecked.count ());
 	boost::property_tree::ptree request;
 	request.put ("action", "unchecked");
 	request.put ("count", 2);
@@ -5500,7 +5500,7 @@ TEST (rpc, unchecked_get)
 				.build_shared ();
 	node->process_active (open);
 	// Waits for the open block to get saved in the database
-	ASSERT_TIMELY (10s, 1 == node->unchecked.count ());
+	ASSERT_TIMELY_EQ (10s, 1, node->unchecked.count ());
 	boost::property_tree::ptree request{};
 	request.put ("action", "unchecked_get");
 	request.put ("hash", open->hash ().to_string ());
@@ -5540,12 +5540,12 @@ TEST (rpc, unchecked_clear)
 	node->process_active (open);
 	boost::property_tree::ptree request{};
 	// Waits for the open block to get saved in the database
-	ASSERT_TIMELY (10s, 1 == node->unchecked.count ());
+	ASSERT_TIMELY_EQ (10s, 1, node->unchecked.count ());
 	request.put ("action", "unchecked_clear");
 	auto response = wait_response (system, rpc_ctx, request);
 
 	// Waits for the open block to get saved in the database
-	ASSERT_TIMELY (10s, 0 == node->unchecked.count ());
+	ASSERT_TIMELY_EQ (10s, 0, node->unchecked.count ());
 }
 
 TEST (rpc, unopened)
@@ -6207,7 +6207,7 @@ TEST (rpc, epoch_upgrade)
 	request.put ("key", epoch_signer.prv.to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
 	ASSERT_EQ ("1", response.get<std::string> ("started"));
-	ASSERT_TIMELY (10s, 4 == node->store.account.count (node->store.tx_begin_read ()));
+	ASSERT_TIMELY_EQ (10s, 4, node->store.account.count (node->store.tx_begin_read ()));
 	// Check upgrade
 	{
 		auto transaction (node->store.tx_begin_read ());
@@ -6270,7 +6270,7 @@ TEST (rpc, epoch_upgrade)
 	request.put ("epoch", 2);
 	auto response2 (wait_response (system, rpc_ctx, request));
 	ASSERT_EQ ("1", response2.get<std::string> ("started"));
-	ASSERT_TIMELY (10s, 5 == node->store.account.count (node->store.tx_begin_read ()));
+	ASSERT_TIMELY_EQ (10s, 5, node->store.account.count (node->store.tx_begin_read ()));
 	// Check upgrade
 	{
 		auto transaction (node->store.tx_begin_read ());
@@ -6371,7 +6371,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 	request.put ("key", epoch_signer.prv.to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
 	ASSERT_EQ ("1", response.get<std::string> ("started"));
-	ASSERT_TIMELY (5s, 4 == node->store.account.count (node->store.tx_begin_read ()));
+	ASSERT_TIMELY_EQ (5s, 4, node->store.account.count (node->store.tx_begin_read ()));
 	// Check upgrade
 	{
 		auto transaction (node->store.tx_begin_read ());
@@ -6434,7 +6434,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 	request.put ("epoch", 2);
 	auto response2 (wait_response (system, rpc_ctx, request));
 	ASSERT_EQ ("1", response2.get<std::string> ("started"));
-	ASSERT_TIMELY (5s, 5 == node->store.account.count (node->store.tx_begin_read ()));
+	ASSERT_TIMELY_EQ (5s, 5, node->store.account.count (node->store.tx_begin_read ()));
 	// Check upgrade
 	{
 		auto transaction (node->store.tx_begin_read ());

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -207,7 +207,7 @@ TEST (wallet, multithreaded_send_async)
 				}
 			}));
 		}
-		ASSERT_TIMELY (1000s, system.nodes[0]->balance (nano::dev::genesis_key.pub) == (nano::dev::constants.genesis_amount - num_of_threads * num_of_sends * 1000));
+		ASSERT_TIMELY_EQ (1000s, system.nodes[0]->balance (nano::dev::genesis_key.pub), (nano::dev::constants.genesis_amount - num_of_threads * num_of_sends * 1000));
 	}
 	for (auto i (threads.begin ()), n (threads.end ()); i != n; ++i)
 	{
@@ -513,7 +513,7 @@ TEST (store, unchecked_load)
 		node.unchecked.put (i, block);
 	}
 	// Waits for all the blocks to get saved in the database
-	ASSERT_TIMELY (8000s, num_unchecked == node.unchecked.count ());
+	ASSERT_TIMELY_EQ (8000s, num_unchecked, node.unchecked.count ());
 }
 
 TEST (store, vote_load)
@@ -710,8 +710,8 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in), num_accounts * 2 - 2);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), 0);
 
-	ASSERT_TIMELY (40s, (node->ledger.cache.cemented_count - 1) == node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
-	ASSERT_TIMELY (10s, node->active.election_winner_details_size () == 0);
+	ASSERT_TIMELY_EQ (40s, (node->ledger.cache.cemented_count - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 }
 
 TEST (confirmation_height, many_accounts_many_confirmations)
@@ -768,13 +768,13 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	}
 
 	auto const num_blocks_to_confirm = (num_accounts - 1) * 2;
-	ASSERT_TIMELY (1500s, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in) == num_blocks_to_confirm);
+	ASSERT_TIMELY_EQ (1500s, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_blocks_to_confirm);
 
 	auto num_confirmed_bounded = node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in);
 	ASSERT_GE (num_confirmed_bounded, nano::confirmation_height::unbounded_cutoff);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), num_blocks_to_confirm - num_confirmed_bounded);
 
-	ASSERT_TIMELY (60s, (node->ledger.cache.cemented_count - 1) == node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (60s, (node->ledger.cache.cemented_count - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
 
 	auto transaction = node->store.tx_begin_read ();
 	size_t cemented_count = 0;
@@ -786,9 +786,9 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	ASSERT_EQ (num_blocks_to_confirm + 1, cemented_count);
 	ASSERT_EQ (cemented_count, node->ledger.cache.cemented_count);
 
-	ASSERT_TIMELY (20s, (node->ledger.cache.cemented_count - 1) == node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (20s, (node->ledger.cache.cemented_count - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
 
-	ASSERT_TIMELY (10s, node->active.election_winner_details_size () == 0);
+	ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 }
 
 TEST (confirmation_height, long_chains)
@@ -934,8 +934,8 @@ TEST (confirmation_height, long_chains)
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in), num_blocks * 2 + 2);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), 0);
 
-	ASSERT_TIMELY (40s, (node->ledger.cache.cemented_count - 1) == node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
-	ASSERT_TIMELY (10s, node->active.election_winner_details_size () == 0);
+	ASSERT_TIMELY_EQ (40s, (node->ledger.cache.cemented_count - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 }
 
 TEST (confirmation_height, dynamic_algorithm)
@@ -974,16 +974,16 @@ TEST (confirmation_height, dynamic_algorithm)
 	}
 
 	node->confirmation_height_processor.add (state_blocks.front ());
-	ASSERT_TIMELY (20s, node->ledger.cache.cemented_count == 2);
+	ASSERT_TIMELY_EQ (20s, node->ledger.cache.cemented_count, 2);
 
 	node->confirmation_height_processor.add (latest_genesis);
 
-	ASSERT_TIMELY (20s, node->ledger.cache.cemented_count == num_blocks + 1);
+	ASSERT_TIMELY_EQ (20s, node->ledger.cache.cemented_count, num_blocks + 1);
 
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_blocks);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in), 1);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), num_blocks - 1);
-	ASSERT_TIMELY (10s, node->active.election_winner_details_size () == 0);
+	ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 }
 
 /*
@@ -1069,12 +1069,12 @@ TEST (confirmation_height, dynamic_algorithm_no_transition_while_pending)
 			node->confirmation_height_processor.unpause ();
 		}
 
-		ASSERT_TIMELY (10s, node->ledger.cache.cemented_count == num_blocks + 1);
+		ASSERT_TIMELY_EQ (10s, node->ledger.cache.cemented_count, num_blocks + 1);
 
 		ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_blocks);
 		ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in), 0);
 		ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), num_blocks);
-		ASSERT_TIMELY (10s, node->active.election_winner_details_size () == 0);
+		ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 	}
 }
 
@@ -1562,7 +1562,7 @@ TEST (telemetry, under_load)
 	std::thread thread1 (thread_func, nano::dev::genesis_key, latest_genesis, nano::dev::constants.genesis_amount - num_blocks);
 	std::thread thread2 (thread_func, key, latest_key, num_blocks);
 
-	ASSERT_TIMELY (200s, node1->ledger.cache.block_count == num_blocks * 2 + 3);
+	ASSERT_TIMELY_EQ (200s, node1->ledger.cache.block_count, num_blocks * 2 + 3);
 
 	thread1.join ();
 	thread2.join ();
@@ -1713,7 +1713,7 @@ TEST (telemetry, many_nodes)
 		ASSERT_EQ (data.cemented_count, 1);
 		ASSERT_LE (data.peer_count, 9U);
 		ASSERT_EQ (data.account_count, 1);
-		ASSERT_TRUE (data.block_count == 2);
+		ASSERT_EQ (data.block_count, 2);
 		ASSERT_EQ (data.protocol_version, nano::dev::network_params.network.protocol_version);
 		ASSERT_GE (data.bandwidth_cap, 100000);
 		ASSERT_LT (data.bandwidth_cap, 100000 + system.nodes.size ());
@@ -1885,7 +1885,7 @@ TEST (node, mass_block_new)
 		{
 			node.process_active (block);
 		}
-		ASSERT_TIMELY (200s, node.ledger.cache.block_count == next_block_count);
+		ASSERT_TIMELY_EQ (200s, node.ledger.cache.block_count, next_block_count);
 		next_block_count += num_blocks;
 		node.block_processor.flush ();
 		// Clear all active
@@ -2015,7 +2015,7 @@ TEST (node, aggressive_flooding)
 	});
 
 	// This test is only valid if a non-aggressive flood would not reach every peer
-	ASSERT_TIMELY (5s, node1.network.size () == nodes_wallets.size ());
+	ASSERT_TIMELY_EQ (5s, node1.network.size (), nodes_wallets.size ());
 	ASSERT_LT (node1.network.fanout (), nodes_wallets.size ());
 
 	// Each new node should see genesis representative
@@ -2059,10 +2059,10 @@ TEST (node, aggressive_flooding)
 
 	ASSERT_TIMELY (!nano::slow_instrumentation () ? 10s : 40s, all_received ());
 
-	ASSERT_TIMELY (!nano::slow_instrumentation () ? 10s : 40s, node1.ledger.cache.block_count == 1 + 2 * nodes_wallets.size ());
+	ASSERT_TIMELY_EQ (!nano::slow_instrumentation () ? 10s : 40s, node1.ledger.cache.block_count, 1 + 2 * nodes_wallets.size ());
 
 	// Wait until the main node sees all representatives
-	ASSERT_TIMELY (!nano::slow_instrumentation () ? 10s : 40s, node1.rep_crawler.principal_representatives ().size () == nodes_wallets.size ());
+	ASSERT_TIMELY_EQ (!nano::slow_instrumentation () ? 10s : 40s, node1.rep_crawler.principal_representatives ().size (), nodes_wallets.size ());
 
 	// Generate blocks and ensure they are sent to all representatives
 	nano::state_block_builder builder;


### PR DESCRIPTION
This PR targets issue #4364 

The way we do assert equals have often been done this way:
ASSERT_TRUE(a == b)
but is now replaced with
ASSERT_EQ(a, b)

Also this format
ASSERT_TIMELY(5s, a == b)
is replaced with
ASSERT_TIMELY_EQ(5s, a, b)

The replacement was automated by a script to avoid human error.
Two asserts had multiple conditions and have manually been split into the individual asserts