### PR TITLE
Remove block_processor::flush function

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -61,8 +61,7 @@ TEST (confirmation_height, single)
 		ASSERT_EQ (nano::dev::genesis->hash (), confirmation_height_info.frontier);
 
 		node->process_active (send1);
-		node->block_processor.flush ();
-
+		ASSERT_TIMELY (5s, nano::test::exists (*node, { send1 }));
 		ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 1);
 
 		{
@@ -538,7 +537,6 @@ TEST (confirmation_height, gap_live)
 
 		// Now complete the chain where the block comes in on the live network
 		node->process_active (open1);
-		node->block_processor.flush ();
 
 		ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 6);
 
@@ -1220,7 +1218,6 @@ TEST (confirmation_height, observers)
 		add_callback_stats (*node1);
 
 		node1->process_active (send1);
-		node1->block_processor.flush ();
 		ASSERT_TIMELY_EQ (10s, node1->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out), 1);
 		auto transaction = node1->store.tx_begin_read ();
 		ASSERT_TRUE (node1->ledger.block_confirmed (transaction, send1->hash ()));

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -513,14 +513,16 @@ TEST (confirmation_height, gap_live)
 		node->block_processor.add (send1);
 		node->block_processor.add (send2);
 		node->block_processor.add (send3);
+		// node->block_processor.add (open1); Witheld for test
 		node->block_processor.add (receive1);
-		node->block_processor.flush ();
+		ASSERT_TIMELY (5s, nano::test::exists (*node, { send1, send2, send3 }));
+		ASSERT_TIMELY (5s, node->unchecked.exists ({ open1->hash (), receive1->hash () }));
 
 		add_callback_stats (*node);
 
 		// Receive 2 comes in on the live network, however the chain has not been finished so it gets added to unchecked
 		node->process_active (receive2);
-		node->block_processor.flush ();
+		ASSERT_TIMELY (5s, node->unchecked.exists ({ receive1->hash (), receive2->hash () }));
 
 		// Confirmation heights should not be updated
 		{

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1497,17 +1497,13 @@ TEST (confirmation_height, callback_confirmed_history)
 		add_callback_stats (*node);
 
 		node->process_active (send1);
-		ASSERT_NE (nano::test::start_election (system, *node, send1->hash ()), nullptr);
+		std::shared_ptr<nano::election> election;
+		ASSERT_TIMELY (5s, election = nano::test::start_election (system, *node, send1->hash ()));
 		{
-			node->process_active (send);
-			node->block_processor.flush ();
-
 			// The write guard prevents the confirmation height processor doing any writes
 			auto write_guard = node->write_database_queue.wait (nano::writer::testing);
 
 			// Confirm send1
-			auto election = node->active.election (send1->qualified_root ());
-			ASSERT_NE (nullptr, election);
 			election->force_confirm ();
 			ASSERT_TIMELY_EQ (10s, node->active.size (), 0);
 			ASSERT_EQ (0, node->active.recently_cemented.list ().size ());

--- a/nano/core_test/gap_cache.cpp
+++ b/nano/core_test/gap_cache.cpp
@@ -157,11 +157,9 @@ TEST (gap_cache, two_dependencies)
 				.build_shared ();
 	ASSERT_EQ (0, node1.gap_cache.size ());
 	node1.block_processor.add (send2);
-	node1.block_processor.flush ();
-	ASSERT_EQ (1, node1.gap_cache.size ());
+	ASSERT_TIMELY_EQ (5s, 1, node1.gap_cache.size ());
 	node1.block_processor.add (open);
-	node1.block_processor.flush ();
-	ASSERT_EQ (2, node1.gap_cache.size ());
+	ASSERT_TIMELY_EQ (5s, 2, node1.gap_cache.size ());
 	node1.block_processor.add (send1);
 	ASSERT_TIMELY_EQ (5s, node1.gap_cache.size (), 0);
 	ASSERT_TIMELY (5s, node1.store.block.exists (node1.store.tx_begin_read (), send1->hash ()));

--- a/nano/core_test/gap_cache.cpp
+++ b/nano/core_test/gap_cache.cpp
@@ -163,7 +163,6 @@ TEST (gap_cache, two_dependencies)
 	node1.block_processor.flush ();
 	ASSERT_EQ (2, node1.gap_cache.size ());
 	node1.block_processor.add (send1);
-	node1.block_processor.flush ();
 	ASSERT_TIMELY_EQ (5s, node1.gap_cache.size (), 0);
 	ASSERT_TIMELY (5s, node1.store.block.exists (node1.store.tx_begin_read (), send1->hash ()));
 	ASSERT_TIMELY (5s, node1.store.block.exists (node1.store.tx_begin_read (), send2->hash ()));

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -423,9 +423,9 @@ TEST (receivable_processor, send_with_receive)
 	ASSERT_EQ (amount, node2.balance (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, node2.balance (key2.pub));
 	node1.process_active (block1);
-	node1.block_processor.flush ();
+	ASSERT_TIMELY (5s, nano::test::exists (node1, { block1 }));
 	node2.process_active (block1);
-	node2.block_processor.flush ();
+	ASSERT_TIMELY (5s, nano::test::exists (node2, { block1 }));
 	ASSERT_EQ (amount - node1.config.receive_minimum.number (), node1.balance (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, node1.balance (key2.pub));
 	ASSERT_EQ (amount - node1.config.receive_minimum.number (), node2.balance (nano::dev::genesis_key.pub));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -575,7 +575,6 @@ TEST (node, fork_publish)
 					 .build_shared ();
 		node1.work_generate_blocking (*send2);
 		node1.process_active (send1);
-		node1.block_processor.flush ();
 		ASSERT_TIMELY_EQ (5s, 1, node1.active.size ());
 		auto election (node1.active.election (send1->qualified_root ()));
 		ASSERT_NE (nullptr, election);
@@ -673,9 +672,7 @@ TEST (node, fork_keep)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	node1.process_active (send1);
-	node1.block_processor.flush ();
 	node2.process_active (send1);
-	node2.block_processor.flush ();
 	ASSERT_TIMELY_EQ (5s, 1, node1.active.size ());
 	ASSERT_TIMELY_EQ (5s, 1, node2.active.size ());
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -728,9 +725,7 @@ TEST (node, fork_flip)
 	auto ignored_channel{ std::make_shared<nano::transport::channel_tcp> (node1, std::weak_ptr<nano::transport::socket> ()) };
 
 	node1.network.inbound (publish1, ignored_channel);
-	node1.block_processor.flush ();
 	node2.network.inbound (publish2, ignored_channel);
-	node2.block_processor.flush ();
 	ASSERT_TIMELY_EQ (5s, 1, node1.active.size ());
 	ASSERT_TIMELY_EQ (5s, 1, node2.active.size ());
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -2083,7 +2078,6 @@ TEST (node, online_reps_election)
 				 .work (*node1.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	node1.process_active (send1);
-	node1.block_processor.flush ();
 	ASSERT_TIMELY_EQ (5s, 1, node1.active.size ());
 	// Process vote for ongoing election
 	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::milliseconds_since_epoch (), 0, std::vector<nano::block_hash>{ send1->hash () });
@@ -2453,7 +2447,6 @@ TEST (node, local_votes_cache_fork)
 	node_config.peering_port = system.get_available_port ();
 	auto & node2 (*system.add_node (node_config, node_flags));
 	node2.process_active (send1_fork);
-	node2.block_processor.flush ();
 	ASSERT_TIMELY (5s, node2.ledger.block_or_pruned_exists (send1->hash ()));
 }
 
@@ -3337,7 +3330,6 @@ TEST (node, bidirectional_tcp)
 				 .work (*node1->work_generate_blocking (send1->hash ()))
 				 .build_shared ();
 	node2->process_active (send2);
-	node2->block_processor.flush ();
 	ASSERT_TIMELY (10s, node1->ledger.block_or_pruned_exists (send2->hash ()) && node2->ledger.block_or_pruned_exists (send2->hash ()));
 	// Test block confirmation from node 2 (add representative to node 2)
 	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -355,8 +355,7 @@ TEST (node, receive_gap)
 	nano::publish message{ nano::dev::network_params.network, block };
 	auto channel1 = std::make_shared<nano::transport::fake::channel> (node1);
 	node1.network.inbound (message, channel1);
-	node1.block_processor.flush ();
-	ASSERT_EQ (1, node1.gap_cache.size ());
+	ASSERT_TIMELY_EQ (5s, 1, node1.gap_cache.size ());
 }
 
 TEST (node, merge_peers)
@@ -581,7 +580,7 @@ TEST (node, fork_publish)
 		// Wait until the genesis rep activated & makes vote
 		ASSERT_TIMELY_EQ (1s, election->votes ().size (), 2);
 		node1.process_active (send2);
-		node1.block_processor.flush ();
+		ASSERT_TIMELY (5s, node1.active.active (*send2));
 		auto votes1 (election->votes ());
 		auto existing1 (votes1.find (nano::dev::genesis_key.pub));
 		ASSERT_NE (votes1.end (), existing1);
@@ -676,10 +675,11 @@ TEST (node, fork_keep)
 	ASSERT_TIMELY_EQ (5s, 1, node1.active.size ());
 	ASSERT_TIMELY_EQ (5s, 1, node2.active.size ());
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	// Fill node with forked blocks
 	node1.process_active (send2);
-	node1.block_processor.flush ();
+	ASSERT_TIMELY (5s, node1.active.active (*send2));
 	node2.process_active (send2);
-	node2.block_processor.flush ();
+	ASSERT_TIMELY (5s, node2.active.active (*send2));
 	auto election1 (node2.active.election (nano::qualified_root (nano::dev::genesis->hash (), nano::dev::genesis->hash ())));
 	ASSERT_NE (nullptr, election1);
 	ASSERT_EQ (1, election1->votes ().size ());
@@ -729,10 +729,11 @@ TEST (node, fork_flip)
 	ASSERT_TIMELY_EQ (5s, 1, node1.active.size ());
 	ASSERT_TIMELY_EQ (5s, 1, node2.active.size ());
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	// Fill nodes with forked blocks
 	node1.network.inbound (publish2, ignored_channel);
-	node1.block_processor.flush ();
+	ASSERT_TIMELY (5s, node1.active.active (*send2));
 	node2.network.inbound (publish1, ignored_channel);
-	node2.block_processor.flush ();
+	ASSERT_TIMELY (5s, node2.active.active (*send1));
 	auto election1 (node2.active.election (nano::qualified_root (nano::dev::genesis->hash (), nano::dev::genesis->hash ())));
 	ASSERT_NE (nullptr, election1);
 	ASSERT_EQ (1, election1->votes ().size ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2971,8 +2971,7 @@ TEST (node, block_processor_reject_state)
 	send1->signature.bytes[0] ^= 1;
 	ASSERT_FALSE (node.ledger.block_or_pruned_exists (send1->hash ()));
 	node.process_active (send1);
-	auto flushed = std::async (std::launch::async, [&node] { node.block_processor.flush (); });
-	ASSERT_NE (std::future_status::timeout, flushed.wait_for (5s));
+	ASSERT_TIMELY_EQ (5s, 1, node.stats.count (nano::stat::type::blockprocessor, nano::stat::detail::bad_signature));
 	ASSERT_FALSE (node.ledger.block_or_pruned_exists (send1->hash ()));
 	auto send2 = builder.make_block ()
 				 .account (nano::dev::genesis_key.pub)
@@ -2984,9 +2983,7 @@ TEST (node, block_processor_reject_state)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	node.process_active (send2);
-	auto flushed2 = std::async (std::launch::async, [&node] { node.block_processor.flush (); });
-	ASSERT_NE (std::future_status::timeout, flushed2.wait_for (5s));
-	ASSERT_TRUE (node.ledger.block_or_pruned_exists (send2->hash ()));
+	ASSERT_TIMELY (5s, node.ledger.block_or_pruned_exists (send2->hash ()));
 }
 
 TEST (node, block_processor_full)

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -946,7 +946,7 @@ TEST (wallet, change_seed)
 	wallet->insert_adhoc (nano::dev::genesis_key.prv, false);
 	auto block (wallet->send_action (nano::dev::genesis_key.pub, pub, 100));
 	ASSERT_NE (nullptr, block);
-	system.nodes[0]->block_processor.flush ();
+	ASSERT_TIMELY (5s, nano::test::exists (*system.nodes[0], { block }));
 	{
 		auto transaction (wallet->wallets.tx_begin_write ());
 		wallet->change_seed (transaction, seed1);
@@ -980,7 +980,7 @@ TEST (wallet, deterministic_restore)
 	wallet->insert_adhoc (nano::dev::genesis_key.prv, false);
 	auto block (wallet->send_action (nano::dev::genesis_key.pub, pub, 100));
 	ASSERT_NE (nullptr, block);
-	system.nodes[0]->block_processor.flush ();
+	ASSERT_TIMELY (5s, nano::test::exists (*system.nodes[0], { block }));
 	{
 		auto transaction (wallet->wallets.tx_begin_write ());
 		wallet->deterministic_restore (transaction);

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -210,8 +210,7 @@ TEST (websocket, stopped_election)
 	nano::publish publish1{ nano::dev::network_params.network, send1 };
 	auto channel1 = std::make_shared<nano::transport::fake::channel> (*node1);
 	node1->network.inbound (publish1, channel1);
-	node1->block_processor.flush ();
-	ASSERT_TIMELY (1s, node1->active.election (send1->qualified_root ()));
+	ASSERT_TIMELY (5s, node1->active.election (send1->qualified_root ()));
 	node1->active.erase (*send1);
 
 	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -990,7 +990,6 @@ int main (int argc, char * const * argv)
 				}
 			}
 
-			node->block_processor.flush ();
 			auto end (std::chrono::high_resolution_clock::now ());
 			auto time (std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count ());
 			node->stop ();
@@ -1083,7 +1082,10 @@ int main (int argc, char * const * argv)
 				node->process_active (block);
 				blocks.pop_front ();
 			}
-			node->block_processor.flush ();
+			while (node->block_processor.size () > 0)
+			{
+				std::this_thread::sleep_for (std::chrono::milliseconds (100));
+			}
 			// Processing votes
 			std::cerr << boost::str (boost::format ("Starting processing %1% votes\n") % max_votes);
 			auto begin (std::chrono::high_resolution_clock::now ());
@@ -1191,7 +1193,6 @@ int main (int argc, char * const * argv)
 			{
 				node1->block_processor.add (block);
 			}
-			node1->block_processor.flush ();
 			auto iteration (0);
 			while (node1->ledger.cache.block_count != count * 2 + 1)
 			{
@@ -1241,7 +1242,6 @@ int main (int argc, char * const * argv)
 				node2->block_processor.add (block);
 				blocks.pop_front ();
 			}
-			node2->block_processor.flush ();
 			while (node2->ledger.cache.block_count != count * 2 + 1)
 			{
 				std::this_thread::sleep_for (std::chrono::milliseconds (500));
@@ -1835,8 +1835,6 @@ int main (int argc, char * const * argv)
 					std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked)") % node.node->ledger.cache.block_count % node.node->unchecked.count ()) << std::endl;
 				}
 			}
-
-			node.node->block_processor.flush ();
 
 			auto end (std::chrono::high_resolution_clock::now ());
 			auto time (std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count ());

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -37,17 +37,6 @@ void nano::block_processor::stop ()
 	nano::join_or_pass (processing_thread);
 }
 
-void nano::block_processor::flush ()
-{
-	flushing = true;
-	nano::unique_lock<nano::mutex> lock{ mutex };
-	while (!stopped && (have_blocks () || active))
-	{
-		condition.wait (lock);
-	}
-	flushing = false;
-}
-
 std::size_t nano::block_processor::size ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -29,7 +29,6 @@ class block_processor final
 public:
 	explicit block_processor (nano::node &, nano::write_database_queue &);
 	void stop ();
-	void flush ();
 	std::size_t size ();
 	bool full ();
 	bool half_full ();

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1887,7 +1887,10 @@ TEST (node, mass_block_new)
 		}
 		ASSERT_TIMELY_EQ (200s, node.ledger.cache.block_count, next_block_count);
 		next_block_count += num_blocks;
-		node.block_processor.flush ();
+		while (node.block_processor.size () > 0)
+		{
+			std::this_thread::sleep_for (std::chrono::milliseconds{ 100 });
+		}
 		// Clear all active
 		{
 			nano::lock_guard<nano::mutex> guard{ node.active.mutex };


### PR DESCRIPTION
The ::flush style functions have been disfavored as they're error and deadlock-prone.  Depending on them in unit tests is problematic as their effect can change over time as components are added or removed from the node.

Removing the block_processor::flush function is done in 5 commits with increasing complexity and finally removing it from the legacy bootstrap processor as well its implementation in the final commit.