### PR TITLE
Print stacktrace in unit tests when receiving signal SIGSEGV

### DIFF
--- a/nano/core_test/core_test_main.cc
+++ b/nano/core_test/core_test_main.cc
@@ -1,10 +1,14 @@
 #include "gtest/gtest.h"
 
 #include <nano/lib/logging.hpp>
+#include <nano/lib/stacktrace.hpp>
 #include <nano/node/common.hpp>
 #include <nano/secure/utility.hpp>
 
 #include <boost/filesystem/path.hpp>
+
+#include <stdlib.h>
+#include <signal.h>
 
 constexpr std::size_t OPEN_FILE_DESCRIPTORS_LIMIT = 16384;
 
@@ -17,8 +21,16 @@ namespace test
 void force_nano_dev_network ();
 }
 
+void signalHandler(int signum)
+{
+	std::cerr << "SIGSEGV signal handler\n";
+	std::cerr << nano::generate_stacktrace () << std::endl;
+	exit(signum);
+}
+
 GTEST_API_ int main (int argc, char ** argv)
 {
+	signal(SIGSEGV, signalHandler);
 	nano::logger::initialize_for_tests (nano::log_config::tests_default ());
 	nano::set_file_descriptor_limit (OPEN_FILE_DESCRIPTORS_LIMIT);
 	nano::force_nano_dev_network ();


### PR DESCRIPTION
When unit tests fail with memory access error (SIGSEGV), we don;t print a stack trace.
We currently have a problem where a unit tests fails often with memory access fault and we need to find out why.
This fix fixes that problem for Linux and MacOS. It does not work for Windows but we can fix windows later.