### PR TITLE
Fix bootstrap unit tests

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1458,9 +1458,10 @@ TEST (bootstrap_processor, wallet_lazy_frontier)
 	node0->block_processor.add (receive1);
 	node0->block_processor.add (send2);
 	node0->block_processor.add (receive2);
-	node0->block_processor.flush ();
+	ASSERT_TIMELY (5s, nano::test::exists (*node0, { send1, receive1, send2, receive2 }));
+
 	// Start wallet lazy bootstrap
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work));
+	auto node1 = system.make_disconnected_node ();
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	auto wallet (node1->wallets.create (nano::random_wallet_id ()));
 	ASSERT_NE (nullptr, wallet);

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -280,17 +280,19 @@ TEST (bulk_pull, count_limit)
 	ASSERT_EQ (nullptr, block);
 }
 
-TEST (bootstrap_processor, DISABLED_process_none)
+TEST (bootstrap_processor, process_none)
 {
 	nano::test::system system (1);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work));
-	ASSERT_FALSE (node1->init_error ());
-	auto done (false);
+	auto node0 = system.nodes[0];
+	auto node1 = system.make_disconnected_node ();
+
+	bool done = false;
+	node0->observers.socket_accepted.add ([&] (nano::transport::socket & socket) {
+		done = true;
+	});
+
 	node1->bootstrap_initiator.bootstrap (system.nodes[0]->network.endpoint (), false);
-	while (!done)
-	{
-		system.io_ctx.run_one ();
-	}
+	ASSERT_TIMELY (5s, done);
 	node1->stop ();
 }
 

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1337,8 +1337,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	ASSERT_EQ (1, node1->ledger.cache.pruned_count);
 	ASSERT_TRUE (nano::test::block_or_pruned_all_exists (*node1, { send1, send2, open, state_open }));
 	// Start lazy bootstrap with last block in sender chain
-	config.peering_port = system.get_available_port ();
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags, 1));
+	auto node2 = system.make_disconnected_node (config, node_flags);
 	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -408,8 +408,10 @@ TEST (bootstrap_processor, process_new)
 	auto send = system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, amount);
 	ASSERT_NE (nullptr, send);
 	ASSERT_TIMELY (5s, !node1->balance (key2.pub).is_zero ());
-	auto receive = node2->block (node2->latest (key2.pub));
-	ASSERT_NE (nullptr, receive);
+
+	// wait for the receive block on node2
+	std::shared_ptr<nano::block> receive;
+	ASSERT_TIMELY (5s, receive = node2->block (node2->latest (key2.pub)));
 
 	// All blocks should be propagated & confirmed
 	ASSERT_TIMELY (5s, nano::test::confirmed (*node1, { send, receive }));

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -312,6 +312,7 @@ TEST (bootstrap_processor, process_one)
 	ASSERT_TIMELY (5s, node0->latest (nano::dev::genesis_key.pub) != nano::dev::genesis->hash ());
 
 	node_flags.disable_rep_crawler = true;
+	node_config.peering_port = system.get_available_port ();
 	auto node1 = system.make_disconnected_node (node_config, node_flags);
 	ASSERT_NE (node0->latest (nano::dev::genesis_key.pub), node1->latest (nano::dev::genesis_key.pub));
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
@@ -396,6 +397,7 @@ TEST (bootstrap_processor, process_new)
 	nano::keypair key2;
 
 	auto node1 = system.add_node (config, node_flags);
+	config.peering_port = system.get_available_port ();
 	auto node2 = system.add_node (config, node_flags);
 
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -483,6 +485,7 @@ TEST (bootstrap_processor, DISABLED_pull_requeue_network_error)
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	auto node1 (system.add_node (config, node_flags));
+	config.peering_port = system.get_available_port ();
 	auto node2 (system.add_node (config, node_flags));
 	nano::keypair key1;
 
@@ -595,6 +598,7 @@ TEST (bootstrap_processor, push_diamond_pruning)
 	config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
+	config.peering_port = system.get_available_port ();
 	auto node1 = system.make_disconnected_node (config, node_flags);
 
 	nano::block_builder builder;
@@ -959,6 +963,7 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	ASSERT_TRUE (nano::test::start_elections (system, *node0, blocks, true));
 	ASSERT_TIMELY (5s, nano::test::confirmed (*node0, blocks));
 
+	config.peering_port = system.get_available_port ();
 	auto node1 = system.make_disconnected_node (config, node_flags);
 
 	// Processing chain to prune for node1
@@ -1388,6 +1393,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	ASSERT_TRUE (nano::test::exists (*node1, { send2, open, state_open }));
 
 	// Start lazy bootstrap with last block in sender chain
+	config.peering_port = system.get_available_port ();
 	auto node2 = system.make_disconnected_node (config, node_flags);
 	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -830,13 +830,11 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.enable_pruning = true;
-	auto node0 (system.add_node (config, node_flags));
-	nano::keypair key1;
-	nano::keypair key2;
-	// Generating test chain
+	auto node0 = system.add_node (config, node_flags);
 
 	nano::state_block_builder builder;
 
+	// send Gxrb_ratio raw from genesis to genesis
 	auto send1 = builder
 				 .account (nano::dev::genesis_key.pub)
 				 .previous (nano::dev::genesis->hash ())
@@ -846,6 +844,8 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node0->work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build_shared ();
+
+	// receive send1
 	auto receive1 = builder
 					.make_block ()
 					.account (nano::dev::genesis_key.pub)
@@ -856,6 +856,9 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*node0->work_generate_blocking (send1->hash ()))
 					.build_shared ();
+
+	// change rep of genesis account to be key1
+	nano::keypair key1;
 	auto change1 = builder
 				   .make_block ()
 				   .account (nano::dev::genesis_key.pub)
@@ -866,6 +869,9 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*node0->work_generate_blocking (receive1->hash ()))
 				   .build_shared ();
+
+	// change rep of genesis account to be rep2
+	nano::keypair key2;
 	auto change2 = builder
 				   .make_block ()
 				   .account (nano::dev::genesis_key.pub)
@@ -876,6 +882,8 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*node0->work_generate_blocking (change1->hash ()))
 				   .build_shared ();
+
+	// send Gxrb_ratio from genesis to key1 and genesis rep back to genesis account
 	auto send2 = builder
 				 .make_block ()
 				 .account (nano::dev::genesis_key.pub)
@@ -886,6 +894,8 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node0->work_generate_blocking (change2->hash ()))
 				 .build_shared ();
+
+	// receive send2 and rep of key1 to be itself
 	auto receive2 = builder
 					.make_block ()
 					.account (key1.pub)
@@ -896,6 +906,8 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 					.sign (key1.prv, key1.pub)
 					.work (*node0->work_generate_blocking (key1.pub))
 					.build_shared ();
+
+	// send Gxrb_ratio raw, all available balance, from key1 to key2
 	auto send3 = builder
 				 .make_block ()
 				 .account (key1.pub)
@@ -906,6 +918,8 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 				 .sign (key1.prv, key1.pub)
 				 .work (*node0->work_generate_blocking (receive2->hash ()))
 				 .build_shared ();
+
+	// receive send3 on key2, set rep of key2 to be itself
 	auto receive3 = builder
 					.make_block ()
 					.account (key2.pub)
@@ -917,39 +931,41 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 					.work (*node0->work_generate_blocking (key2.pub))
 					.build_shared ();
 
-	// Processing test chain
-	node0->block_processor.add (send1);
-	node0->block_processor.add (receive1);
-	node0->block_processor.add (change1);
-	node0->block_processor.add (change2);
-	node0->block_processor.add (send2);
-	node0->block_processor.add (receive2);
-	node0->block_processor.add (send3);
-	node0->block_processor.add (receive3);
-	ASSERT_TIMELY_EQ (5s, 9, node0->ledger.cache.block_count);
+	std::vector<std::shared_ptr<nano::block>> blocks = { send1, receive1, change1, change2, send2, receive2, send3, receive3 };
+	ASSERT_TRUE (nano::test::process (*node0, blocks));
+	ASSERT_TRUE (nano::test::start_elections (system, *node0, blocks, true));
+	ASSERT_TIMELY (5s, nano::test::confirmed (*node0, blocks));
+
+	auto node1 = system.make_disconnected_node (config, node_flags);
+
 	// Processing chain to prune for node1
-	config.peering_port = system.get_available_port ();
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags, 1));
-	node1->start ();
 	node1->process_active (send1);
 	node1->process_active (receive1);
 	node1->process_active (change1);
 	node1->process_active (change2);
-	ASSERT_TIMELY (5s, node1->block (change2->hash ()) != nullptr);
+	ASSERT_TIMELY (5s, nano::test::exists (*node1, { send1, receive1, change1, change2 }));
+
 	// Confirm last block to prune previous
 	ASSERT_TRUE (nano::test::start_elections (system, *node1, { send1, receive1, change1, change2 }, true));
-	ASSERT_TIMELY (5s, node1->block_confirmed (send1->hash ()) && node1->block_confirmed (receive1->hash ()) && node1->block_confirmed (change1->hash ()) && node1->block_confirmed (change2->hash ()) && node1->active.empty ());
+	ASSERT_TIMELY (5s, node1->block_confirmed (send1->hash ()));
+	ASSERT_TIMELY (5s, node1->block_confirmed (receive1->hash ()));
+	ASSERT_TIMELY (5s, node1->block_confirmed (change1->hash ()));
+	ASSERT_TIMELY (5s, node1->block_confirmed (change2->hash ()));
+	ASSERT_TIMELY (5s, node1->active.empty ());
 	ASSERT_EQ (5, node1->ledger.cache.block_count);
 	ASSERT_EQ (5, node1->ledger.cache.cemented_count);
+
 	// Pruning action
 	node1->ledger_pruning (2, false);
 	ASSERT_EQ (9, node0->ledger.cache.block_count);
 	ASSERT_EQ (0, node0->ledger.cache.pruned_count);
 	ASSERT_EQ (5, node1->ledger.cache.block_count);
 	ASSERT_EQ (3, node1->ledger.cache.pruned_count);
+
 	// Start lazy bootstrap with last block in chain known
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive3->hash (), true);
+
 	// Check processed blocks
 	ASSERT_TIMELY_EQ (5s, node1->ledger.cache.block_count, 9);
 	ASSERT_TIMELY (5s, node1->balance (key2.pub) != 0);

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1910,15 +1910,15 @@ TEST (frontier_req, confirmed_frontier)
 TEST (bulk, genesis)
 {
 	nano::test::system system;
-	nano::node_config config (system.get_available_port ());
+	nano::node_config config = system.default_config ();
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	node_flags.disable_lazy_bootstrap = true;
 	auto node1 = system.add_node (config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work));
-	ASSERT_FALSE (node2->init_error ());
+
+	auto node2 = system.make_disconnected_node ();
 	nano::block_hash latest1 (node1->latest (nano::dev::genesis_key.pub));
 	nano::block_hash latest2 (node2->latest (nano::dev::genesis_key.pub));
 	ASSERT_EQ (latest1, latest2);

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1374,9 +1374,7 @@ TEST (bootstrap_processor, lazy_cancel)
 	nano::keypair key1;
 	// Generating test chain
 
-	nano::state_block_builder builder;
-
-	auto send1 = builder
+	auto send1 = nano::state_block_builder ()
 				 .account (nano::dev::genesis_key.pub)
 				 .previous (nano::dev::genesis->hash ())
 				 .representative (nano::dev::genesis_key.pub)
@@ -1387,7 +1385,7 @@ TEST (bootstrap_processor, lazy_cancel)
 				 .build_shared ();
 
 	// Start lazy bootstrap with last block in chain known
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work));
+	auto node1 = system.make_disconnected_node ();
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (send1->hash (), true); // Start "confirmed" block bootstrap
 	{

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1191,13 +1191,14 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
 
 	// Start lazy bootstrap with last block in chain known
-	auto node2 = system.add_node (system.default_config (), node_flags);
+	auto node2 = system.make_disconnected_node (std::nullopt, node_flags);
 	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (15s, !node2->bootstrap_initiator.in_progress ());
 	ASSERT_TIMELY (15s, nano::test::block_or_pruned_all_exists (*node2, { send1, open, send2 }));
 	ASSERT_EQ (1, node2->stats.count (nano::stat::type::bootstrap, nano::stat::detail::bulk_pull_failed_account, nano::stat::dir::in));
+	node2->stop ();
 }
 
 TEST (bootstrap_processor, lazy_destinations)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -309,15 +309,12 @@ TEST (bootstrap_processor, process_one)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto send (system.wallet (0)->send_action (nano::dev::genesis_key.pub, nano::dev::genesis_key.pub, 100));
 	ASSERT_NE (nullptr, send);
+	ASSERT_TIMELY (5s, node0->latest (nano::dev::genesis_key.pub) != nano::dev::genesis->hash ());
 
-	node_config.peering_port = system.get_available_port ();
 	node_flags.disable_rep_crawler = true;
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), node_config, system.work, node_flags));
-	nano::block_hash hash1 (node0->latest (nano::dev::genesis_key.pub));
-	nano::block_hash hash2 (node1->latest (nano::dev::genesis_key.pub));
-	ASSERT_NE (hash1, hash2);
+	auto node1 = system.make_disconnected_node (node_config, node_flags);
+	ASSERT_NE (node0->latest (nano::dev::genesis_key.pub), node1->latest (nano::dev::genesis_key.pub));
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_NE (node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
 	ASSERT_TIMELY_EQ (10s, node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
 	node1->stop ();
 }

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1598,11 +1598,13 @@ TEST (bootstrap_processor, multiple_attempts)
 	node1->block_processor.add (receive1);
 	node1->block_processor.add (send2);
 	node1->block_processor.add (receive2);
-	node1->block_processor.flush ();
+	nano::test::exists (*node1, { send1, receive1, send2, receive2 });
+
 	// Start 2 concurrent bootstrap attempts
 	nano::node_config node_config = system.default_config ();
 	node_config.bootstrap_initiator_threads = 3;
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), node_config, system.work));
+
+	auto node2 = system.make_disconnected_node (node_config);
 	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true);
 	node2->bootstrap_initiator.bootstrap ();

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -730,9 +730,10 @@ TEST (bootstrap_processor, lazy_hash)
 	node0->block_processor.add (receive1);
 	node0->block_processor.add (send2);
 	node0->block_processor.add (receive2);
-	node0->block_processor.flush ();
+	ASSERT_TIMELY (5s, nano::test::exists (*node0, { send1, receive1, send2, receive2 }));
+
 	// Start lazy bootstrap with last block in chain known
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work));
+	auto node1 = system.make_disconnected_node ();
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true);
 	{

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -582,11 +582,10 @@ TEST (bootstrap_processor, DISABLED_push_diamond_pruning)
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 (system.add_node (config));
 	nano::keypair key;
-	config.peering_port = system.get_available_port ();
 	config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
 	node_flags.enable_pruning = true;
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config, system.work, node_flags, 1));
+	auto node1 = system.make_disconnected_node (config, node_flags);
 	ASSERT_FALSE (node1->init_error ());
 	auto latest (node0->latest (nano::dev::genesis_key.pub));
 	nano::block_builder builder;
@@ -646,7 +645,6 @@ TEST (bootstrap_processor, DISABLED_push_diamond_pruning)
 	// 2nd bootstrap
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
 	ASSERT_TIMELY_EQ (10s, node0->balance (nano::dev::genesis_key.pub), 100);
-	ASSERT_EQ (100, node0->balance (nano::dev::genesis_key.pub));
 	node1->stop ();
 }
 

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -2075,7 +2075,7 @@ TEST (bulk, genesis_pruning)
 	ASSERT_EQ (0, node1->ledger.cache.pruned_count);
 
 	ASSERT_TRUE (nano::test::start_elections (system, *node1, { send3 }, true));
-	ASSERT_TIMELY (5s, node1->active.empty ());
+	ASSERT_TIMELY (5s, nano::test::confirmed (*node1, { send3 }));
 
 	node1->ledger_pruning (2, false);
 	ASSERT_EQ (2, node1->ledger.cache.pruned_count);

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1976,7 +1976,7 @@ TEST (bulk, offline_send)
 TEST (bulk, DISABLED_genesis_pruning)
 {
 	nano::test::system system;
-	nano::node_config config (system.get_available_port ());
+	nano::node_config config = system.default_config ();
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	config.enable_voting = false; // Remove after allowing pruned voting
 	nano::node_flags node_flags;
@@ -1987,8 +1987,8 @@ TEST (bulk, DISABLED_genesis_pruning)
 	auto node1 = system.add_node (config, node_flags);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	node_flags.enable_pruning = false;
-	auto node2 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work, node_flags));
-	ASSERT_FALSE (node2->init_error ());
+
+	auto node2 = system.make_disconnected_node (std::nullopt, node_flags);
 	nano::block_hash latest1 (node1->latest (nano::dev::genesis_key.pub));
 	nano::block_hash latest2 (node2->latest (nano::dev::genesis_key.pub));
 	ASSERT_EQ (latest1, latest2);

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1064,14 +1064,14 @@ TEST (bootstrap_processor, lazy_max_pull_count)
 	node0->block_processor.add (change1);
 	node0->block_processor.add (change2);
 	node0->block_processor.add (change3);
-	node0->block_processor.flush ();
+	ASSERT_TIMELY (5s, nano::test::exists (*node0, { send1, receive1, send2, receive2, change1, change2, change3 }));
+
 	// Start lazy bootstrap with last block in chain known
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work));
+	auto node1 = system.make_disconnected_node ();
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (change3->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (10s, node1->block (change3->hash ()));
-
 	node1->stop ();
 }
 

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -483,7 +483,6 @@ TEST (bootstrap_processor, DISABLED_pull_requeue_network_error)
 	nano::node_flags node_flags;
 	node_flags.disable_bootstrap_bulk_push_client = true;
 	auto node1 (system.add_node (config, node_flags));
-	config.peering_port = system.get_available_port ();
 	auto node2 (system.add_node (config, node_flags));
 	nano::keypair key1;
 

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -526,8 +526,7 @@ TEST (bootstrap_processor, DISABLED_push_diamond)
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto node0 (system.add_node (config));
 	nano::keypair key;
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work));
-	ASSERT_FALSE (node1->init_error ());
+	auto node1 = system.make_disconnected_node ();
 	auto wallet1 (node1->wallets.create (100));
 	wallet1->insert_adhoc (nano::dev::genesis_key.prv);
 	wallet1->insert_adhoc (key.prv);
@@ -568,8 +567,7 @@ TEST (bootstrap_processor, DISABLED_push_diamond)
 				   .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_TIMELY_EQ (10s, node0->balance (nano::dev::genesis_key.pub), 100);
-	ASSERT_EQ (100, node0->balance (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (5s, node0->balance (nano::dev::genesis_key.pub), 100);
 	node1->stop ();
 }
 

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -376,14 +376,13 @@ TEST (bootstrap_processor, process_state)
 	node0->work_generate_blocking (*block2);
 	ASSERT_EQ (nano::process_result::progress, node0->process (*block1).code);
 	ASSERT_EQ (nano::process_result::progress, node0->process (*block2).code);
+	ASSERT_TIMELY_EQ (5s, nano::test::account_info (*node0, nano::dev::genesis_key.pub).block_count, 3);
 
-	config.peering_port = system.get_available_port ();
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work, node_flags));
+	auto node1 = system.make_disconnected_node (std::nullopt, node_flags);
 	ASSERT_EQ (node0->latest (nano::dev::genesis_key.pub), block2->hash ());
 	ASSERT_NE (node1->latest (nano::dev::genesis_key.pub), block2->hash ());
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_NE (node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
-	ASSERT_TIMELY_EQ (10s, node1->latest (nano::dev::genesis_key.pub), node0->latest (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (5s, node1->latest (nano::dev::genesis_key.pub), block2->hash ());
 	node1->stop ();
 }
 

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -805,9 +805,10 @@ TEST (bootstrap_processor, lazy_hash_bootstrap_id)
 	node0->block_processor.add (receive1);
 	node0->block_processor.add (send2);
 	node0->block_processor.add (receive2);
-	node0->block_processor.flush ();
+	ASSERT_TIMELY (5s, nano::test::exists (*node0, { send1, receive1, send2, receive2 }));
+
 	// Start lazy bootstrap with last block in chain known
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work));
+	auto node1 = system.make_disconnected_node ();
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive2->hash (), true, "123456");
 	{

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1135,13 +1135,14 @@ TEST (bootstrap_processor, DISABLED_lazy_unclear_state_link)
 				   .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
 	// Start lazy bootstrap with last block in chain known
-	auto node2 = system.add_node (system.default_config (), node_flags);
+	auto node2 = system.make_disconnected_node (std::nullopt, node_flags);
 	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (receive->hash ());
 	// Check processed blocks
 	ASSERT_TIMELY (10s, !node2->bootstrap_initiator.in_progress ());
 	ASSERT_TIMELY (5s, nano::test::block_or_pruned_all_exists (*node2, { send1, send2, open, receive }));
 	ASSERT_EQ (0, node2->stats.count (nano::stat::type::bootstrap, nano::stat::detail::bulk_pull_failed_account, nano::stat::dir::in));
+	node2->stop ();
 }
 
 TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1200,7 +1200,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 	ASSERT_EQ (1, node2->stats.count (nano::stat::type::bootstrap, nano::stat::detail::bulk_pull_failed_account, nano::stat::dir::in));
 }
 
-TEST (bootstrap_processor, DISABLED_lazy_destinations)
+TEST (bootstrap_processor, lazy_destinations)
 {
 	nano::test::system system;
 	nano::node_config config = system.default_config ();
@@ -1258,12 +1258,14 @@ TEST (bootstrap_processor, DISABLED_lazy_destinations)
 	ASSERT_EQ (nano::process_result::progress, node1->process (*state_open).code);
 
 	// Start lazy bootstrap with last block in sender chain
-	auto node2 = system.add_node (system.default_config (), node_flags);
+	auto node2 = system.make_disconnected_node (std::nullopt, node_flags);
 	nano::test::establish_tcp (system, *node2, node1->network.endpoint ());
 	node2->bootstrap_initiator.bootstrap_lazy (send2->hash ());
+
 	// Check processed blocks
-	ASSERT_TIMELY (10s, !node2->bootstrap_initiator.in_progress ());
+	ASSERT_TIMELY (5s, !node2->bootstrap_initiator.in_progress ());
 	ASSERT_TRUE (nano::test::block_or_pruned_all_exists (*node2, { send1, send2, open, state_open }));
+	node2->stop ();
 }
 
 TEST (bootstrap_processor, lazy_pruning_missing_block)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -467,11 +467,10 @@ TEST (bootstrap_processor, pull_diamond)
 				   .work (*system.work.generate (send1->hash ()))
 				   .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node0->process (*receive).code);
-	auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work));
-	ASSERT_FALSE (node1->init_error ());
+
+	auto node1 = system.make_disconnected_node ();
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
-	ASSERT_TIMELY_EQ (10s, node1->balance (nano::dev::genesis_key.pub), 100);
-	ASSERT_EQ (100, node1->balance (nano::dev::genesis_key.pub));
+	ASSERT_TIMELY_EQ (5s, node1->balance (nano::dev::genesis_key.pub), 100);
 	node1->stop ();
 }
 

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1526,7 +1526,8 @@ TEST (bootstrap_processor, wallet_lazy_pending)
 	node0->block_processor.add (send1);
 	node0->block_processor.add (receive1);
 	node0->block_processor.add (send2);
-	node0->block_processor.flush ();
+	nano::test::exists (*node0, { send1, receive1, send2 });
+
 	// Start wallet lazy bootstrap
 	auto node1 = system.add_node ();
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -125,6 +125,19 @@ std::shared_ptr<nano::node> nano::test::system::add_node (nano::node_config cons
 	return node;
 }
 
+std::shared_ptr<nano::node> nano::test::system::make_disconnected_node (std::optional<nano::node_config> opt_node_config, nano::node_flags flags)
+{
+	nano::node_config node_config = opt_node_config.has_value () ? *opt_node_config : default_config ();
+	auto node = std::make_shared<nano::node> (io_ctx, nano::unique_path (), node_config, work, flags);
+	if (node->init_error ())
+	{
+		std::cerr << "node init error\n";
+		return nullptr;
+	}
+	node->start ();
+	return node;
+}
+
 nano::test::system::system ()
 {
 	auto scale_str = std::getenv ("DEADLINE_SCALE_FACTOR");

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -5,6 +5,7 @@
 #include <nano/node/node.hpp>
 
 #include <chrono>
+#include <optional>
 
 namespace nano
 {
@@ -57,6 +58,10 @@ namespace test
 		nano::node & node (std::size_t index) const;
 		std::shared_ptr<nano::node> add_node (nano::node_flags = nano::node_flags (), nano::transport::transport_type = nano::transport::transport_type::tcp);
 		std::shared_ptr<nano::node> add_node (nano::node_config const &, nano::node_flags = nano::node_flags (), nano::transport::transport_type = nano::transport::transport_type::tcp, std::optional<nano::keypair> const & rep = std::nullopt);
+
+		// Make an independent node that uses system resources but is not part of the system node list and does not automatically connect to other nodes
+		std::shared_ptr<nano::node> make_disconnected_node (std::optional<nano::node_config> opt_node_config = std::nullopt, nano::node_flags = nano::node_flags ());
+
 		/*
 		 * Returns default config for node running in test environment
 		 */

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -3,6 +3,7 @@
 #include <nano/node/scheduler/manual.hpp>
 #include <nano/node/scheduler/priority.hpp>
 #include <nano/node/transport/fake.hpp>
+#include <nano/store/block.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -313,5 +314,24 @@ void nano::test::print_all_account_info (nano::node & node)
 			std::cout << "  Conf. Height:        " << height_info.height << std::endl;
 			std::cout << "  Conf. Frontier:      " << height_info.frontier.to_string () << std::endl;
 		}
+	}
+}
+
+void nano::test::print_all_blocks (nano::node & node)
+{
+	auto tx = node.store.tx_begin_read ();
+	auto i = node.store.block.begin (tx);
+	auto end = node.store.block.end ();
+	std::cout << "Listing all blocks" << std::endl;
+	for (; i != end; ++i)
+	{
+		nano::block_hash hash = i->first;
+		nano::store::block_w_sideband sideband = i->second;
+		std::shared_ptr<nano::block> b = sideband.block;
+		std::cout << "Hash: " << hash.to_string () << std::endl;
+		const auto acc = sideband.sideband.account;
+		std::cout << "Acc: " << acc.to_string () << "(" << acc.to_account () << ")" << std::endl;
+		std::cout << "Height: " << sideband.sideband.height << std::endl;
+		std::cout << b->to_json ();
 	}
 }

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -273,6 +273,28 @@ bool nano::test::start_elections (nano::test::system & system_a, nano::node & no
 	return nano::test::start_elections (system_a, node_a, blocks_to_hashes (blocks_a), forced_a);
 }
 
+nano::account_info nano::test::account_info (nano::node const & node, nano::account const & acc)
+{
+	auto const tx = node.ledger.store.tx_begin_read ();
+	auto opt = node.ledger.account_info (tx, acc);
+	if (opt.has_value ())
+	{
+		return opt.value ();
+	}
+	return {};
+}
+
+uint64_t nano::test::account_height (nano::node const & node, nano::account const & acc)
+{
+	auto const tx = node.ledger.store.tx_begin_read ();
+	nano::confirmation_height_info height_info;
+	if (!node.ledger.store.confirmation_height.get (tx, acc, height_info))
+	{
+		return 0;
+	}
+	return height_info.height;
+}
+
 void nano::test::print_all_account_info (nano::node & node)
 {
 	auto const tx = node.ledger.store.tx_begin_read ();

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -388,10 +388,19 @@ namespace test
 	[[nodiscard]] bool start_elections (nano::test::system &, nano::node &, std::vector<std::shared_ptr<nano::block>> const &, bool const forced_a = false);
 
 	/**
+	 *  Return account_info for account "acc", if account is not found, a default initialised object is returned
+	 */
+	nano::account_info account_info (nano::node const & node, nano::account const & acc);
+
+	/**
+	 * Return the account height, returns 0 on error
+	 */
+	uint64_t account_height (nano::node const & node, nano::account const & acc);
+
+	/**
 	 * \brief Debugging function to print all accounts in a ledger. Intented to be used to debug unit tests.
 	 * \param ledger
 	 */
 	void print_all_account_info (nano::node & node);
-
 }
 }

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -399,8 +399,12 @@ namespace test
 
 	/**
 	 * \brief Debugging function to print all accounts in a ledger. Intented to be used to debug unit tests.
-	 * \param ledger
 	 */
 	void print_all_account_info (nano::node & node);
+
+	/**
+	 * \brief Debugging function to print all blocks in a node. Intented to be used to debug unit tests.
+	 */
+	void print_all_blocks (nano::node & node);
 }
 }


### PR DESCRIPTION
This fixes a number of issues with the bootstrap tests.
This work was triggered by https://github.com/nanocurrency/nano-node/pull/4368, which was flawed.

A common mistake that I have seen before is to convert manually created instances of nano::node (without using `system.add_node`). Often people assume that this is just old code and that the manual construction of the object can be tidied up by the add_node call. But in many cases these manual node constructions are there so that the node is not connected to anything, add_node runs code to connect all nodes in a system.

Many tests depended on or simply called block_processor.flush(). I removed all instances of block processor flush as it shouldn't be needed and is known to be buggy.

Some tests were supposedly disabling the legacy bootstrap and testing the lazy bootstrap. But since we now have ascending bootstrap, these tests had to modified to disable the ascending bootstrap too.

Many tests were setting the network port semi-automatically but there is no need to do so, it is more flexible to let the OS pick a port number.

I re-enabled some tests that were disabled due to failing intermittedly.

resolves #3559
resolves #3517
resolves #3640
resolves #3613
