### PR TITLE
Link nano_lib with boost::property_tree which is at least referenced by nano/lib/blocks.hpp

### DIFF
--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -124,6 +124,7 @@ target_link_libraries(
   Boost::dll
   Boost::multiprecision
   Boost::program_options
+  Boost::property_tree
   Boost::stacktrace)
 
 if(NANO_STACKTRACE_BACKTRACE)


### PR DESCRIPTION
This fixes build error referencing boost::property_tree headers.