### PR TITLE
Allow overriding of default application path directory

### DIFF
--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -9,6 +9,13 @@ static std::vector<std::filesystem::path> all_unique_paths;
 std::filesystem::path nano::working_path (nano::networks network)
 {
 	auto result (nano::app_path ());
+
+	if (auto path_override = nano::get_env ("NANO_APP_PATH"))
+	{
+		result = *path_override;
+		std::cerr << "Application path overridden by NANO_APP_PATH environment variable: " << result << std::endl;
+	}
+
 	switch (network)
 	{
 		case nano::networks::invalid:


### PR DESCRIPTION
The current implementation doesn't allow changing the default application data directory. This limitation is problematic because it doesn't allow to direct all test suite data to a ramdisk. Also it's sometimes more convenient to configure certain settings via environment variables.