### PR TITLE
Fix election scheduler.no vacancy ; Prevent block activation while in confirmation_heigh_processor 

### DIFF
--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -89,6 +89,8 @@ TEST (election_scheduler, no_vacancy)
 				.build_shared ();
 	ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
 	node.process_confirmed (nano::election_status{ send });
+	// Receive block should not be activated by `activate_successors` as this will start an undesired election
+	std::this_thread::sleep_for (100ms);
 
 	auto receive = builder.make_block ()
 				   .account (key.pub)

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -49,7 +49,7 @@ bool nano::scheduler::priority::activate (nano::account const & account_a, store
 			auto hash = conf_info.height == 0 ? info->open_block : node.store.block.successor (transaction, conf_info.frontier);
 			auto block = node.store.block.get (transaction, hash);
 			debug_assert (block != nullptr);
-			if (node.ledger.dependents_confirmed (transaction, *block))
+			if (node.ledger.dependents_confirmed (transaction, *block) && !node.confirmation_height_processor.is_processing_block (hash))
 			{
 				stats.inc (nano::stat::type::election_scheduler, nano::stat::detail::activated);
 				auto balance = node.ledger.balance (transaction, hash);


### PR DESCRIPTION
The ` scheduler.no vacancy`testcase has a failure rate of about 1 - 2%. 
With this PR it passes 100% of 100k runs.

### Description of the solution

- I added a test that blocks being processed in the confirmation_height_processor don't get activated.
The tracing shows, that a block can be activated while it's already being processed by the confirmation_heigh_processor.
```
[2024-02-01 16:45:40.764] [node_1y5t6] [node::process_confirmed] [trace] event: "node::process_confirmed",
block: {
   type: "state",
   hash: "6C3211C73E447A95BADE5AA0601103E9C3582D68C4D8F8FB8CBACF34C17EB06D"
   ...  

[2024-02-01 16:45:40.764] [node_1y5t6] [election_scheduler::block_activated] [trace] event: "election_scheduler::block_activated",
account: "nano_1w8bty5rfkmmmh9fbxnj8ng1isfzntaq3n9gcxamgo14wp69so7ojfixkaxt",
block: {
   type: "state",
   hash: "6C3211C73E447A95BADE5AA0601103E9C3582D68C4D8F8FB8CBACF34C17EB06D",
   ...
   ```
 - I introduced a small delay after the processing the send block before creating the receive block.
 The issue seen is that if the the receive block already exists, it can be activated by the `activate_successors` inside `block_cemented_callback` of the send block.
 This triggers an undesired election that uses up the 1 vacancy slot.


```
[debug] create send: {
   type: "state",
   hash: "A422EEECB992D117090249168D19E1F237AB89ABC96C2A5DE04C8DC4FDFFEB3C",
 ...

[node_33ur8] [node::process_confirmed] [trace] event: "node::process_confirmed",
block: {
   type: "state",
   hash: "A422EEECB992D117090249168D19E1F237AB89ABC96C2A5DE04C8DC4FDFFEB3C",
... 

[debug] create receive: {
   type: "state",
   hash: "6C3211C73E447A95BADE5AA0601103E9C3582D68C4D8F8FB8CBACF34C17EB06D",
...
   
[node_33ur8] [active_transactions] [debug] activate_successors - Account: [nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo]
[node_33ur8] [active_transactions] [debug] activate_successors - Destination: [nano_1w8bty5rfkmmmh9fbxnj8ng1isfzntaq3n9gcxamgo14wp69so7ojfixkaxt]

[node_33ur8] [election_scheduler::block_activated] [trace] event: "election_scheduler::block_activated",
account: "nano_1w8bty5rfkmmmh9fbxnj8ng1isfzntaq3n9gcxamgo14wp69so7ojfixkaxt",
block: {
   type: "state",
   hash: "6C3211C73E447A95BADE5AA0601103E9C3582D68C4D8F8FB8CBACF34C17EB06D",
...

[node_33ur8] [election_scheduler::insert_priority] [trace] event: "election_scheduler::insert_priority",
time: 1024087149837,
block: {
   type: "state",
   hash: "6C3211C73E447A95BADE5AA0601103E9C3582D68C4D8F8FB8CBACF34C17EB06D",
 ...

[node_33ur8] [active_transactions::active_started] [trace] event: "active_transactions::active_started",
behavior: "normal",
election: {
   qualified_root: "70C9D78786CA739BCED4F691351C0865BFA69170D0EE5751375402E5887CD4B50000000000000000000000000000000000000000000000000000000000000000",
   behaviour: "normal",
   height: 1,
   status: {
      winner: "6C3211C73E447A95BADE5AA0601103E9C3582D68C4D8F8FB8CBACF34C17EB06D",
 ```
   