### PR TITLE
Prs/fix unittests active transactions.inactive votes cache election start

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -528,10 +528,10 @@ TEST (active_transactions, inactive_votes_cache_election_start)
 	node.vote_processor.vote (vote0, std::make_shared<nano::transport::inproc::channel> (node, node));
 	ASSERT_TIMELY_EQ (5s, 0, node.active.size ());
 	ASSERT_TIMELY_EQ (5s, 5, node.ledger.cache.cemented_count);
-	ASSERT_TRUE (nano::test::confirmed (node, { send1, send2, open1, open2 }));
+	ASSERT_TIMELY (1s, nano::test::confirmed (node, { send1, send2, open1, open2 }));
 
 	// A late block arrival also checks the inactive votes cache
-	ASSERT_TRUE (node.active.empty ());
+	ASSERT_TIMELY (1s, node.active.empty ());
 	auto send4_cache (node.vote_cache.find (send4->hash ()));
 	ASSERT_TRUE (send4_cache);
 	ASSERT_EQ (3, send4_cache->voters ().size ());

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -67,6 +67,8 @@ void nano::active_transactions::stop ()
 
 void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::block> const & block_a)
 {
+	//There is a race between execution of block_cemented_callback and void nano::scheduler::priority::run ()
+	std::this_thread::sleep_for (10ms); 
 	auto transaction = node.store.tx_begin_read ();
 	auto status_type = election_status (transaction, block_a);
 

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -68,7 +68,7 @@ void nano::active_transactions::stop ()
 void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::block> const & block_a)
 {
 	//There is a race between execution of block_cemented_callback and void nano::scheduler::priority::run ()
-	std::this_thread::sleep_for (10ms); 
+	std::this_thread::sleep_for (10ms);
 	auto transaction = node.store.tx_begin_read ();
 	auto status_type = election_status (transaction, block_a);
 


### PR DESCRIPTION
This testcase has 2 different issues.
This is not meant to be a real fix, but a help for further investigation.

### Issue 1
```
[----------] 1 test from active_transactions
[ RUN      ] active_transactions.inactive_votes_cache_election_start
/Users/bl/Dev/Git/nano-node/nano/core_test/active_transactions.cpp:529: Failure
Expected equality of these values:
  0
  node.active.size ()
    Which is: 1
[  FAILED  ] active_transactions.inactive_votes_cache_election_start (5195 ms)
```
The reason for this failure is because there is a race condition between the `block_cemented_callback` and the priority scheduler loop. Sometimes the block gets cemented before the priority scheduler loop has started as you can see in the stats log below:

<img width="954" alt="Screenshot 2024-01-26 at 22 03 07" src="https://github.com/nanocurrency/nano-node/assets/85646666/b45474bb-031b-42bb-87df-4c2312db57f8">


--> I didn't know how to fix it, but added a delay in the `block_cemented_callback` to show that the error is gone.

### Issue 2

```
[==========] Running 1 test from 1 test suite.
[ RUN      ] active_transactions.inactive_votes_cache_election_start
nano-node/nano/core_test/active_transactions.cpp:534: Failure
Value of: node.active.empty ()
  Actual: false
Expected: true
[  FAILED  ] active_transactions.inactive_votes_cache_election_start (327 ms)
```
I relaxed the conditions to timely, so the following will apply : 
- when `node.ledger.cache.cemented_count` is incremented, `nano::test::confirmed` eventually returns true 
- when `nano::test::confirmed` returns true for all blocks, `node.active.empty ()`will eventually return true
