### PR TITLE
Change collect_container_info to be a member of nano::block_processor

### DIFF
--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -412,20 +412,20 @@ void nano::block_processor::queue_unchecked (store::write_transaction const & tr
 	node.unchecked.trigger (hash_or_account_a);
 }
 
-std::unique_ptr<nano::container_info_component> nano::collect_container_info (block_processor & block_processor, std::string const & name)
+std::unique_ptr<nano::container_info_component> nano::block_processor::collect_container_info (std::string const & name)
 {
 	std::size_t blocks_count;
 	std::size_t forced_count;
 
 	{
-		nano::lock_guard<nano::mutex> guard{ block_processor.mutex };
-		blocks_count = block_processor.blocks.size ();
-		forced_count = block_processor.forced.size ();
+		nano::lock_guard<nano::mutex> guard{ mutex };
+		blocks_count = blocks.size ();
+		forced_count = forced.size ();
 	}
 
 	auto composite = std::make_unique<container_info_composite> (name);
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "blocks", blocks_count, sizeof (decltype (block_processor.blocks)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "forced", forced_count, sizeof (decltype (block_processor.forced)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "blocks", blocks_count, sizeof (decltype (blocks)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "forced", forced_count, sizeof (decltype (forced)::value_type) }));
 	return composite;
 }
 

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -75,6 +75,7 @@ public:
 	bool have_blocks_ready ();
 	bool have_blocks ();
 	void process_blocks ();
+	std::unique_ptr<container_info_component> collect_container_info (std::string const & name);
 
 	std::atomic<bool> flushing{ false };
 
@@ -110,7 +111,5 @@ private:
 	nano::condition_variable condition;
 	nano::mutex mutex{ mutex_identifier (mutexes::block_processor) };
 	std::thread processing_thread;
-
-	friend std::unique_ptr<container_info_component> collect_container_info (block_processor & block_processor, std::string const & name);
 };
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -537,7 +537,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (no
 	composite->add_component (collect_container_info (node.wallets, "wallets"));
 	composite->add_component (collect_container_info (node.vote_processor, "vote_processor"));
 	composite->add_component (collect_container_info (node.rep_crawler, "rep_crawler"));
-	composite->add_component (collect_container_info (node.block_processor, "block_processor"));
+	composite->add_component (node.block_processor.collect_container_info ("block_processor"));
 	composite->add_component (collect_container_info (node.online_reps, "online_reps"));
 	composite->add_component (collect_container_info (node.history, "history"));
 	composite->add_component (node.block_uniquer.collect_container_info ("block_uniquer"));


### PR DESCRIPTION
Previously this free function was declared as a friend before it was declared as a function which gave a compiler warning.