### PR TITLE
Applying [[noreturn]] attribute to asset_internal

### DIFF
--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -29,7 +29,7 @@ namespace program_options
 }
 }
 
-void assert_internal (char const * check_expr, char const * func, char const * file, unsigned int line, bool is_release_assert, std::string_view error = "");
+[[noreturn]] void assert_internal (char const * check_expr, char const * func, char const * file, unsigned int line, bool is_release_assert, std::string_view error = "");
 
 #define release_assert_1(check) check ? (void)0 : assert_internal (#check, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__, true)
 #define release_assert_2(check, error_msg) check ? (void)0 : assert_internal (#check, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__, true, error_msg)


### PR DESCRIPTION
This will silence warnings/errors in functions that don't return values in control flow paths that end with release_assert. `warning: non-void function does not return a value in all control paths [-Wreturn-type]`