### PR TITLE
work_pool: move stopping from destructor to stop function

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1012,14 +1012,15 @@ TEST (mdb_block_store, sideband_height)
 	nano::block_builder builder;
 	auto transaction (store.tx_begin_write ());
 	store.initialize (transaction, ledger.cache, nano::dev::constants);
-	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_guard pool_guard{ pool };
 	auto send = builder
 				.send ()
 				.previous (nano::dev::genesis->hash ())
 				.destination (nano::dev::genesis_key.pub)
 				.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.obj.generate (nano::dev::genesis->hash ()))
+				.work (*pool.generate (nano::dev::genesis->hash ()))
 				.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	auto receive = builder
@@ -1027,7 +1028,7 @@ TEST (mdb_block_store, sideband_height)
 				   .previous (send->hash ())
 				   .source (send->hash ())
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.obj.generate (send->hash ()))
+				   .work (*pool.generate (send->hash ()))
 				   .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
 	auto change = builder
@@ -1035,7 +1036,7 @@ TEST (mdb_block_store, sideband_height)
 				  .previous (receive->hash ())
 				  .representative (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.obj.generate (receive->hash ()))
+				  .work (*pool.generate (receive->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change).code);
 	auto state_send1 = builder
@@ -1046,7 +1047,7 @@ TEST (mdb_block_store, sideband_height)
 					   .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 					   .link (key1.pub)
 					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					   .work (*pool.obj.generate (change->hash ()))
+					   .work (*pool.generate (change->hash ()))
 					   .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send1).code);
 	auto state_send2 = builder
@@ -1057,7 +1058,7 @@ TEST (mdb_block_store, sideband_height)
 					   .balance (nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio)
 					   .link (key2.pub)
 					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					   .work (*pool.obj.generate (state_send1->hash ()))
+					   .work (*pool.generate (state_send1->hash ()))
 					   .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send2).code);
 	auto state_send3 = builder
@@ -1068,7 +1069,7 @@ TEST (mdb_block_store, sideband_height)
 					   .balance (nano::dev::constants.genesis_amount - 3 * nano::Gxrb_ratio)
 					   .link (key3.pub)
 					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					   .work (*pool.obj.generate (state_send2->hash ()))
+					   .work (*pool.generate (state_send2->hash ()))
 					   .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send3).code);
 	auto state_open = builder
@@ -1079,7 +1080,7 @@ TEST (mdb_block_store, sideband_height)
 					  .balance (nano::Gxrb_ratio)
 					  .link (state_send1->hash ())
 					  .sign (key1.prv, key1.pub)
-					  .work (*pool.obj.generate (key1.pub))
+					  .work (*pool.generate (key1.pub))
 					  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_open).code);
 	auto epoch = builder
@@ -1090,7 +1091,7 @@ TEST (mdb_block_store, sideband_height)
 				 .balance (nano::Gxrb_ratio)
 				 .link (ledger.epoch_link (nano::epoch::epoch_1))
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.obj.generate (state_open->hash ()))
+				 .work (*pool.generate (state_open->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch).code);
 	ASSERT_EQ (nano::epoch::epoch_1, ledger.version (*epoch));
@@ -1102,7 +1103,7 @@ TEST (mdb_block_store, sideband_height)
 					  .balance (0)
 					  .link (ledger.epoch_link (nano::epoch::epoch_1))
 					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					  .work (*pool.obj.generate (key2.pub))
+					  .work (*pool.generate (key2.pub))
 					  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch_open).code);
 	ASSERT_EQ (nano::epoch::epoch_1, ledger.version (*epoch_open));
@@ -1114,7 +1115,7 @@ TEST (mdb_block_store, sideband_height)
 						 .balance (nano::Gxrb_ratio)
 						 .link (state_send2->hash ())
 						 .sign (key2.prv, key2.pub)
-						 .work (*pool.obj.generate (epoch_open->hash ()))
+						 .work (*pool.generate (epoch_open->hash ()))
 						 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_receive).code);
 	auto open = builder
@@ -1123,7 +1124,7 @@ TEST (mdb_block_store, sideband_height)
 				.representative (nano::dev::genesis_key.pub)
 				.account (key3.pub)
 				.sign (key3.prv, key3.pub)
-				.work (*pool.obj.generate (key3.pub))
+				.work (*pool.generate (key3.pub))
 				.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
 	auto block1 (store.block.get (transaction, nano::dev::genesis->hash ()));

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -2040,7 +2040,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::write_database_queue write_database_queue (false);
 	boost::latch initialized_latch{ 0 };
-	nano::test::start_stop_container<nano::work_pool> pool { nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto send = builder

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1165,7 +1165,7 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 		nano::stats stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
-		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+		nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		nano::keypair key1;
 		nano::block_builder builder;
 		auto send = builder
@@ -1174,7 +1174,7 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 					.destination (key1.pub)
 					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (nano::dev::genesis->hash ()))
+					.work (*pool.obj.generate (nano::dev::genesis->hash ()))
 					.build_shared ();
 		{
 			auto transaction (store->tx_begin_write ());
@@ -1255,7 +1255,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		nano::stats stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
-		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+		nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		nano::keypair key1;
 		nano::block_builder builder;
 		auto send = builder
@@ -1264,7 +1264,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 					.destination (key1.pub)
 					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (nano::dev::genesis->hash ()))
+					.work (*pool.obj.generate (nano::dev::genesis->hash ()))
 					.build_shared ();
 		{
 			auto transaction (store->tx_begin_write ());
@@ -1332,7 +1332,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		nano::stats stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
-		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+		nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		nano::keypair key1;
 		nano::block_builder builder;
 		auto send = builder
@@ -1341,7 +1341,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 					.destination (key1.pub)
 					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (nano::dev::genesis->hash ()))
+					.work (*pool.obj.generate (nano::dev::genesis->hash ()))
 					.build_shared ();
 		auto open = builder
 					.state ()
@@ -1351,7 +1351,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 					.balance (nano::Gxrb_ratio)
 					.link (send->hash ())
 					.sign (key1.prv, key1.pub)
-					.work (*pool.generate (key1.pub))
+					.work (*pool.obj.generate (key1.pub))
 					.build_shared ();
 		{
 			auto transaction (store->tx_begin_write ());
@@ -2040,7 +2040,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::write_database_queue write_database_queue (false);
 	boost::latch initialized_latch{ 0 };
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool { nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto send = builder
@@ -2049,7 +2049,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 				.destination (key1.pub)
 				.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				.build_shared ();
 	auto send1 = builder
 				 .send ()
@@ -2057,7 +2057,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send->hash ()))
+				 .work (*pool.obj.generate (send->hash ()))
 				 .build_shared ();
 	{
 		auto transaction (store->tx_begin_write ());
@@ -2103,7 +2103,7 @@ TEST (confirmation_height, pruned_source)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::write_database_queue write_database_queue (false);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1, key2;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2114,7 +2114,7 @@ TEST (confirmation_height, pruned_source)
 				 .balance (nano::dev::constants.genesis_amount - 100)
 				 .link (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	auto open1 = builder
 				 .state ()
@@ -2124,7 +2124,7 @@ TEST (confirmation_height, pruned_source)
 				 .balance (100)
 				 .link (send1->hash ())
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.generate (key1.pub))
+				 .work (*pool.obj.generate (key1.pub))
 				 .build_shared ();
 	auto send2 = builder
 				 .state ()
@@ -2134,7 +2134,7 @@ TEST (confirmation_height, pruned_source)
 				 .balance (50)
 				 .link (key2.pub)
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.generate (open1->hash ()))
+				 .work (*pool.obj.generate (open1->hash ()))
 				 .build_shared ();
 	auto send3 = builder
 				 .state ()
@@ -2144,7 +2144,7 @@ TEST (confirmation_height, pruned_source)
 				 .balance (25)
 				 .link (key2.pub)
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.generate (send2->hash ()))
+				 .work (*pool.obj.generate (send2->hash ()))
 				 .build_shared ();
 	auto open2 = builder
 				 .state ()
@@ -2154,7 +2154,7 @@ TEST (confirmation_height, pruned_source)
 				 .balance (50)
 				 .link (send2->hash ())
 				 .sign (key2.prv, key2.pub)
-				 .work (*pool.generate (key2.pub))
+				 .work (*pool.obj.generate (key2.pub))
 				 .build_shared ();
 	{
 		auto transaction (store->tx_begin_write ());

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1165,7 +1165,8 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 		nano::stats stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
-		nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+		nano::test::start_stop_guard pool_guard{ pool };
 		nano::keypair key1;
 		nano::block_builder builder;
 		auto send = builder
@@ -1174,7 +1175,7 @@ TEST (confirmation_heightDeathTest, rollback_added_block)
 					.destination (key1.pub)
 					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.obj.generate (nano::dev::genesis->hash ()))
+					.work (*pool.generate (nano::dev::genesis->hash ()))
 					.build_shared ();
 		{
 			auto transaction (store->tx_begin_write ());
@@ -1255,7 +1256,8 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		nano::stats stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
-		nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+		nano::test::start_stop_guard pool_guard{ pool };
 		nano::keypair key1;
 		nano::block_builder builder;
 		auto send = builder
@@ -1264,7 +1266,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 					.destination (key1.pub)
 					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.obj.generate (nano::dev::genesis->hash ()))
+					.work (*pool.generate (nano::dev::genesis->hash ()))
 					.build_shared ();
 		{
 			auto transaction (store->tx_begin_write ());
@@ -1332,7 +1334,8 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		nano::stats stats;
 		nano::ledger ledger (*store, stats, nano::dev::constants);
 		nano::write_database_queue write_database_queue (false);
-		nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+		nano::test::start_stop_guard pool_guard{ pool };
 		nano::keypair key1;
 		nano::block_builder builder;
 		auto send = builder
@@ -1341,7 +1344,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 					.destination (key1.pub)
 					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.obj.generate (nano::dev::genesis->hash ()))
+					.work (*pool.generate (nano::dev::genesis->hash ()))
 					.build_shared ();
 		auto open = builder
 					.state ()
@@ -1351,7 +1354,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 					.balance (nano::Gxrb_ratio)
 					.link (send->hash ())
 					.sign (key1.prv, key1.pub)
-					.work (*pool.obj.generate (key1.pub))
+					.work (*pool.generate (key1.pub))
 					.build_shared ();
 		{
 			auto transaction (store->tx_begin_write ());
@@ -2040,7 +2043,8 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::write_database_queue write_database_queue (false);
 	boost::latch initialized_latch{ 0 };
-	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_guard pool_guard{ pool };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto send = builder
@@ -2049,7 +2053,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 				.destination (key1.pub)
 				.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.obj.generate (nano::dev::genesis->hash ()))
+				.work (*pool.generate (nano::dev::genesis->hash ()))
 				.build_shared ();
 	auto send1 = builder
 				 .send ()
@@ -2057,7 +2061,7 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.obj.generate (send->hash ()))
+				 .work (*pool.generate (send->hash ()))
 				 .build_shared ();
 	{
 		auto transaction (store->tx_begin_write ());
@@ -2103,7 +2107,8 @@ TEST (confirmation_height, pruned_source)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::write_database_queue write_database_queue (false);
-	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_guard pool_guard{ pool };
 	nano::keypair key1, key2;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2114,7 +2119,7 @@ TEST (confirmation_height, pruned_source)
 				 .balance (nano::dev::constants.genesis_amount - 100)
 				 .link (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	auto open1 = builder
 				 .state ()
@@ -2124,7 +2129,7 @@ TEST (confirmation_height, pruned_source)
 				 .balance (100)
 				 .link (send1->hash ())
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.obj.generate (key1.pub))
+				 .work (*pool.generate (key1.pub))
 				 .build_shared ();
 	auto send2 = builder
 				 .state ()
@@ -2134,7 +2139,7 @@ TEST (confirmation_height, pruned_source)
 				 .balance (50)
 				 .link (key2.pub)
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.obj.generate (open1->hash ()))
+				 .work (*pool.generate (open1->hash ()))
 				 .build_shared ();
 	auto send3 = builder
 				 .state ()
@@ -2144,7 +2149,7 @@ TEST (confirmation_height, pruned_source)
 				 .balance (25)
 				 .link (key2.pub)
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.obj.generate (send2->hash ()))
+				 .work (*pool.generate (send2->hash ()))
 				 .build_shared ();
 	auto open2 = builder
 				 .state ()
@@ -2154,7 +2159,7 @@ TEST (confirmation_height, pruned_source)
 				 .balance (50)
 				 .link (send2->hash ())
 				 .sign (key2.prv, key2.pub)
-				 .work (*pool.obj.generate (key2.pub))
+				 .work (*pool.generate (key2.pub))
 				 .build_shared ();
 	{
 		auto transaction (store->tx_begin_write ());

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -65,7 +65,7 @@ TEST (ledger, process_modifies_sideband)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -75,7 +75,7 @@ TEST (ledger, process_modifies_sideband)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (store.tx_begin_write (), *send1).code);
 	ASSERT_EQ (send1->sideband ().timestamp, store.block.get (store.tx_begin_read (), send1->hash ())->sideband ().timestamp);
@@ -88,7 +88,7 @@ TEST (ledger, process_send)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
 	nano::keypair key2;
@@ -99,7 +99,7 @@ TEST (ledger, process_send)
 				.destination (key2.pub)
 				.balance (50)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (info1->head))
+				.work (*pool.obj.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 = send->hash ();
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, info1->head));
@@ -130,7 +130,7 @@ TEST (ledger, process_send)
 				.representative (key2.pub)
 				.account (key2.pub)
 				.sign (key2.prv, key2.pub)
-				.work (*pool.generate (key2.pub))
+				.work (*pool.obj.generate (key2.pub))
 				.build ();
 	nano::block_hash hash2 (open->hash ());
 	// This was a valid block, it should progress.
@@ -198,7 +198,7 @@ TEST (ledger, process_receive)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
 	nano::keypair key2;
@@ -209,7 +209,7 @@ TEST (ledger, process_receive)
 				.destination (key2.pub)
 				.balance (50)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (info1->head))
+				.work (*pool.obj.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 (send->hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
@@ -220,7 +220,7 @@ TEST (ledger, process_receive)
 				.representative (key3.pub)
 				.account (key2.pub)
 				.sign (key2.prv, key2.pub)
-				.work (*pool.generate (key2.pub))
+				.work (*pool.obj.generate (key2.pub))
 				.build ();
 	nano::block_hash hash2 (open->hash ());
 	auto return1 = ledger.process (transaction, *open);
@@ -237,7 +237,7 @@ TEST (ledger, process_receive)
 				 .destination (key2.pub)
 				 .balance (25)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (hash1))
+				 .work (*pool.obj.generate (hash1))
 				 .build ();
 	nano::block_hash hash3 = send2->hash ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
@@ -246,7 +246,7 @@ TEST (ledger, process_receive)
 				   .previous (hash2)
 				   .source (hash3)
 				   .sign (key2.prv, key2.pub)
-				   .work (*pool.generate (hash2))
+				   .work (*pool.obj.generate (hash2))
 				   .build ();
 	auto hash4 = receive->hash ();
 	ASSERT_EQ (key2.pub, store.frontier.get (transaction, hash2));
@@ -286,7 +286,7 @@ TEST (ledger, rollback_receiver)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
 	nano::keypair key2;
@@ -297,7 +297,7 @@ TEST (ledger, rollback_receiver)
 				.destination (key2.pub)
 				.balance (50)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (info1->head))
+				.work (*pool.obj.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 (send->hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
@@ -308,7 +308,7 @@ TEST (ledger, rollback_receiver)
 				.representative (key3.pub)
 				.account (key2.pub)
 				.sign (key2.prv, key2.pub)
-				.work (*pool.generate (key2.pub))
+				.work (*pool.obj.generate (key2.pub))
 				.build ();
 	nano::block_hash hash2 (open->hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
@@ -335,7 +335,7 @@ TEST (ledger, rollback_representation)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key5;
 	nano::block_builder builder;
 	auto change1 = builder
@@ -343,7 +343,7 @@ TEST (ledger, rollback_representation)
 				   .previous (nano::dev::genesis->hash ())
 				   .representative (key5.pub)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (nano::dev::genesis->hash ()))
+				   .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				   .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
 	nano::keypair key3;
@@ -352,7 +352,7 @@ TEST (ledger, rollback_representation)
 				   .previous (change1->hash ())
 				   .representative (key3.pub)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (change1->hash ()))
+				   .work (*pool.obj.generate (change1->hash ()))
 				   .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change2).code);
 	nano::keypair key2;
@@ -362,7 +362,7 @@ TEST (ledger, rollback_representation)
 				 .destination (key2.pub)
 				 .balance (50)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (change2->hash ()))
+				 .work (*pool.obj.generate (change2->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	nano::keypair key4;
@@ -372,7 +372,7 @@ TEST (ledger, rollback_representation)
 				.representative (key4.pub)
 				.account (key2.pub)
 				.sign (key2.prv, key2.pub)
-				.work (*pool.generate (key2.pub))
+				.work (*pool.obj.generate (key2.pub))
 				.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
 	auto send2 = builder
@@ -381,7 +381,7 @@ TEST (ledger, rollback_representation)
 				 .destination (key2.pub)
 				 .balance (1)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	auto receive1 = builder
@@ -389,7 +389,7 @@ TEST (ledger, rollback_representation)
 					.previous (open->hash ())
 					.source (send2->hash ())
 					.sign (key2.prv, key2.pub)
-					.work (*pool.generate (open->hash ()))
+					.work (*pool.obj.generate (open->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_EQ (1, ledger.weight (key3.pub));
@@ -425,7 +425,7 @@ TEST (ledger, receive_rollback)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send = builder
 				.send ()
@@ -433,7 +433,7 @@ TEST (ledger, receive_rollback)
 				.destination (nano::dev::genesis_key.pub)
 				.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	auto receive = builder
@@ -441,7 +441,7 @@ TEST (ledger, receive_rollback)
 				   .previous (send->hash ())
 				   .source (send->hash ())
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (send->hash ()))
+				   .work (*pool.obj.generate (send->hash ()))
 				   .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
 	ASSERT_FALSE (ledger.rollback (transaction, receive->hash ()));
@@ -453,7 +453,7 @@ TEST (ledger, process_duplicate)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
 	nano::keypair key2;
@@ -464,7 +464,7 @@ TEST (ledger, process_duplicate)
 				.destination (key2.pub)
 				.balance (50)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (info1->head))
+				.work (*pool.obj.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 (send->hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
@@ -475,7 +475,7 @@ TEST (ledger, process_duplicate)
 				.representative (1)
 				.account (key2.pub)
 				.sign (key2.prv, key2.pub)
-				.work (*pool.generate (key2.pub))
+				.work (*pool.obj.generate (key2.pub))
 				.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
 	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *open).code);
@@ -506,7 +506,7 @@ TEST (ledger, representative_change)
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
 	nano::keypair key2;
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
@@ -517,7 +517,7 @@ TEST (ledger, representative_change)
 				 .previous (info1->head)
 				 .representative (key2.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (info1->head))
+				 .work (*pool.obj.generate (info1->head))
 				 .build ();
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, info1->head));
 	auto return1 (ledger.process (transaction, *block));
@@ -549,7 +549,7 @@ TEST (ledger, send_fork)
 	nano::keypair key2;
 	nano::keypair key3;
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
 	nano::block_builder builder;
@@ -559,7 +559,7 @@ TEST (ledger, send_fork)
 				 .destination (key2.pub)
 				 .balance (100)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (info1->head))
+				 .work (*pool.obj.generate (info1->head))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
 	auto block2 = builder
@@ -568,7 +568,7 @@ TEST (ledger, send_fork)
 				  .destination (key3.pub)
 				  .balance (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (info1->head))
+				  .work (*pool.obj.generate (info1->head))
 				  .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block2).code);
 }
@@ -581,7 +581,7 @@ TEST (ledger, receive_fork)
 	nano::keypair key2;
 	nano::keypair key3;
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
 	nano::block_builder builder;
@@ -591,7 +591,7 @@ TEST (ledger, receive_fork)
 				 .destination (key2.pub)
 				 .balance (100)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (info1->head))
+				 .work (*pool.obj.generate (info1->head))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
 	auto block2 = builder
@@ -600,7 +600,7 @@ TEST (ledger, receive_fork)
 				  .representative (key2.pub)
 				  .account (key2.pub)
 				  .sign (key2.prv, key2.pub)
-				  .work (*pool.generate (key2.pub))
+				  .work (*pool.obj.generate (key2.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
 	auto block3 = builder
@@ -608,7 +608,7 @@ TEST (ledger, receive_fork)
 				  .previous (block2->hash ())
 				  .representative (key3.pub)
 				  .sign (key2.prv, key2.pub)
-				  .work (*pool.generate (block2->hash ()))
+				  .work (*pool.obj.generate (block2->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
 	auto block4 = builder
@@ -617,7 +617,7 @@ TEST (ledger, receive_fork)
 				  .destination (key2.pub)
 				  .balance (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block->hash ()))
+				  .work (*pool.obj.generate (block->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block4).code);
 	auto block5 = builder
@@ -625,7 +625,7 @@ TEST (ledger, receive_fork)
 				  .previous (block2->hash ())
 				  .source (block4->hash ())
 				  .sign (key2.prv, key2.pub)
-				  .work (*pool.generate (block2->hash ()))
+				  .work (*pool.obj.generate (block2->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block5).code);
 }
@@ -638,7 +638,7 @@ TEST (ledger, open_fork)
 	nano::keypair key2;
 	nano::keypair key3;
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
 	nano::block_builder builder;
@@ -648,7 +648,7 @@ TEST (ledger, open_fork)
 				 .destination (key2.pub)
 				 .balance (100)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (info1->head))
+				 .work (*pool.obj.generate (info1->head))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
 	auto block2 = builder
@@ -657,7 +657,7 @@ TEST (ledger, open_fork)
 				  .representative (key2.pub)
 				  .account (key2.pub)
 				  .sign (key2.prv, key2.pub)
-				  .work (*pool.generate (key2.pub))
+				  .work (*pool.obj.generate (key2.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
 	auto block3 = builder
@@ -666,7 +666,7 @@ TEST (ledger, open_fork)
 				  .representative (key3.pub)
 				  .account (key2.pub)
 				  .sign (key2.prv, key2.pub)
-				  .work (*pool.generate (key2.pub))
+				  .work (*pool.obj.generate (key2.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block3).code);
 }
@@ -689,7 +689,7 @@ TEST (ledger, representation)
 	auto & store = ctx.store ();
 	auto & rep_weights = ledger.cache.rep_weights;
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	ASSERT_EQ (nano::dev::constants.genesis_amount, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	nano::keypair key2;
 	nano::block_builder builder;
@@ -699,7 +699,7 @@ TEST (ledger, representation)
 				  .destination (key2.pub)
 				  .balance (nano::dev::constants.genesis_amount - 100)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, rep_weights.representation_get (nano::dev::genesis_key.pub));
@@ -710,7 +710,7 @@ TEST (ledger, representation)
 				  .representative (key3.pub)
 				  .account (key2.pub)
 				  .sign (key2.prv, key2.pub)
-				  .work (*pool.generate (key2.pub))
+				  .work (*pool.obj.generate (key2.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, rep_weights.representation_get (nano::dev::genesis_key.pub));
@@ -722,7 +722,7 @@ TEST (ledger, representation)
 				  .destination (key2.pub)
 				  .balance (nano::dev::constants.genesis_amount - 200)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block1->hash ()))
+				  .work (*pool.obj.generate (block1->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
@@ -733,7 +733,7 @@ TEST (ledger, representation)
 				  .previous (block2->hash ())
 				  .source (block3->hash ())
 				  .sign (key2.prv, key2.pub)
-				  .work (*pool.generate (block2->hash ()))
+				  .work (*pool.obj.generate (block2->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block4).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
@@ -745,7 +745,7 @@ TEST (ledger, representation)
 				  .previous (block4->hash ())
 				  .representative (key4.pub)
 				  .sign (key2.prv, key2.pub)
-				  .work (*pool.generate (block4->hash ()))
+				  .work (*pool.obj.generate (block4->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block5).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
@@ -759,7 +759,7 @@ TEST (ledger, representation)
 				  .destination (key5.pub)
 				  .balance (100)
 				  .sign (key2.prv, key2.pub)
-				  .work (*pool.generate (block5->hash ()))
+				  .work (*pool.obj.generate (block5->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block6).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
@@ -774,7 +774,7 @@ TEST (ledger, representation)
 				  .representative (key6.pub)
 				  .account (key5.pub)
 				  .sign (key5.prv, key5.pub)
-				  .work (*pool.generate (key5.pub))
+				  .work (*pool.obj.generate (key5.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block7).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
@@ -789,7 +789,7 @@ TEST (ledger, representation)
 				  .destination (key5.pub)
 				  .balance (0)
 				  .sign (key2.prv, key2.pub)
-				  .work (*pool.generate (block6->hash ()))
+				  .work (*pool.obj.generate (block6->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block8).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
@@ -803,7 +803,7 @@ TEST (ledger, representation)
 				  .previous (block7->hash ())
 				  .source (block8->hash ())
 				  .sign (key5.prv, key5.pub)
-				  .work (*pool.generate (block7->hash ()))
+				  .work (*pool.obj.generate (block7->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block9).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
@@ -823,7 +823,7 @@ TEST (ledger, double_open)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key2;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -832,7 +832,7 @@ TEST (ledger, double_open)
 				 .destination (key2.pub)
 				 .balance (1)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto open1 = builder
@@ -841,7 +841,7 @@ TEST (ledger, double_open)
 				 .representative (key2.pub)
 				 .account (key2.pub)
 				 .sign (key2.prv, key2.pub)
-				 .work (*pool.generate (key2.pub))
+				 .work (*pool.obj.generate (key2.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	auto open2 = builder
@@ -850,7 +850,7 @@ TEST (ledger, double_open)
 				 .representative (nano::dev::genesis_key.pub)
 				 .account (key2.pub)
 				 .sign (key2.prv, key2.pub)
-				 .work (*pool.generate (key2.pub))
+				 .work (*pool.obj.generate (key2.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *open2).code);
 }
@@ -861,7 +861,7 @@ TEST (ledger, double_receive)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key2;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -870,7 +870,7 @@ TEST (ledger, double_receive)
 				 .destination (key2.pub)
 				 .balance (1)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto open1 = builder
@@ -879,7 +879,7 @@ TEST (ledger, double_receive)
 				 .representative (key2.pub)
 				 .account (key2.pub)
 				 .sign (key2.prv, key2.pub)
-				 .work (*pool.generate (key2.pub))
+				 .work (*pool.obj.generate (key2.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	auto receive1 = builder
@@ -887,7 +887,7 @@ TEST (ledger, double_receive)
 					.previous (open1->hash ())
 					.source (send1->hash ())
 					.sign (key2.prv, key2.pub)
-					.work (*pool.generate (open1->hash ()))
+					.work (*pool.obj.generate (open1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *receive1).code);
 }
@@ -1202,7 +1202,7 @@ TEST (ledger, fail_change_old)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block = builder
@@ -1210,7 +1210,7 @@ TEST (ledger, fail_change_old)
 				 .previous (nano::dev::genesis->hash ())
 				 .representative (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
 	ASSERT_EQ (nano::process_result::progress, result1.code);
@@ -1224,7 +1224,7 @@ TEST (ledger, fail_change_gap_previous)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block = builder
@@ -1232,7 +1232,7 @@ TEST (ledger, fail_change_gap_previous)
 				 .previous (1)
 				 .representative (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::root (1)))
+				 .work (*pool.obj.generate (nano::root (1)))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
 	ASSERT_EQ (nano::process_result::gap_previous, result1.code);
@@ -1244,7 +1244,7 @@ TEST (ledger, fail_state_bad_signature)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto block = builder
 				 .state ()
@@ -1254,7 +1254,7 @@ TEST (ledger, fail_state_bad_signature)
 				 .balance (0)
 				 .link (nano::dev::genesis_key.pub)
 				 .sign (nano::keypair ().prv, 0)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
 	ASSERT_EQ (nano::process_result::bad_signature, result1.code);
@@ -1266,7 +1266,7 @@ TEST (ledger, fail_epoch_bad_signature)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto block = builder
 				 .state ()
@@ -1276,7 +1276,7 @@ TEST (ledger, fail_epoch_bad_signature)
 				 .balance (nano::dev::constants.genesis_amount)
 				 .link (ledger.epoch_link (nano::epoch::epoch_1))
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	block->signature.bytes[0] ^= 1;
 	auto result1 = ledger.process (transaction, *block);
@@ -1292,7 +1292,7 @@ TEST (ledger, fail_change_bad_signature)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block = builder
@@ -1300,7 +1300,7 @@ TEST (ledger, fail_change_bad_signature)
 				 .previous (nano::dev::genesis->hash ())
 				 .representative (key1.pub)
 				 .sign (nano::keypair ().prv, 0)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
 	ASSERT_EQ (nano::process_result::bad_signature, result1.code);
@@ -1312,7 +1312,7 @@ TEST (ledger, fail_change_fork)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1320,7 +1320,7 @@ TEST (ledger, fail_change_fork)
 				  .previous (nano::dev::genesis->hash ())
 				  .representative (key1.pub)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
 	ASSERT_EQ (nano::process_result::progress, result1.code);
@@ -1330,7 +1330,7 @@ TEST (ledger, fail_change_fork)
 				  .previous (nano::dev::genesis->hash ())
 				  .representative (key2.pub)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
 	ASSERT_EQ (nano::process_result::fork, result2.code);
@@ -1342,7 +1342,7 @@ TEST (ledger, fail_send_old)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block = builder
@@ -1351,7 +1351,7 @@ TEST (ledger, fail_send_old)
 				 .destination (key1.pub)
 				 .balance (1)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
 	ASSERT_EQ (nano::process_result::progress, result1.code);
@@ -1365,7 +1365,7 @@ TEST (ledger, fail_send_gap_previous)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block = builder
@@ -1374,7 +1374,7 @@ TEST (ledger, fail_send_gap_previous)
 				 .destination (key1.pub)
 				 .balance (1)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::root (1)))
+				 .work (*pool.obj.generate (nano::root (1)))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
 	ASSERT_EQ (nano::process_result::gap_previous, result1.code);
@@ -1386,7 +1386,7 @@ TEST (ledger, fail_send_bad_signature)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block = builder
@@ -1395,7 +1395,7 @@ TEST (ledger, fail_send_bad_signature)
 				 .destination (key1.pub)
 				 .balance (1)
 				 .sign (nano::keypair ().prv, 0)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
 	ASSERT_EQ (nano::process_result::bad_signature, result1.code);
@@ -1407,7 +1407,7 @@ TEST (ledger, fail_send_negative_spend)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1416,7 +1416,7 @@ TEST (ledger, fail_send_negative_spend)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	nano::keypair key2;
@@ -1426,7 +1426,7 @@ TEST (ledger, fail_send_negative_spend)
 				  .destination (key2.pub)
 				  .balance (2)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block1->hash ()))
+				  .work (*pool.obj.generate (block1->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::negative_spend, ledger.process (transaction, *block2).code);
 }
@@ -1437,7 +1437,7 @@ TEST (ledger, fail_send_fork)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1446,7 +1446,7 @@ TEST (ledger, fail_send_fork)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	nano::keypair key2;
@@ -1456,7 +1456,7 @@ TEST (ledger, fail_send_fork)
 				  .destination (key2.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block2).code);
 }
@@ -1467,7 +1467,7 @@ TEST (ledger, fail_open_old)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1476,7 +1476,7 @@ TEST (ledger, fail_open_old)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	auto block2 = builder
@@ -1485,7 +1485,7 @@ TEST (ledger, fail_open_old)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
 	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *block2).code);
@@ -1497,7 +1497,7 @@ TEST (ledger, fail_open_gap_source)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block2 = builder
@@ -1506,7 +1506,7 @@ TEST (ledger, fail_open_gap_source)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
 	ASSERT_EQ (nano::process_result::gap_source, result2.code);
@@ -1518,7 +1518,7 @@ TEST (ledger, fail_open_bad_signature)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1527,7 +1527,7 @@ TEST (ledger, fail_open_bad_signature)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	auto block2 = builder
@@ -1536,7 +1536,7 @@ TEST (ledger, fail_open_bad_signature)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	block2->signature.clear ();
 	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, *block2).code);
@@ -1548,7 +1548,7 @@ TEST (ledger, fail_open_fork_previous)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1557,7 +1557,7 @@ TEST (ledger, fail_open_fork_previous)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	auto block2 = builder
@@ -1566,7 +1566,7 @@ TEST (ledger, fail_open_fork_previous)
 				  .destination (key1.pub)
 				  .balance (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block1->hash ()))
+				  .work (*pool.obj.generate (block1->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
 	auto block3 = builder
@@ -1575,7 +1575,7 @@ TEST (ledger, fail_open_fork_previous)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
 	auto block4 = builder
@@ -1584,7 +1584,7 @@ TEST (ledger, fail_open_fork_previous)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block4).code);
 	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
@@ -1596,7 +1596,7 @@ TEST (ledger, fail_open_account_mismatch)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1605,7 +1605,7 @@ TEST (ledger, fail_open_account_mismatch)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	nano::keypair badkey;
@@ -1615,7 +1615,7 @@ TEST (ledger, fail_open_account_mismatch)
 				  .representative (1)
 				  .account (badkey.pub)
 				  .sign (badkey.prv, badkey.pub)
-				  .work (*pool.generate (badkey.pub))
+				  .work (*pool.obj.generate (badkey.pub))
 				  .build ();
 	ASSERT_NE (nano::process_result::progress, ledger.process (transaction, *block2).code);
 	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
@@ -1627,7 +1627,7 @@ TEST (ledger, fail_receive_old)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1636,7 +1636,7 @@ TEST (ledger, fail_receive_old)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	auto block2 = builder
@@ -1645,7 +1645,7 @@ TEST (ledger, fail_receive_old)
 				  .destination (key1.pub)
 				  .balance (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block1->hash ()))
+				  .work (*pool.obj.generate (block1->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
 	auto block3 = builder
@@ -1654,7 +1654,7 @@ TEST (ledger, fail_receive_old)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
 	auto block4 = builder
@@ -1662,7 +1662,7 @@ TEST (ledger, fail_receive_old)
 				  .previous (block3->hash ())
 				  .source (block2->hash ())
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (block3->hash ()))
+				  .work (*pool.obj.generate (block3->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block4).code);
 	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *block4).code);
@@ -1674,7 +1674,7 @@ TEST (ledger, fail_receive_gap_source)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1683,7 +1683,7 @@ TEST (ledger, fail_receive_gap_source)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
 	ASSERT_EQ (nano::process_result::progress, result1.code);
@@ -1693,7 +1693,7 @@ TEST (ledger, fail_receive_gap_source)
 				  .destination (key1.pub)
 				  .balance (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block1->hash ()))
+				  .work (*pool.obj.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
 	ASSERT_EQ (nano::process_result::progress, result2.code);
@@ -1703,7 +1703,7 @@ TEST (ledger, fail_receive_gap_source)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
 	ASSERT_EQ (nano::process_result::progress, result3.code);
@@ -1712,7 +1712,7 @@ TEST (ledger, fail_receive_gap_source)
 				  .previous (block3->hash ())
 				  .source (1)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (block3->hash ()))
+				  .work (*pool.obj.generate (block3->hash ()))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block4);
 	ASSERT_EQ (nano::process_result::gap_source, result4.code);
@@ -1724,7 +1724,7 @@ TEST (ledger, fail_receive_overreceive)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1733,7 +1733,7 @@ TEST (ledger, fail_receive_overreceive)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
 	ASSERT_EQ (nano::process_result::progress, result1.code);
@@ -1743,7 +1743,7 @@ TEST (ledger, fail_receive_overreceive)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block2);
 	ASSERT_EQ (nano::process_result::progress, result3.code);
@@ -1752,7 +1752,7 @@ TEST (ledger, fail_receive_overreceive)
 				  .previous (block2->hash ())
 				  .source (block1->hash ())
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (block2->hash ()))
+				  .work (*pool.obj.generate (block2->hash ()))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block3);
 	ASSERT_EQ (nano::process_result::unreceivable, result4.code);
@@ -1764,7 +1764,7 @@ TEST (ledger, fail_receive_bad_signature)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1773,7 +1773,7 @@ TEST (ledger, fail_receive_bad_signature)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
 	ASSERT_EQ (nano::process_result::progress, result1.code);
@@ -1783,7 +1783,7 @@ TEST (ledger, fail_receive_bad_signature)
 				  .destination (key1.pub)
 				  .balance (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block1->hash ()))
+				  .work (*pool.obj.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
 	ASSERT_EQ (nano::process_result::progress, result2.code);
@@ -1793,7 +1793,7 @@ TEST (ledger, fail_receive_bad_signature)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
 	ASSERT_EQ (nano::process_result::progress, result3.code);
@@ -1802,7 +1802,7 @@ TEST (ledger, fail_receive_bad_signature)
 				  .previous (block3->hash ())
 				  .source (block2->hash ())
 				  .sign (nano::keypair ().prv, 0)
-				  .work (*pool.generate (block3->hash ()))
+				  .work (*pool.obj.generate (block3->hash ()))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block4);
 	ASSERT_EQ (nano::process_result::bad_signature, result4.code);
@@ -1814,7 +1814,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1823,7 +1823,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
 	ASSERT_EQ (nano::process_result::progress, result1.code);
@@ -1833,7 +1833,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 				  .destination (key1.pub)
 				  .balance (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block1->hash ()))
+				  .work (*pool.obj.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
 	ASSERT_EQ (nano::process_result::progress, result2.code);
@@ -1843,7 +1843,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
 	ASSERT_EQ (nano::process_result::progress, result3.code);
@@ -1852,7 +1852,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 				  .previous (1)
 				  .source (block2->hash ())
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (nano::root (1)))
+				  .work (*pool.obj.generate (nano::root (1)))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block4);
 	ASSERT_EQ (nano::process_result::gap_previous, result4.code);
@@ -1864,7 +1864,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1873,7 +1873,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
 	ASSERT_EQ (nano::process_result::progress, result1.code);
@@ -1883,7 +1883,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 				  .destination (key1.pub)
 				  .balance (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block1->hash ()))
+				  .work (*pool.obj.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
 	ASSERT_EQ (nano::process_result::progress, result2.code);
@@ -1892,7 +1892,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 				  .previous (1)
 				  .source (block2->hash ())
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (nano::root (1)))
+				  .work (*pool.obj.generate (nano::root (1)))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
 	ASSERT_EQ (nano::process_result::gap_previous, result3.code);
@@ -1904,7 +1904,7 @@ TEST (ledger, fail_receive_fork_previous)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1913,7 +1913,7 @@ TEST (ledger, fail_receive_fork_previous)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
 	ASSERT_EQ (nano::process_result::progress, result1.code);
@@ -1923,7 +1923,7 @@ TEST (ledger, fail_receive_fork_previous)
 				  .destination (key1.pub)
 				  .balance (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block1->hash ()))
+				  .work (*pool.obj.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
 	ASSERT_EQ (nano::process_result::progress, result2.code);
@@ -1933,7 +1933,7 @@ TEST (ledger, fail_receive_fork_previous)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
 	ASSERT_EQ (nano::process_result::progress, result3.code);
@@ -1944,7 +1944,7 @@ TEST (ledger, fail_receive_fork_previous)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (block3->hash ()))
+				  .work (*pool.obj.generate (block3->hash ()))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block4);
 	ASSERT_EQ (nano::process_result::progress, result4.code);
@@ -1953,7 +1953,7 @@ TEST (ledger, fail_receive_fork_previous)
 				  .previous (block3->hash ())
 				  .source (block2->hash ())
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (block3->hash ()))
+				  .work (*pool.obj.generate (block3->hash ()))
 				  .build ();
 	auto result5 = ledger.process (transaction, *block5);
 	ASSERT_EQ (nano::process_result::fork, result5.code);
@@ -1965,7 +1965,7 @@ TEST (ledger, fail_receive_received_source)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	nano::block_builder builder;
 	auto block1 = builder
@@ -1974,7 +1974,7 @@ TEST (ledger, fail_receive_received_source)
 				  .destination (key1.pub)
 				  .balance (2)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
 	ASSERT_EQ (nano::process_result::progress, result1.code);
@@ -1984,7 +1984,7 @@ TEST (ledger, fail_receive_received_source)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block1->hash ()))
+				  .work (*pool.obj.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
 	ASSERT_EQ (nano::process_result::progress, result2.code);
@@ -1994,7 +1994,7 @@ TEST (ledger, fail_receive_received_source)
 				  .destination (key1.pub)
 				  .balance (0)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block2->hash ()))
+				  .work (*pool.obj.generate (block2->hash ()))
 				  .build ();
 	auto result6 = ledger.process (transaction, *block6);
 	ASSERT_EQ (nano::process_result::progress, result6.code);
@@ -2004,7 +2004,7 @@ TEST (ledger, fail_receive_received_source)
 				  .representative (1)
 				  .account (key1.pub)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (key1.pub))
+				  .work (*pool.obj.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
 	ASSERT_EQ (nano::process_result::progress, result3.code);
@@ -2015,7 +2015,7 @@ TEST (ledger, fail_receive_received_source)
 				  .destination (key1.pub)
 				  .balance (1)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (block3->hash ()))
+				  .work (*pool.obj.generate (block3->hash ()))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block4);
 	ASSERT_EQ (nano::process_result::progress, result4.code);
@@ -2024,7 +2024,7 @@ TEST (ledger, fail_receive_received_source)
 				  .previous (block4->hash ())
 				  .source (block2->hash ())
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (block4->hash ()))
+				  .work (*pool.obj.generate (block4->hash ()))
 				  .build ();
 	auto result5 = ledger.process (transaction, *block5);
 	ASSERT_EQ (nano::process_result::progress, result5.code);
@@ -2033,7 +2033,7 @@ TEST (ledger, fail_receive_received_source)
 				  .previous (block3->hash ())
 				  .source (block2->hash ())
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (block3->hash ()))
+				  .work (*pool.obj.generate (block3->hash ()))
 				  .build ();
 	auto result7 = ledger.process (transaction, *block7);
 	ASSERT_EQ (nano::process_result::fork, result7.code);
@@ -2056,7 +2056,7 @@ TEST (ledger, latest_root)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key;
 	ASSERT_EQ (key.pub, ledger.latest_root (transaction, key.pub).as_account ());
 	auto hash1 = ledger.latest (transaction, nano::dev::genesis_key.pub);
@@ -2067,7 +2067,7 @@ TEST (ledger, latest_root)
 				.destination (0)
 				.balance (1)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (hash1))
+				.work (*pool.obj.generate (hash1))
 				.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	ASSERT_EQ (send->hash (), ledger.latest_root (transaction, nano::dev::genesis_key.pub).as_block_hash ());
@@ -2080,7 +2080,7 @@ TEST (ledger, change_representative_move_representation)
 	auto & store = ctx.store ();
 	nano::keypair key1;
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	nano::block_builder builder;
 	auto send = builder
@@ -2089,7 +2089,7 @@ TEST (ledger, change_representative_move_representation)
 				.destination (key1.pub)
 				.balance (0)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
@@ -2099,7 +2099,7 @@ TEST (ledger, change_representative_move_representation)
 				  .previous (send->hash ())
 				  .representative (key2.pub)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (send->hash ()))
+				  .work (*pool.obj.generate (send->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change).code);
 	nano::keypair key3;
@@ -2109,7 +2109,7 @@ TEST (ledger, change_representative_move_representation)
 				.representative (key3.pub)
 				.account (key1.pub)
 				.sign (key1.prv, key1.pub)
-				.work (*pool.generate (key1.pub))
+				.work (*pool.obj.generate (key1.pub))
 				.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key3.pub));
@@ -2121,7 +2121,7 @@ TEST (ledger, send_open_receive_rollback)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
 	nano::keypair key1;
@@ -2132,7 +2132,7 @@ TEST (ledger, send_open_receive_rollback)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - 50)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (info1->head))
+				 .work (*pool.obj.generate (info1->head))
 				 .build ();
 	auto return1 = ledger.process (transaction, *send1);
 	ASSERT_EQ (nano::process_result::progress, return1.code);
@@ -2142,7 +2142,7 @@ TEST (ledger, send_open_receive_rollback)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - 100)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build ();
 	auto return2 = ledger.process (transaction, *send2);
 	ASSERT_EQ (nano::process_result::progress, return2.code);
@@ -2153,7 +2153,7 @@ TEST (ledger, send_open_receive_rollback)
 				.representative (key2.pub)
 				.account (key1.pub)
 				.sign (key1.prv, key1.pub)
-				.work (*pool.generate (key1.pub))
+				.work (*pool.obj.generate (key1.pub))
 				.build ();
 	auto return4 = ledger.process (transaction, *open);
 	ASSERT_EQ (nano::process_result::progress, return4.code);
@@ -2162,7 +2162,7 @@ TEST (ledger, send_open_receive_rollback)
 				   .previous (open->hash ())
 				   .source (send1->hash ())
 				   .sign (key1.prv, key1.pub)
-				   .work (*pool.generate (open->hash ()))
+				   .work (*pool.obj.generate (open->hash ()))
 				   .build ();
 	auto return5 = ledger.process (transaction, *receive);
 	ASSERT_EQ (nano::process_result::progress, return5.code);
@@ -2175,7 +2175,7 @@ TEST (ledger, send_open_receive_rollback)
 				   .previous (send2->hash ())
 				   .representative (key3.pub)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (send2->hash ()))
+				   .work (*pool.obj.generate (send2->hash ()))
 				   .build ();
 	auto return6 = ledger.process (transaction, *change1);
 	ASSERT_EQ (nano::process_result::progress, return6.code);
@@ -2210,7 +2210,7 @@ TEST (ledger, bootstrap_rep_weight)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	nano::keypair key2;
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	{
 		auto transaction = store.tx_begin_write ();
 		auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
@@ -2222,7 +2222,7 @@ TEST (ledger, bootstrap_rep_weight)
 					.destination (key2.pub)
 					.balance (std::numeric_limits<nano::uint128_t>::max () - 50)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (info1->head))
+					.work (*pool.obj.generate (info1->head))
 					.build ();
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	}
@@ -2243,7 +2243,7 @@ TEST (ledger, bootstrap_rep_weight)
 					.destination (key2.pub)
 					.balance (std::numeric_limits<nano::uint128_t>::max () - 100)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (info1->head))
+					.work (*pool.obj.generate (info1->head))
 					.build ();
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 	}
@@ -2257,7 +2257,7 @@ TEST (ledger, block_destination_source)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair dest;
 	nano::uint128_t balance (nano::dev::constants.genesis_amount);
 	balance -= nano::Gxrb_ratio;
@@ -2268,7 +2268,7 @@ TEST (ledger, block_destination_source)
 				  .destination (dest.pub)
 				  .balance (balance)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	balance -= nano::Gxrb_ratio;
 	auto block2 = builder
@@ -2277,7 +2277,7 @@ TEST (ledger, block_destination_source)
 				  .destination (nano::dev::genesis->account ())
 				  .balance (balance)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block1->hash ()))
+				  .work (*pool.obj.generate (block1->hash ()))
 				  .build ();
 	balance += nano::Gxrb_ratio;
 	auto block3 = builder
@@ -2285,7 +2285,7 @@ TEST (ledger, block_destination_source)
 				  .previous (block2->hash ())
 				  .source (block2->hash ())
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block2->hash ()))
+				  .work (*pool.obj.generate (block2->hash ()))
 				  .build ();
 	balance -= nano::Gxrb_ratio;
 	auto block4 = builder
@@ -2296,7 +2296,7 @@ TEST (ledger, block_destination_source)
 				  .balance (balance)
 				  .link (dest.pub)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block3->hash ()))
+				  .work (*pool.obj.generate (block3->hash ()))
 				  .build ();
 	balance -= nano::Gxrb_ratio;
 	auto block5 = builder
@@ -2307,7 +2307,7 @@ TEST (ledger, block_destination_source)
 				  .balance (balance)
 				  .link (nano::dev::genesis->account ())
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block4->hash ()))
+				  .work (*pool.obj.generate (block4->hash ()))
 				  .build ();
 	balance += nano::Gxrb_ratio;
 	auto block6 = builder
@@ -2318,7 +2318,7 @@ TEST (ledger, block_destination_source)
 				  .balance (balance)
 				  .link (block5->hash ())
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (block5->hash ()))
+				  .work (*pool.obj.generate (block5->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
@@ -2347,7 +2347,7 @@ TEST (ledger, state_account)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -2357,7 +2357,7 @@ TEST (ledger, state_account)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_EQ (nano::dev::genesis->account (), ledger.account (transaction, send1->hash ()));
@@ -2369,7 +2369,7 @@ TEST (ledger, state_send_receive)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -2379,7 +2379,7 @@ TEST (ledger, state_send_receive)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
@@ -2402,7 +2402,7 @@ TEST (ledger, state_send_receive)
 					.balance (nano::dev::constants.genesis_amount)
 					.link (send1->hash ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send1->hash ()))
+					.work (*pool.obj.generate (send1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_TRUE (store.block.exists (transaction, receive1->hash ()));
@@ -2426,7 +2426,7 @@ TEST (ledger, state_receive)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .send ()
@@ -2434,7 +2434,7 @@ TEST (ledger, state_receive)
 				 .destination (nano::dev::genesis->account ())
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
@@ -2452,7 +2452,7 @@ TEST (ledger, state_receive)
 					.balance (nano::dev::constants.genesis_amount)
 					.link (send1->hash ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send1->hash ()))
+					.work (*pool.obj.generate (send1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_TRUE (store.block.exists (transaction, receive1->hash ()));
@@ -2474,7 +2474,7 @@ TEST (ledger, state_rep_change)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
 	nano::block_builder builder;
 	auto change1 = builder
@@ -2485,7 +2485,7 @@ TEST (ledger, state_rep_change)
 				   .balance (nano::dev::constants.genesis_amount)
 				   .link (0)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (nano::dev::genesis->hash ()))
+				   .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				   .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
 	ASSERT_TRUE (store.block.exists (transaction, change1->hash ()));
@@ -2508,7 +2508,7 @@ TEST (ledger, state_open)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2519,7 +2519,7 @@ TEST (ledger, state_open)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
@@ -2538,7 +2538,7 @@ TEST (ledger, state_open)
 				 .balance (nano::Gxrb_ratio)
 				 .link (send1->hash ())
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	ASSERT_FALSE (store.pending.exists (transaction, nano::pending_key (destination.pub, send1->hash ())));
@@ -2563,7 +2563,7 @@ TEST (ledger, send_after_state_fail)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -2573,7 +2573,7 @@ TEST (ledger, send_after_state_fail)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto send2 = builder
@@ -2582,7 +2582,7 @@ TEST (ledger, send_after_state_fail)
 				 .destination (nano::dev::genesis->account ())
 				 .balance (nano::dev::constants.genesis_amount - (2 * nano::Gxrb_ratio))
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *send2).code);
 }
@@ -2594,7 +2594,7 @@ TEST (ledger, receive_after_state_fail)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -2604,7 +2604,7 @@ TEST (ledger, receive_after_state_fail)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto receive1 = builder
@@ -2612,7 +2612,7 @@ TEST (ledger, receive_after_state_fail)
 					.previous (send1->hash ())
 					.source (send1->hash ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send1->hash ()))
+					.work (*pool.obj.generate (send1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *receive1).code);
 }
@@ -2624,7 +2624,7 @@ TEST (ledger, change_after_state_fail)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -2634,7 +2634,7 @@ TEST (ledger, change_after_state_fail)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	nano::keypair rep;
@@ -2643,7 +2643,7 @@ TEST (ledger, change_after_state_fail)
 				   .previous (send1->hash ())
 				   .representative (rep.pub)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (send1->hash ()))
+				   .work (*pool.obj.generate (send1->hash ()))
 				   .build ();
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *change1).code);
 }
@@ -2654,7 +2654,7 @@ TEST (ledger, state_unreceivable_fail)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .send ()
@@ -2662,7 +2662,7 @@ TEST (ledger, state_unreceivable_fail)
 				 .destination (nano::dev::genesis->account ())
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
@@ -2680,7 +2680,7 @@ TEST (ledger, state_unreceivable_fail)
 					.balance (nano::dev::constants.genesis_amount)
 					.link (1)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send1->hash ()))
+					.work (*pool.obj.generate (send1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::gap_source, ledger.process (transaction, *receive1).code);
 }
@@ -2691,7 +2691,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .send ()
@@ -2699,7 +2699,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 				 .destination (nano::dev::genesis->account ())
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
@@ -2717,7 +2717,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 					.link (send1->hash ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send1->hash ()))
+					.work (*pool.obj.generate (send1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::balance_mismatch, ledger.process (transaction, *receive1).code);
 }
@@ -2728,7 +2728,7 @@ TEST (ledger, state_no_link_amount_fail)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -2738,7 +2738,7 @@ TEST (ledger, state_no_link_amount_fail)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	nano::keypair rep;
@@ -2750,7 +2750,7 @@ TEST (ledger, state_no_link_amount_fail)
 				   .balance (nano::dev::constants.genesis_amount)
 				   .link (0)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (send1->hash ()))
+				   .work (*pool.obj.generate (send1->hash ()))
 				   .build ();
 	ASSERT_EQ (nano::process_result::balance_mismatch, ledger.process (transaction, *change1).code);
 }
@@ -2761,7 +2761,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -2771,7 +2771,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
@@ -2790,7 +2790,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 					.balance (nano::Gxrb_ratio)
 					.link (send1->hash ())
 					.sign (key.prv, key.pub)
-					.work (*pool.generate (key.pub))
+					.work (*pool.obj.generate (key.pub))
 					.build ();
 	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *receive1).code);
 }
@@ -2801,7 +2801,7 @@ TEST (ledger, state_open_state_fork)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2812,7 +2812,7 @@ TEST (ledger, state_open_state_fork)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto open1 = builder
@@ -2823,7 +2823,7 @@ TEST (ledger, state_open_state_fork)
 				 .balance (nano::Gxrb_ratio)
 				 .link (send1->hash ())
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	auto open2 = builder
@@ -2832,7 +2832,7 @@ TEST (ledger, state_open_state_fork)
 				 .representative (nano::dev::genesis->account ())
 				 .account (destination.pub)
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *open2).code);
 	ASSERT_EQ (open1->root (), open2->root ());
@@ -2844,7 +2844,7 @@ TEST (ledger, state_state_open_fork)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2855,7 +2855,7 @@ TEST (ledger, state_state_open_fork)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto open1 = builder
@@ -2864,7 +2864,7 @@ TEST (ledger, state_state_open_fork)
 				 .representative (nano::dev::genesis->account ())
 				 .account (destination.pub)
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	auto open2 = builder
@@ -2875,7 +2875,7 @@ TEST (ledger, state_state_open_fork)
 				 .balance (nano::Gxrb_ratio)
 				 .link (send1->hash ())
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *open2).code);
 	ASSERT_EQ (open1->root (), open2->root ());
@@ -2888,7 +2888,7 @@ TEST (ledger, state_open_previous_fail)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2899,7 +2899,7 @@ TEST (ledger, state_open_previous_fail)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto open1 = builder
@@ -2910,7 +2910,7 @@ TEST (ledger, state_open_previous_fail)
 				 .balance (nano::Gxrb_ratio)
 				 .link (send1->hash ())
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (1))
+				 .work (*pool.obj.generate (1))
 				 .build ();
 	ASSERT_EQ (nano::process_result::gap_previous, ledger.process (transaction, *open1).code);
 }
@@ -2921,7 +2921,7 @@ TEST (ledger, state_open_source_fail)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2932,7 +2932,7 @@ TEST (ledger, state_open_source_fail)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto open1 = builder
@@ -2943,7 +2943,7 @@ TEST (ledger, state_open_source_fail)
 				 .balance (0)
 				 .link (0)
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::gap_source, ledger.process (transaction, *open1).code);
 }
@@ -2954,7 +2954,7 @@ TEST (ledger, state_send_change)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2965,7 +2965,7 @@ TEST (ledger, state_send_change)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
@@ -2988,7 +2988,7 @@ TEST (ledger, state_receive_change)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -2998,7 +2998,7 @@ TEST (ledger, state_receive_change)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
@@ -3017,7 +3017,7 @@ TEST (ledger, state_receive_change)
 					.balance (nano::dev::constants.genesis_amount)
 					.link (send1->hash ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send1->hash ()))
+					.work (*pool.obj.generate (send1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_TRUE (store.block.exists (transaction, receive1->hash ()));
@@ -3040,7 +3040,7 @@ TEST (ledger, state_open_old)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -3051,7 +3051,7 @@ TEST (ledger, state_open_old)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto open1 = builder
@@ -3060,7 +3060,7 @@ TEST (ledger, state_open_old)
 				 .representative (nano::dev::genesis->account ())
 				 .account (destination.pub)
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.balance (transaction, open1->hash ()));
@@ -3074,7 +3074,7 @@ TEST (ledger, state_receive_old)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -3085,7 +3085,7 @@ TEST (ledger, state_receive_old)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto send2 = builder
@@ -3096,7 +3096,7 @@ TEST (ledger, state_receive_old)
 				 .balance (nano::dev::constants.genesis_amount - (2 * nano::Gxrb_ratio))
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	auto open1 = builder
@@ -3105,7 +3105,7 @@ TEST (ledger, state_receive_old)
 				 .representative (nano::dev::genesis->account ())
 				 .account (destination.pub)
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	auto receive1 = builder
@@ -3113,7 +3113,7 @@ TEST (ledger, state_receive_old)
 					.previous (open1->hash ())
 					.source (send2->hash ())
 					.sign (destination.prv, destination.pub)
-					.work (*pool.generate (open1->hash ()))
+					.work (*pool.obj.generate (open1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_EQ (2 * nano::Gxrb_ratio, ledger.balance (transaction, receive1->hash ()));
@@ -3127,7 +3127,7 @@ TEST (ledger, state_rollback_send)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -3137,7 +3137,7 @@ TEST (ledger, state_rollback_send)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
@@ -3165,7 +3165,7 @@ TEST (ledger, state_rollback_receive)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -3175,7 +3175,7 @@ TEST (ledger, state_rollback_receive)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto receive1 = builder
@@ -3186,7 +3186,7 @@ TEST (ledger, state_rollback_receive)
 					.balance (nano::dev::constants.genesis_amount)
 					.link (send1->hash ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send1->hash ()))
+					.work (*pool.obj.generate (send1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_FALSE (store.pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), receive1->hash ())));
@@ -3207,7 +3207,7 @@ TEST (ledger, state_rollback_received_send)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -3218,7 +3218,7 @@ TEST (ledger, state_rollback_received_send)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (key.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto receive1 = builder
@@ -3229,7 +3229,7 @@ TEST (ledger, state_rollback_received_send)
 					.balance (nano::Gxrb_ratio)
 					.link (send1->hash ())
 					.sign (key.prv, key.pub)
-					.work (*pool.generate (key.pub))
+					.work (*pool.obj.generate (key.pub))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_FALSE (store.pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), receive1->hash ())));
@@ -3250,7 +3250,7 @@ TEST (ledger, state_rep_change_rollback)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
 	nano::block_builder builder;
 	auto change1 = builder
@@ -3261,7 +3261,7 @@ TEST (ledger, state_rep_change_rollback)
 				   .balance (nano::dev::constants.genesis_amount)
 				   .link (0)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (nano::dev::genesis->hash ()))
+				   .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				   .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
 	ASSERT_FALSE (ledger.rollback (transaction, change1->hash ()));
@@ -3277,7 +3277,7 @@ TEST (ledger, state_open_rollback)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -3288,7 +3288,7 @@ TEST (ledger, state_open_rollback)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto open1 = builder
@@ -3299,7 +3299,7 @@ TEST (ledger, state_open_rollback)
 				 .balance (nano::Gxrb_ratio)
 				 .link (send1->hash ())
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	ASSERT_FALSE (ledger.rollback (transaction, open1->hash ()));
@@ -3319,7 +3319,7 @@ TEST (ledger, state_send_change_rollback)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair rep;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -3330,7 +3330,7 @@ TEST (ledger, state_send_change_rollback)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_FALSE (ledger.rollback (transaction, send1->hash ()));
@@ -3347,7 +3347,7 @@ TEST (ledger, state_receive_change_rollback)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -3357,7 +3357,7 @@ TEST (ledger, state_receive_change_rollback)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	nano::keypair rep;
@@ -3369,7 +3369,7 @@ TEST (ledger, state_receive_change_rollback)
 					.balance (nano::dev::constants.genesis_amount)
 					.link (send1->hash ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send1->hash ()))
+					.work (*pool.obj.generate (send1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_FALSE (ledger.rollback (transaction, receive1->hash ()));
@@ -3386,7 +3386,7 @@ TEST (ledger, epoch_blocks_v1_general)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto epoch1 = builder
@@ -3397,7 +3397,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				  .balance (nano::dev::constants.genesis_amount)
 				  .link (ledger.epoch_link (nano::epoch::epoch_1))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
 	ASSERT_FALSE (epoch1->sideband ().details.is_send);
@@ -3413,7 +3413,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				  .balance (nano::dev::constants.genesis_amount)
 				  .link (ledger.epoch_link (nano::epoch::epoch_1))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (epoch1->hash ()))
+				  .work (*pool.obj.generate (epoch1->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *epoch2).code);
 	auto genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
@@ -3437,7 +3437,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				   .previous (epoch1->hash ())
 				   .representative (nano::dev::genesis->account ())
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (epoch1->hash ()))
+				   .work (*pool.obj.generate (epoch1->hash ()))
 				   .build ();
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *change1).code);
 	auto send1 = builder
@@ -3448,7 +3448,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (epoch1->hash ()))
+				 .work (*pool.obj.generate (epoch1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (send1->sideband ().details.is_send);
@@ -3462,7 +3462,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				 .representative (nano::dev::genesis->account ())
 				 .account (destination.pub)
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open1).code);
 	auto epoch3 = builder
@@ -3473,7 +3473,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				  .balance (0)
 				  .link (ledger.epoch_link (nano::epoch::epoch_1))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (destination.pub))
+				  .work (*pool.obj.generate (destination.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::representative_mismatch, ledger.process (transaction, *epoch3).code);
 	auto epoch4 = builder
@@ -3484,7 +3484,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				  .balance (0)
 				  .link (ledger.epoch_link (nano::epoch::epoch_1))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (destination.pub))
+				  .work (*pool.obj.generate (destination.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch4).code);
 	ASSERT_FALSE (epoch4->sideband ().details.is_send);
@@ -3497,7 +3497,7 @@ TEST (ledger, epoch_blocks_v1_general)
 					.previous (epoch4->hash ())
 					.source (send1->hash ())
 					.sign (destination.prv, destination.pub)
-					.work (*pool.generate (epoch4->hash ()))
+					.work (*pool.obj.generate (epoch4->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *receive1).code);
 	auto receive2 = builder
@@ -3508,7 +3508,7 @@ TEST (ledger, epoch_blocks_v1_general)
 					.balance (nano::Gxrb_ratio)
 					.link (send1->hash ())
 					.sign (destination.prv, destination.pub)
-					.work (*pool.generate (epoch4->hash ()))
+					.work (*pool.obj.generate (epoch4->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
@@ -3529,7 +3529,7 @@ TEST (ledger, epoch_blocks_v2_general)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto epoch1 = builder
@@ -3540,7 +3540,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .balance (nano::dev::constants.genesis_amount)
 				  .link (ledger.epoch_link (nano::epoch::epoch_2))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	// Trying to upgrade from epoch 0 to epoch 2. It is a requirement epoch upgrades are sequential unless the account is unopened
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *epoch1).code);
@@ -3566,7 +3566,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .balance (nano::dev::constants.genesis_amount)
 				  .link (ledger.epoch_link (nano::epoch::epoch_2))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (epoch1->hash ()))
+				  .work (*pool.obj.generate (epoch1->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch2).code);
 	ASSERT_EQ (nano::epoch::epoch_2, epoch2->sideband ().details.epoch);
@@ -3579,7 +3579,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .balance (nano::dev::constants.genesis_amount)
 				  .link (ledger.epoch_link (nano::epoch::epoch_2))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (epoch2->hash ()))
+				  .work (*pool.obj.generate (epoch2->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *epoch3).code);
 	auto genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
@@ -3598,7 +3598,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				   .previous (epoch1->hash ())
 				   .representative (nano::dev::genesis->account ())
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (epoch1->hash ()))
+				   .work (*pool.obj.generate (epoch1->hash ()))
 				   .build ();
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *change1).code);
 	auto send1 = builder
@@ -3609,7 +3609,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (epoch1->hash ()))
+				 .work (*pool.obj.generate (epoch1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_EQ (nano::epoch::epoch_1, send1->sideband ().details.epoch);
@@ -3620,7 +3620,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				 .representative (nano::dev::genesis->account ())
 				 .account (destination.pub)
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open1).code);
 	auto epoch4 = builder
@@ -3631,7 +3631,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .balance (0)
 				  .link (ledger.epoch_link (nano::epoch::epoch_1))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (destination.pub))
+				  .work (*pool.obj.generate (destination.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch4).code);
 	ASSERT_EQ (nano::epoch::epoch_1, epoch4->sideband ().details.epoch);
@@ -3644,7 +3644,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .balance (0)
 				  .link (ledger.epoch_link (nano::epoch::epoch_2))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (epoch4->hash ()))
+				  .work (*pool.obj.generate (epoch4->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::representative_mismatch, ledger.process (transaction, *epoch5).code);
 	auto epoch6 = builder
@@ -3655,7 +3655,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .balance (0)
 				  .link (ledger.epoch_link (nano::epoch::epoch_2))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (epoch4->hash ()))
+				  .work (*pool.obj.generate (epoch4->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch6).code);
 	ASSERT_EQ (nano::epoch::epoch_2, epoch6->sideband ().details.epoch);
@@ -3665,7 +3665,7 @@ TEST (ledger, epoch_blocks_v2_general)
 					.previous (epoch6->hash ())
 					.source (send1->hash ())
 					.sign (destination.prv, destination.pub)
-					.work (*pool.generate (epoch6->hash ()))
+					.work (*pool.obj.generate (epoch6->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *receive1).code);
 	auto receive2 = builder
@@ -3676,7 +3676,7 @@ TEST (ledger, epoch_blocks_v2_general)
 					.balance (nano::Gxrb_ratio)
 					.link (send1->hash ())
 					.sign (destination.prv, destination.pub)
-					.work (*pool.generate (epoch6->hash ()))
+					.work (*pool.obj.generate (epoch6->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
 	ASSERT_EQ (nano::epoch::epoch_2, receive2->sideband ().details.epoch);
@@ -3694,7 +3694,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -3705,7 +3705,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto epoch1 = builder
@@ -3716,7 +3716,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				  .link (ledger.epoch_link (nano::epoch::epoch_1))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (send1->hash ()))
+				  .work (*pool.obj.generate (send1->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
 	auto send2 = builder
@@ -3727,7 +3727,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (epoch1->hash ()))
+				 .work (*pool.obj.generate (epoch1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	ASSERT_EQ (nano::epoch::epoch_1, send2->sideband ().details.epoch);
@@ -3738,7 +3738,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .representative (destination.pub)
 				 .account (destination.pub)
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (destination.pub))
+				 .work (*pool.obj.generate (destination.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	ASSERT_EQ (nano::epoch::epoch_0, open1->sideband ().details.epoch);
@@ -3748,7 +3748,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 					.previous (open1->hash ())
 					.source (send2->hash ())
 					.sign (destination.prv, destination.pub)
-					.work (*pool.generate (open1->hash ()))
+					.work (*pool.obj.generate (open1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *receive1).code);
 	auto receive2 = builder
@@ -3759,7 +3759,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 					.balance (nano::Gxrb_ratio * 2)
 					.link (send2->hash ())
 					.sign (destination.prv, destination.pub)
-					.work (*pool.generate (open1->hash ()))
+					.work (*pool.obj.generate (open1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
@@ -3791,7 +3791,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .balance (nano::Gxrb_ratio)
 				 .link (destination2.pub)
 				 .sign (destination.prv, destination.pub)
-				 .work (*pool.generate (receive2->hash ()))
+				 .work (*pool.obj.generate (receive2->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
 	auto open2 = builder
@@ -3800,7 +3800,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .representative (destination2.pub)
 				 .account (destination2.pub)
 				 .sign (destination2.prv, destination2.pub)
-				 .work (*pool.generate (destination2.pub))
+				 .work (*pool.obj.generate (destination2.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open2).code);
 	// Upgrade to epoch 2 and send to destination. Try to create an open block from an epoch 2 source block.
@@ -3813,7 +3813,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				  .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
 				  .link (ledger.epoch_link (nano::epoch::epoch_2))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (send2->hash ()))
+				  .work (*pool.obj.generate (send2->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch2).code);
 	auto send4 = builder
@@ -3824,7 +3824,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 3)
 				 .link (destination3.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (epoch2->hash ()))
+				 .work (*pool.obj.generate (epoch2->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send4).code);
 	auto open3 = builder
@@ -3833,7 +3833,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .representative (destination3.pub)
 				 .account (destination3.pub)
 				 .sign (destination3.prv, destination3.pub)
-				 .work (*pool.generate (destination3.pub))
+				 .work (*pool.obj.generate (destination3.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open3).code);
 	// Send it to an epoch 1 account
@@ -3845,7 +3845,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 4)
 				 .link (destination.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send4->hash ()))
+				 .work (*pool.obj.generate (send4->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send5).code);
 	destination_info = ledger.account_info (transaction, destination.pub);
@@ -3859,7 +3859,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 					.balance (nano::Gxrb_ratio * 2)
 					.link (send5->hash ())
 					.sign (destination.prv, destination.pub)
-					.work (*pool.generate (send3->hash ()))
+					.work (*pool.obj.generate (send3->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive3).code);
 	ASSERT_EQ (nano::epoch::epoch_2, receive3->sideband ().details.epoch);
@@ -3877,7 +3877,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 5)
 				 .link (destination4.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send5->hash ()))
+				 .work (*pool.obj.generate (send5->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send6).code);
 	auto epoch4 = builder
@@ -3888,7 +3888,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				  .balance (0)
 				  .link (ledger.epoch_link (nano::epoch::epoch_2))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (destination4.pub))
+				  .work (*pool.obj.generate (destination4.pub))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch4).code);
 	ASSERT_EQ (nano::epoch::epoch_2, epoch4->sideband ().details.epoch);
@@ -3902,7 +3902,7 @@ TEST (ledger, epoch_blocks_fork)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	nano::block_builder builder;
 	auto send1 = builder
@@ -3911,7 +3911,7 @@ TEST (ledger, epoch_blocks_fork)
 				 .destination (nano::account{})
 				 .balance (nano::dev::constants.genesis_amount)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto epoch1 = builder
@@ -3922,7 +3922,7 @@ TEST (ledger, epoch_blocks_fork)
 				  .balance (nano::dev::constants.genesis_amount)
 				  .link (ledger.epoch_link (nano::epoch::epoch_1))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *epoch1).code);
 	auto epoch2 = builder
@@ -3933,7 +3933,7 @@ TEST (ledger, epoch_blocks_fork)
 				  .balance (nano::dev::constants.genesis_amount)
 				  .link (ledger.epoch_link (nano::epoch::epoch_2))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *epoch2).code);
 	auto epoch3 = builder
@@ -3944,7 +3944,7 @@ TEST (ledger, epoch_blocks_fork)
 				  .balance (nano::dev::constants.genesis_amount)
 				  .link (ledger.epoch_link (nano::epoch::epoch_1))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (send1->hash ()))
+				  .work (*pool.obj.generate (send1->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch3).code);
 	ASSERT_EQ (nano::epoch::epoch_1, epoch3->sideband ().details.epoch);
@@ -3957,7 +3957,7 @@ TEST (ledger, epoch_blocks_fork)
 				  .balance (nano::dev::constants.genesis_amount)
 				  .link (ledger.epoch_link (nano::epoch::epoch_2))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (send1->hash ()))
+				  .work (*pool.obj.generate (send1->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *epoch2).code);
 }
@@ -3967,7 +3967,7 @@ TEST (ledger, successor_epoch)
 	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .send ()
@@ -3975,7 +3975,7 @@ TEST (ledger, successor_epoch)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - 1)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	auto open = builder
 				.state ()
@@ -3985,7 +3985,7 @@ TEST (ledger, successor_epoch)
 				.balance (1)
 				.link (send1->hash ())
 				.sign (key1.prv, key1.pub)
-				.work (*pool.generate (key1.pub))
+				.work (*pool.obj.generate (key1.pub))
 				.build ();
 	auto change = builder
 				  .state ()
@@ -3995,7 +3995,7 @@ TEST (ledger, successor_epoch)
 				  .balance (1)
 				  .link (0)
 				  .sign (key1.prv, key1.pub)
-				  .work (*pool.generate (open->hash ()))
+				  .work (*pool.obj.generate (open->hash ()))
 				  .build ();
 	auto open_hash = open->hash ();
 	auto send2 = builder
@@ -4004,7 +4004,7 @@ TEST (ledger, successor_epoch)
 				 .destination (reinterpret_cast<nano::account const &> (open_hash))
 				 .balance (nano::dev::constants.genesis_amount - 2)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build ();
 	auto epoch_open = builder
 					  .state ()
@@ -4014,7 +4014,7 @@ TEST (ledger, successor_epoch)
 					  .balance (0)
 					  .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
 					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					  .work (*pool.generate (open->hash ()))
+					  .work (*pool.obj.generate (open->hash ()))
 					  .build ();
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
@@ -4033,7 +4033,7 @@ TEST (ledger, epoch_open_pending)
 	nano::block_builder builder{};
 	nano::test::system system{ 1 };
 	auto & node1 = *system.nodes[0];
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1{};
 	auto epoch_open = builder.state ()
 					  .account (key1.pub)
@@ -4042,7 +4042,7 @@ TEST (ledger, epoch_open_pending)
 					  .balance (0)
 					  .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
 					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					  .work (*pool.generate (key1.pub))
+					  .work (*pool.obj.generate (key1.pub))
 					  .build_shared ();
 	auto process_result = node1.ledger.process (node1.store.tx_begin_write (), *epoch_open);
 	ASSERT_EQ (nano::process_result::gap_epoch_open_pending, process_result.code);
@@ -4062,7 +4062,7 @@ TEST (ledger, epoch_open_pending)
 				 .balance (nano::dev::constants.genesis_amount - 100)
 				 .link (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	node1.block_processor.add (send1);
 	ASSERT_TIMELY (10s, node1.ledger.block_or_pruned_exists (epoch_open->hash ()));
@@ -4075,7 +4075,7 @@ TEST (ledger, block_hash_account_conflict)
 	auto & node1 (*system.nodes[0]);
 	nano::keypair key1;
 	nano::keypair key2;
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 
 	/*
 	 * Generate a send block whose destination is a block hash already
@@ -4088,7 +4088,7 @@ TEST (ledger, block_hash_account_conflict)
 				 .balance (nano::dev::constants.genesis_amount - 100)
 				 .link (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 
 	auto receive1 = builder.state ()
@@ -4098,7 +4098,7 @@ TEST (ledger, block_hash_account_conflict)
 					.balance (100)
 					.link (send1->hash ())
 					.sign (key1.prv, key1.pub)
-					.work (*pool.generate (key1.pub))
+					.work (*pool.obj.generate (key1.pub))
 					.build_shared ();
 
 	/*
@@ -4114,7 +4114,7 @@ TEST (ledger, block_hash_account_conflict)
 				 .balance (90)
 				 .link (receive1->hash ())
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.generate (receive1->hash ()))
+				 .work (*pool.obj.generate (receive1->hash ()))
 				 .build_shared ();
 
 	/*
@@ -4128,7 +4128,7 @@ TEST (ledger, block_hash_account_conflict)
 					   .balance (0)
 					   .link (node1.ledger.epoch_link (nano::epoch::epoch_1))
 					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					   .work (*pool.generate (receive1->hash ()))
+					   .work (*pool.obj.generate (receive1->hash ()))
 					   .build_shared ();
 
 	node1.work_generate_blocking (*send1);
@@ -4167,7 +4167,7 @@ TEST (ledger, could_fit)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair destination;
 	// Test legacy and state change blocks could_fit
 	nano::block_builder builder;
@@ -4176,7 +4176,7 @@ TEST (ledger, could_fit)
 				   .previous (nano::dev::genesis->hash ())
 				   .representative (nano::dev::genesis->account ())
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (nano::dev::genesis->hash ()))
+				   .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				   .build ();
 	auto change2 = builder
 				   .state ()
@@ -4186,7 +4186,7 @@ TEST (ledger, could_fit)
 				   .balance (nano::dev::constants.genesis_amount)
 				   .link (0)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (nano::dev::genesis->hash ()))
+				   .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				   .build ();
 	ASSERT_TRUE (ledger.could_fit (transaction, *change1));
 	ASSERT_TRUE (ledger.could_fit (transaction, *change2));
@@ -4198,7 +4198,7 @@ TEST (ledger, could_fit)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - 1)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (change1->hash ()))
+				 .work (*pool.obj.generate (change1->hash ()))
 				 .build ();
 	auto send2 = builder
 				 .state ()
@@ -4208,7 +4208,7 @@ TEST (ledger, could_fit)
 				 .balance (nano::dev::constants.genesis_amount - 1)
 				 .link (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (change1->hash ()))
+				 .work (*pool.obj.generate (change1->hash ()))
 				 .build ();
 	ASSERT_FALSE (ledger.could_fit (transaction, *send1));
 	ASSERT_FALSE (ledger.could_fit (transaction, *send2));
@@ -4224,7 +4224,7 @@ TEST (ledger, could_fit)
 				 .representative (nano::dev::genesis->account ())
 				 .account (key1.pub)
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.generate (key1.pub))
+				 .work (*pool.obj.generate (key1.pub))
 				 .build ();
 	auto open2 = builder
 				 .state ()
@@ -4234,7 +4234,7 @@ TEST (ledger, could_fit)
 				 .balance (1)
 				 .link (send2->hash ())
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.generate (key1.pub))
+				 .work (*pool.obj.generate (key1.pub))
 				 .build ();
 	ASSERT_FALSE (ledger.could_fit (transaction, *open1));
 	ASSERT_FALSE (ledger.could_fit (transaction, *open2));
@@ -4255,7 +4255,7 @@ TEST (ledger, could_fit)
 				 .balance (nano::dev::constants.genesis_amount - 2)
 				 .link (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send2->hash ()))
+				 .work (*pool.obj.generate (send2->hash ()))
 				 .build ();
 	// Test legacy and state receive
 	auto receive1 = builder
@@ -4263,7 +4263,7 @@ TEST (ledger, could_fit)
 					.previous (open1->hash ())
 					.source (send3->hash ())
 					.sign (key1.prv, key1.pub)
-					.work (*pool.generate (open1->hash ()))
+					.work (*pool.obj.generate (open1->hash ()))
 					.build ();
 	auto receive2 = builder
 					.state ()
@@ -4273,7 +4273,7 @@ TEST (ledger, could_fit)
 					.balance (2)
 					.link (send3->hash ())
 					.sign (key1.prv, key1.pub)
-					.work (*pool.generate (open1->hash ()))
+					.work (*pool.obj.generate (open1->hash ()))
 					.build ();
 	ASSERT_FALSE (ledger.could_fit (transaction, *receive1));
 	ASSERT_FALSE (ledger.could_fit (transaction, *receive2));
@@ -4289,7 +4289,7 @@ TEST (ledger, could_fit)
 				  .balance (2)
 				  .link (ledger.epoch_link (nano::epoch::epoch_1))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (receive1->hash ()))
+				  .work (*pool.obj.generate (receive1->hash ()))
 				  .build ();
 	ASSERT_FALSE (ledger.could_fit (transaction, *epoch1));
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
@@ -4571,7 +4571,7 @@ TEST (ledger, confirmation_height_not_updated)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = store.tx_begin_write ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto account_info = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (account_info);
 	nano::keypair key;
@@ -4582,7 +4582,7 @@ TEST (ledger, confirmation_height_not_updated)
 				 .destination (key.pub)
 				 .balance (50)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (account_info->head))
+				 .work (*pool.obj.generate (account_info->head))
 				 .build ();
 	nano::confirmation_height_info confirmation_height_info;
 	ASSERT_FALSE (store.confirmation_height.get (transaction, nano::dev::genesis->account (), confirmation_height_info));
@@ -4598,7 +4598,7 @@ TEST (ledger, confirmation_height_not_updated)
 				 .representative (nano::dev::genesis->account ())
 				 .account (key.pub)
 				 .sign (key.prv, key.pub)
-				 .work (*pool.generate (key.pub))
+				 .work (*pool.obj.generate (key.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	ASSERT_TRUE (store.confirmation_height.get (transaction, key.pub, confirmation_height_info));
@@ -4643,7 +4643,7 @@ TEST (ledger, work_validation)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto gen = nano::dev::genesis_key;
 	nano::keypair key;
@@ -4657,7 +4657,7 @@ TEST (ledger, work_validation)
 			block_a.block_work_set (block_a.block_work () + 1);
 		}
 		EXPECT_EQ (nano::process_result::insufficient_work, ledger.process (store.tx_begin_write (), block_a).code);
-		block_a.block_work_set (*pool.generate (block_a.root (), threshold));
+		block_a.block_work_set (*pool.obj.generate (block_a.root (), threshold));
 		EXPECT_EQ (nano::process_result::progress, ledger.process (store.tx_begin_write (), block_a).code);
 	};
 
@@ -4735,7 +4735,7 @@ TEST (ledger, dependents_confirmed)
 	auto transaction = store.tx_begin_write ();
 	nano::block_builder builder;
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *nano::dev::genesis));
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	auto send1 = builder.state ()
 				 .account (nano::dev::genesis->account ())
@@ -4744,7 +4744,7 @@ TEST (ledger, dependents_confirmed)
 				 .balance (nano::dev::constants.genesis_amount - 100)
 				 .link (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *send1));
@@ -4755,7 +4755,7 @@ TEST (ledger, dependents_confirmed)
 				 .balance (nano::dev::constants.genesis_amount - 200)
 				 .link (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *send2));
@@ -4766,7 +4766,7 @@ TEST (ledger, dependents_confirmed)
 					.balance (100)
 					.link (send1->hash ())
 					.sign (key1.prv, key1.pub)
-					.work (*pool.generate (key1.pub))
+					.work (*pool.obj.generate (key1.pub))
 					.build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive1));
@@ -4782,7 +4782,7 @@ TEST (ledger, dependents_confirmed)
 					.balance (200)
 					.link (send2->hash ())
 					.sign (key1.prv, key1.pub)
-					.work (*pool.generate (receive1->hash ()))
+					.work (*pool.obj.generate (receive1->hash ()))
 					.build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive2));
@@ -4807,7 +4807,7 @@ TEST (ledger, dependents_confirmed_pruning)
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::block_builder builder;
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	auto send1 = builder.state ()
 				 .account (nano::dev::genesis->account ())
@@ -4816,7 +4816,7 @@ TEST (ledger, dependents_confirmed_pruning)
 				 .balance (nano::dev::constants.genesis_amount - 100)
 				 .link (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	auto send2 = builder.state ()
@@ -4826,7 +4826,7 @@ TEST (ledger, dependents_confirmed_pruning)
 				 .balance (nano::dev::constants.genesis_amount - 200)
 				 .link (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build_shared ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	nano::confirmation_height_info height;
@@ -4842,7 +4842,7 @@ TEST (ledger, dependents_confirmed_pruning)
 					.balance (100)
 					.link (send1->hash ())
 					.sign (key1.prv, key1.pub)
-					.work (*pool.generate (key1.pub))
+					.work (*pool.obj.generate (key1.pub))
 					.build_shared ();
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *receive1));
 }
@@ -4855,7 +4855,7 @@ TEST (ledger, block_confirmed)
 	auto transaction = store.tx_begin_write ();
 	nano::block_builder builder;
 	ASSERT_TRUE (ledger.block_confirmed (transaction, nano::dev::genesis->hash ()));
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;
 	auto send1 = builder.state ()
 				 .account (nano::dev::genesis->account ())
@@ -4864,7 +4864,7 @@ TEST (ledger, block_confirmed)
 				 .balance (nano::dev::constants.genesis_amount - 100)
 				 .link (key1.pub)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	// Must be safe against non-existing blocks
 	ASSERT_FALSE (ledger.block_confirmed (transaction, send1->hash ()));
@@ -4883,7 +4883,7 @@ TEST (ledger, cache)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto & stats = ctx.stats ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 
 	size_t const total = 100;
@@ -4914,7 +4914,7 @@ TEST (ledger, cache)
 					.balance (nano::dev::constants.genesis_amount - (i + 1))
 					.link (key.pub)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (latest))
+					.work (*pool.obj.generate (latest))
 					.build ();
 		auto open = builder.state ()
 					.account (key.pub)
@@ -4923,7 +4923,7 @@ TEST (ledger, cache)
 					.balance (1)
 					.link (send->hash ())
 					.sign (key.prv, key.pub)
-					.work (*pool.generate (key.pub))
+					.work (*pool.obj.generate (key.pub))
 					.build ();
 		{
 			auto transaction (store.tx_begin_write ());
@@ -4996,7 +4996,7 @@ TEST (ledger, pruning_action)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -5006,7 +5006,7 @@ TEST (ledger, pruning_action)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
@@ -5022,7 +5022,7 @@ TEST (ledger, pruning_action)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
@@ -5048,7 +5048,7 @@ TEST (ledger, pruning_action)
 					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 					.link (send1->hash ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send2->hash ()))
+					.work (*pool.obj.generate (send2->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_TRUE (store->block.exists (transaction, receive1->hash ()));
@@ -5080,7 +5080,7 @@ TEST (ledger, pruning_large_chain)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	size_t send_receive_pairs (20);
 	auto last_hash (nano::dev::genesis->hash ());
 	nano::block_builder builder;
@@ -5094,7 +5094,7 @@ TEST (ledger, pruning_large_chain)
 					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 					.link (nano::dev::genesis->account ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (last_hash))
+					.work (*pool.obj.generate (last_hash))
 					.build ();
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
 		ASSERT_TRUE (store->block.exists (transaction, send->hash ()));
@@ -5106,7 +5106,7 @@ TEST (ledger, pruning_large_chain)
 					   .balance (nano::dev::constants.genesis_amount)
 					   .link (send->hash ())
 					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					   .work (*pool.generate (send->hash ()))
+					   .work (*pool.obj.generate (send->hash ()))
 					   .build ();
 		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
 		ASSERT_TRUE (store->block.exists (transaction, receive->hash ()));
@@ -5135,7 +5135,7 @@ TEST (ledger, pruning_source_rollback)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto epoch1 = builder
 				  .state ()
@@ -5145,7 +5145,7 @@ TEST (ledger, pruning_source_rollback)
 				  .balance (nano::dev::constants.genesis_amount)
 				  .link (ledger.epoch_link (nano::epoch::epoch_1))
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
 	auto send1 = builder
@@ -5156,7 +5156,7 @@ TEST (ledger, pruning_source_rollback)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (epoch1->hash ()))
+				 .work (*pool.obj.generate (epoch1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
@@ -5168,7 +5168,7 @@ TEST (ledger, pruning_source_rollback)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
@@ -5193,7 +5193,7 @@ TEST (ledger, pruning_source_rollback)
 					.balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 					.link (send1->hash ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send2->hash ()))
+					.work (*pool.obj.generate (send2->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
@@ -5223,7 +5223,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .send ()
@@ -5231,7 +5231,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 				 .destination (nano::dev::genesis->account ())
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
@@ -5242,7 +5242,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
@@ -5253,7 +5253,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 				 .destination (nano::dev::genesis->account ())
 				 .balance (nano::dev::constants.genesis_amount - 3 * nano::Gxrb_ratio)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send2->hash ()))
+				 .work (*pool.obj.generate (send2->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
 	ASSERT_TRUE (store->block.exists (transaction, send3->hash ()));
@@ -5281,7 +5281,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 					.previous (send3->hash ())
 					.source (send1->hash ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send3->hash ()))
+					.work (*pool.obj.generate (send3->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
@@ -5306,7 +5306,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 				 .representative (nano::dev::genesis->account ())
 				 .account (key1.pub)
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.generate (key1.pub))
+				 .work (*pool.obj.generate (key1.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (key1.pub, send2->hash ())));
@@ -5336,7 +5336,7 @@ TEST (ledger, pruning_process_error)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -5346,7 +5346,7 @@ TEST (ledger, pruning_process_error)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_EQ (0, ledger.cache.pruned_count);
@@ -5366,7 +5366,7 @@ TEST (ledger, pruning_process_error)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::gap_previous, ledger.process (transaction, *send2).code);
 	ASSERT_EQ (1, ledger.cache.pruned_count);
@@ -5384,7 +5384,7 @@ TEST (ledger, pruning_legacy_blocks)
 	nano::keypair key1;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .send ()
@@ -5392,7 +5392,7 @@ TEST (ledger, pruning_legacy_blocks)
 				 .destination (nano::dev::genesis->account ())
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
@@ -5401,7 +5401,7 @@ TEST (ledger, pruning_legacy_blocks)
 					.previous (send1->hash ())
 					.source (send1->hash ())
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*pool.generate (send1->hash ()))
+					.work (*pool.obj.generate (send1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
 	auto change1 = builder
@@ -5409,7 +5409,7 @@ TEST (ledger, pruning_legacy_blocks)
 				   .previous (receive1->hash ())
 				   .representative (key1.pub)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (receive1->hash ()))
+				   .work (*pool.obj.generate (receive1->hash ()))
 				   .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
 	auto send2 = builder
@@ -5418,7 +5418,7 @@ TEST (ledger, pruning_legacy_blocks)
 				 .destination (key1.pub)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (change1->hash ()))
+				 .work (*pool.obj.generate (change1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	auto open1 = builder
@@ -5427,7 +5427,7 @@ TEST (ledger, pruning_legacy_blocks)
 				 .representative (nano::dev::genesis->account ())
 				 .account (key1.pub)
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.generate (key1.pub))
+				 .work (*pool.obj.generate (key1.pub))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
 	auto send3 = builder
@@ -5436,7 +5436,7 @@ TEST (ledger, pruning_legacy_blocks)
 				 .destination (nano::dev::genesis->account ())
 				 .balance (0)
 				 .sign (key1.prv, key1.pub)
-				 .work (*pool.generate (open1->hash ()))
+				 .work (*pool.obj.generate (open1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
 	// Pruning action
@@ -5469,7 +5469,7 @@ TEST (ledger, pruning_safe_functions)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -5479,7 +5479,7 @@ TEST (ledger, pruning_safe_functions)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
@@ -5491,7 +5491,7 @@ TEST (ledger, pruning_safe_functions)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
@@ -5530,7 +5530,7 @@ TEST (ledger, hash_root_random)
 	ledger.pruning = true;
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send1 = builder
 				 .state ()
@@ -5540,7 +5540,7 @@ TEST (ledger, hash_root_random)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
 	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
@@ -5552,7 +5552,7 @@ TEST (ledger, hash_root_random)
 				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2)
 				 .link (nano::dev::genesis->account ())
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (send1->hash ()))
+				 .work (*pool.obj.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
 	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
@@ -5591,7 +5591,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	uint16_t port = 100;
 	nano::store::lmdb::component store{ logger, path / "data.ldb", nano::dev::constants };
 	nano::ledger ledger{ store, system.stats, nano::dev::constants };
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 
 	std::shared_ptr<nano::block> send = nano::state_block_builder ()
 										.account (nano::dev::genesis_key.pub)
@@ -5600,7 +5600,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 										.link (nano::account (10))
 										.balance (nano::dev::constants.genesis_amount - 100)
 										.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-										.work (*pool.generate (nano::dev::genesis->hash ()))
+										.work (*pool.obj.generate (nano::dev::genesis->hash ()))
 										.build_shared ();
 
 	nano::endpoint_key endpoint_key (address.to_bytes (), port);
@@ -5662,7 +5662,7 @@ TEST (ledger, unconfirmed_frontiers)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 
 	auto unconfirmed_frontiers = ledger.unconfirmed_frontiers ();
 	ASSERT_TRUE (unconfirmed_frontiers.empty ());
@@ -5677,7 +5677,7 @@ TEST (ledger, unconfirmed_frontiers)
 				.balance (nano::dev::constants.genesis_amount - 100)
 				.link (key.pub)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (latest))
+				.work (*pool.obj.generate (latest))
 				.build ();
 
 	ASSERT_EQ (nano::process_result::progress, ledger.process (store.tx_begin_write (), *send).code);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -68,8 +68,9 @@ TEST (node, block_store_path_failure)
 	nano::test::system system;
 	auto service (std::make_shared<boost::asio::io_context> ());
 	auto path (nano::unique_path ());
-	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	auto node (std::make_shared<nano::node> (*service, system.get_available_port (), path, pool.obj));
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_guard pool_guard{ pool };
+	auto node (std::make_shared<nano::node> (*service, system.get_available_port (), path, pool));
 	ASSERT_TRUE (node->wallets.items.empty ());
 	node->stop ();
 }
@@ -99,9 +100,10 @@ TEST (node, password_fanout)
 	auto path (nano::unique_path ());
 	nano::node_config config;
 	config.peering_port = system.get_available_port ();
-	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_guard pool_guard{ pool };
 	config.password_fanout = 10;
-	nano::node node (io_ctx, path, config, pool.obj);
+	nano::node node (io_ctx, path, config, pool);
 	auto wallet (node.wallets.create (100));
 	ASSERT_EQ (10, wallet->store.password.values.size ());
 	node.stop ();

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -68,8 +68,8 @@ TEST (node, block_store_path_failure)
 	nano::test::system system;
 	auto service (std::make_shared<boost::asio::io_context> ());
 	auto path (nano::unique_path ());
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-	auto node (std::make_shared<nano::node> (*service, system.get_available_port (), path, pool));
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	auto node (std::make_shared<nano::node> (*service, system.get_available_port (), path, pool.obj));
 	ASSERT_TRUE (node->wallets.items.empty ());
 	node->stop ();
 }
@@ -99,9 +99,9 @@ TEST (node, password_fanout)
 	auto path (nano::unique_path ());
 	nano::node_config config;
 	config.peering_port = system.get_available_port ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	config.password_fanout = 10;
-	nano::node node (io_ctx, path, config, pool);
+	nano::node node (io_ctx, path, config, pool.obj);
 	auto wallet (node.wallets.create (100));
 	ASSERT_EQ (10, wallet->store.password.values.size ());
 	node.stop ();

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -18,7 +18,7 @@ TEST (processor_service, bad_send_signature)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
 	nano::keypair key2;
@@ -29,7 +29,7 @@ TEST (processor_service, bad_send_signature)
 				.destination (nano::dev::genesis_key.pub)
 				.balance (50)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (info1->head))
+				.work (*pool.obj.generate (info1->head))
 				.build ();
 	send->signature.bytes[32] ^= 0x1;
 	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, *send).code);
@@ -44,7 +44,7 @@ TEST (processor_service, bad_receive_signature)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction (store->tx_begin_write ());
 	store->initialize (transaction, ledger.cache, ledger.constants);
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
 	nano::block_builder builder;
@@ -54,7 +54,7 @@ TEST (processor_service, bad_receive_signature)
 				.destination (nano::dev::genesis_key.pub)
 				.balance (50)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (info1->head))
+				.work (*pool.obj.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 (send->hash ());
 	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
@@ -65,7 +65,7 @@ TEST (processor_service, bad_receive_signature)
 				   .previous (hash1)
 				   .source (hash1)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (hash1))
+				   .work (*pool.obj.generate (hash1))
 				   .build ();
 	receive->signature.bytes[32] ^= 0x1;
 	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, *receive).code);

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -102,8 +102,8 @@ TEST (work, opencl)
 		{
 			// 0 threads, should add 1 for managing OpenCL
 			nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, 0, std::chrono::nanoseconds (0), [&opencl] (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::atomic<int> & ticket_a) {
-									 return opencl->generate_work (version_a, root_a, difficulty_a);
-								 } };
+																	   return opencl->generate_work (version_a, root_a, difficulty_a);
+																   } };
 			ASSERT_NE (nullptr, pool.obj.opencl);
 			nano::root root;
 			uint64_t difficulty (0xff00000000000000);

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -39,6 +39,7 @@ public:
 	work_pool (nano::network_constants & network_constants, unsigned, std::chrono::nanoseconds = std::chrono::nanoseconds (0), std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> = nullptr);
 	~work_pool ();
 	void loop (uint64_t);
+	void start ();
 	void stop ();
 	void cancel (nano::root const &);
 	void generate (nano::work_version const, nano::root const &, uint64_t, std::function<void (boost::optional<uint64_t> const &)>);
@@ -57,6 +58,7 @@ public:
 	std::chrono::nanoseconds pow_rate_limiter;
 	std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)> opencl;
 	nano::observer_set<bool> work_observers;
+	unsigned max_threads;
 };
 
 std::unique_ptr<container_info_component> collect_container_info (work_pool & work_pool, std::string const & name);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -582,6 +582,7 @@ void nano::node::process_local_async (std::shared_ptr<nano::block> const & block
 
 void nano::node::start ()
 {
+	work.start ();
 	long_inactivity_cleanup ();
 	network.start ();
 	add_initial_peers ();
@@ -698,7 +699,7 @@ void nano::node::stop ()
 	stats.stop ();
 	epoch_upgrader.stop ();
 	workers.stop ();
-	// work pool is not stopped on purpose due to testing setup
+	work.stop ();
 }
 
 void nano::node::keepalive_preconfigured (std::vector<std::string> const & peers_a)

--- a/nano/test_common/ledger.cpp
+++ b/nano/test_common/ledger.cpp
@@ -1,3 +1,5 @@
+#include "testutil.hpp"
+
 #include <nano/node/make_store.hpp>
 #include <nano/node/node.hpp>
 #include <nano/test_common/ledger.hpp>
@@ -45,7 +47,7 @@ auto nano::test::context::ledger_empty () -> ledger_context
 auto nano::test::context::ledger_send_receive () -> ledger_context
 {
 	std::deque<std::shared_ptr<nano::block>> blocks;
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send = builder.state ()
 				.make_block ()
@@ -55,7 +57,7 @@ auto nano::test::context::ledger_send_receive () -> ledger_context
 				.balance (nano::dev::constants.genesis_amount - 1)
 				.link (nano::dev::genesis_key.pub)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				.build_shared ();
 	blocks.push_back (send);
 	auto receive = builder.state ()
@@ -66,7 +68,7 @@ auto nano::test::context::ledger_send_receive () -> ledger_context
 				   .balance (nano::dev::constants.genesis_amount)
 				   .link (send->hash ())
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (send->hash ()))
+				   .work (*pool.obj.generate (send->hash ()))
 				   .build_shared ();
 	blocks.push_back (receive);
 	return ledger_context{ std::move (blocks) };
@@ -75,7 +77,7 @@ auto nano::test::context::ledger_send_receive () -> ledger_context
 auto nano::test::context::ledger_send_receive_legacy () -> ledger_context
 {
 	std::deque<std::shared_ptr<nano::block>> blocks;
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
 	auto send = builder.send ()
 				.make_block ()
@@ -83,7 +85,7 @@ auto nano::test::context::ledger_send_receive_legacy () -> ledger_context
 				.destination (nano::dev::genesis_key.pub)
 				.balance (nano::dev::constants.genesis_amount - 1)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.work (*pool.obj.generate (nano::dev::genesis->hash ()))
 				.build_shared ();
 	blocks.push_back (send);
 	auto receive = builder.receive ()
@@ -91,7 +93,7 @@ auto nano::test::context::ledger_send_receive_legacy () -> ledger_context
 				   .previous (send->hash ())
 				   .source (send->hash ())
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.generate (send->hash ()))
+				   .work (*pool.obj.generate (send->hash ()))
 				   .build_shared ();
 	blocks.push_back (receive);
 	return ledger_context{ std::move (blocks) };

--- a/nano/test_common/ledger.cpp
+++ b/nano/test_common/ledger.cpp
@@ -47,7 +47,8 @@ auto nano::test::context::ledger_empty () -> ledger_context
 auto nano::test::context::ledger_send_receive () -> ledger_context
 {
 	std::deque<std::shared_ptr<nano::block>> blocks;
-	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_guard pool_guard{ pool };
 	nano::block_builder builder;
 	auto send = builder.state ()
 				.make_block ()
@@ -57,7 +58,7 @@ auto nano::test::context::ledger_send_receive () -> ledger_context
 				.balance (nano::dev::constants.genesis_amount - 1)
 				.link (nano::dev::genesis_key.pub)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.obj.generate (nano::dev::genesis->hash ()))
+				.work (*pool.generate (nano::dev::genesis->hash ()))
 				.build_shared ();
 	blocks.push_back (send);
 	auto receive = builder.state ()
@@ -68,7 +69,7 @@ auto nano::test::context::ledger_send_receive () -> ledger_context
 				   .balance (nano::dev::constants.genesis_amount)
 				   .link (send->hash ())
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.obj.generate (send->hash ()))
+				   .work (*pool.generate (send->hash ()))
 				   .build_shared ();
 	blocks.push_back (receive);
 	return ledger_context{ std::move (blocks) };
@@ -77,7 +78,8 @@ auto nano::test::context::ledger_send_receive () -> ledger_context
 auto nano::test::context::ledger_send_receive_legacy () -> ledger_context
 {
 	std::deque<std::shared_ptr<nano::block>> blocks;
-	nano::test::start_stop_container<nano::work_pool> pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::test::start_stop_guard pool_guard{ pool };
 	nano::block_builder builder;
 	auto send = builder.send ()
 				.make_block ()
@@ -85,7 +87,7 @@ auto nano::test::context::ledger_send_receive_legacy () -> ledger_context
 				.destination (nano::dev::genesis_key.pub)
 				.balance (nano::dev::constants.genesis_amount - 1)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.obj.generate (nano::dev::genesis->hash ()))
+				.work (*pool.generate (nano::dev::genesis->hash ()))
 				.build_shared ();
 	blocks.push_back (send);
 	auto receive = builder.receive ()
@@ -93,7 +95,7 @@ auto nano::test::context::ledger_send_receive_legacy () -> ledger_context
 				   .previous (send->hash ())
 				   .source (send->hash ())
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				   .work (*pool.obj.generate (send->hash ()))
+				   .work (*pool.generate (send->hash ()))
 				   .build_shared ();
 	blocks.push_back (receive);
 	return ledger_context{ std::move (blocks) };

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -140,6 +140,7 @@ std::shared_ptr<nano::node> nano::test::system::make_disconnected_node (std::opt
 
 nano::test::system::system ()
 {
+	work.start ();
 	auto scale_str = std::getenv ("DEADLINE_SCALE_FACTOR");
 	if (scale_str)
 	{
@@ -150,6 +151,7 @@ nano::test::system::system ()
 nano::test::system::system (uint16_t count_a, nano::transport::transport_type type_a, nano::node_flags flags_a) :
 	system ()
 {
+	work.start ();
 	nodes.reserve (count_a);
 	for (uint16_t i (0); i < count_a; ++i)
 	{

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -232,10 +232,18 @@ namespace test
 		std::atomic<unsigned> required_count;
 	};
 
-	/**
+	// Concept to check if a type has start and stop methods
+	template<typename T>
+	concept start_stoppable = requires(T t) {
+		{ t.start() } -> std::same_as<void>;
+		{ t.stop() } -> std::same_as<void>;
+	};
+
+	/**lk
 	 * A helper that calls `start` from constructor and `stop` from destructor
 	 */
 	template <class T>
+	requires start_stoppable<T>
 	class start_stop_guard
 	{
 	public:
@@ -252,6 +260,28 @@ namespace test
 
 	private:
 		T & ref;
+	};
+
+	/**
+	 * A container that constructs and stores an object and calls `start` from constructor and `stop` from destructor (RAII)
+	 */
+	template <typename T>
+	requires start_stoppable<T>
+	struct start_stop_container
+	{
+		template <typename... Args>
+		explicit start_stop_container(Args&&... args) :
+			obj(std::forward<Args>(args)...)
+		{
+			obj.start();
+		}
+
+		~start_stop_container ()
+		{
+			obj.stop ();
+		}
+
+		T obj;
 	};
 
 	void wait_peer_connections (nano::test::system &);

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -233,17 +233,21 @@ namespace test
 	};
 
 	// Concept to check if a type has start and stop methods
-	template<typename T>
-	concept start_stoppable = requires(T t) {
-		{ t.start() } -> std::same_as<void>;
-		{ t.stop() } -> std::same_as<void>;
+	template <typename T>
+	concept start_stoppable = requires (T t) {
+		{
+			t.start ()
+		} -> std::same_as<void>;
+		{
+			t.stop ()
+		} -> std::same_as<void>;
 	};
 
 	/**lk
 	 * A helper that calls `start` from constructor and `stop` from destructor
 	 */
 	template <class T>
-	requires start_stoppable<T>
+		requires start_stoppable<T>
 	class start_stop_guard
 	{
 	public:
@@ -266,14 +270,14 @@ namespace test
 	 * A container that constructs and stores an object and calls `start` from constructor and `stop` from destructor (RAII)
 	 */
 	template <typename T>
-	requires start_stoppable<T>
+		requires start_stoppable<T>
 	struct start_stop_container
 	{
 		template <typename... Args>
-		explicit start_stop_container(Args&&... args) :
-			obj(std::forward<Args>(args)...)
+		explicit start_stop_container (Args &&... args) :
+			obj (std::forward<Args> (args)...)
 		{
-			obj.start();
+			obj.start ();
 		}
 
 		~start_stop_container ()

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -232,22 +232,10 @@ namespace test
 		std::atomic<unsigned> required_count;
 	};
 
-	// Concept to check if a type has start and stop methods
-	template <typename T>
-	concept start_stoppable = requires (T t) {
-		{
-			t.start ()
-		} -> std::same_as<void>;
-		{
-			t.stop ()
-		} -> std::same_as<void>;
-	};
-
-	/**lk
+	/**
 	 * A helper that calls `start` from constructor and `stop` from destructor
 	 */
 	template <class T>
-		requires start_stoppable<T>
 	class start_stop_guard
 	{
 	public:
@@ -264,28 +252,6 @@ namespace test
 
 	private:
 		T & ref;
-	};
-
-	/**
-	 * A container that constructs and stores an object and calls `start` from constructor and `stop` from destructor (RAII)
-	 */
-	template <typename T>
-		requires start_stoppable<T>
-	struct start_stop_container
-	{
-		template <typename... Args>
-		explicit start_stop_container (Args &&... args) :
-			obj (std::forward<Args> (args)...)
-		{
-			obj.start ();
-		}
-
-		~start_stop_container ()
-		{
-			obj.stop ();
-		}
-
-		T obj;
 	};
 
 	void wait_peer_connections (nano::test::system &);


### PR DESCRIPTION
The work_pool starts a number of threads and joins them in the destructor.
This is pattern we want to break. We want to have a separate stop stage before destruction.
This change makes work_pool follow the new pattern.