### PR TITLE
Include thread header in threading.hpp

### DIFF
--- a/nano/lib/threading.hpp
+++ b/nano/lib/threading.hpp
@@ -4,6 +4,8 @@
 
 #include <boost/thread/thread.hpp>
 
+#include <thread>
+
 namespace nano
 {
 namespace thread_attributes


### PR DESCRIPTION
Fixes build issue where this header references std::thread.