### PR TITLE
Avoid printing warning about cerr and colors in default cli mode

### DIFF
--- a/nano/lib/logging.cpp
+++ b/nano/lib/logging.cpp
@@ -282,6 +282,7 @@ nano::log_config nano::log_config::cli_default ()
 {
 	log_config config{};
 	config.default_level = nano::log::level::critical;
+	config.console.colors = false; // to avoid printing warning about cerr and colors
 	config.console.to_cerr = true; // Use cerr to avoid interference with CLI output that goes to stdout
 	config.file.enable = false;
 	return config;


### PR DESCRIPTION
In cli mode, we default to colors plus cerr so we always get a warning about colors not showing in cerr. Now it defaults to cerr and no colors and the warning does not show up.