### PR TITLE
Remove cleanup functions related to unchecked blocks.

### DIFF
--- a/nano/node/bootstrap/bootstrap_legacy.cpp
+++ b/nano/node/bootstrap/bootstrap_legacy.cpp
@@ -244,10 +244,6 @@ void nano::bootstrap_attempt_legacy::run ()
 		{
 			request_push (lock);
 		}
-		if (!stopped)
-		{
-			node->unchecked_cleanup ();
-		}
 	}
 	lock.unlock ();
 	stop ();

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -131,8 +131,6 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 		flags_a.disable_bootstrap_listener = (vm.count ("disable_bootstrap_listener") > 0);
 	}
 	flags_a.disable_providing_telemetry_metrics = (vm.count ("disable_providing_telemetry_metrics") > 0);
-	flags_a.disable_unchecked_cleanup = (vm.count ("disable_unchecked_cleanup") > 0);
-	flags_a.disable_unchecked_drop = (vm.count ("disable_unchecked_drop") > 0);
 	flags_a.disable_block_processor_unchecked_deletion = (vm.count ("disable_block_processor_unchecked_deletion") > 0);
 	flags_a.enable_pruning = (vm.count ("enable_pruning") > 0);
 	flags_a.allow_bootstrap_peers_duplicates = (vm.count ("allow_bootstrap_peers_duplicates") > 0);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -433,13 +433,6 @@ nano::node::node (boost::asio::io_context & io_ctx_a, std::filesystem::path cons
 
 				logger.info (nano::log::type::node, "************************************ ================= ************************************");
 			}
-
-			// Drop unchecked blocks if initial bootstrap is completed
-			if (!flags.disable_unchecked_drop && !use_bootstrap_weight && !flags.read_only)
-			{
-				logger.info (nano::log::type::node, "Dropping unchecked blocks...");
-				unchecked.clear ();
-			}
 		}
 
 		ledger.pruning = flags.enable_pruning || store.pruned.count (store.tx_begin_read ()) > 0;
@@ -609,13 +602,6 @@ void nano::node::start ()
 	if (!flags.disable_legacy_bootstrap && !flags.disable_ongoing_bootstrap)
 	{
 		ongoing_bootstrap ();
-	}
-	if (!flags.disable_unchecked_cleanup)
-	{
-		auto this_l (shared ());
-		workers.push_task ([this_l] () {
-			this_l->ongoing_unchecked_cleanup ();
-		});
 	}
 	if (flags.enable_pruning)
 	{
@@ -945,56 +931,6 @@ void nano::node::bootstrap_wallet ()
 	{
 		bootstrap_initiator.bootstrap_wallet (accounts);
 	}
-}
-
-void nano::node::unchecked_cleanup ()
-{
-	std::vector<nano::uint128_t> digests;
-	std::deque<nano::unchecked_key> cleaning_list;
-	auto const attempt (bootstrap_initiator.current_attempt ());
-	const bool long_attempt (attempt != nullptr && std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - attempt->attempt_start).count () > config.unchecked_cutoff_time.count ());
-	// Collect old unchecked keys
-	if (ledger.cache.block_count >= ledger.bootstrap_weight_max_blocks && !long_attempt)
-	{
-		auto const now (nano::seconds_since_epoch ());
-		auto const transaction (store.tx_begin_read ());
-		// Max 1M records to clean, max 2 minutes reading to prevent slow i/o systems issues
-		unchecked.for_each (
-		[this, &digests, &cleaning_list, &now] (nano::unchecked_key const & key, nano::unchecked_info const & info) {
-			if ((now - info.modified ()) > static_cast<uint64_t> (config.unchecked_cutoff_time.count ()))
-			{
-				digests.push_back (network.publish_filter.hash (info.block));
-				cleaning_list.push_back (key);
-			} }, [iterations = 0, count = 1024 * 1024] () mutable { return iterations++ < count; });
-	}
-	if (!cleaning_list.empty ())
-	{
-		logger.info (nano::log::type::node, "Deleting {} old unchecked blocks", cleaning_list.size ());
-	}
-	// Delete old unchecked keys in batches
-	while (!cleaning_list.empty ())
-	{
-		std::size_t deleted_count (0);
-		while (deleted_count++ < 2 * 1024 && !cleaning_list.empty ())
-		{
-			auto key (cleaning_list.front ());
-			cleaning_list.pop_front ();
-			if (unchecked.exists (key))
-			{
-				unchecked.del (key);
-			}
-		}
-	}
-	// Delete from the duplicate filter
-	network.publish_filter.clear (digests);
-}
-
-void nano::node::ongoing_unchecked_cleanup ()
-{
-	unchecked_cleanup ();
-	workers.add_timed_task (std::chrono::steady_clock::now () + network_params.node.unchecked_cleaning_interval, [this_l = shared ()] () {
-		this_l->ongoing_unchecked_cleanup ();
-	});
 }
 
 bool nano::node::collect_ledger_pruning_targets (std::deque<nano::block_hash> & pruning_targets_a, nano::account & last_account_a, uint64_t const batch_read_size_a, uint64_t const max_depth_a, uint64_t const cutoff_time_a)

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -101,11 +101,9 @@ public:
 	void ongoing_rep_calculation ();
 	void ongoing_bootstrap ();
 	void ongoing_peer_store ();
-	void ongoing_unchecked_cleanup ();
 	void backup_wallet ();
 	void search_receivable_all ();
 	void bootstrap_wallet ();
-	void unchecked_cleanup ();
 	bool collect_ledger_pruning_targets (std::deque<nano::block_hash> &, nano::account &, uint64_t const, uint64_t const, uint64_t const);
 	void ledger_pruning (uint64_t const, bool);
 	void ongoing_ledger_pruning ();

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -152,8 +152,6 @@ public:
 	bool disable_rep_crawler{ false };
 	bool disable_request_loop{ false }; // For testing only
 	bool disable_tcp_realtime{ false };
-	bool disable_unchecked_cleanup{ false };
-	bool disable_unchecked_drop{ true };
 	bool disable_providing_telemetry_metrics{ false };
 	bool disable_ongoing_telemetry_requests{ false };
 	bool disable_block_processor_unchecked_deletion{ false };


### PR DESCRIPTION
Since the addition of the ascending bootstrapped, all unchecked blocks are held in memory and there is already a size limit on how many are kept in the container. Previously these blocks were stored on disk and the number of items was unbounded which necessitated periodic cleanup.

Cleaning the unchecked blocks could actually negatively affect the ascending bootstrapper and clobber critical blocks it needs causing the need to download them again.