### PR TITLE
Fix for node.fork_publish_inactive

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -644,10 +644,9 @@ TEST (node, fork_publish_inactive)
 
 	ASSERT_EQ (nano::process_result::fork, node.process_local (send2).value ().code);
 
-	auto blocks = election->blocks ();
-	ASSERT_TIMELY_EQ (5s, blocks.size (), 2);
-	ASSERT_NE (blocks.end (), blocks.find (send1->hash ()));
-	ASSERT_NE (blocks.end (), blocks.find (send2->hash ()));
+	ASSERT_TIMELY_EQ (5s, election->blocks ().size (), 2);
+	ASSERT_NE (election->blocks ().end (), election->blocks ().find (send1->hash ()));
+	ASSERT_NE (election->blocks ().end (), election->blocks ().find (send2->hash ()));
 	ASSERT_EQ (election->winner ()->hash (), send1->hash ());
 	ASSERT_NE (election->winner ()->hash (), send2->hash ());
 }

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -645,8 +645,14 @@ TEST (node, fork_publish_inactive)
 	ASSERT_EQ (nano::process_result::fork, node.process_local (send2).value ().code);
 
 	ASSERT_TIMELY_EQ (5s, election->blocks ().size (), 2);
-	ASSERT_TRUE (election->blocks ().end () != election->blocks ().find (send1->hash ()));
-	ASSERT_TRUE (election->blocks ().end () != election->blocks ().find (send2->hash ()));
+
+	auto find_block = [&election] (nano::block_hash hash_a) -> bool {
+		auto blocks = election->blocks ();
+		return blocks.end () != blocks.find (hash_a);
+	};
+	ASSERT_TRUE (find_block (send1->hash ()));
+	ASSERT_TRUE (find_block (send2->hash ()));
+
 	ASSERT_EQ (election->winner ()->hash (), send1->hash ());
 	ASSERT_NE (election->winner ()->hash (), send2->hash ());
 }

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -645,8 +645,8 @@ TEST (node, fork_publish_inactive)
 	ASSERT_EQ (nano::process_result::fork, node.process_local (send2).value ().code);
 
 	ASSERT_TIMELY_EQ (5s, election->blocks ().size (), 2);
-	ASSERT_NE (election->blocks ().end (), election->blocks ().find (send1->hash ()));
-	ASSERT_NE (election->blocks ().end (), election->blocks ().find (send2->hash ()));
+	ASSERT_TRUE (election->blocks ().end () != election->blocks ().find (send1->hash ()));
+	ASSERT_TRUE (election->blocks ().end () != election->blocks ().find (send2->hash ()));
 	ASSERT_EQ (election->winner ()->hash (), send1->hash ());
 	ASSERT_NE (election->winner ()->hash (), send2->hash ());
 }


### PR DESCRIPTION
By taking a copy of blocks and saving it into a variable we are not giving a chance to the ASSET_TIMELY to work if the result is not immediately correct.