### PR TITLE
Prevent elections from being started after being processed by `confirmation_heigh_processor`

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -428,7 +428,7 @@ nano::election_insertion_result nano::active_transactions::insert (std::shared_p
 	auto const existing = roots.get<tag_root> ().find (root);
 	if (existing == roots.get<tag_root> ().end ())
 	{
-		if (!recently_confirmed.exists (root) && !node.confirmation_height_processor.is_processing_or_confirmed (hash))
+		if (!recently_confirmed.exists (root) && !confirmation_height_processor.is_processing_or_confirmed (hash))
 		{
 			result.inserted = true;
 			auto observe_rep_cb = [&node = node] (auto const & rep_a) {

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -428,7 +428,7 @@ nano::election_insertion_result nano::active_transactions::insert (std::shared_p
 	auto const existing = roots.get<tag_root> ().find (root);
 	if (existing == roots.get<tag_root> ().end ())
 	{
-		if (!recently_confirmed.exists (root))
+		if (!recently_confirmed.exists (root) && !node.confirmation_height_processor.is_processing_or_confirmed (hash))
 		{
 			result.inserted = true;
 			auto observe_rep_cb = [&node = node] (auto const & rep_a) {

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -234,6 +234,11 @@ bool nano::confirmation_height_processor::is_processing_block (nano::block_hash 
 	return is_processing_added_block (hash_a) || unbounded_processor.has_iterated_over_block (hash_a);
 }
 
+bool nano::confirmation_height_processor::is_processing_or_confirmed (nano::block_hash const & hash_a) const
+{
+	return is_processing_added_block (hash_a) || unbounded_processor.has_iterated_or_confirmed (hash_a);
+}
+
 nano::block_hash nano::confirmation_height_processor::current () const
 {
 	nano::lock_guard<nano::mutex> lk (mutex);

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -41,6 +41,7 @@ public:
 	std::size_t awaiting_processing_size () const;
 	bool is_processing_added_block (nano::block_hash const & hash_a) const;
 	bool is_processing_block (nano::block_hash const &) const;
+	bool is_processing_or_confirmed (nano::block_hash const &) const;
 	nano::block_hash current () const;
 
 	/*

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -464,7 +464,7 @@ void nano::confirmation_height_unbounded::clear_process_vars ()
 		{
 			const auto & block_hash = pair.first;
 			recently_confirmed.push_back (block_hash);
-		}		
+		}
 		block_cache.clear ();
 
 		// Ensure recently_confirmed doesn't exceed max_recently_confirmed
@@ -479,13 +479,6 @@ bool nano::confirmation_height_unbounded::has_iterated_over_block (nano::block_h
 {
 	nano::lock_guard<nano::mutex> guard (block_cache_mutex);
 	return block_cache.count (hash_a) == 1;
-}
-
-bool nano::confirmation_height_unbounded::is_recently_confirmed (nano::block_hash const & hash_a) const
-{
-	nano::lock_guard<nano::mutex> guard (block_cache_mutex);
-	auto result = std::find (recently_confirmed.begin (), recently_confirmed.end (), hash_a) != recently_confirmed.end ();
-	return result;
 }
 
 bool nano::confirmation_height_unbounded::has_iterated_or_confirmed (nano::block_hash const & hash_a) const

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -26,7 +26,6 @@ public:
 	void process (std::shared_ptr<nano::block> original_block);
 	void cement_blocks (nano::write_guard &);
 	bool has_iterated_over_block (nano::block_hash const &) const;
-	bool is_recently_confirmed (nano::block_hash const &) const;
 	bool has_iterated_or_confirmed (nano::block_hash const &) const;
 
 private:

--- a/nano/node/confirmation_height_unbounded.hpp
+++ b/nano/node/confirmation_height_unbounded.hpp
@@ -26,6 +26,8 @@ public:
 	void process (std::shared_ptr<nano::block> original_block);
 	void cement_blocks (nano::write_guard &);
 	bool has_iterated_over_block (nano::block_hash const &) const;
+	bool is_recently_confirmed (nano::block_hash const &) const;
+	bool has_iterated_or_confirmed (nano::block_hash const &) const;
 
 private:
 	class confirmed_iterated_pair
@@ -74,6 +76,8 @@ private:
 	mutable nano::mutex block_cache_mutex;
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> block_cache;
 	uint64_t block_cache_size () const;
+	static constexpr size_t max_recently_confirmed = 65536;
+	std::deque<nano::block_hash> recently_confirmed;
 
 	nano::timer<std::chrono::milliseconds> timer;
 


### PR DESCRIPTION
Currently it is possible that an election gets scheduled for a block that is being processed or has been processed by the `confirmation_heigh_processor`.

This introduces a deque of recently confirmed hashes by the `confirmation_height_unbounded` processor and keeps track of the last 65536 confirmed hashes, similar to the `active_transactions`class.

It addresses the intermittent failures of the following test cases :
- `election_scheduler.no_vacancy`
- `active_transactions.inactive_votes_cache_election_start` 

