### PR TITLE
Remove unnecessary unlock/lock of a mutex

### DIFF
--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -366,10 +366,7 @@ void nano::election::confirm_if_quorum (nano::unique_lock<nano::mutex> & lock_a)
 	{
 		if (node.ledger.cache.final_votes_confirmation_canary.load () && !is_quorum.exchange (true) && node.config.enable_voting && node.wallets.reps ().voting > 0)
 		{
-			auto hash = status.winner->hash ();
-			lock_a.unlock ();
-			node.final_generator.add (root, hash);
-			lock_a.lock ();
+			node.final_generator.add (root, status.winner->hash ());
 		}
 		if (!node.ledger.cache.final_votes_confirmation_canary.load () || final_weight >= node.online_reps.delta ())
 		{


### PR DESCRIPTION
node.final_generator.add() used to do further work in the same context and there was the possibility of a deadlock.
But now it just adds to a queue so there should not be a deadlock danger. So the lock/unlock should not be needed.