### PR TITLE
Simplify system::get_available_port()

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -57,7 +57,8 @@ TEST (network, tcp_connection)
 TEST (network, construction_with_specified_port)
 {
 	nano::test::system system{};
-	auto const port = system.get_available_port (/* do not allow 0 port */ false);
+	auto const port = nano::test::speculatively_choose_a_free_tcp_bind_port ();
+	ASSERT_NE (port, 0);
 	auto const node = system.add_node (nano::node_config{ port });
 	EXPECT_EQ (port, node->network.port);
 	EXPECT_EQ (port, node->network.endpoint ().port ());

--- a/nano/test_common/network.hpp
+++ b/nano/test_common/network.hpp
@@ -18,7 +18,11 @@ namespace test
 	class system;
 	/** Waits until a TCP connection is established and returns the TCP channel on success*/
 	std::shared_ptr<nano::transport::channel_tcp> establish_tcp (nano::test::system &, nano::node &, nano::endpoint const &);
+
 	/** Adds a node to the system without establishing connections */
 	std::shared_ptr<nano::node> add_outer_node (nano::test::system & system, nano::node_flags = nano::node_flags ());
+
+	/** speculatively (it is not guaranteed that the port will remain free) find a free tcp binding port and return it */
+	uint16_t speculatively_choose_a_free_tcp_bind_port ();
 }
 }

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -61,7 +61,12 @@ namespace test
 		 * Returns default config for node running in test environment
 		 */
 		nano::node_config default_config ();
-		uint16_t get_available_port (bool can_be_zero = true);
+
+		/*
+		 * Returns port 0 by default, to let the O/S choose a port number.
+		 * If NANO_TEST_BASE_PORT is set then it allocates numbers by itself from that range.
+		 */
+		uint16_t get_available_port ();
 
 	public:
 		boost::asio::io_context io_ctx;


### PR DESCRIPTION
The function get_available_port is too confusing. To simplify it, I am refactoring one test job it has into a separate test function.

The test function speculatively chooses a free tcp binding port, for one unit test case, to check that the node can be configured with a manual port.