### PR TITLE
Clean up ledger::process return value.

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -149,7 +149,7 @@ TEST (active_transactions, confirm_frontier)
 		node2.rep_crawler.probable_reps.emplace (nano::dev::genesis_key.pub, *peers.begin ());
 	}
 
-	ASSERT_EQ (nano::process_result::progress, node2.process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node2.process (*send));
 	ASSERT_TIMELY (5s, !node2.active.empty ());
 
 	// Save election to check request count afterwards
@@ -490,10 +490,10 @@ TEST (active_transactions, inactive_votes_cache_election_start)
 				 .sign (key2.prv, key2.pub)
 				 .work (*system.work.generate (key2.pub))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
-	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
-	ASSERT_EQ (nano::process_result::progress, node.process (*open1).code);
-	ASSERT_EQ (nano::process_result::progress, node.process (*open2).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*send1));
+	ASSERT_EQ (nano::block_status::progress, node.process (*send2));
+	ASSERT_EQ (nano::block_status::progress, node.process (*open1));
+	ASSERT_EQ (nano::block_status::progress, node.process (*open2));
 	ASSERT_TIMELY_EQ (5s, 5, node.ledger.cache.block_count);
 	ASSERT_TRUE (node.active.empty ());
 	ASSERT_EQ (1, node.ledger.cache.cemented_count);
@@ -1095,14 +1095,14 @@ TEST (active_transactions, conflicting_block_vote_existing_election)
 				.build_shared ();
 	auto vote_fork = nano::test::make_final_vote (nano::dev::genesis_key, { fork });
 
-	ASSERT_EQ (nano::process_result::progress, node.process_local (send).value ().code);
+	ASSERT_EQ (nano::block_status::progress, node.process_local (send).value ());
 	ASSERT_TIMELY_EQ (5s, 1, node.active.size ());
 
 	// Vote for conflicting block, but the block does not yet exist in the ledger
 	node.active.vote (vote_fork);
 
 	// Block now gets processed
-	ASSERT_EQ (nano::process_result::fork, node.process_local (fork).value ().code);
+	ASSERT_EQ (nano::block_status::fork, node.process_local (fork).value ());
 
 	// Election must be confirmed
 	auto election (node.active.election (fork->qualified_root ()));
@@ -1165,11 +1165,11 @@ TEST (active_transactions, activate_account_chain)
 				   .sign (key.prv, key.pub)
 				   .work (*system.work.generate (open->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
-	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
-	ASSERT_EQ (nano::process_result::progress, node.process (*send3).code);
-	ASSERT_EQ (nano::process_result::progress, node.process (*open).code);
-	ASSERT_EQ (nano::process_result::progress, node.process (*receive).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*send));
+	ASSERT_EQ (nano::block_status::progress, node.process (*send2));
+	ASSERT_EQ (nano::block_status::progress, node.process (*send3));
+	ASSERT_EQ (nano::block_status::progress, node.process (*open));
+	ASSERT_EQ (nano::block_status::progress, node.process (*receive));
 
 	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node.active.election (send->qualified_root ()));
@@ -1248,9 +1248,9 @@ TEST (active_transactions, activate_inactive)
 				.work (*system.work.generate (key.pub))
 				.build_shared ();
 
-	ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
-	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
-	ASSERT_EQ (nano::process_result::progress, node.process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*send));
+	ASSERT_EQ (nano::block_status::progress, node.process (*send2));
+	ASSERT_EQ (nano::block_status::progress, node.process (*open));
 
 	auto election = nano::test::start_election (system, node, send2->hash ());
 	ASSERT_NE (nullptr, election);
@@ -1285,7 +1285,7 @@ TEST (active_transactions, list_active)
 				.work (*system.work.generate (nano::dev::genesis->hash ()))
 				.build_shared ();
 
-	ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*send));
 
 	auto send2 = builder.make_block ()
 				 .account (nano::dev::genesis_key.pub)
@@ -1297,7 +1297,7 @@ TEST (active_transactions, list_active)
 				 .work (*system.work.generate (send->hash ()))
 				 .build_shared ();
 
-	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*send2));
 
 	auto open = builder.make_block ()
 				.account (key.pub)
@@ -1309,7 +1309,7 @@ TEST (active_transactions, list_active)
 				.work (*system.work.generate (key.pub))
 				.build_shared ();
 
-	ASSERT_EQ (nano::process_result::progress, node.process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*open));
 
 	ASSERT_TRUE (nano::test::start_elections (system, node, { send, send2, open }));
 	ASSERT_EQ (3, node.active.size ());
@@ -1342,7 +1342,7 @@ TEST (active_transactions, vacancy)
 					.work (*system.work.generate (nano::dev::genesis->hash ()))
 					.build_shared ();
 		node.active.vacancy_update = [&updated] () { updated = true; };
-		ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
+		ASSERT_EQ (nano::block_status::progress, node.process (*send));
 		ASSERT_EQ (1, node.active.vacancy ());
 		ASSERT_EQ (0, node.active.size ());
 		node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
@@ -1383,7 +1383,7 @@ TEST (active_transactions, fifo)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (latest_hash))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*send1));
 	node.process_confirmed (nano::election_status{ send1 });
 	ASSERT_TIMELY (5s, node.block_confirmed (send1->hash ()));
 
@@ -1398,7 +1398,7 @@ TEST (active_transactions, fifo)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (latest_hash))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*send2));
 	node.process_confirmed (nano::election_status{ send2 });
 	ASSERT_TIMELY (5s, node.block_confirmed (send2->hash ()));
 
@@ -1411,7 +1411,7 @@ TEST (active_transactions, fifo)
 					.sign (key0.prv, key0.pub)
 					.work (*system.work.generate (key0.pub))
 					.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*receive1).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*receive1));
 
 	auto receive2 = builder.make_block ()
 					.previous (0)
@@ -1422,7 +1422,7 @@ TEST (active_transactions, fifo)
 					.sign (key1.prv, key1.pub)
 					.work (*system.work.generate (key1.pub))
 					.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*receive2).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*receive2));
 
 	// Ensure first transaction becomes active
 	node.scheduler.manual.push (receive1);

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1021,7 +1021,7 @@ TEST (mdb_block_store, sideband_height)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*pool.generate (nano::dev::genesis->hash ()))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 	auto receive = builder
 				   .receive ()
 				   .previous (send->hash ())
@@ -1029,7 +1029,7 @@ TEST (mdb_block_store, sideband_height)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*pool.generate (send->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive));
 	auto change = builder
 				  .change ()
 				  .previous (receive->hash ())
@@ -1037,7 +1037,7 @@ TEST (mdb_block_store, sideband_height)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (receive->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *change));
 	auto state_send1 = builder
 					   .state ()
 					   .account (nano::dev::genesis_key.pub)
@@ -1048,7 +1048,7 @@ TEST (mdb_block_store, sideband_height)
 					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					   .work (*pool.generate (change->hash ()))
 					   .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *state_send1));
 	auto state_send2 = builder
 					   .state ()
 					   .account (nano::dev::genesis_key.pub)
@@ -1059,7 +1059,7 @@ TEST (mdb_block_store, sideband_height)
 					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					   .work (*pool.generate (state_send1->hash ()))
 					   .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *state_send2));
 	auto state_send3 = builder
 					   .state ()
 					   .account (nano::dev::genesis_key.pub)
@@ -1070,7 +1070,7 @@ TEST (mdb_block_store, sideband_height)
 					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					   .work (*pool.generate (state_send2->hash ()))
 					   .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_send3).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *state_send3));
 	auto state_open = builder
 					  .state ()
 					  .account (key1.pub)
@@ -1081,7 +1081,7 @@ TEST (mdb_block_store, sideband_height)
 					  .sign (key1.prv, key1.pub)
 					  .work (*pool.generate (key1.pub))
 					  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_open).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *state_open));
 	auto epoch = builder
 				 .state ()
 				 .account (key1.pub)
@@ -1092,7 +1092,7 @@ TEST (mdb_block_store, sideband_height)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (state_open->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch));
 	ASSERT_EQ (nano::epoch::epoch_1, ledger.version (*epoch));
 	auto epoch_open = builder
 					  .state ()
@@ -1104,7 +1104,7 @@ TEST (mdb_block_store, sideband_height)
 					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					  .work (*pool.generate (key2.pub))
 					  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch_open).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch_open));
 	ASSERT_EQ (nano::epoch::epoch_1, ledger.version (*epoch_open));
 	auto state_receive = builder
 						 .state ()
@@ -1116,7 +1116,7 @@ TEST (mdb_block_store, sideband_height)
 						 .sign (key2.prv, key2.pub)
 						 .work (*pool.generate (epoch_open->hash ()))
 						 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *state_receive).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *state_receive));
 	auto open = builder
 				.open ()
 				.source (state_send3->hash ())
@@ -1125,7 +1125,7 @@ TEST (mdb_block_store, sideband_height)
 				.sign (key3.prv, key3.pub)
 				.work (*pool.generate (key3.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open));
 	auto block1 (store.block.get (transaction, nano::dev::genesis->hash ()));
 	ASSERT_EQ (block1->sideband ().height, 1);
 	auto block2 (store.block.get (transaction, send->hash ()));

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -69,7 +69,7 @@ TEST (bulk_pull, end_not_owned)
 	open->refresh ();
 	open->signature = nano::sign_message (key2.prv, key2.pub, open->hash ());
 	system.nodes[0]->work_generate_blocking (*open);
-	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, system.nodes[0]->process (*open));
 	auto connection (std::make_shared<nano::transport::tcp_server> (std::make_shared<nano::transport::socket> (*system.nodes[0], nano::transport::socket::endpoint_type_t::server), system.nodes[0]));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
 	req->start = key2.pub;
@@ -122,7 +122,7 @@ TEST (bulk_pull, ascending_one_hash)
 				  .work (0)
 				  .build_shared ();
 	node.work_generate_blocking (*block1);
-	ASSERT_EQ (nano::process_result::progress, node.process (*block1).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*block1));
 	auto socket = std::make_shared<nano::transport::socket> (node, nano::transport::socket::endpoint_type_t::server);
 	auto connection = std::make_shared<nano::transport::tcp_server> (socket, system.nodes[0]);
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
@@ -154,7 +154,7 @@ TEST (bulk_pull, ascending_two_account)
 				  .work (0)
 				  .build_shared ();
 	node.work_generate_blocking (*block1);
-	ASSERT_EQ (nano::process_result::progress, node.process (*block1).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*block1));
 	auto socket = std::make_shared<nano::transport::socket> (node, nano::transport::socket::endpoint_type_t::server);
 	auto connection = std::make_shared<nano::transport::tcp_server> (socket, system.nodes[0]);
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
@@ -189,7 +189,7 @@ TEST (bulk_pull, ascending_end)
 				  .work (0)
 				  .build_shared ();
 	node.work_generate_blocking (*block1);
-	ASSERT_EQ (nano::process_result::progress, node.process (*block1).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*block1));
 	auto socket = std::make_shared<nano::transport::socket> (node, nano::transport::socket::endpoint_type_t::server);
 	auto connection = std::make_shared<nano::transport::tcp_server> (socket, system.nodes[0]);
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
@@ -249,7 +249,7 @@ TEST (bulk_pull, count_limit)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (node0->latest (nano::dev::genesis_key.pub)))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node0->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node0->process (*send1));
 	auto receive1 = builder
 					.receive ()
 					.previous (send1->hash ())
@@ -257,7 +257,7 @@ TEST (bulk_pull, count_limit)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*system.work.generate (send1->hash ()))
 					.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node0->process (*receive1).code);
+	ASSERT_EQ (nano::block_status::progress, node0->process (*receive1));
 
 	auto connection (std::make_shared<nano::transport::tcp_server> (std::make_shared<nano::transport::socket> (*node0, nano::transport::socket::endpoint_type_t::server), node0));
 	auto req = std::make_unique<nano::bulk_pull> (nano::dev::network_params.network);
@@ -375,8 +375,8 @@ TEST (bootstrap_processor, process_state)
 
 	node0->work_generate_blocking (*block1);
 	node0->work_generate_blocking (*block2);
-	ASSERT_EQ (nano::process_result::progress, node0->process (*block1).code);
-	ASSERT_EQ (nano::process_result::progress, node0->process (*block2).code);
+	ASSERT_EQ (nano::block_status::progress, node0->process (*block1));
+	ASSERT_EQ (nano::block_status::progress, node0->process (*block2));
 	ASSERT_TIMELY_EQ (5s, nano::test::account_info (*node0, nano::dev::genesis_key.pub).block_count, 3);
 
 	auto node1 = system.make_disconnected_node (std::nullopt, node_flags);
@@ -444,7 +444,7 @@ TEST (bootstrap_processor, pull_diamond)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (node0->latest (nano::dev::genesis_key.pub)))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node0->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node0->process (*send1));
 	auto open = builder
 				.open ()
 				.source (send1->hash ())
@@ -453,7 +453,7 @@ TEST (bootstrap_processor, pull_diamond)
 				.sign (key.prv, key.pub)
 				.work (*system.work.generate (key.pub))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node0->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node0->process (*open));
 	auto send2 = builder
 				 .send ()
 				 .previous (open->hash ())
@@ -462,7 +462,7 @@ TEST (bootstrap_processor, pull_diamond)
 				 .sign (key.prv, key.pub)
 				 .work (*system.work.generate (open->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node0->process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node0->process (*send2));
 	auto receive = builder
 				   .receive ()
 				   .previous (send1->hash ())
@@ -470,7 +470,7 @@ TEST (bootstrap_processor, pull_diamond)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*system.work.generate (send1->hash ()))
 				   .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node0->process (*receive).code);
+	ASSERT_EQ (nano::block_status::progress, node0->process (*receive));
 
 	auto node1 = system.make_disconnected_node ();
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
@@ -541,7 +541,7 @@ TEST (bootstrap_processor, push_diamond)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send1));
 
 	// open key account receiving all balance of genesis
 	auto open = builder
@@ -552,7 +552,7 @@ TEST (bootstrap_processor, push_diamond)
 				.sign (key.prv, key.pub)
 				.work (*system.work.generate (key.pub))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 
 	// send from key to genesis 100 raw
 	auto send2 = builder
@@ -563,7 +563,7 @@ TEST (bootstrap_processor, push_diamond)
 				 .sign (key.prv, key.pub)
 				 .work (*system.work.generate (open->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send2));
 
 	// receive the 100 raw on genesis
 	auto receive = builder
@@ -573,7 +573,7 @@ TEST (bootstrap_processor, push_diamond)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*system.work.generate (send1->hash ()))
 				   .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*receive));
 
 	nano::node_config config = system.default_config ();
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
@@ -614,7 +614,7 @@ TEST (bootstrap_processor, push_diamond_pruning)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send1));
 
 	// receive all balance on key
 	auto open = builder
@@ -625,7 +625,7 @@ TEST (bootstrap_processor, push_diamond_pruning)
 				.sign (key.prv, key.pub)
 				.work (*system.work.generate (key.pub))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 
 	// 1st bootstrap
 	node1->bootstrap_initiator.bootstrap (node0->network.endpoint (), false);
@@ -643,7 +643,7 @@ TEST (bootstrap_processor, push_diamond_pruning)
 				 .sign (key.prv, key.pub)
 				 .work (*system.work.generate (open->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send2));
 
 	// receive the 100 raw from key on genesis
 	auto receive = builder
@@ -653,7 +653,7 @@ TEST (bootstrap_processor, push_diamond_pruning)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*system.work.generate (send1->hash ()))
 				   .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*receive));
 
 	{
 		auto transaction (node1->store.tx_begin_write ());
@@ -1130,7 +1130,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send1));
 	auto send2 = builder
 				 .state ()
 				 .account (nano::dev::genesis_key.pub)
@@ -1141,7 +1141,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send1->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send2));
 	auto open = builder
 				.open ()
 				.source (send1->hash ())
@@ -1150,7 +1150,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link)
 				.sign (key.prv, key.pub)
 				.work (*system.work.generate (key.pub))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 	auto receive = builder
 				   .state ()
 				   .account (key.pub)
@@ -1161,7 +1161,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link)
 				   .sign (key.prv, key.pub)
 				   .work (*system.work.generate (open->hash ()))
 				   .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*receive).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*receive));
 
 	ASSERT_TIMELY (5s, nano::test::exists (*node1, { send1, send2, open, receive }));
 
@@ -1200,7 +1200,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send1));
 	auto open = builder
 				.open ()
 				.source (send1->hash ())
@@ -1209,7 +1209,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 				.sign (key.prv, key.pub)
 				.work (*system.work.generate (key.pub))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 	auto send2 = builder
 				 .state ()
 				 .account (key.pub)
@@ -1220,7 +1220,7 @@ TEST (bootstrap_processor, lazy_unclear_state_link_not_existing)
 				 .sign (key.prv, key.pub)
 				 .work (*system.work.generate (open->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send2));
 
 	// Start lazy bootstrap with last block in chain known
 	auto node2 = system.make_disconnected_node (std::nullopt, node_flags);
@@ -1259,7 +1259,7 @@ TEST (bootstrap_processor, lazy_destinations)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send1));
 
 	// send Gxrb_ratio raw from genesis to key2
 	auto send2 = builder
@@ -1272,7 +1272,7 @@ TEST (bootstrap_processor, lazy_destinations)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send1->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send2));
 
 	// receive send1 on key1
 	auto open = builder
@@ -1283,7 +1283,7 @@ TEST (bootstrap_processor, lazy_destinations)
 				.sign (key1.prv, key1.pub)
 				.work (*system.work.generate (key1.pub))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 
 	// receive send2 on key2
 	auto state_open = builder
@@ -1296,7 +1296,7 @@ TEST (bootstrap_processor, lazy_destinations)
 					  .sign (key2.prv, key2.pub)
 					  .work (*system.work.generate (key2.pub))
 					  .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*state_open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*state_open));
 
 	// Start lazy bootstrap with last block in sender chain
 	auto node2 = system.make_disconnected_node (std::nullopt, node_flags);
@@ -1744,7 +1744,7 @@ TEST (frontier_req, count)
 				 .work (0)
 				 .build_shared ();
 	node1->work_generate_blocking (*send1);
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send1));
 	auto receive1 = builder
 					.make_block ()
 					.account (key1.pub)
@@ -1756,7 +1756,7 @@ TEST (frontier_req, count)
 					.work (0)
 					.build_shared ();
 	node1->work_generate_blocking (*receive1);
-	ASSERT_EQ (nano::process_result::progress, node1->process (*receive1).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*receive1));
 
 	auto connection (std::make_shared<nano::transport::tcp_server> (std::make_shared<nano::transport::socket> (*node1, nano::transport::socket::endpoint_type_t::server), node1));
 	auto req = std::make_unique<nano::frontier_req> (nano::dev::network_params.network);
@@ -1839,7 +1839,7 @@ TEST (frontier_req, confirmed_frontier)
 				 .work (0)
 				 .build_shared ();
 	node1->work_generate_blocking (*send1);
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send1));
 	auto send2 = builder
 				 .make_block ()
 				 .account (nano::dev::genesis_key.pub)
@@ -1851,7 +1851,7 @@ TEST (frontier_req, confirmed_frontier)
 				 .work (0)
 				 .build_shared ();
 	node1->work_generate_blocking (*send2);
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send2));
 	auto receive1 = builder
 					.make_block ()
 					.account (key_before_genesis.pub)
@@ -1863,7 +1863,7 @@ TEST (frontier_req, confirmed_frontier)
 					.work (0)
 					.build_shared ();
 	node1->work_generate_blocking (*receive1);
-	ASSERT_EQ (nano::process_result::progress, node1->process (*receive1).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*receive1));
 	auto receive2 = builder
 					.make_block ()
 					.account (key_after_genesis.pub)
@@ -1875,7 +1875,7 @@ TEST (frontier_req, confirmed_frontier)
 					.work (0)
 					.build_shared ();
 	node1->work_generate_blocking (*receive2);
-	ASSERT_EQ (nano::process_result::progress, node1->process (*receive2).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*receive2));
 
 	// Request for all accounts (confirmed only)
 	auto connection (std::make_shared<nano::transport::tcp_server> (std::make_shared<nano::transport::socket> (*node1, nano::transport::socket::endpoint_type_t::server), node1));

--- a/nano/core_test/bootstrap_ascending.cpp
+++ b/nano/core_test/bootstrap_ascending.cpp
@@ -171,7 +171,7 @@ TEST (bootstrap_ascending, account_base)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node0.process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node0.process (*send1));
 	auto & node1 = *system.add_node (flags);
 	ASSERT_TIMELY (5s, node1.block (send1->hash ()) != nullptr);
 }
@@ -206,8 +206,8 @@ TEST (bootstrap_ascending, account_inductive)
 	//	std::cerr << "Genesis: " << nano::dev::genesis->hash ().to_string () << std::endl;
 	//	std::cerr << "Send1: " << send1->hash ().to_string () << std::endl;
 	//	std::cerr << "Send2: " << send2->hash ().to_string () << std::endl;
-	ASSERT_EQ (nano::process_result::progress, node0.process (*send1).code);
-	ASSERT_EQ (nano::process_result::progress, node0.process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node0.process (*send1));
+	ASSERT_EQ (nano::block_status::progress, node0.process (*send2));
 	auto & node1 = *system.add_node (flags);
 	ASSERT_TIMELY (50s, node1.block (send2->hash ()) != nullptr);
 }
@@ -248,8 +248,8 @@ TEST (bootstrap_ascending, trace_base)
 	//	std::cerr << "receive1: " << receive1->hash ().to_string () << std::endl;
 	auto & node1 = *system.add_node ();
 	//	std::cerr << "--------------- Start ---------------\n";
-	ASSERT_EQ (nano::process_result::progress, node0.process (*send1).code);
-	ASSERT_EQ (nano::process_result::progress, node0.process (*receive1).code);
+	ASSERT_EQ (nano::block_status::progress, node0.process (*send1));
+	ASSERT_EQ (nano::block_status::progress, node0.process (*receive1));
 	ASSERT_EQ (node1.store.pending.begin (node1.store.tx_begin_read (), nano::pending_key{ key.pub, 0 }), node1.store.pending.end ());
 	//	std::cerr << "node0: " << node0.network.endpoint () << std::endl;
 	//	std::cerr << "node1: " << node1.network.endpoint () << std::endl;

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -199,20 +199,20 @@ TEST (confirmation_height, multiple_accounts)
 
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send3).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send2));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send3));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open3).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open2));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open3));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send4).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send5).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send4));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send5));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send6).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive2).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send6));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive2));
 
 			// Check confirmation heights of all the accounts (except genesis) are uninitialized (0),
 			// as we have any just added them to the ledger and not processed any live transactions yet.
@@ -669,20 +669,20 @@ TEST (confirmation_height, send_receive_between_2_accounts)
 		// Unpocketed send
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open1).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open1));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send2));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive1));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send3).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send4).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send3));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send4));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive3).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive2));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive3));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send5).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send6).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send5));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send6));
 		}
 
 		add_callback_stats (*node);
@@ -793,14 +793,14 @@ TEST (confirmation_height, send_receive_self)
 					 .build ();
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send3).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send2));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send3));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive3).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send4).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive2));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive3));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send4));
 		}
 
 		add_callback_stats (*node);
@@ -1023,30 +1023,30 @@ TEST (confirmation_height, all_block_types)
 
 		{
 			auto transaction (store.tx_begin_write ());
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_open).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *state_open));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_receive).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send2));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *state_receive));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_send).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *change).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_change).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *state_send));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *change));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *state_change));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *epoch).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *epoch1).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *epoch));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *epoch1));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_receive2).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *state_send1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *state_receive2));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_send2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_send3).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *state_send2));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *state_send3));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_send4).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *state_receive3).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *state_send4));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *state_receive3));
 		}
 
 		add_callback_stats (*node);
@@ -1117,7 +1117,7 @@ TEST (confirmation_height, conflict_rollback_cemented)
 					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					  .work (*system.work.generate (genesis_hash))
 					  .build_shared ();
-		ASSERT_EQ (nano::process_result::progress, node1->process (*fork1a).code);
+		ASSERT_EQ (nano::block_status::progress, node1->process (*fork1a));
 		ASSERT_TRUE (nano::test::start_elections (system, *node1, { fork1a }, true));
 		ASSERT_TIMELY (5s, nano::test::confirmed (*node1, { fork1a }));
 
@@ -1269,7 +1269,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 		{
 			auto transaction (store->tx_begin_write ());
 			store->initialize (transaction, ledger.cache, ledger.constants);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 		}
 
 		uint64_t batch_write_size = 2048;
@@ -1290,7 +1290,7 @@ TEST (confirmation_heightDeathTest, modified_chain)
 			ASSERT_DEATH_IF_SUPPORTED (bounded_processor.cement_blocks (scoped_write_guard), "");
 		}
 
-		ASSERT_EQ (nano::process_result::progress, ledger.process (store->tx_begin_write (), *send).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (store->tx_begin_write (), *send));
 		store->confirmation_height.put (store->tx_begin_write (), nano::dev::genesis->account (), { 1, nano::dev::genesis->hash () });
 
 		nano::confirmation_height_unbounded unbounded_processor (
@@ -1356,8 +1356,8 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		{
 			auto transaction (store->tx_begin_write ());
 			store->initialize (transaction, ledger.cache, ledger.constants);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open));
 		}
 
 		uint64_t batch_write_size = 2048;
@@ -1379,7 +1379,7 @@ TEST (confirmation_heightDeathTest, modified_chain_account_removed)
 		}
 
 		// Reset conditions and test with the bounded processor
-		ASSERT_EQ (nano::process_result::progress, ledger.process (store->tx_begin_write (), *open).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (store->tx_begin_write (), *open));
 		store->confirmation_height.put (store->tx_begin_write (), nano::dev::genesis->account (), { 1, nano::dev::genesis->hash () });
 
 		nano::confirmation_height_bounded bounded_processor (
@@ -1434,8 +1434,8 @@ TEST (confirmation_height, pending_observer_callbacks)
 
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send1));
 		}
 
 		add_callback_stats (*node);
@@ -1482,7 +1482,7 @@ TEST (confirmation_height, callback_confirmed_history)
 					.build_shared ();
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 		}
 
 		auto send1 = builder
@@ -1586,9 +1586,9 @@ TEST (confirmation_height, dependent_election)
 					 .build_shared ();
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send2));
 		}
 
 		add_callback_stats (*node);
@@ -1729,21 +1729,21 @@ TEST (confirmation_height, cemented_gap_below_receive)
 
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *dummy_send));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send2));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send1).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive2));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *dummy_send1));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send3).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send2).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send3));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *dummy_send2));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open1).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open1));
 		}
 
 		std::vector<nano::block_hash> observer_order;
@@ -1889,21 +1889,21 @@ TEST (confirmation_height, cemented_gap_below_no_cache)
 
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *dummy_send));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive1));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send2));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive2).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send1).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive2));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *dummy_send1));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send3).code);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *dummy_send2).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send3));
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *dummy_send2));
 
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open1).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open1));
 		}
 
 		// Force some blocks to be cemented so that the cached confirmed info variable is empty
@@ -1959,7 +1959,7 @@ TEST (confirmation_height, election_winner_details_clearing)
 						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 						   .work (*system.work.generate (latest))
 						   .build_shared ();
-		ASSERT_EQ (nano::process_result::progress, node->process (*send1).code);
+		ASSERT_EQ (nano::block_status::progress, node->process (*send1));
 
 		auto const send2 = builder.make_block ()
 						   .previous (send1->hash ())
@@ -1968,7 +1968,7 @@ TEST (confirmation_height, election_winner_details_clearing)
 						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 						   .work (*system.work.generate (send1->hash ()))
 						   .build_shared ();
-		ASSERT_EQ (nano::process_result::progress, node->process (*send2).code);
+		ASSERT_EQ (nano::block_status::progress, node->process (*send2));
 
 		auto const send3 = builder.make_block ()
 						   .previous (send2->hash ())
@@ -1977,7 +1977,7 @@ TEST (confirmation_height, election_winner_details_clearing)
 						   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 						   .work (*system.work.generate (send2->hash ()))
 						   .build_shared ();
-		ASSERT_EQ (nano::process_result::progress, node->process (*send3).code);
+		ASSERT_EQ (nano::block_status::progress, node->process (*send3));
 
 		node->process_confirmed (nano::election_status{ send2 });
 		ASSERT_TIMELY (5s, node->block_confirmed (send2->hash ()));
@@ -2062,8 +2062,8 @@ TEST (confirmation_height, unbounded_block_cache_iteration)
 	{
 		auto transaction (store->tx_begin_write ());
 		store->initialize (transaction, ledger.cache, nano::dev::constants);
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	}
 
 	nano::confirmation_height_processor confirmation_height_processor (ledger, write_database_queue, 10ms, logger, initialized_latch, nano::confirmation_height_mode::unbounded);
@@ -2159,11 +2159,11 @@ TEST (confirmation_height, pruned_source)
 	{
 		auto transaction (store->tx_begin_write ());
 		store->initialize (transaction, ledger.cache, nano::dev::constants);
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open2).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send3));
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open2));
 	}
 	uint64_t batch_write_size = 2;
 	std::atomic<bool> stopped{ false };

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -27,7 +27,7 @@ TEST (conflicts, start_stop)
 				 .work (0)
 				 .build_shared ();
 	node1.work_generate_blocking (*send1);
-	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*send1));
 	ASSERT_EQ (0, node1.active.size ());
 	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
@@ -56,7 +56,7 @@ TEST (conflicts, add_existing)
 	node1.work_generate_blocking (*send1);
 
 	// add the block to ledger as an unconfirmed block
-	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*send1));
 
 	// wait for send1 to be inserted in the ledger
 	ASSERT_TIMELY (5s, node1.block (send1->hash ()));

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -224,7 +224,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 	ASSERT_TIMELY (5s, node1.block (send1->hash ()) != nullptr);
 
 	auto const open1 = nano::open_block_builder{}.make_block ().account (key1.pub).source (send1->hash ()).representative (key1.pub).sign (key1.prv, key1.pub).work (*system.work.generate (key1.pub)).build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1.process (*open1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*open1));
 
 	nano::keypair key2;
 	auto const send2 = builder.make_block ()
@@ -234,7 +234,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 					   .sign (key1.prv, key1.pub)
 					   .work (*system.work.generate (open1->hash ()))
 					   .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*send2));
 	ASSERT_TIMELY_EQ (5s, node1.ledger.cache.block_count, 4);
 
 	node_config.peering_port = system.get_available_port ();

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -87,7 +87,7 @@ TEST (election_scheduler, no_vacancy)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*system.work.generate (nano::dev::genesis->hash ()))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*send));
 	node.process_confirmed (nano::election_status{ send });
 
 	auto receive = builder.make_block ()
@@ -99,7 +99,7 @@ TEST (election_scheduler, no_vacancy)
 				   .sign (key.prv, key.pub)
 				   .work (*system.work.generate (key.pub))
 				   .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*receive).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*receive));
 	node.process_confirmed (nano::election_status{ receive });
 
 	// Second, process two eligible transactions
@@ -112,7 +112,7 @@ TEST (election_scheduler, no_vacancy)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*system.work.generate (send->hash ()))
 				  .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*block1).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*block1));
 
 	// There is vacancy so it should be inserted
 	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
@@ -128,7 +128,7 @@ TEST (election_scheduler, no_vacancy)
 				  .sign (key.prv, key.pub)
 				  .work (*system.work.generate (receive->hash ()))
 				  .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*block2).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*block2));
 
 	// There is no vacancy so it should stay queued
 	node.scheduler.priority.activate (key.pub, node.store.tx_begin_read ());

--- a/nano/core_test/frontiers_confirmation.cpp
+++ b/nano/core_test/frontiers_confirmation.cpp
@@ -29,7 +29,7 @@ TEST (frontiers_confirmation, mode)
 					.build ();
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 		}
 		ASSERT_TIMELY_EQ (5s, node->active.size (), 1);
 	}
@@ -51,7 +51,7 @@ TEST (frontiers_confirmation, mode)
 					.build ();
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 		}
 		ASSERT_TIMELY_EQ (5s, node->active.size (), 1);
 	}
@@ -73,7 +73,7 @@ TEST (frontiers_confirmation, mode)
 					.build ();
 		{
 			auto transaction = node->store.tx_begin_write ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 		}
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 		std::this_thread::sleep_for (std::chrono::seconds (1));

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -77,7 +77,7 @@ TEST (ledger, process_modifies_sideband)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (store.tx_begin_write (), *send1));
 	ASSERT_EQ (send1->sideband ().timestamp, store.block.get (store.tx_begin_read (), send1->hash ())->sideband ().timestamp);
 }
 
@@ -111,7 +111,7 @@ TEST (ledger, process_send)
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash1));
 	ASSERT_TRUE (store.frontier.get (transaction, info1->head).is_zero ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, hash1));
-	ASSERT_EQ (nano::process_result::progress, return1.code);
+	ASSERT_EQ (nano::block_status::progress, return1);
 	ASSERT_EQ (nano::dev::genesis_key.pub, ledger.account (*send));
 	ASSERT_EQ (50, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_receivable (transaction, key2.pub));
@@ -135,12 +135,12 @@ TEST (ledger, process_send)
 	nano::block_hash hash2 (open->hash ());
 	// This was a valid block, it should progress.
 	auto return2 = ledger.process (transaction, *open);
-	ASSERT_EQ (nano::process_result::progress, return2.code);
+	ASSERT_EQ (nano::block_status::progress, return2);
 	ASSERT_EQ (key2.pub, open->sideband ().account);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, open->sideband ().balance.number ());
 	ASSERT_EQ (1, open->sideband ().height);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash2));
-	ASSERT_EQ (nano::process_result::progress, return2.code);
+	ASSERT_EQ (nano::block_status::progress, return2);
 	ASSERT_EQ (key2.pub, ledger.account (*open));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.amount (transaction, hash2));
 	ASSERT_EQ (key2.pub, store.frontier.get (transaction, hash2));
@@ -212,7 +212,7 @@ TEST (ledger, process_receive)
 				.work (*pool.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 (send->hash ());
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 	nano::keypair key3;
 	auto open = builder
 				.open ()
@@ -224,7 +224,7 @@ TEST (ledger, process_receive)
 				.build ();
 	nano::block_hash hash2 (open->hash ());
 	auto return1 = ledger.process (transaction, *open);
-	ASSERT_EQ (nano::process_result::progress, return1.code);
+	ASSERT_EQ (nano::block_status::progress, return1);
 	ASSERT_EQ (key2.pub, ledger.account (*open));
 	ASSERT_EQ (key2.pub, open->sideband ().account);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, open->sideband ().balance.number ());
@@ -240,7 +240,7 @@ TEST (ledger, process_receive)
 				 .work (*pool.generate (hash1))
 				 .build ();
 	nano::block_hash hash3 = send2->hash ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	auto receive = builder
 				   .receive ()
 				   .previous (hash2)
@@ -257,7 +257,7 @@ TEST (ledger, process_receive)
 	ASSERT_EQ (25, ledger.amount (transaction, hash4));
 	ASSERT_TRUE (store.frontier.get (transaction, hash2).is_zero ());
 	ASSERT_EQ (key2.pub, store.frontier.get (transaction, hash4));
-	ASSERT_EQ (nano::process_result::progress, return2.code);
+	ASSERT_EQ (nano::block_status::progress, return2);
 	ASSERT_EQ (key2.pub, ledger.account (*receive));
 	ASSERT_EQ (hash4, ledger.latest (transaction, key2.pub));
 	ASSERT_EQ (25, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
@@ -300,7 +300,7 @@ TEST (ledger, rollback_receiver)
 				.work (*pool.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 (send->hash ());
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 	nano::keypair key3;
 	auto open = builder
 				.open ()
@@ -311,7 +311,7 @@ TEST (ledger, rollback_receiver)
 				.work (*pool.generate (key2.pub))
 				.build ();
 	nano::block_hash hash2 (open->hash ());
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open));
 	ASSERT_EQ (hash2, ledger.latest (transaction, key2.pub));
 	ASSERT_EQ (50, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_balance (transaction, key2.pub));
@@ -345,7 +345,7 @@ TEST (ledger, rollback_representation)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*pool.generate (nano::dev::genesis->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *change1));
 	nano::keypair key3;
 	auto change2 = builder
 				   .change ()
@@ -354,7 +354,7 @@ TEST (ledger, rollback_representation)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*pool.generate (change1->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *change2));
 	nano::keypair key2;
 	auto send1 = builder
 				 .send ()
@@ -364,7 +364,7 @@ TEST (ledger, rollback_representation)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (change2->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	nano::keypair key4;
 	auto open = builder
 				.open ()
@@ -374,7 +374,7 @@ TEST (ledger, rollback_representation)
 				.sign (key2.prv, key2.pub)
 				.work (*pool.generate (key2.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open));
 	auto send2 = builder
 				 .send ()
 				 .previous (send1->hash ())
@@ -383,7 +383,7 @@ TEST (ledger, rollback_representation)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	auto receive1 = builder
 					.receive ()
 					.previous (open->hash ())
@@ -391,7 +391,7 @@ TEST (ledger, rollback_representation)
 					.sign (key2.prv, key2.pub)
 					.work (*pool.generate (open->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_EQ (1, ledger.weight (key3.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 1, ledger.weight (key4.pub));
 	auto info1 = ledger.account_info (transaction, key2.pub);
@@ -435,7 +435,7 @@ TEST (ledger, receive_rollback)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*pool.generate (nano::dev::genesis->hash ()))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 	auto receive = builder
 				   .receive ()
 				   .previous (send->hash ())
@@ -443,7 +443,7 @@ TEST (ledger, receive_rollback)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*pool.generate (send->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive));
 	ASSERT_FALSE (ledger.rollback (transaction, receive->hash ()));
 }
 
@@ -467,8 +467,8 @@ TEST (ledger, process_duplicate)
 				.work (*pool.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 (send->hash ());
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
-	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *send).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
+	ASSERT_EQ (nano::block_status::old, ledger.process (transaction, *send));
 	auto open = builder
 				.open ()
 				.source (hash1)
@@ -477,8 +477,8 @@ TEST (ledger, process_duplicate)
 				.sign (key2.prv, key2.pub)
 				.work (*pool.generate (key2.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
-	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *open).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open));
+	ASSERT_EQ (nano::block_status::old, ledger.process (transaction, *open));
 }
 
 TEST (ledger, representative_genesis)
@@ -524,7 +524,7 @@ TEST (ledger, representative_change)
 	ASSERT_EQ (0, ledger.amount (transaction, block->hash ()));
 	ASSERT_TRUE (store.frontier.get (transaction, info1->head).is_zero ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, store.frontier.get (transaction, block->hash ()));
-	ASSERT_EQ (nano::process_result::progress, return1.code);
+	ASSERT_EQ (nano::block_status::progress, return1);
 	ASSERT_EQ (nano::dev::genesis_key.pub, ledger.account (*block));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key2.pub));
@@ -561,7 +561,7 @@ TEST (ledger, send_fork)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (info1->head))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block));
 	auto block2 = builder
 				  .send ()
 				  .previous (info1->head)
@@ -570,7 +570,7 @@ TEST (ledger, send_fork)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (info1->head))
 				  .build ();
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, *block2));
 }
 
 TEST (ledger, receive_fork)
@@ -593,7 +593,7 @@ TEST (ledger, receive_fork)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (info1->head))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block));
 	auto block2 = builder
 				  .open ()
 				  .source (block->hash ())
@@ -602,7 +602,7 @@ TEST (ledger, receive_fork)
 				  .sign (key2.prv, key2.pub)
 				  .work (*pool.generate (key2.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block2));
 	auto block3 = builder
 				  .change ()
 				  .previous (block2->hash ())
@@ -610,7 +610,7 @@ TEST (ledger, receive_fork)
 				  .sign (key2.prv, key2.pub)
 				  .work (*pool.generate (block2->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block3));
 	auto block4 = builder
 				  .send ()
 				  .previous (block->hash ())
@@ -619,7 +619,7 @@ TEST (ledger, receive_fork)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (block->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block4).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block4));
 	auto block5 = builder
 				  .receive ()
 				  .previous (block2->hash ())
@@ -627,7 +627,7 @@ TEST (ledger, receive_fork)
 				  .sign (key2.prv, key2.pub)
 				  .work (*pool.generate (block2->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block5).code);
+	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, *block5));
 }
 
 TEST (ledger, open_fork)
@@ -650,7 +650,7 @@ TEST (ledger, open_fork)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (info1->head))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block));
 	auto block2 = builder
 				  .open ()
 				  .source (block->hash ())
@@ -659,7 +659,7 @@ TEST (ledger, open_fork)
 				  .sign (key2.prv, key2.pub)
 				  .work (*pool.generate (key2.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block2));
 	auto block3 = builder
 				  .open ()
 				  .source (block->hash ())
@@ -668,7 +668,7 @@ TEST (ledger, open_fork)
 				  .sign (key2.prv, key2.pub)
 				  .work (*pool.generate (key2.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block3).code);
+	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, *block3));
 }
 
 TEST (ledger, representation_changes)
@@ -701,7 +701,7 @@ TEST (ledger, representation)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block1));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	nano::keypair key3;
 	auto block2 = builder
@@ -712,7 +712,7 @@ TEST (ledger, representation)
 				  .sign (key2.prv, key2.pub)
 				  .work (*pool.generate (key2.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block2));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key3.pub));
@@ -724,7 +724,7 @@ TEST (ledger, representation)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (block1->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block3));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (100, rep_weights.representation_get (key3.pub));
@@ -735,7 +735,7 @@ TEST (ledger, representation)
 				  .sign (key2.prv, key2.pub)
 				  .work (*pool.generate (block2->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block4).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block4));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (200, rep_weights.representation_get (key3.pub));
@@ -747,7 +747,7 @@ TEST (ledger, representation)
 				  .sign (key2.prv, key2.pub)
 				  .work (*pool.generate (block4->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block5).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block5));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
@@ -761,7 +761,7 @@ TEST (ledger, representation)
 				  .sign (key2.prv, key2.pub)
 				  .work (*pool.generate (block5->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block6).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block6));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
@@ -776,7 +776,7 @@ TEST (ledger, representation)
 				  .sign (key5.prv, key5.pub)
 				  .work (*pool.generate (key5.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block7).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block7));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
@@ -791,7 +791,7 @@ TEST (ledger, representation)
 				  .sign (key2.prv, key2.pub)
 				  .work (*pool.generate (block6->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block8).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block8));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
@@ -805,7 +805,7 @@ TEST (ledger, representation)
 				  .sign (key5.prv, key5.pub)
 				  .work (*pool.generate (block7->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block9).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block9));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 200, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key2.pub));
 	ASSERT_EQ (0, rep_weights.representation_get (key3.pub));
@@ -834,7 +834,7 @@ TEST (ledger, double_open)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto open1 = builder
 				 .open ()
 				 .source (send1->hash ())
@@ -843,7 +843,7 @@ TEST (ledger, double_open)
 				 .sign (key2.prv, key2.pub)
 				 .work (*pool.generate (key2.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	auto open2 = builder
 				 .open ()
 				 .source (send1->hash ())
@@ -852,7 +852,7 @@ TEST (ledger, double_open)
 				 .sign (key2.prv, key2.pub)
 				 .work (*pool.generate (key2.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *open2).code);
+	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, *open2));
 }
 
 TEST (ledger, double_receive)
@@ -872,7 +872,7 @@ TEST (ledger, double_receive)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto open1 = builder
 				 .open ()
 				 .source (send1->hash ())
@@ -881,7 +881,7 @@ TEST (ledger, double_receive)
 				 .sign (key2.prv, key2.pub)
 				 .work (*pool.generate (key2.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	auto receive1 = builder
 					.receive ()
 					.previous (open1->hash ())
@@ -889,7 +889,7 @@ TEST (ledger, double_receive)
 					.sign (key2.prv, key2.pub)
 					.work (*pool.generate (open1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::unreceivable, ledger.process (transaction, *receive1));
 }
 
 TEST (votes, check_signature)
@@ -911,7 +911,7 @@ TEST (votes, check_signature)
 	node1.work_generate_blocking (*send1);
 	{
 		auto transaction (node1.store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
+		ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *send1));
 	}
 	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
@@ -941,7 +941,7 @@ TEST (votes, add_one)
 				 .build_shared ();
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *send1));
 	node1.start_election (send1);
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
@@ -983,7 +983,7 @@ TEST (votes, add_existing)
 										 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 										 .build ();
 	node1.work_generate_blocking (*send1);
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (node1.store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (node1.store.tx_begin_write (), *send1));
 	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
@@ -1042,7 +1042,7 @@ TEST (votes, add_old)
 				 .build_shared ();
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *send1));
 	node1.start_election (send1);
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
@@ -1100,8 +1100,8 @@ TEST (votes, DISABLED_add_old_different_account)
 				 .work (0)
 				 .build_shared ();
 	node1.work_generate_blocking (*send2);
-	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
-	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*send1));
+	ASSERT_EQ (nano::block_status::progress, node1.process (*send2));
 	ASSERT_TRUE (nano::test::start_elections (system, node1, { send1, send2 }));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election1);
@@ -1147,7 +1147,7 @@ TEST (votes, add_cooldown)
 				 .build_shared ();
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *send1));
 	node1.start_election (send1);
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
@@ -1190,7 +1190,7 @@ TEST (ledger, successor)
 				 .build ();
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *send1));
 	ASSERT_EQ (*send1, *node1.ledger.successor (transaction, nano::qualified_root (nano::root (0), nano::dev::genesis->hash ())));
 	ASSERT_EQ (*nano::dev::genesis, *node1.ledger.successor (transaction, nano::dev::genesis->qualified_root ()));
 	ASSERT_EQ (nullptr, node1.ledger.successor (transaction, nano::qualified_root (0)));
@@ -1213,9 +1213,9 @@ TEST (ledger, fail_change_old)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
-	ASSERT_EQ (nano::process_result::progress, result1.code);
+	ASSERT_EQ (nano::block_status::progress, result1);
 	auto result2 = ledger.process (transaction, *block);
-	ASSERT_EQ (nano::process_result::old, result2.code);
+	ASSERT_EQ (nano::block_status::old, result2);
 }
 
 TEST (ledger, fail_change_gap_previous)
@@ -1235,7 +1235,7 @@ TEST (ledger, fail_change_gap_previous)
 				 .work (*pool.generate (nano::root (1)))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
-	ASSERT_EQ (nano::process_result::gap_previous, result1.code);
+	ASSERT_EQ (nano::block_status::gap_previous, result1);
 }
 
 TEST (ledger, fail_state_bad_signature)
@@ -1257,7 +1257,7 @@ TEST (ledger, fail_state_bad_signature)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
-	ASSERT_EQ (nano::process_result::bad_signature, result1.code);
+	ASSERT_EQ (nano::block_status::bad_signature, result1);
 }
 
 TEST (ledger, fail_epoch_bad_signature)
@@ -1280,10 +1280,10 @@ TEST (ledger, fail_epoch_bad_signature)
 				 .build_shared ();
 	block->signature.bytes[0] ^= 1;
 	auto result1 = ledger.process (transaction, *block);
-	ASSERT_EQ (nano::process_result::bad_signature, result1.code); // Fails epoch signature
+	ASSERT_EQ (nano::block_status::bad_signature, result1); // Fails epoch signature
 	block->signature.bytes[0] ^= 1;
 	auto result2 = ledger.process (transaction, *block);
-	ASSERT_EQ (nano::process_result::progress, result2.code); // Succeeds with epoch signature
+	ASSERT_EQ (nano::block_status::progress, result2); // Succeeds with epoch signature
 }
 
 TEST (ledger, fail_change_bad_signature)
@@ -1303,7 +1303,7 @@ TEST (ledger, fail_change_bad_signature)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
-	ASSERT_EQ (nano::process_result::bad_signature, result1.code);
+	ASSERT_EQ (nano::block_status::bad_signature, result1);
 }
 
 TEST (ledger, fail_change_fork)
@@ -1323,7 +1323,7 @@ TEST (ledger, fail_change_fork)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
-	ASSERT_EQ (nano::process_result::progress, result1.code);
+	ASSERT_EQ (nano::block_status::progress, result1);
 	nano::keypair key2;
 	auto block2 = builder
 				  .change ()
@@ -1333,7 +1333,7 @@ TEST (ledger, fail_change_fork)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
-	ASSERT_EQ (nano::process_result::fork, result2.code);
+	ASSERT_EQ (nano::block_status::fork, result2);
 }
 
 TEST (ledger, fail_send_old)
@@ -1354,9 +1354,9 @@ TEST (ledger, fail_send_old)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
-	ASSERT_EQ (nano::process_result::progress, result1.code);
+	ASSERT_EQ (nano::block_status::progress, result1);
 	auto result2 = ledger.process (transaction, *block);
-	ASSERT_EQ (nano::process_result::old, result2.code);
+	ASSERT_EQ (nano::block_status::old, result2);
 }
 
 TEST (ledger, fail_send_gap_previous)
@@ -1377,7 +1377,7 @@ TEST (ledger, fail_send_gap_previous)
 				 .work (*pool.generate (nano::root (1)))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
-	ASSERT_EQ (nano::process_result::gap_previous, result1.code);
+	ASSERT_EQ (nano::block_status::gap_previous, result1);
 }
 
 TEST (ledger, fail_send_bad_signature)
@@ -1398,7 +1398,7 @@ TEST (ledger, fail_send_bad_signature)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	auto result1 = ledger.process (transaction, *block);
-	ASSERT_EQ (nano::process_result::bad_signature, result1.code);
+	ASSERT_EQ (nano::block_status::bad_signature, result1);
 }
 
 TEST (ledger, fail_send_negative_spend)
@@ -1418,7 +1418,7 @@ TEST (ledger, fail_send_negative_spend)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block1));
 	nano::keypair key2;
 	auto block2 = builder
 				  .send ()
@@ -1428,7 +1428,7 @@ TEST (ledger, fail_send_negative_spend)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (block1->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::negative_spend, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::block_status::negative_spend, ledger.process (transaction, *block2));
 }
 
 TEST (ledger, fail_send_fork)
@@ -1448,7 +1448,7 @@ TEST (ledger, fail_send_fork)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block1));
 	nano::keypair key2;
 	auto block2 = builder
 				  .send ()
@@ -1458,7 +1458,7 @@ TEST (ledger, fail_send_fork)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, *block2));
 }
 
 TEST (ledger, fail_open_old)
@@ -1478,7 +1478,7 @@ TEST (ledger, fail_open_old)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block1));
 	auto block2 = builder
 				  .open ()
 				  .source (block1->hash ())
@@ -1487,8 +1487,8 @@ TEST (ledger, fail_open_old)
 				  .sign (key1.prv, key1.pub)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
-	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block2));
+	ASSERT_EQ (nano::block_status::old, ledger.process (transaction, *block2));
 }
 
 TEST (ledger, fail_open_gap_source)
@@ -1509,7 +1509,7 @@ TEST (ledger, fail_open_gap_source)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
-	ASSERT_EQ (nano::process_result::gap_source, result2.code);
+	ASSERT_EQ (nano::block_status::gap_source, result2);
 }
 
 TEST (ledger, fail_open_bad_signature)
@@ -1529,7 +1529,7 @@ TEST (ledger, fail_open_bad_signature)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block1));
 	auto block2 = builder
 				  .open ()
 				  .source (block1->hash ())
@@ -1539,7 +1539,7 @@ TEST (ledger, fail_open_bad_signature)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
 	block2->signature.clear ();
-	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::block_status::bad_signature, ledger.process (transaction, *block2));
 }
 
 TEST (ledger, fail_open_fork_previous)
@@ -1559,7 +1559,7 @@ TEST (ledger, fail_open_fork_previous)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block1));
 	auto block2 = builder
 				  .send ()
 				  .previous (block1->hash ())
@@ -1568,7 +1568,7 @@ TEST (ledger, fail_open_fork_previous)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (block1->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block2));
 	auto block3 = builder
 				  .open ()
 				  .source (block1->hash ())
@@ -1577,7 +1577,7 @@ TEST (ledger, fail_open_fork_previous)
 				  .sign (key1.prv, key1.pub)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block3));
 	auto block4 = builder
 				  .open ()
 				  .source (block2->hash ())
@@ -1586,7 +1586,7 @@ TEST (ledger, fail_open_fork_previous)
 				  .sign (key1.prv, key1.pub)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *block4).code);
+	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, *block4));
 	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
 }
 
@@ -1607,7 +1607,7 @@ TEST (ledger, fail_open_account_mismatch)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block1));
 	nano::keypair badkey;
 	auto block2 = builder
 				  .open ()
@@ -1617,7 +1617,7 @@ TEST (ledger, fail_open_account_mismatch)
 				  .sign (badkey.prv, badkey.pub)
 				  .work (*pool.generate (badkey.pub))
 				  .build ();
-	ASSERT_NE (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	ASSERT_NE (nano::block_status::progress, ledger.process (transaction, *block2));
 	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
 }
 
@@ -1638,7 +1638,7 @@ TEST (ledger, fail_receive_old)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block1));
 	auto block2 = builder
 				  .send ()
 				  .previous (block1->hash ())
@@ -1647,7 +1647,7 @@ TEST (ledger, fail_receive_old)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (block1->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block2));
 	auto block3 = builder
 				  .open ()
 				  .source (block1->hash ())
@@ -1656,7 +1656,7 @@ TEST (ledger, fail_receive_old)
 				  .sign (key1.prv, key1.pub)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block3));
 	auto block4 = builder
 				  .receive ()
 				  .previous (block3->hash ())
@@ -1664,8 +1664,8 @@ TEST (ledger, fail_receive_old)
 				  .sign (key1.prv, key1.pub)
 				  .work (*pool.generate (block3->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block4).code);
-	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *block4).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block4));
+	ASSERT_EQ (nano::block_status::old, ledger.process (transaction, *block4));
 }
 
 TEST (ledger, fail_receive_gap_source)
@@ -1686,7 +1686,7 @@ TEST (ledger, fail_receive_gap_source)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
-	ASSERT_EQ (nano::process_result::progress, result1.code);
+	ASSERT_EQ (nano::block_status::progress, result1);
 	auto block2 = builder
 				  .send ()
 				  .previous (block1->hash ())
@@ -1696,7 +1696,7 @@ TEST (ledger, fail_receive_gap_source)
 				  .work (*pool.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
-	ASSERT_EQ (nano::process_result::progress, result2.code);
+	ASSERT_EQ (nano::block_status::progress, result2);
 	auto block3 = builder
 				  .open ()
 				  .source (block1->hash ())
@@ -1706,7 +1706,7 @@ TEST (ledger, fail_receive_gap_source)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
-	ASSERT_EQ (nano::process_result::progress, result3.code);
+	ASSERT_EQ (nano::block_status::progress, result3);
 	auto block4 = builder
 				  .receive ()
 				  .previous (block3->hash ())
@@ -1715,7 +1715,7 @@ TEST (ledger, fail_receive_gap_source)
 				  .work (*pool.generate (block3->hash ()))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block4);
-	ASSERT_EQ (nano::process_result::gap_source, result4.code);
+	ASSERT_EQ (nano::block_status::gap_source, result4);
 }
 
 TEST (ledger, fail_receive_overreceive)
@@ -1736,7 +1736,7 @@ TEST (ledger, fail_receive_overreceive)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
-	ASSERT_EQ (nano::process_result::progress, result1.code);
+	ASSERT_EQ (nano::block_status::progress, result1);
 	auto block2 = builder
 				  .open ()
 				  .source (block1->hash ())
@@ -1746,7 +1746,7 @@ TEST (ledger, fail_receive_overreceive)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block2);
-	ASSERT_EQ (nano::process_result::progress, result3.code);
+	ASSERT_EQ (nano::block_status::progress, result3);
 	auto block3 = builder
 				  .receive ()
 				  .previous (block2->hash ())
@@ -1755,7 +1755,7 @@ TEST (ledger, fail_receive_overreceive)
 				  .work (*pool.generate (block2->hash ()))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block3);
-	ASSERT_EQ (nano::process_result::unreceivable, result4.code);
+	ASSERT_EQ (nano::block_status::unreceivable, result4);
 }
 
 TEST (ledger, fail_receive_bad_signature)
@@ -1776,7 +1776,7 @@ TEST (ledger, fail_receive_bad_signature)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
-	ASSERT_EQ (nano::process_result::progress, result1.code);
+	ASSERT_EQ (nano::block_status::progress, result1);
 	auto block2 = builder
 				  .send ()
 				  .previous (block1->hash ())
@@ -1786,7 +1786,7 @@ TEST (ledger, fail_receive_bad_signature)
 				  .work (*pool.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
-	ASSERT_EQ (nano::process_result::progress, result2.code);
+	ASSERT_EQ (nano::block_status::progress, result2);
 	auto block3 = builder
 				  .open ()
 				  .source (block1->hash ())
@@ -1796,7 +1796,7 @@ TEST (ledger, fail_receive_bad_signature)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
-	ASSERT_EQ (nano::process_result::progress, result3.code);
+	ASSERT_EQ (nano::block_status::progress, result3);
 	auto block4 = builder
 				  .receive ()
 				  .previous (block3->hash ())
@@ -1805,7 +1805,7 @@ TEST (ledger, fail_receive_bad_signature)
 				  .work (*pool.generate (block3->hash ()))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block4);
-	ASSERT_EQ (nano::process_result::bad_signature, result4.code);
+	ASSERT_EQ (nano::block_status::bad_signature, result4);
 }
 
 TEST (ledger, fail_receive_gap_previous_opened)
@@ -1826,7 +1826,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
-	ASSERT_EQ (nano::process_result::progress, result1.code);
+	ASSERT_EQ (nano::block_status::progress, result1);
 	auto block2 = builder
 				  .send ()
 				  .previous (block1->hash ())
@@ -1836,7 +1836,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 				  .work (*pool.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
-	ASSERT_EQ (nano::process_result::progress, result2.code);
+	ASSERT_EQ (nano::block_status::progress, result2);
 	auto block3 = builder
 				  .open ()
 				  .source (block1->hash ())
@@ -1846,7 +1846,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
-	ASSERT_EQ (nano::process_result::progress, result3.code);
+	ASSERT_EQ (nano::block_status::progress, result3);
 	auto block4 = builder
 				  .receive ()
 				  .previous (1)
@@ -1855,7 +1855,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 				  .work (*pool.generate (nano::root (1)))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block4);
-	ASSERT_EQ (nano::process_result::gap_previous, result4.code);
+	ASSERT_EQ (nano::block_status::gap_previous, result4);
 }
 
 TEST (ledger, fail_receive_gap_previous_unopened)
@@ -1876,7 +1876,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
-	ASSERT_EQ (nano::process_result::progress, result1.code);
+	ASSERT_EQ (nano::block_status::progress, result1);
 	auto block2 = builder
 				  .send ()
 				  .previous (block1->hash ())
@@ -1886,7 +1886,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 				  .work (*pool.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
-	ASSERT_EQ (nano::process_result::progress, result2.code);
+	ASSERT_EQ (nano::block_status::progress, result2);
 	auto block3 = builder
 				  .receive ()
 				  .previous (1)
@@ -1895,7 +1895,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 				  .work (*pool.generate (nano::root (1)))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
-	ASSERT_EQ (nano::process_result::gap_previous, result3.code);
+	ASSERT_EQ (nano::block_status::gap_previous, result3);
 }
 
 TEST (ledger, fail_receive_fork_previous)
@@ -1916,7 +1916,7 @@ TEST (ledger, fail_receive_fork_previous)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
-	ASSERT_EQ (nano::process_result::progress, result1.code);
+	ASSERT_EQ (nano::block_status::progress, result1);
 	auto block2 = builder
 				  .send ()
 				  .previous (block1->hash ())
@@ -1926,7 +1926,7 @@ TEST (ledger, fail_receive_fork_previous)
 				  .work (*pool.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
-	ASSERT_EQ (nano::process_result::progress, result2.code);
+	ASSERT_EQ (nano::block_status::progress, result2);
 	auto block3 = builder
 				  .open ()
 				  .source (block1->hash ())
@@ -1936,7 +1936,7 @@ TEST (ledger, fail_receive_fork_previous)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
-	ASSERT_EQ (nano::process_result::progress, result3.code);
+	ASSERT_EQ (nano::block_status::progress, result3);
 	nano::keypair key2;
 	auto block4 = builder
 				  .send ()
@@ -1947,7 +1947,7 @@ TEST (ledger, fail_receive_fork_previous)
 				  .work (*pool.generate (block3->hash ()))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block4);
-	ASSERT_EQ (nano::process_result::progress, result4.code);
+	ASSERT_EQ (nano::block_status::progress, result4);
 	auto block5 = builder
 				  .receive ()
 				  .previous (block3->hash ())
@@ -1956,7 +1956,7 @@ TEST (ledger, fail_receive_fork_previous)
 				  .work (*pool.generate (block3->hash ()))
 				  .build ();
 	auto result5 = ledger.process (transaction, *block5);
-	ASSERT_EQ (nano::process_result::fork, result5.code);
+	ASSERT_EQ (nano::block_status::fork, result5);
 }
 
 TEST (ledger, fail_receive_received_source)
@@ -1977,7 +1977,7 @@ TEST (ledger, fail_receive_received_source)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto result1 = ledger.process (transaction, *block1);
-	ASSERT_EQ (nano::process_result::progress, result1.code);
+	ASSERT_EQ (nano::block_status::progress, result1);
 	auto block2 = builder
 				  .send ()
 				  .previous (block1->hash ())
@@ -1987,7 +1987,7 @@ TEST (ledger, fail_receive_received_source)
 				  .work (*pool.generate (block1->hash ()))
 				  .build ();
 	auto result2 = ledger.process (transaction, *block2);
-	ASSERT_EQ (nano::process_result::progress, result2.code);
+	ASSERT_EQ (nano::block_status::progress, result2);
 	auto block6 = builder
 				  .send ()
 				  .previous (block2->hash ())
@@ -1997,7 +1997,7 @@ TEST (ledger, fail_receive_received_source)
 				  .work (*pool.generate (block2->hash ()))
 				  .build ();
 	auto result6 = ledger.process (transaction, *block6);
-	ASSERT_EQ (nano::process_result::progress, result6.code);
+	ASSERT_EQ (nano::block_status::progress, result6);
 	auto block3 = builder
 				  .open ()
 				  .source (block1->hash ())
@@ -2007,7 +2007,7 @@ TEST (ledger, fail_receive_received_source)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
 	auto result3 = ledger.process (transaction, *block3);
-	ASSERT_EQ (nano::process_result::progress, result3.code);
+	ASSERT_EQ (nano::block_status::progress, result3);
 	nano::keypair key2;
 	auto block4 = builder
 				  .send ()
@@ -2018,7 +2018,7 @@ TEST (ledger, fail_receive_received_source)
 				  .work (*pool.generate (block3->hash ()))
 				  .build ();
 	auto result4 = ledger.process (transaction, *block4);
-	ASSERT_EQ (nano::process_result::progress, result4.code);
+	ASSERT_EQ (nano::block_status::progress, result4);
 	auto block5 = builder
 				  .receive ()
 				  .previous (block4->hash ())
@@ -2027,7 +2027,7 @@ TEST (ledger, fail_receive_received_source)
 				  .work (*pool.generate (block4->hash ()))
 				  .build ();
 	auto result5 = ledger.process (transaction, *block5);
-	ASSERT_EQ (nano::process_result::progress, result5.code);
+	ASSERT_EQ (nano::block_status::progress, result5);
 	auto block7 = builder
 				  .receive ()
 				  .previous (block3->hash ())
@@ -2036,7 +2036,7 @@ TEST (ledger, fail_receive_received_source)
 				  .work (*pool.generate (block3->hash ()))
 				  .build ();
 	auto result7 = ledger.process (transaction, *block7);
-	ASSERT_EQ (nano::process_result::fork, result7.code);
+	ASSERT_EQ (nano::block_status::fork, result7);
 }
 
 TEST (ledger, latest_empty)
@@ -2069,7 +2069,7 @@ TEST (ledger, latest_root)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*pool.generate (hash1))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 	ASSERT_EQ (send->hash (), ledger.latest_root (transaction, nano::dev::genesis_key.pub).as_block_hash ());
 }
 
@@ -2091,7 +2091,7 @@ TEST (ledger, change_representative_move_representation)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*pool.generate (nano::dev::genesis->hash ()))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	nano::keypair key2;
 	auto change = builder
@@ -2101,7 +2101,7 @@ TEST (ledger, change_representative_move_representation)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (send->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *change));
 	nano::keypair key3;
 	auto open = builder
 				.open ()
@@ -2111,7 +2111,7 @@ TEST (ledger, change_representative_move_representation)
 				.sign (key1.prv, key1.pub)
 				.work (*pool.generate (key1.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key3.pub));
 }
 
@@ -2135,7 +2135,7 @@ TEST (ledger, send_open_receive_rollback)
 				 .work (*pool.generate (info1->head))
 				 .build ();
 	auto return1 = ledger.process (transaction, *send1);
-	ASSERT_EQ (nano::process_result::progress, return1.code);
+	ASSERT_EQ (nano::block_status::progress, return1);
 	auto send2 = builder
 				 .send ()
 				 .previous (send1->hash ())
@@ -2145,7 +2145,7 @@ TEST (ledger, send_open_receive_rollback)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
 	auto return2 = ledger.process (transaction, *send2);
-	ASSERT_EQ (nano::process_result::progress, return2.code);
+	ASSERT_EQ (nano::block_status::progress, return2);
 	nano::keypair key2;
 	auto open = builder
 				.open ()
@@ -2156,7 +2156,7 @@ TEST (ledger, send_open_receive_rollback)
 				.work (*pool.generate (key1.pub))
 				.build ();
 	auto return4 = ledger.process (transaction, *open);
-	ASSERT_EQ (nano::process_result::progress, return4.code);
+	ASSERT_EQ (nano::block_status::progress, return4);
 	auto receive = builder
 				   .receive ()
 				   .previous (open->hash ())
@@ -2165,7 +2165,7 @@ TEST (ledger, send_open_receive_rollback)
 				   .work (*pool.generate (open->hash ()))
 				   .build ();
 	auto return5 = ledger.process (transaction, *receive);
-	ASSERT_EQ (nano::process_result::progress, return5.code);
+	ASSERT_EQ (nano::block_status::progress, return5);
 	nano::keypair key3;
 	ASSERT_EQ (100, ledger.weight (key2.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, ledger.weight (nano::dev::genesis_key.pub));
@@ -2178,7 +2178,7 @@ TEST (ledger, send_open_receive_rollback)
 				   .work (*pool.generate (send2->hash ()))
 				   .build ();
 	auto return6 = ledger.process (transaction, *change1);
-	ASSERT_EQ (nano::process_result::progress, return6.code);
+	ASSERT_EQ (nano::block_status::progress, return6);
 	ASSERT_EQ (100, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 100, ledger.weight (key3.pub));
@@ -2224,7 +2224,7 @@ TEST (ledger, bootstrap_rep_weight)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (info1->head))
 					.build ();
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 	}
 	ASSERT_EQ (2, ledger.cache.block_count);
 	{
@@ -2245,7 +2245,7 @@ TEST (ledger, bootstrap_rep_weight)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (info1->head))
 					.build ();
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 	}
 	ASSERT_EQ (3, ledger.cache.block_count);
 	ASSERT_EQ (0, ledger.weight (key2.pub));
@@ -2320,12 +2320,12 @@ TEST (ledger, block_destination_source)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (block5->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block1).code);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block2).code);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block3).code);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block4).code);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block5).code);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *block6).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block2));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block3));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block4));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block5));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *block6));
 	ASSERT_EQ (balance, ledger.balance (transaction, block6->hash ()));
 	ASSERT_EQ (dest.pub, ledger.block_destination (transaction, *block1));
 	ASSERT_TRUE (ledger.block_source (transaction, *block1).is_zero ());
@@ -2359,7 +2359,7 @@ TEST (ledger, state_account)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_EQ (nano::dev::genesis->account (), ledger.account (transaction, send1->hash ()));
 }
 
@@ -2381,7 +2381,7 @@ TEST (ledger, state_send_receive)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
 	auto send2 = store.block.get (transaction, send1->hash ());
 	ASSERT_NE (nullptr, send2);
@@ -2404,7 +2404,7 @@ TEST (ledger, state_send_receive)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_TRUE (store.block.exists (transaction, receive1->hash ()));
 	auto receive2 = store.block.get (transaction, receive1->hash ());
 	ASSERT_NE (nullptr, receive2);
@@ -2436,7 +2436,7 @@ TEST (ledger, state_receive)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
 	auto send2 = store.block.get (transaction, send1->hash ());
 	ASSERT_NE (nullptr, send2);
@@ -2454,7 +2454,7 @@ TEST (ledger, state_receive)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_TRUE (store.block.exists (transaction, receive1->hash ()));
 	auto receive2 = store.block.get (transaction, receive1->hash ());
 	ASSERT_NE (nullptr, receive2);
@@ -2487,7 +2487,7 @@ TEST (ledger, state_rep_change)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*pool.generate (nano::dev::genesis->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *change1));
 	ASSERT_TRUE (store.block.exists (transaction, change1->hash ()));
 	auto change2 = store.block.get (transaction, change1->hash ());
 	ASSERT_NE (nullptr, change2);
@@ -2521,7 +2521,7 @@ TEST (ledger, state_open)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
 	auto send2 = store.block.get (transaction, send1->hash ());
 	ASSERT_NE (nullptr, send2);
@@ -2540,7 +2540,7 @@ TEST (ledger, state_open)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	ASSERT_FALSE (store.pending.exists (transaction, nano::pending_key (destination.pub, send1->hash ())));
 	ASSERT_TRUE (store.block.exists (transaction, open1->hash ()));
 	auto open2 = store.block.get (transaction, open1->hash ());
@@ -2575,7 +2575,7 @@ TEST (ledger, send_after_state_fail)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto send2 = builder
 				 .send ()
 				 .previous (send1->hash ())
@@ -2584,7 +2584,7 @@ TEST (ledger, send_after_state_fail)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::block_position, ledger.process (transaction, *send2));
 }
 
 // Make sure old block types can't be inserted after a state block.
@@ -2606,7 +2606,7 @@ TEST (ledger, receive_after_state_fail)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto receive1 = builder
 					.receive ()
 					.previous (send1->hash ())
@@ -2614,7 +2614,7 @@ TEST (ledger, receive_after_state_fail)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::block_position, ledger.process (transaction, *receive1));
 }
 
 // Make sure old block types can't be inserted after a state block.
@@ -2636,7 +2636,7 @@ TEST (ledger, change_after_state_fail)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	nano::keypair rep;
 	auto change1 = builder
 				   .change ()
@@ -2645,7 +2645,7 @@ TEST (ledger, change_after_state_fail)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*pool.generate (send1->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *change1).code);
+	ASSERT_EQ (nano::block_status::block_position, ledger.process (transaction, *change1));
 }
 
 TEST (ledger, state_unreceivable_fail)
@@ -2664,7 +2664,7 @@ TEST (ledger, state_unreceivable_fail)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
 	auto send2 = store.block.get (transaction, send1->hash ());
 	ASSERT_NE (nullptr, send2);
@@ -2682,7 +2682,7 @@ TEST (ledger, state_unreceivable_fail)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::gap_source, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::gap_source, ledger.process (transaction, *receive1));
 }
 
 TEST (ledger, state_receive_bad_amount_fail)
@@ -2701,7 +2701,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
 	auto send2 = store.block.get (transaction, send1->hash ());
 	ASSERT_NE (nullptr, send2);
@@ -2719,7 +2719,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::balance_mismatch, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::balance_mismatch, ledger.process (transaction, *receive1));
 }
 
 TEST (ledger, state_no_link_amount_fail)
@@ -2740,7 +2740,7 @@ TEST (ledger, state_no_link_amount_fail)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	nano::keypair rep;
 	auto change1 = builder
 				   .state ()
@@ -2752,7 +2752,7 @@ TEST (ledger, state_no_link_amount_fail)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*pool.generate (send1->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::balance_mismatch, ledger.process (transaction, *change1).code);
+	ASSERT_EQ (nano::block_status::balance_mismatch, ledger.process (transaction, *change1));
 }
 
 TEST (ledger, state_receive_wrong_account_fail)
@@ -2773,7 +2773,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
 	auto send2 = store.block.get (transaction, send1->hash ());
 	ASSERT_NE (nullptr, send2);
@@ -2792,7 +2792,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 					.sign (key.prv, key.pub)
 					.work (*pool.generate (key.pub))
 					.build ();
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::unreceivable, ledger.process (transaction, *receive1));
 }
 
 TEST (ledger, state_open_state_fork)
@@ -2814,7 +2814,7 @@ TEST (ledger, state_open_state_fork)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto open1 = builder
 				 .state ()
 				 .account (destination.pub)
@@ -2825,7 +2825,7 @@ TEST (ledger, state_open_state_fork)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	auto open2 = builder
 				 .open ()
 				 .source (send1->hash ())
@@ -2834,7 +2834,7 @@ TEST (ledger, state_open_state_fork)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *open2).code);
+	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, *open2));
 	ASSERT_EQ (open1->root (), open2->root ());
 }
 
@@ -2857,7 +2857,7 @@ TEST (ledger, state_state_open_fork)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto open1 = builder
 				 .open ()
 				 .source (send1->hash ())
@@ -2866,7 +2866,7 @@ TEST (ledger, state_state_open_fork)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	auto open2 = builder
 				 .state ()
 				 .account (destination.pub)
@@ -2877,7 +2877,7 @@ TEST (ledger, state_state_open_fork)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *open2).code);
+	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, *open2));
 	ASSERT_EQ (open1->root (), open2->root ());
 	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
 }
@@ -2901,7 +2901,7 @@ TEST (ledger, state_open_previous_fail)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto open1 = builder
 				 .state ()
 				 .account (destination.pub)
@@ -2912,7 +2912,7 @@ TEST (ledger, state_open_previous_fail)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (1))
 				 .build ();
-	ASSERT_EQ (nano::process_result::gap_previous, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::gap_previous, ledger.process (transaction, *open1));
 }
 
 TEST (ledger, state_open_source_fail)
@@ -2934,7 +2934,7 @@ TEST (ledger, state_open_source_fail)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto open1 = builder
 				 .state ()
 				 .account (destination.pub)
@@ -2945,7 +2945,7 @@ TEST (ledger, state_open_source_fail)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::gap_source, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::gap_source, ledger.process (transaction, *open1));
 }
 
 TEST (ledger, state_send_change)
@@ -2967,7 +2967,7 @@ TEST (ledger, state_send_change)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
 	auto send2 = store.block.get (transaction, send1->hash ());
 	ASSERT_NE (nullptr, send2);
@@ -3000,7 +3000,7 @@ TEST (ledger, state_receive_change)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
 	auto send2 = store.block.get (transaction, send1->hash ());
 	ASSERT_NE (nullptr, send2);
@@ -3019,7 +3019,7 @@ TEST (ledger, state_receive_change)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_TRUE (store.block.exists (transaction, receive1->hash ()));
 	auto receive2 = store.block.get (transaction, receive1->hash ());
 	ASSERT_NE (nullptr, receive2);
@@ -3053,7 +3053,7 @@ TEST (ledger, state_open_old)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto open1 = builder
 				 .open ()
 				 .source (send1->hash ())
@@ -3062,7 +3062,7 @@ TEST (ledger, state_open_old)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.balance (transaction, open1->hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, open1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
@@ -3087,7 +3087,7 @@ TEST (ledger, state_receive_old)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto send2 = builder
 				 .state ()
 				 .account (nano::dev::genesis->account ())
@@ -3098,7 +3098,7 @@ TEST (ledger, state_receive_old)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	auto open1 = builder
 				 .open ()
 				 .source (send1->hash ())
@@ -3107,7 +3107,7 @@ TEST (ledger, state_receive_old)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	auto receive1 = builder
 					.receive ()
 					.previous (open1->hash ())
@@ -3115,7 +3115,7 @@ TEST (ledger, state_receive_old)
 					.sign (destination.prv, destination.pub)
 					.work (*pool.generate (open1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_EQ (2 * nano::Gxrb_ratio, ledger.balance (transaction, receive1->hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis->account ()));
@@ -3139,7 +3139,7 @@ TEST (ledger, state_rollback_send)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store.block.exists (transaction, send1->hash ()));
 	auto send2 = store.block.get (transaction, send1->hash ());
 	ASSERT_NE (nullptr, send2);
@@ -3177,7 +3177,7 @@ TEST (ledger, state_rollback_receive)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto receive1 = builder
 					.state ()
 					.account (nano::dev::genesis->account ())
@@ -3188,7 +3188,7 @@ TEST (ledger, state_rollback_receive)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_FALSE (store.pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), receive1->hash ())));
 	ASSERT_FALSE (ledger.rollback (transaction, receive1->hash ()));
 	auto info = ledger.pending_info (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ()));
@@ -3220,7 +3220,7 @@ TEST (ledger, state_rollback_received_send)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto receive1 = builder
 					.state ()
 					.account (key.pub)
@@ -3231,7 +3231,7 @@ TEST (ledger, state_rollback_received_send)
 					.sign (key.prv, key.pub)
 					.work (*pool.generate (key.pub))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_FALSE (store.pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), receive1->hash ())));
 	ASSERT_FALSE (ledger.rollback (transaction, send1->hash ()));
 	ASSERT_FALSE (store.pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
@@ -3263,7 +3263,7 @@ TEST (ledger, state_rep_change_rollback)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*pool.generate (nano::dev::genesis->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *change1));
 	ASSERT_FALSE (ledger.rollback (transaction, change1->hash ()));
 	ASSERT_FALSE (store.block.exists (transaction, change1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.account_balance (transaction, nano::dev::genesis->account ()));
@@ -3290,7 +3290,7 @@ TEST (ledger, state_open_rollback)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto open1 = builder
 				 .state ()
 				 .account (destination.pub)
@@ -3301,7 +3301,7 @@ TEST (ledger, state_open_rollback)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	ASSERT_FALSE (ledger.rollback (transaction, open1->hash ()));
 	ASSERT_FALSE (store.block.exists (transaction, open1->hash ()));
 	ASSERT_EQ (0, ledger.account_balance (transaction, destination.pub));
@@ -3332,7 +3332,7 @@ TEST (ledger, state_send_change_rollback)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_FALSE (ledger.rollback (transaction, send1->hash ()));
 	ASSERT_FALSE (store.block.exists (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.account_balance (transaction, nano::dev::genesis->account ()));
@@ -3359,7 +3359,7 @@ TEST (ledger, state_receive_change_rollback)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	nano::keypair rep;
 	auto receive1 = builder
 					.state ()
@@ -3371,7 +3371,7 @@ TEST (ledger, state_receive_change_rollback)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_FALSE (ledger.rollback (transaction, receive1->hash ()));
 	ASSERT_FALSE (store.block.exists (transaction, receive1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.account_balance (transaction, nano::dev::genesis->account ()));
@@ -3399,7 +3399,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch1));
 	ASSERT_FALSE (epoch1->sideband ().details.is_send);
 	ASSERT_FALSE (epoch1->sideband ().details.is_receive);
 	ASSERT_TRUE (epoch1->sideband ().details.is_epoch);
@@ -3415,7 +3415,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (epoch1->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *epoch2).code);
+	ASSERT_EQ (nano::block_status::block_position, ledger.process (transaction, *epoch2));
 	auto genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
 	ASSERT_TRUE (genesis_info);
 	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_1);
@@ -3423,7 +3423,7 @@ TEST (ledger, epoch_blocks_v1_general)
 	genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
 	ASSERT_TRUE (genesis_info);
 	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_0);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch1));
 	genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
 	ASSERT_TRUE (genesis_info);
 	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_1);
@@ -3439,7 +3439,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*pool.generate (epoch1->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *change1).code);
+	ASSERT_EQ (nano::block_status::block_position, ledger.process (transaction, *change1));
 	auto send1 = builder
 				 .state ()
 				 .account (nano::dev::genesis->account ())
@@ -3450,7 +3450,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (epoch1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (send1->sideband ().details.is_send);
 	ASSERT_FALSE (send1->sideband ().details.is_receive);
 	ASSERT_FALSE (send1->sideband ().details.is_epoch);
@@ -3464,7 +3464,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::unreceivable, ledger.process (transaction, *open1));
 	auto epoch3 = builder
 				  .state ()
 				  .account (destination.pub)
@@ -3475,7 +3475,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (destination.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::representative_mismatch, ledger.process (transaction, *epoch3).code);
+	ASSERT_EQ (nano::block_status::representative_mismatch, ledger.process (transaction, *epoch3));
 	auto epoch4 = builder
 				  .state ()
 				  .account (destination.pub)
@@ -3486,7 +3486,7 @@ TEST (ledger, epoch_blocks_v1_general)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (destination.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch4).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch4));
 	ASSERT_FALSE (epoch4->sideband ().details.is_send);
 	ASSERT_FALSE (epoch4->sideband ().details.is_receive);
 	ASSERT_TRUE (epoch4->sideband ().details.is_epoch);
@@ -3499,7 +3499,7 @@ TEST (ledger, epoch_blocks_v1_general)
 					.sign (destination.prv, destination.pub)
 					.work (*pool.generate (epoch4->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::block_position, ledger.process (transaction, *receive1));
 	auto receive2 = builder
 					.state ()
 					.account (destination.pub)
@@ -3510,7 +3510,7 @@ TEST (ledger, epoch_blocks_v1_general)
 					.sign (destination.prv, destination.pub)
 					.work (*pool.generate (epoch4->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive2));
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
 	ASSERT_EQ (0, ledger.balance (transaction, epoch4->hash ()));
@@ -3543,7 +3543,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	// Trying to upgrade from epoch 0 to epoch 2. It is a requirement epoch upgrades are sequential unless the account is unopened
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *epoch1).code);
+	ASSERT_EQ (nano::block_status::block_position, ledger.process (transaction, *epoch1));
 	// Set it to the first epoch and it should now succeed
 	epoch1 = builder
 			 .state ()
@@ -3555,7 +3555,7 @@ TEST (ledger, epoch_blocks_v2_general)
 			 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 			 .work (epoch1->work)
 			 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch1));
 	ASSERT_EQ (nano::epoch::epoch_1, epoch1->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_0, epoch1->sideband ().source_epoch); // Not used for epoch blocks
 	auto epoch2 = builder
@@ -3568,7 +3568,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (epoch1->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch2));
 	ASSERT_EQ (nano::epoch::epoch_2, epoch2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_0, epoch2->sideband ().source_epoch); // Not used for epoch blocks
 	auto epoch3 = builder
@@ -3581,7 +3581,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (epoch2->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *epoch3).code);
+	ASSERT_EQ (nano::block_status::block_position, ledger.process (transaction, *epoch3));
 	auto genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
 	ASSERT_TRUE (genesis_info);
 	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_2);
@@ -3589,7 +3589,7 @@ TEST (ledger, epoch_blocks_v2_general)
 	genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
 	ASSERT_TRUE (genesis_info);
 	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_0);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch1));
 	genesis_info = ledger.account_info (transaction, nano::dev::genesis->account ());
 	ASSERT_TRUE (genesis_info);
 	ASSERT_EQ (genesis_info->epoch (), nano::epoch::epoch_1);
@@ -3600,7 +3600,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*pool.generate (epoch1->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *change1).code);
+	ASSERT_EQ (nano::block_status::block_position, ledger.process (transaction, *change1));
 	auto send1 = builder
 				 .state ()
 				 .account (nano::dev::genesis->account ())
@@ -3611,7 +3611,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (epoch1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_EQ (nano::epoch::epoch_1, send1->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_0, send1->sideband ().source_epoch); // Not used for send blocks
 	auto open1 = builder
@@ -3622,7 +3622,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::unreceivable, ledger.process (transaction, *open1));
 	auto epoch4 = builder
 				  .state ()
 				  .account (destination.pub)
@@ -3633,7 +3633,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (destination.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch4).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch4));
 	ASSERT_EQ (nano::epoch::epoch_1, epoch4->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_0, epoch4->sideband ().source_epoch); // Not used for epoch blocks
 	auto epoch5 = builder
@@ -3646,7 +3646,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (epoch4->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::representative_mismatch, ledger.process (transaction, *epoch5).code);
+	ASSERT_EQ (nano::block_status::representative_mismatch, ledger.process (transaction, *epoch5));
 	auto epoch6 = builder
 				  .state ()
 				  .account (destination.pub)
@@ -3657,7 +3657,7 @@ TEST (ledger, epoch_blocks_v2_general)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (epoch4->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch6).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch6));
 	ASSERT_EQ (nano::epoch::epoch_2, epoch6->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_0, epoch6->sideband ().source_epoch); // Not used for epoch blocks
 	auto receive1 = builder
@@ -3667,7 +3667,7 @@ TEST (ledger, epoch_blocks_v2_general)
 					.sign (destination.prv, destination.pub)
 					.work (*pool.generate (epoch6->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::block_position, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::block_position, ledger.process (transaction, *receive1));
 	auto receive2 = builder
 					.state ()
 					.account (destination.pub)
@@ -3678,7 +3678,7 @@ TEST (ledger, epoch_blocks_v2_general)
 					.sign (destination.prv, destination.pub)
 					.work (*pool.generate (epoch6->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive2));
 	ASSERT_EQ (nano::epoch::epoch_2, receive2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
 	ASSERT_EQ (0, ledger.balance (transaction, epoch6->hash ()));
@@ -3707,7 +3707,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto epoch1 = builder
 				  .state ()
 				  .account (nano::dev::genesis->account ())
@@ -3718,7 +3718,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (send1->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch1));
 	auto send2 = builder
 				 .state ()
 				 .account (nano::dev::genesis->account ())
@@ -3729,7 +3729,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (epoch1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	ASSERT_EQ (nano::epoch::epoch_1, send2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_0, send2->sideband ().source_epoch); // Not used for send blocks
 	auto open1 = builder
@@ -3740,7 +3740,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (destination.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	ASSERT_EQ (nano::epoch::epoch_0, open1->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_0, open1->sideband ().source_epoch);
 	auto receive1 = builder
@@ -3750,7 +3750,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 					.sign (destination.prv, destination.pub)
 					.work (*pool.generate (open1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::unreceivable, ledger.process (transaction, *receive1));
 	auto receive2 = builder
 					.state ()
 					.account (destination.pub)
@@ -3761,7 +3761,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 					.sign (destination.prv, destination.pub)
 					.work (*pool.generate (open1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive2));
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
 	auto destination_info = ledger.account_info (transaction, destination.pub);
@@ -3776,7 +3776,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	ASSERT_EQ (nano::dev::genesis_key.pub, pending_send2->source);
 	ASSERT_EQ (nano::Gxrb_ratio, pending_send2->amount.number ());
 	ASSERT_EQ (nano::epoch::epoch_1, pending_send2->epoch);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive2));
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
 	destination_info = ledger.account_info (transaction, destination.pub);
@@ -3793,7 +3793,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .sign (destination.prv, destination.pub)
 				 .work (*pool.generate (receive2->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send3));
 	auto open2 = builder
 				 .open ()
 				 .source (send3->hash ())
@@ -3802,7 +3802,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .sign (destination2.prv, destination2.pub)
 				 .work (*pool.generate (destination2.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open2).code);
+	ASSERT_EQ (nano::block_status::unreceivable, ledger.process (transaction, *open2));
 	// Upgrade to epoch 2 and send to destination. Try to create an open block from an epoch 2 source block.
 	nano::keypair destination3;
 	auto epoch2 = builder
@@ -3815,7 +3815,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (send2->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch2));
 	auto send4 = builder
 				 .state ()
 				 .account (nano::dev::genesis->account ())
@@ -3826,7 +3826,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (epoch2->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send4).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send4));
 	auto open3 = builder
 				 .open ()
 				 .source (send4->hash ())
@@ -3835,7 +3835,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .sign (destination3.prv, destination3.pub)
 				 .work (*pool.generate (destination3.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::unreceivable, ledger.process (transaction, *open3).code);
+	ASSERT_EQ (nano::block_status::unreceivable, ledger.process (transaction, *open3));
 	// Send it to an epoch 1 account
 	auto send5 = builder
 				 .state ()
@@ -3847,7 +3847,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send4->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send5).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send5));
 	destination_info = ledger.account_info (transaction, destination.pub);
 	ASSERT_TRUE (destination_info);
 	ASSERT_EQ (destination_info->epoch (), nano::epoch::epoch_1);
@@ -3861,7 +3861,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 					.sign (destination.prv, destination.pub)
 					.work (*pool.generate (send3->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive3).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive3));
 	ASSERT_EQ (nano::epoch::epoch_2, receive3->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_2, receive3->sideband ().source_epoch);
 	destination_info = ledger.account_info (transaction, destination.pub);
@@ -3879,7 +3879,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send5->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send6).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send6));
 	auto epoch4 = builder
 				  .state ()
 				  .account (destination4.pub)
@@ -3890,7 +3890,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (destination4.pub))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch4).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch4));
 	ASSERT_EQ (nano::epoch::epoch_2, epoch4->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_0, epoch4->sideband ().source_epoch); // Not used for epoch blocks
 	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
@@ -3913,7 +3913,7 @@ TEST (ledger, epoch_blocks_fork)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto epoch1 = builder
 				  .state ()
 				  .account (nano::dev::genesis->account ())
@@ -3924,7 +3924,7 @@ TEST (ledger, epoch_blocks_fork)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *epoch1).code);
+	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, *epoch1));
 	auto epoch2 = builder
 				  .state ()
 				  .account (nano::dev::genesis->account ())
@@ -3935,7 +3935,7 @@ TEST (ledger, epoch_blocks_fork)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *epoch2).code);
+	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, *epoch2));
 	auto epoch3 = builder
 				  .state ()
 				  .account (nano::dev::genesis->account ())
@@ -3946,7 +3946,7 @@ TEST (ledger, epoch_blocks_fork)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (send1->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch3).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch3));
 	ASSERT_EQ (nano::epoch::epoch_1, epoch3->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_0, epoch3->sideband ().source_epoch); // Not used for epoch state blocks
 	auto epoch4 = builder
@@ -3959,7 +3959,7 @@ TEST (ledger, epoch_blocks_fork)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (send1->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::fork, ledger.process (transaction, *epoch2).code);
+	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, *epoch2));
 }
 
 TEST (ledger, successor_epoch)
@@ -4017,11 +4017,11 @@ TEST (ledger, successor_epoch)
 					  .work (*pool.generate (open->hash ()))
 					  .build ();
 	auto transaction (node1.store.tx_begin_write ());
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send1).code);
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *open).code);
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *change).code);
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *send2).code);
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *epoch_open).code);
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *send1));
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *open));
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *change));
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *send2));
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *epoch_open));
 	ASSERT_EQ (*change, *node1.ledger.successor (transaction, change->qualified_root ()));
 	ASSERT_EQ (*epoch_open, *node1.ledger.successor (transaction, epoch_open->qualified_root ()));
 	ASSERT_EQ (nano::epoch::epoch_1, epoch_open->sideband ().details.epoch);
@@ -4045,7 +4045,7 @@ TEST (ledger, epoch_open_pending)
 					  .work (*pool.generate (key1.pub))
 					  .build_shared ();
 	auto process_result = node1.ledger.process (node1.store.tx_begin_write (), *epoch_open);
-	ASSERT_EQ (nano::process_result::gap_epoch_open_pending, process_result.code);
+	ASSERT_EQ (nano::block_status::gap_epoch_open_pending, process_result);
 	node1.block_processor.add (epoch_open);
 	// Waits for the block to get saved in the database
 	ASSERT_TIMELY_EQ (10s, 1, node1.unchecked.count ());
@@ -4135,10 +4135,10 @@ TEST (ledger, block_hash_account_conflict)
 	node1.work_generate_blocking (*receive1);
 	node1.work_generate_blocking (*send2);
 	node1.work_generate_blocking (*open_epoch1);
-	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
-	ASSERT_EQ (nano::process_result::progress, node1.process (*receive1).code);
-	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
-	ASSERT_EQ (nano::process_result::progress, node1.process (*open_epoch1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*send1));
+	ASSERT_EQ (nano::block_status::progress, node1.process (*receive1));
+	ASSERT_EQ (nano::block_status::progress, node1.process (*send2));
+	ASSERT_EQ (nano::block_status::progress, node1.process (*open_epoch1));
 	ASSERT_TRUE (nano::test::start_elections (system, node1, { send1, receive1, send2, open_epoch1 }));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election1);
@@ -4212,7 +4212,7 @@ TEST (ledger, could_fit)
 				 .build ();
 	ASSERT_FALSE (ledger.could_fit (transaction, *send1));
 	ASSERT_FALSE (ledger.could_fit (transaction, *send2));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *change1));
 	ASSERT_TRUE (ledger.could_fit (transaction, *change1));
 	ASSERT_TRUE (ledger.could_fit (transaction, *change2));
 	ASSERT_TRUE (ledger.could_fit (transaction, *send1));
@@ -4238,12 +4238,12 @@ TEST (ledger, could_fit)
 				 .build ();
 	ASSERT_FALSE (ledger.could_fit (transaction, *open1));
 	ASSERT_FALSE (ledger.could_fit (transaction, *open2));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	ASSERT_TRUE (ledger.could_fit (transaction, *send1));
 	ASSERT_TRUE (ledger.could_fit (transaction, *send2));
 	ASSERT_TRUE (ledger.could_fit (transaction, *open1));
 	ASSERT_TRUE (ledger.could_fit (transaction, *open2));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	ASSERT_TRUE (ledger.could_fit (transaction, *open1));
 	ASSERT_TRUE (ledger.could_fit (transaction, *open2));
 	// Create another send to receive
@@ -4277,7 +4277,7 @@ TEST (ledger, could_fit)
 					.build ();
 	ASSERT_FALSE (ledger.could_fit (transaction, *receive1));
 	ASSERT_FALSE (ledger.could_fit (transaction, *receive2));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send3));
 	ASSERT_TRUE (ledger.could_fit (transaction, *receive1));
 	ASSERT_TRUE (ledger.could_fit (transaction, *receive2));
 	// Test epoch (state)
@@ -4292,11 +4292,11 @@ TEST (ledger, could_fit)
 				  .work (*pool.generate (receive1->hash ()))
 				  .build ();
 	ASSERT_FALSE (ledger.could_fit (transaction, *epoch1));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_TRUE (ledger.could_fit (transaction, *receive1));
 	ASSERT_TRUE (ledger.could_fit (transaction, *receive2));
 	ASSERT_TRUE (ledger.could_fit (transaction, *epoch1));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch1));
 	ASSERT_TRUE (ledger.could_fit (transaction, *epoch1));
 }
 
@@ -4588,7 +4588,7 @@ TEST (ledger, confirmation_height_not_updated)
 	ASSERT_FALSE (store.confirmation_height.get (transaction, nano::dev::genesis->account (), confirmation_height_info));
 	ASSERT_EQ (1, confirmation_height_info.height);
 	ASSERT_EQ (nano::dev::genesis->hash (), confirmation_height_info.frontier);
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_FALSE (store.confirmation_height.get (transaction, nano::dev::genesis->account (), confirmation_height_info));
 	ASSERT_EQ (1, confirmation_height_info.height);
 	ASSERT_EQ (nano::dev::genesis->hash (), confirmation_height_info.frontier);
@@ -4600,7 +4600,7 @@ TEST (ledger, confirmation_height_not_updated)
 				 .sign (key.prv, key.pub)
 				 .work (*pool.generate (key.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	ASSERT_TRUE (store.confirmation_height.get (transaction, key.pub, confirmation_height_info));
 	ASSERT_EQ (0, confirmation_height_info.height);
 	ASSERT_EQ (nano::block_hash (0), confirmation_height_info.frontier);
@@ -4621,7 +4621,7 @@ TEST (ledger, zero_rep)
 				  .work (*system.work.generate (nano::dev::genesis->hash ()))
 				  .build ();
 	auto transaction (node1.store.tx_begin_write ());
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *block1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *block1));
 	ASSERT_EQ (0, node1.ledger.cache.rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, node1.ledger.cache.rep_weights.representation_get (0));
 	auto block2 = builder.state ()
@@ -4633,7 +4633,7 @@ TEST (ledger, zero_rep)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*system.work.generate (block1->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *block2).code);
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *block2));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, node1.ledger.cache.rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, node1.ledger.cache.rep_weights.representation_get (0));
 }
@@ -4656,9 +4656,9 @@ TEST (ledger, work_validation)
 		{
 			block_a.block_work_set (block_a.block_work () + 1);
 		}
-		EXPECT_EQ (nano::process_result::insufficient_work, ledger.process (store.tx_begin_write (), block_a).code);
+		EXPECT_EQ (nano::block_status::insufficient_work, ledger.process (store.tx_begin_write (), block_a));
 		block_a.block_work_set (*pool.generate (block_a.root (), threshold));
-		EXPECT_EQ (nano::process_result::progress, ledger.process (store.tx_begin_write (), block_a).code);
+		EXPECT_EQ (nano::block_status::progress, ledger.process (store.tx_begin_write (), block_a));
 	};
 
 	std::error_code ec;
@@ -4746,7 +4746,7 @@ TEST (ledger, dependents_confirmed)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *send1));
 	auto send2 = builder.state ()
 				 .account (nano::dev::genesis->account ())
@@ -4757,7 +4757,7 @@ TEST (ledger, dependents_confirmed)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send1->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *send2));
 	auto receive1 = builder.state ()
 					.account (key1.pub)
@@ -4768,7 +4768,7 @@ TEST (ledger, dependents_confirmed)
 					.sign (key1.prv, key1.pub)
 					.work (*pool.generate (key1.pub))
 					.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive1));
 	nano::confirmation_height_info height;
 	ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::dev::genesis->account (), height));
@@ -4784,7 +4784,7 @@ TEST (ledger, dependents_confirmed)
 					.sign (key1.prv, key1.pub)
 					.work (*pool.generate (receive1->hash ()))
 					.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive2));
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive2));
 	ASSERT_TRUE (ledger.store.confirmation_height.get (transaction, key1.pub, height));
 	height.height += 1;
@@ -4818,7 +4818,7 @@ TEST (ledger, dependents_confirmed_pruning)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	auto send2 = builder.state ()
 				 .account (nano::dev::genesis->account ())
 				 .previous (send1->hash ())
@@ -4828,7 +4828,7 @@ TEST (ledger, dependents_confirmed_pruning)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send1->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	nano::confirmation_height_info height;
 	ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::dev::genesis->account (), height));
 	height.height = 3;
@@ -4868,7 +4868,7 @@ TEST (ledger, block_confirmed)
 				 .build ();
 	// Must be safe against non-existing blocks
 	ASSERT_FALSE (ledger.block_confirmed (transaction, send1->hash ()));
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_FALSE (ledger.block_confirmed (transaction, send1->hash ()));
 	nano::confirmation_height_info height;
 	ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::dev::genesis->account (), height));
@@ -4927,7 +4927,7 @@ TEST (ledger, cache)
 					.build ();
 		{
 			auto transaction (store.tx_begin_write ());
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 		}
 
 		++block_count;
@@ -4937,7 +4937,7 @@ TEST (ledger, cache)
 
 		{
 			auto transaction (store.tx_begin_write ());
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open));
 		}
 
 		++block_count;
@@ -5008,7 +5008,7 @@ TEST (ledger, pruning_action)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
 	auto send1_stored (store->block.get (transaction, send1->hash ()));
 	ASSERT_NE (nullptr, send1_stored);
@@ -5024,7 +5024,7 @@ TEST (ledger, pruning_action)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Pruning action
 	ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 1));
@@ -5050,7 +5050,7 @@ TEST (ledger, pruning_action)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send2->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_TRUE (store->block.exists (transaction, receive1->hash ()));
 	auto receive1_stored (store->block.get (transaction, receive1->hash ()));
 	ASSERT_NE (nullptr, receive1_stored);
@@ -5096,7 +5096,7 @@ TEST (ledger, pruning_large_chain)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (last_hash))
 					.build ();
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 		ASSERT_TRUE (store->block.exists (transaction, send->hash ()));
 		auto receive = builder
 					   .state ()
@@ -5108,7 +5108,7 @@ TEST (ledger, pruning_large_chain)
 					   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					   .work (*pool.generate (send->hash ()))
 					   .build ();
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive));
 		ASSERT_TRUE (store->block.exists (transaction, receive->hash ()));
 		last_hash = receive->hash ();
 	}
@@ -5147,7 +5147,7 @@ TEST (ledger, pruning_source_rollback)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*pool.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *epoch1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *epoch1));
 	auto send1 = builder
 				 .state ()
 				 .account (nano::dev::genesis->account ())
@@ -5158,7 +5158,7 @@ TEST (ledger, pruning_source_rollback)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (epoch1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	auto send2 = builder
 				 .state ()
@@ -5170,7 +5170,7 @@ TEST (ledger, pruning_source_rollback)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Pruning action
 	ASSERT_EQ (2, ledger.pruning_action (transaction, send1->hash (), 1));
@@ -5195,7 +5195,7 @@ TEST (ledger, pruning_source_rollback)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send2->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (5, ledger.cache.block_count);
@@ -5207,7 +5207,7 @@ TEST (ledger, pruning_source_rollback)
 	ASSERT_EQ (nano::Gxrb_ratio, info2->amount.number ());
 	ASSERT_EQ (nano::epoch::epoch_1, info2->epoch);
 	// Process receive block again
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (5, ledger.cache.block_count);
@@ -5233,7 +5233,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	nano::keypair key1;
 	auto send2 = builder
@@ -5244,7 +5244,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (key1.pub, send2->hash ())));
 	auto send3 = builder
@@ -5255,7 +5255,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send2->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send3));
 	ASSERT_TRUE (store->block.exists (transaction, send3->hash ()));
 	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send3->hash ())));
 	// Pruning action
@@ -5283,7 +5283,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send3->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (5, ledger.cache.block_count);
@@ -5295,7 +5295,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	ASSERT_EQ (nano::Gxrb_ratio, info3->amount.number ());
 	ASSERT_EQ (nano::epoch::epoch_0, info3->epoch);
 	// Process receive block again
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (5, ledger.cache.block_count);
@@ -5308,7 +5308,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 				 .sign (key1.prv, key1.pub)
 				 .work (*pool.generate (key1.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (key1.pub, send2->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (6, ledger.cache.block_count);
@@ -5320,7 +5320,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	ASSERT_EQ (nano::Gxrb_ratio, info4->amount.number ());
 	ASSERT_EQ (nano::epoch::epoch_0, info4->epoch);
 	// Process open block again
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	ASSERT_FALSE (store->pending.exists (transaction, nano::pending_key (key1.pub, send2->hash ())));
 	ASSERT_EQ (2, ledger.cache.pruned_count);
 	ASSERT_EQ (6, ledger.cache.block_count);
@@ -5348,7 +5348,7 @@ TEST (ledger, pruning_process_error)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_EQ (0, ledger.cache.pruned_count);
 	ASSERT_EQ (2, ledger.cache.block_count);
 	// Pruning action for latest block (not valid action)
@@ -5356,7 +5356,7 @@ TEST (ledger, pruning_process_error)
 	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
 	ASSERT_TRUE (store->pruned.exists (transaction, send1->hash ()));
 	// Attempt to process pruned block again
-	ASSERT_EQ (nano::process_result::old, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::old, ledger.process (transaction, *send1));
 	// Attept to process new block after pruned
 	auto send2 = builder
 				 .state ()
@@ -5368,7 +5368,7 @@ TEST (ledger, pruning_process_error)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::gap_previous, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::gap_previous, ledger.process (transaction, *send2));
 	ASSERT_EQ (1, ledger.cache.pruned_count);
 	ASSERT_EQ (2, ledger.cache.block_count);
 }
@@ -5394,7 +5394,7 @@ TEST (ledger, pruning_legacy_blocks)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store->pending.exists (transaction, nano::pending_key (nano::dev::genesis->account (), send1->hash ())));
 	auto receive1 = builder
 					.receive ()
@@ -5403,7 +5403,7 @@ TEST (ledger, pruning_legacy_blocks)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (send1->hash ()))
 					.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive1));
 	auto change1 = builder
 				   .change ()
 				   .previous (receive1->hash ())
@@ -5411,7 +5411,7 @@ TEST (ledger, pruning_legacy_blocks)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*pool.generate (receive1->hash ()))
 				   .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *change1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *change1));
 	auto send2 = builder
 				 .send ()
 				 .previous (change1->hash ())
@@ -5420,7 +5420,7 @@ TEST (ledger, pruning_legacy_blocks)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (change1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	auto open1 = builder
 				 .open ()
 				 .source (send2->hash ())
@@ -5429,7 +5429,7 @@ TEST (ledger, pruning_legacy_blocks)
 				 .sign (key1.prv, key1.pub)
 				 .work (*pool.generate (key1.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open1));
 	auto send3 = builder
 				 .send ()
 				 .previous (open1->hash ())
@@ -5438,7 +5438,7 @@ TEST (ledger, pruning_legacy_blocks)
 				 .sign (key1.prv, key1.pub)
 				 .work (*pool.generate (open1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send3).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send3));
 	// Pruning action
 	ASSERT_EQ (3, ledger.pruning_action (transaction, change1->hash (), 2));
 	ASSERT_EQ (1, ledger.pruning_action (transaction, open1->hash (), 1));
@@ -5481,7 +5481,7 @@ TEST (ledger, pruning_safe_functions)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
 	auto send2 = builder
 				 .state ()
@@ -5493,7 +5493,7 @@ TEST (ledger, pruning_safe_functions)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Pruning action
 	ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 1));
@@ -5542,7 +5542,7 @@ TEST (ledger, hash_root_random)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send1).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send1));
 	ASSERT_TRUE (store->block.exists (transaction, send1->hash ()));
 	auto send2 = builder
 				 .state ()
@@ -5554,7 +5554,7 @@ TEST (ledger, hash_root_random)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send2).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send2));
 	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Pruning action
 	ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 1));
@@ -5680,7 +5680,7 @@ TEST (ledger, unconfirmed_frontiers)
 				.work (*pool.generate (latest))
 				.build ();
 
-	ASSERT_EQ (nano::process_result::progress, ledger.process (store.tx_begin_write (), *send).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (store.tx_begin_write (), *send));
 
 	unconfirmed_frontiers = ledger.unconfirmed_frontiers ();
 	ASSERT_EQ (unconfirmed_frontiers.size (), 1);

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -366,7 +366,7 @@ TEST (receivable_processor, confirm_insufficient_pos)
 				  .work (0)
 				  .build_shared ();
 	node1.work_generate_blocking (*block1);
-	ASSERT_EQ (nano::process_result::progress, node1.process (*block1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*block1));
 	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	nano::keypair key1;
 	auto vote = nano::test::make_vote (key1, { block1 }, 0, 0);
@@ -389,7 +389,7 @@ TEST (receivable_processor, confirm_sufficient_pos)
 				  .work (0)
 				  .build_shared ();
 	node1.work_generate_blocking (*block1);
-	ASSERT_EQ (nano::process_result::progress, node1.process (*block1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*block1));
 	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
 	auto vote = nano::test::make_vote (nano::dev::genesis_key, { block1 }, 0, 0);
 	nano::confirm_ack con1{ nano::dev::network_params.network, vote };

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -32,7 +32,7 @@ TEST (processor_service, bad_send_signature)
 				.work (*pool.generate (info1->head))
 				.build ();
 	send->signature.bytes[32] ^= 0x1;
-	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, *send).code);
+	ASSERT_EQ (nano::block_status::bad_signature, ledger.process (transaction, *send));
 }
 
 TEST (processor_service, bad_receive_signature)
@@ -57,7 +57,7 @@ TEST (processor_service, bad_receive_signature)
 				.work (*pool.generate (info1->head))
 				.build ();
 	nano::block_hash hash1 (send->hash ());
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 	auto info2 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info2);
 	auto receive = builder
@@ -68,5 +68,5 @@ TEST (processor_service, bad_receive_signature)
 				   .work (*pool.generate (hash1))
 				   .build ();
 	receive->signature.bytes[32] ^= 0x1;
-	ASSERT_EQ (nano::process_result::bad_signature, ledger.process (transaction, *receive).code);
+	ASSERT_EQ (nano::block_status::bad_signature, ledger.process (transaction, *receive));
 }

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -36,7 +36,7 @@ TEST (request_aggregator, one)
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	// Not yet in the ledger
 	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send1));
 	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	// In the ledger but no vote generated yet
@@ -73,7 +73,7 @@ TEST (request_aggregator, one_update)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send1));
 	node.confirmation_height_processor.add (send1);
 	ASSERT_TIMELY (5s, node.ledger.block_confirmed (node.store.tx_begin_read (), send1->hash ()));
 	auto send2 = nano::state_block_builder ()
@@ -85,7 +85,7 @@ TEST (request_aggregator, one_update)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (send1->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send2).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send2));
 	auto receive1 = nano::state_block_builder ()
 					.account (key1.pub)
 					.previous (0)
@@ -95,7 +95,7 @@ TEST (request_aggregator, one_update)
 					.sign (key1.prv, key1.pub)
 					.work (*node.work_generate_blocking (key1.pub))
 					.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *receive1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send2->hash (), send2->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
@@ -139,7 +139,7 @@ TEST (request_aggregator, two)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send1));
 	node.confirmation_height_processor.add (send1);
 	ASSERT_TIMELY (5s, node.ledger.block_confirmed (node.store.tx_begin_read (), send1->hash ()));
 	auto send2 = builder.make_block ()
@@ -160,8 +160,8 @@ TEST (request_aggregator, two)
 					.sign (key1.prv, key1.pub)
 					.work (*node.work_generate_blocking (key1.pub))
 					.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send2).code);
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *receive1).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send2));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *receive1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send2->hash (), send2->root ());
 	request.emplace_back (receive1->hash (), receive1->root ());
@@ -218,7 +218,7 @@ TEST (request_aggregator, two_endpoints)
 				 .build_shared ();
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
-	ASSERT_EQ (nano::process_result::progress, node1.ledger.process (node1.store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (node1.store.tx_begin_write (), *send1));
 	auto dummy_channel1 = std::make_shared<nano::transport::inproc::channel> (node1, node1);
 	auto dummy_channel2 = std::make_shared<nano::transport::inproc::channel> (node2, node2);
 	ASSERT_NE (nano::transport::map_endpoint_to_v6 (dummy_channel1->get_endpoint ()), nano::transport::map_endpoint_to_v6 (dummy_channel2->get_endpoint ()));
@@ -279,7 +279,7 @@ TEST (request_aggregator, split)
 						  .build ());
 		auto const & block = blocks.back ();
 		previous = block->hash ();
-		ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *block).code);
+		ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *block));
 		request.emplace_back (block->hash (), block->root ());
 	}
 	// Confirm all blocks
@@ -325,7 +325,7 @@ TEST (request_aggregator, channel_lifetime)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	{
@@ -356,7 +356,7 @@ TEST (request_aggregator, channel_update)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	std::weak_ptr<nano::transport::channel> channel1_w;
@@ -396,7 +396,7 @@ TEST (request_aggregator, channel_max_queue)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
@@ -424,7 +424,7 @@ TEST (request_aggregator, unique)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
@@ -464,8 +464,8 @@ TEST (request_aggregator, cannot_vote)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send1->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*send1).code);
-	ASSERT_EQ (nano::process_result::progress, node.process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*send1));
+	ASSERT_EQ (nano::block_status::progress, node.process (*send2));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	ASSERT_FALSE (node.ledger.dependents_confirmed (node.store.tx_begin_read (), *send2));
 

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -60,7 +60,7 @@ TEST (system, DISABLED_generate_send_existing)
 						  .work (0)
 						  .build_shared ();
 		node1.work_generate_blocking (*open_block);
-		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *open_block).code);
+		ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *open_block));
 	}
 	ASSERT_GT (node1.balance (stake_preserver.pub), node1.balance (nano::dev::genesis->account ()));
 	auto info2 = node1.ledger.account_info (node1.store.tx_begin_read (), nano::dev::genesis_key.pub);
@@ -111,7 +111,7 @@ TEST (system, DISABLED_generate_send_new)
 						  .work (0)
 						  .build_shared ();
 		node1.work_generate_blocking (*open_block);
-		ASSERT_EQ (nano::process_result::progress, node1.ledger.process (transaction, *open_block).code);
+		ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, *open_block));
 	}
 	ASSERT_GT (node1.balance (stake_preserver.pub), node1.balance (nano::dev::genesis->account ()));
 	std::vector<nano::account> accounts;

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -204,7 +204,7 @@ TEST (vote_processor, no_broadcast_local)
 										.work (*system.work.generate (nano::dev::genesis->hash ()))
 										.build (ec);
 	ASSERT_FALSE (ec);
-	ASSERT_EQ (nano::process_result::progress, node.process_local (send).value ().code);
+	ASSERT_EQ (nano::block_status::progress, node.process_local (send).value ());
 	ASSERT_TIMELY (10s, !node.active.empty ());
 	ASSERT_EQ (2 * node.config.vote_minimum.number (), node.weight (nano::dev::genesis_key.pub));
 	// Insert account in wallet. Votes on node are not enabled.
@@ -257,7 +257,7 @@ TEST (vote_processor, local_broadcast_without_a_representative)
 										.work (*system.work.generate (nano::dev::genesis->hash ()))
 										.build (ec);
 	ASSERT_FALSE (ec);
-	ASSERT_EQ (nano::process_result::progress, node.process_local (send).value ().code);
+	ASSERT_EQ (nano::block_status::progress, node.process_local (send).value ());
 	ASSERT_TIMELY (10s, !node.active.empty ());
 	ASSERT_EQ (node.config.vote_minimum, node.weight (nano::dev::genesis_key.pub));
 	node.start_election (send);
@@ -305,7 +305,7 @@ TEST (vote_processor, no_broadcast_local_with_a_principal_representative)
 										.work (*system.work.generate (nano::dev::genesis->hash ()))
 										.build (ec);
 	ASSERT_FALSE (ec);
-	ASSERT_EQ (nano::process_result::progress, node.process_local (send).value ().code);
+	ASSERT_EQ (nano::block_status::progress, node.process_local (send).value ());
 	ASSERT_TIMELY (10s, !node.active.empty ());
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 2 * node.config.vote_minimum.number (), node.weight (nano::dev::genesis_key.pub));
 	// Insert account in wallet. Votes on node are not enabled.

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -168,12 +168,12 @@ TEST (vote_spacing, vote_generator)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send1));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts));
 	node.generator.add (nano::dev::genesis->hash (), send1->hash ());
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts), 1);
 	ASSERT_FALSE (node.ledger.rollback (node.store.tx_begin_write (), send1->hash ()));
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send2).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send2));
 	node.generator.add (nano::dev::genesis->hash (), send2->hash ());
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_spacing), 1);
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts));
@@ -212,11 +212,11 @@ TEST (vote_spacing, rapid)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send1).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send1));
 	node.generator.add (nano::dev::genesis->hash (), send1->hash ());
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts), 1);
 	ASSERT_FALSE (node.ledger.rollback (node.store.tx_begin_write (), send1->hash ()));
-	ASSERT_EQ (nano::process_result::progress, node.ledger.process (node.store.tx_begin_write (), *send2).code);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), *send2));
 	node.generator.add (nano::dev::genesis->hash (), send2->hash ());
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_spacing), 1);
 	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts));

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1114,7 +1114,7 @@ TEST (wallet, epoch_2_receive_unopened)
 							   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 							   .work (*system.work.generate (key.pub, node.network_params.work.epoch_2))
 							   .build ();
-		ASSERT_EQ (nano::process_result::progress, node.process (*epoch2_unopened).code);
+		ASSERT_EQ (nano::block_status::progress, node.process (*epoch2_unopened));
 
 		wallet.insert_adhoc (key.prv, false);
 
@@ -1175,7 +1175,7 @@ TEST (wallet, search_receivable)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*system.work.generate (nano::dev::genesis->hash ()))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node.process (*send));
 
 	// Pending search should start an election
 	ASSERT_TRUE (node.active.empty ());

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -110,7 +110,7 @@ TEST (wallets, vote_minimum)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, node1.process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*send1));
 	auto open1 = builder
 				 .state ()
 				 .account (key1.pub)
@@ -121,7 +121,7 @@ TEST (wallets, vote_minimum)
 				 .sign (key1.prv, key1.pub)
 				 .work (*system.work.generate (key1.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, node1.process (*open1).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*open1));
 	// send2 with amount vote_minimum - 1 (not voting representative)
 	auto send2 = builder
 				 .state ()
@@ -133,7 +133,7 @@ TEST (wallets, vote_minimum)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, node1.process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*send2));
 	auto open2 = builder
 				 .state ()
 				 .account (key2.pub)
@@ -144,7 +144,7 @@ TEST (wallets, vote_minimum)
 				 .sign (key2.prv, key2.pub)
 				 .work (*system.work.generate (key2.pub))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, node1.process (*open2).code);
+	ASSERT_EQ (nano::block_status::progress, node1.process (*open2));
 	auto wallet (node1.wallets.items.begin ()->second);
 	nano::unique_lock<nano::mutex> representatives_lk (wallet->representatives_mutex);
 	ASSERT_EQ (0, wallet->representatives.size ());
@@ -212,7 +212,7 @@ TEST (wallets, search_receivable)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*system.work.generate (nano::dev::genesis->hash ()))
 					.build ();
-		ASSERT_EQ (nano::process_result::progress, node.process (*send).code);
+		ASSERT_EQ (nano::block_status::progress, node.process (*send));
 
 		// Pending search should start an election
 		ASSERT_TRUE (node.active.empty ());

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -1061,7 +1061,7 @@ TEST (websocket, new_unconfirmed_block)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
 
-	ASSERT_EQ (nano::process_result::progress, node1->process_local (send1).value ().code);
+	ASSERT_EQ (nano::block_status::progress, node1->process_local (send1).value ());
 
 	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -35,9 +35,9 @@ nano::active_transactions::active_transactions (nano::node & node_a, nano::confi
 
 	// Notify elections about alternative (forked) blocks
 	block_processor.block_processed.add ([this] (auto const & result, auto const & context) {
-		switch (result.code)
+		switch (result)
 		{
-			case nano::process_result::fork:
+			case nano::block_status::fork:
 				publish (context.block);
 				break;
 			default:

--- a/nano/node/block_broadcast.cpp
+++ b/nano/node/block_broadcast.cpp
@@ -15,9 +15,9 @@ void nano::block_broadcast::connect (nano::block_processor & block_processor)
 		return;
 	}
 	block_processor.block_processed.add ([this] (auto const & result, auto const & context) {
-		switch (result.code)
+		switch (result)
 		{
-			case nano::process_result::progress:
+			case nano::block_status::progress:
 				observe (context);
 				break;
 			default:

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -51,7 +51,7 @@ public: // Context
 		std::chrono::steady_clock::time_point const arrival{ std::chrono::steady_clock::now () };
 
 	public:
-		using result_t = nano::process_return;
+		using result_t = nano::block_status;
 		std::future<result_t> get_future ();
 
 	private:
@@ -69,7 +69,7 @@ public:
 	bool full ();
 	bool half_full ();
 	void add (std::shared_ptr<nano::block> const &, block_source = block_source::live);
-	std::optional<nano::process_return> add_blocking (std::shared_ptr<nano::block> const & block, block_source);
+	std::optional<nano::block_status> add_blocking (std::shared_ptr<nano::block> const & block, block_source);
 	void force (std::shared_ptr<nano::block> const &);
 	bool should_log ();
 	bool have_blocks_ready ();
@@ -80,17 +80,17 @@ public:
 	std::atomic<bool> flushing{ false };
 
 public: // Events
-	using processed_t = std::tuple<nano::process_return, context>;
+	using processed_t = std::tuple<nano::block_status, context>;
 	using processed_batch_t = std::deque<processed_t>;
 
 	// The batch observer feeds the processed observer
-	nano::observer_set<nano::process_return const &, context const &> block_processed;
+	nano::observer_set<nano::block_status const &, context const &> block_processed;
 	nano::observer_set<processed_batch_t const &> batch_processed;
 
 private:
 	// Roll back block in the ledger that conflicts with 'block'
 	void rollback_competitor (store::write_transaction const &, nano::block const & block);
-	nano::process_return process_one (store::write_transaction const &, context const &, bool forced = false);
+	nano::block_status process_one (store::write_transaction const &, context const &, bool forced = false);
 	void queue_unchecked (store::write_transaction const &, nano::hash_or_account const &);
 	processed_batch_t process_batch (nano::unique_lock<nano::mutex> &);
 	context next ();

--- a/nano/node/bootstrap/bootstrap.cpp
+++ b/nano/node/bootstrap/bootstrap.cpp
@@ -165,7 +165,7 @@ bool nano::bootstrap_initiator::in_progress ()
 	return !attempts_list.empty ();
 }
 
-void nano::bootstrap_initiator::block_processed (store::transaction const & tx, nano::process_return const & result, nano::block const & block)
+void nano::bootstrap_initiator::block_processed (store::transaction const & tx, nano::block_status const & result, nano::block const & block)
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	for (auto & i : attempts_list)

--- a/nano/node/bootstrap/bootstrap.hpp
+++ b/nano/node/bootstrap/bootstrap.hpp
@@ -105,7 +105,7 @@ public:
 	void notify_listeners (bool);
 	void add_observer (std::function<void (bool)> const &);
 	bool in_progress ();
-	void block_processed (store::transaction const & tx, nano::process_return const & result, nano::block const & block);
+	void block_processed (store::transaction const & tx, nano::block_status const & result, nano::block const & block);
 	std::shared_ptr<nano::bootstrap_connections> connections;
 	std::shared_ptr<nano::bootstrap_attempt> new_attempt ();
 	bool has_new_attempts ();

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -138,6 +138,6 @@ bool nano::bootstrap_attempt::process_block (std::shared_ptr<nano::block> const 
 	return stop_pull;
 }
 
-void nano::bootstrap_attempt::block_processed (store::transaction const & tx, nano::process_return const & result, nano::block const & block)
+void nano::bootstrap_attempt::block_processed (store::transaction const & tx, nano::block_status const & result, nano::block const & block)
 {
 }

--- a/nano/node/bootstrap/bootstrap_attempt.hpp
+++ b/nano/node/bootstrap/bootstrap_attempt.hpp
@@ -34,7 +34,7 @@ public:
 	char const * mode_text ();
 	virtual bool process_block (std::shared_ptr<nano::block> const &, nano::account const &, uint64_t, nano::bulk_pull::count_t, bool, unsigned);
 	virtual void get_information (boost::property_tree::ptree &) = 0;
-	virtual void block_processed (store::transaction const & tx, nano::process_return const & result, nano::block const & block);
+	virtual void block_processed (store::transaction const & tx, nano::block_status const & result, nano::block const & block);
 	nano::mutex next_log_mutex;
 	std::chrono::steady_clock::time_point next_log{ std::chrono::steady_clock::now () };
 	std::atomic<unsigned> pulling{ 0 };

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -124,13 +124,13 @@ std::size_t nano::bootstrap_ascending::service::score_size () const
 - Marks an account as blocked if the result code is gap source as there is no reason request additional blocks for this account until the dependency is resolved
 - Marks an account as forwarded if it has been recently referenced by a block that has been inserted.
  */
-void nano::bootstrap_ascending::service::inspect (store::transaction const & tx, nano::process_return const & result, nano::block const & block)
+void nano::bootstrap_ascending::service::inspect (store::transaction const & tx, nano::block_status const & result, nano::block const & block)
 {
 	auto const hash = block.hash ();
 
-	switch (result.code)
+	switch (result)
 	{
-		case nano::process_result::progress:
+		case nano::block_status::progress:
 		{
 			const auto account = ledger.account (tx, hash);
 			const auto is_send = ledger.is_send (tx, block);
@@ -164,7 +164,7 @@ void nano::bootstrap_ascending::service::inspect (store::transaction const & tx,
 			}
 		}
 		break;
-		case nano::process_result::gap_source:
+		case nano::block_status::gap_source:
 		{
 			const auto account = block.previous ().is_zero () ? block.account () : ledger.account (tx, block.previous ());
 			const auto source = block.source ().is_zero () ? block.link ().as_block_hash () : block.source ();
@@ -175,12 +175,12 @@ void nano::bootstrap_ascending::service::inspect (store::transaction const & tx,
 			// TODO: Track stats
 		}
 		break;
-		case nano::process_result::old:
+		case nano::block_status::old:
 		{
 			// TODO: Track stats
 		}
 		break;
-		case nano::process_result::gap_previous:
+		case nano::block_status::gap_previous:
 		{
 			// TODO: Track stats
 		}

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -88,7 +88,7 @@ namespace bootstrap_ascending
 
 	private:
 		/* Inspects a block that has been processed by the block processor */
-		void inspect (store::transaction const &, nano::process_return const & result, nano::block const & block);
+		void inspect (store::transaction const &, nano::block_status const & result, nano::block const & block);
 
 		void throttle_if_needed (nano::unique_lock<nano::mutex> & lock);
 		void run ();

--- a/nano/node/epoch_upgrader.cpp
+++ b/nano/node/epoch_upgrader.cpp
@@ -47,18 +47,18 @@ void nano::epoch_upgrader::upgrade_impl (nano::raw_key const & prv_a, nano::epoc
 		epoch->block_work_set (node.work_generate_blocking (nano::work_version::work_1, root_a, difficulty).value_or (0));
 		bool valid_signature (!nano::validate_message (signer_a, epoch->hash (), epoch->block_signature ()));
 		bool valid_work (node.network_params.work.difficulty (*epoch) >= difficulty);
-		nano::process_result result (nano::process_result::old);
+		nano::block_status result (nano::block_status::old);
 		if (valid_signature && valid_work)
 		{
-			result = node.process_local (epoch).value ().code;
+			result = node.process_local (epoch).value ();
 		}
-		if (result == nano::process_result::progress)
+		if (result == nano::block_status::progress)
 		{
 			++counter;
 		}
 		else
 		{
-			bool fork (result == nano::process_result::fork);
+			bool fork (result == nano::block_status::fork);
 
 			logger.error (nano::log::type::epoch_upgrader, "Failed to upgrade account {} (valid signature: {}, valid work: {}, fork: {})",
 			account_a.to_account (),

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3271,60 +3271,60 @@ void nano::json_handler::process ()
 					else
 					{
 						auto const & result = result_maybe.value ();
-						switch (result.code)
+						switch (result)
 						{
-							case nano::process_result::progress:
+							case nano::block_status::progress:
 							{
 								rpc_l->response_l.put ("hash", block->hash ().to_string ());
 								break;
 							}
-							case nano::process_result::gap_previous:
+							case nano::block_status::gap_previous:
 							{
 								rpc_l->ec = nano::error_process::gap_previous;
 								break;
 							}
-							case nano::process_result::gap_source:
+							case nano::block_status::gap_source:
 							{
 								rpc_l->ec = nano::error_process::gap_source;
 								break;
 							}
-							case nano::process_result::old:
+							case nano::block_status::old:
 							{
 								rpc_l->ec = nano::error_process::old;
 								break;
 							}
-							case nano::process_result::bad_signature:
+							case nano::block_status::bad_signature:
 							{
 								rpc_l->ec = nano::error_process::bad_signature;
 								break;
 							}
-							case nano::process_result::negative_spend:
+							case nano::block_status::negative_spend:
 							{
 								// TODO once we get RPC versioning, this should be changed to "negative spend"
 								rpc_l->ec = nano::error_process::negative_spend;
 								break;
 							}
-							case nano::process_result::balance_mismatch:
+							case nano::block_status::balance_mismatch:
 							{
 								rpc_l->ec = nano::error_process::balance_mismatch;
 								break;
 							}
-							case nano::process_result::unreceivable:
+							case nano::block_status::unreceivable:
 							{
 								rpc_l->ec = nano::error_process::unreceivable;
 								break;
 							}
-							case nano::process_result::block_position:
+							case nano::block_status::block_position:
 							{
 								rpc_l->ec = nano::error_process::block_position;
 								break;
 							}
-							case nano::process_result::gap_epoch_open_pending:
+							case nano::block_status::gap_epoch_open_pending:
 							{
 								rpc_l->ec = nano::error_process::gap_epoch_open_pending;
 								break;
 							}
-							case nano::process_result::fork:
+							case nano::block_status::fork:
 							{
 								bool const force = rpc_l->request.get<bool> ("force", false);
 								if (force)
@@ -3339,12 +3339,12 @@ void nano::json_handler::process ()
 								}
 								break;
 							}
-							case nano::process_result::insufficient_work:
+							case nano::block_status::insufficient_work:
 							{
 								rpc_l->ec = nano::error_process::insufficient_work;
 								break;
 							}
-							case nano::process_result::opened_burn_account:
+							case nano::block_status::opened_burn_account:
 								rpc_l->ec = nano::error_process::opened_burn_account;
 								break;
 							default:

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -559,18 +559,18 @@ void nano::node::process_active (std::shared_ptr<nano::block> const & incoming)
 	block_processor.add (incoming);
 }
 
-[[nodiscard]] nano::process_return nano::node::process (store::write_transaction const & transaction, nano::block & block)
+[[nodiscard]] nano::block_status nano::node::process (store::write_transaction const & transaction, nano::block & block)
 {
 	return ledger.process (transaction, block);
 }
 
-nano::process_return nano::node::process (nano::block & block)
+nano::block_status nano::node::process (nano::block & block)
 {
 	auto const transaction = store.tx_begin_write ({ tables::accounts, tables::blocks, tables::frontiers, tables::pending });
 	return process (transaction, block);
 }
 
-std::optional<nano::process_return> nano::node::process_local (std::shared_ptr<nano::block> const & block_a)
+std::optional<nano::block_status> nano::node::process_local (std::shared_ptr<nano::block> const & block_a)
 {
 	return block_processor.add_blocking (block_a, nano::block_source::local);
 }

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -86,7 +86,7 @@ public:
 	void process_confirmed_data (store::transaction const &, std::shared_ptr<nano::block> const &, nano::block_hash const &, nano::account &, nano::uint128_t &, bool &, bool &, nano::account &);
 	void process_confirmed (nano::election_status const &, uint64_t = 0);
 	void process_active (std::shared_ptr<nano::block> const &);
-	std::optional<nano::process_return> process_local (std::shared_ptr<nano::block> const &);
+	std::optional<nano::block_status> process_local (std::shared_ptr<nano::block> const &);
 	void process_local_async (std::shared_ptr<nano::block> const &);
 	void keepalive_preconfigured (std::vector<std::string> const &);
 	std::shared_ptr<nano::block> block (nano::block_hash const &);
@@ -210,8 +210,8 @@ public: // Testing convenience functions
 		Creates a new write transaction and inserts `block' and returns result
 		Transaction is comitted before function return
 	 */
-	[[nodiscard]] nano::process_return process (nano::block & block);
-	[[nodiscard]] nano::process_return process (store::write_transaction const &, nano::block & block);
+	[[nodiscard]] nano::block_status process (nano::block & block);
+	[[nodiscard]] nano::block_status process (store::write_transaction const &, nano::block & block);
 	nano::block_hash latest (nano::account const &);
 	nano::uint128_t balance (nano::account const &);
 

--- a/nano/node/process_live_dispatcher.cpp
+++ b/nano/node/process_live_dispatcher.cpp
@@ -28,11 +28,11 @@ void nano::process_live_dispatcher::connect (nano::block_processor & block_proce
 	});
 }
 
-void nano::process_live_dispatcher::inspect (nano::process_return const & result, nano::block const & block, store::transaction const & transaction)
+void nano::process_live_dispatcher::inspect (nano::block_status const & result, nano::block const & block, store::transaction const & transaction)
 {
-	switch (result.code)
+	switch (result)
 	{
-		case nano::process_result::progress:
+		case nano::block_status::progress:
 			process_live (block, transaction);
 			break;
 		default:

--- a/nano/node/process_live_dispatcher.hpp
+++ b/nano/node/process_live_dispatcher.hpp
@@ -28,7 +28,7 @@ public:
 
 private:
 	// Block_processor observer
-	void inspect (nano::process_return const & result, nano::block const & block, store::transaction const & transaction);
+	void inspect (nano::block_status const & result, nano::block const & block, store::transaction const & transaction);
 	void process_live (nano::block const & block, store::transaction const & transaction);
 
 	nano::ledger & ledger;

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1054,7 +1054,7 @@ bool nano::wallet::action_complete (std::shared_ptr<nano::block> const & block_a
 		if (!error)
 		{
 			auto result = wallets.node.process_local (block_a);
-			error = !result || result.value ().code != nano::process_result::progress;
+			error = !result || result.value () != nano::block_status::progress;
 			debug_assert (error || block_a->sideband ().details == details_a);
 		}
 		if (!error && generate_work_a)

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -424,8 +424,8 @@ TEST (wallet, create_send)
 	bool error (false);
 	nano::state_block send (error, tree1);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (send).code);
-	ASSERT_EQ (nano::process_result::old, system.nodes[0]->process (send).code);
+	ASSERT_EQ (nano::block_status::progress, system.nodes[0]->process (send));
+	ASSERT_EQ (nano::block_status::old, system.nodes[0]->process (send));
 }
 
 TEST (wallet, create_open_receive)
@@ -458,8 +458,8 @@ TEST (wallet, create_open_receive)
 	bool error (false);
 	nano::state_block open (error, tree1);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (open).code);
-	ASSERT_EQ (nano::process_result::old, system.nodes[0]->process (open).code);
+	ASSERT_EQ (nano::block_status::progress, system.nodes[0]->process (open));
+	ASSERT_EQ (nano::block_status::old, system.nodes[0]->process (open));
 	wallet->block_creation.block->clear ();
 	wallet->block_creation.source->clear ();
 	wallet->block_creation.receive->click ();
@@ -473,8 +473,8 @@ TEST (wallet, create_open_receive)
 	bool error2 (false);
 	nano::state_block receive (error2, tree2);
 	ASSERT_FALSE (error2);
-	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (receive).code);
-	ASSERT_EQ (nano::process_result::old, system.nodes[0]->process (receive).code);
+	ASSERT_EQ (nano::block_status::progress, system.nodes[0]->process (receive));
+	ASSERT_EQ (nano::block_status::old, system.nodes[0]->process (receive));
 }
 
 TEST (wallet, create_change)
@@ -501,8 +501,8 @@ TEST (wallet, create_change)
 	bool error (false);
 	nano::state_block change (error, tree1);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::process_result::progress, system.nodes[0]->process (change).code);
-	ASSERT_EQ (nano::process_result::old, system.nodes[0]->process (change).code);
+	ASSERT_EQ (nano::block_status::progress, system.nodes[0]->process (change));
+	ASSERT_EQ (nano::block_status::old, system.nodes[0]->process (change));
 }
 
 TEST (history, short_text)
@@ -532,11 +532,11 @@ TEST (history, short_text)
 		nano::keypair key;
 		auto latest (ledger.latest (transaction, nano::dev::genesis_key.pub));
 		nano::send_block send (latest, nano::dev::genesis_key.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send));
 		nano::receive_block receive (send.hash (), send.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send.hash ()));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive));
 		nano::change_block change (receive.hash (), key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (receive.hash ()));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, change).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, change));
 	}
 	nano_qt::history history (ledger, nano::dev::genesis_key.pub, *wallet);
 	history.refresh ();
@@ -572,13 +572,13 @@ TEST (history, pruned_source)
 		store->initialize (transaction, ledger.cache, nano::dev::constants);
 		auto latest (ledger.latest (transaction, nano::dev::genesis_key.pub));
 		nano::send_block send1 (latest, nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - 100, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send1).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send1));
 		nano::send_block send2 (send1.hash (), key.pub, nano::dev::constants.genesis_amount - 200, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send1.hash ()));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send2).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
 		nano::receive_block receive (send2.hash (), send1.hash (), nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (send2.hash ()));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive));
 		nano::open_block open (send2.hash (), key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, open).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open));
 		ASSERT_EQ (1, ledger.pruning_action (transaction, send1.hash (), 2));
 		next_pruning = send2.hash ();
 	}
@@ -602,10 +602,10 @@ TEST (history, pruned_source)
 		auto transaction (store->tx_begin_write ());
 		auto latest (ledger.latest (transaction, nano::dev::genesis_key.pub));
 		nano::state_block send (nano::dev::genesis_key.pub, latest, nano::dev::genesis_key.pub, nano::dev::constants.genesis_amount - 200, key.pub, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, send).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send));
 		auto latest_key (ledger.latest (transaction, key.pub));
 		nano::state_block receive (key.pub, latest_key, key.pub, 200, send.hash (), key.prv, key.pub, *system.work.generate (latest_key));
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, receive).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive));
 		ASSERT_EQ (1, ledger.pruning_action (transaction, latest, 2));
 		ASSERT_EQ (1, ledger.pruning_action (transaction, latest_key, 2));
 	}
@@ -718,7 +718,7 @@ TEST (wallet, republish)
 		auto latest (system.nodes[0]->ledger.latest (transaction, nano::dev::genesis_key.pub));
 		nano::send_block block (latest, key.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
 		hash = block.hash ();
-		ASSERT_EQ (nano::process_result::progress, system.nodes[0]->ledger.process (transaction, block).code);
+		ASSERT_EQ (nano::block_status::progress, system.nodes[0]->ledger.process (transaction, block));
 	}
 	auto account (nano::dev::genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
@@ -967,7 +967,7 @@ TEST (wallet, epoch_2_validation)
 		bool error (false);
 		nano::state_block block (error, tree1);
 		EXPECT_FALSE (error);
-		EXPECT_EQ (nano::process_result::progress, node->process (block).code);
+		EXPECT_EQ (nano::block_status::progress, node->process (block));
 		return block.hash ();
 	};
 

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -370,7 +370,7 @@ TEST (rpc, search_receivable)
 				 .build ();
 	{
 		auto transaction (node->store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *block).code);
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *block));
 	}
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -72,7 +72,7 @@ TEST (rpc, account_balance)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
 
-	ASSERT_EQ (nano::process_result::progress, node->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send1));
 	ASSERT_TIMELY (5s, !node->active.active (*send1));
 
 	auto const rpc_ctx = add_rpc (system, node);
@@ -152,7 +152,7 @@ TEST (rpc, account_weight)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node1->work_generate_blocking (latest))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*block).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*block));
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
 	request.put ("action", "account_weight");
@@ -957,9 +957,9 @@ TEST (rpc, history)
 				   .build ();
 	{
 		auto transaction (node0->store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, *usend).code);
-		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, *ureceive).code);
-		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, *uchange).code);
+		ASSERT_EQ (nano::block_status::progress, node0->ledger.process (transaction, *usend));
+		ASSERT_EQ (nano::block_status::progress, node0->ledger.process (transaction, *ureceive));
+		ASSERT_EQ (nano::block_status::progress, node0->ledger.process (transaction, *uchange));
 	}
 	auto const rpc_ctx = add_rpc (system, node0);
 	boost::property_tree::ptree request;
@@ -1041,9 +1041,9 @@ TEST (rpc, account_history)
 				   .build ();
 	{
 		auto transaction (node0->store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, *usend).code);
-		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, *ureceive).code);
-		ASSERT_EQ (nano::process_result::progress, node0->ledger.process (transaction, *uchange).code);
+		ASSERT_EQ (nano::block_status::progress, node0->ledger.process (transaction, *usend));
+		ASSERT_EQ (nano::block_status::progress, node0->ledger.process (transaction, *ureceive));
+		ASSERT_EQ (nano::block_status::progress, node0->ledger.process (transaction, *uchange));
 	}
 	auto const rpc_ctx = add_rpc (system, node0);
 	{
@@ -1557,8 +1557,8 @@ TEST (rpc, process_subtype_open)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node1->work_generate_blocking (latest))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
-	ASSERT_EQ (nano::process_result::progress, node2.process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
+	ASSERT_EQ (nano::block_status::progress, node2.process (*send));
 	auto const rpc_ctx = add_rpc (system, node1);
 	node1->scheduler.manual.push (send);
 	auto open = builder
@@ -1606,8 +1606,8 @@ TEST (rpc, process_subtype_receive)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node1->work_generate_blocking (latest))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
-	ASSERT_EQ (nano::process_result::progress, node2.process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
+	ASSERT_EQ (nano::block_status::progress, node2.process (*send));
 	auto const rpc_ctx = add_rpc (system, node1);
 	node1->scheduler.manual.push (send);
 	auto receive = builder
@@ -2497,7 +2497,7 @@ TEST (rpc, bootstrap)
 				.build ();
 	{
 		auto transaction (node1->store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node1->ledger.process (transaction, *send).code);
+		ASSERT_EQ (nano::block_status::progress, node1->ledger.process (transaction, *send));
 	}
 	auto const rpc_ctx = add_rpc (system0, node);
 	boost::property_tree::ptree request;
@@ -2782,7 +2782,7 @@ TEST (rpc, bootstrap_any)
 				.build ();
 	{
 		auto transaction (system1.nodes[0]->store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, system1.nodes[0]->ledger.process (transaction, *send).code);
+		ASSERT_EQ (nano::block_status::progress, system1.nodes[0]->ledger.process (transaction, *send));
 	}
 	auto const rpc_ctx = add_rpc (system0, node);
 	boost::property_tree::ptree request;
@@ -2808,7 +2808,7 @@ TEST (rpc, republish)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node1->work_generate_blocking (latest))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
 	auto open = builder
 				.open ()
 				.source (send->hash ())
@@ -2817,7 +2817,7 @@ TEST (rpc, republish)
 				.sign (key.prv, key.pub)
 				.work (*node1->work_generate_blocking (key.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
 	request.put ("action", "republish");
@@ -2998,7 +2998,7 @@ TEST (rpc, accounts_balances_unopened_account_with_receivables)
 				.build_shared ();
 	{
 		auto transaction = node->store.tx_begin_write ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 	}
 	ASSERT_TIMELY (5s, node->block (send->hash ()));
 	ASSERT_TIMELY (5s, !node->active.active (*send));
@@ -3531,7 +3531,7 @@ TEST (rpc, search_receivable_all)
 				 .build ();
 	{
 		auto transaction (node->store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *block).code);
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *block));
 	}
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -3563,7 +3563,7 @@ TEST (rpc, wallet_republish)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node1->work_generate_blocking (latest))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
 	auto open = builder
 				.open ()
 				.source (send->hash ())
@@ -3572,7 +3572,7 @@ TEST (rpc, wallet_republish)
 				.sign (key.prv, key.pub)
 				.work (*node1->work_generate_blocking (key.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_republish");
@@ -3607,7 +3607,7 @@ TEST (rpc, delegators)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node1->work_generate_blocking (latest))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
 	auto open = builder
 				.open ()
 				.source (send->hash ())
@@ -3616,7 +3616,7 @@ TEST (rpc, delegators)
 				.sign (key.prv, key.pub)
 				.work (*node1->work_generate_blocking (key.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
 	request.put ("action", "delegators");
@@ -3648,7 +3648,7 @@ TEST (rpc, delegators_parameters)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node1->work_generate_blocking (latest))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
 	auto open = builder
 				.open ()
 				.source (send->hash ())
@@ -3657,7 +3657,7 @@ TEST (rpc, delegators_parameters)
 				.sign (key.prv, key.pub)
 				.work (*node1->work_generate_blocking (key.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 
 	auto const rpc_ctx = add_rpc (system, node1);
 	// Test with "count" = 2
@@ -3758,7 +3758,7 @@ TEST (rpc, delegators_count)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node1->work_generate_blocking (latest))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
 	auto open = builder
 				.open ()
 				.source (send->hash ())
@@ -3767,7 +3767,7 @@ TEST (rpc, delegators_count)
 				.sign (key.prv, key.pub)
 				.work (*node1->work_generate_blocking (key.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
 	request.put ("action", "delegators_count");
@@ -3810,7 +3810,7 @@ TEST (rpc, account_info)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node1->work_generate_blocking (latest))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
 	auto time = nano::seconds_since_epoch ();
 	{
 		auto transaction = node1->store.tx_begin_write ();
@@ -3869,7 +3869,7 @@ TEST (rpc, account_info)
 					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					 .work (*node1->work_generate_blocking (latest))
 					 .build ();
-		ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
+		ASSERT_EQ (nano::block_status::progress, node1->process (*send1));
 		auto send2 = builder
 					 .send ()
 					 .previous (send1->hash ())
@@ -3878,7 +3878,7 @@ TEST (rpc, account_info)
 					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					 .work (*node1->work_generate_blocking (send1->hash ()))
 					 .build ();
-		ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
+		ASSERT_EQ (nano::block_status::progress, node1->process (*send2));
 
 		auto state_change = builder
 							.state ()
@@ -3890,7 +3890,7 @@ TEST (rpc, account_info)
 							.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 							.work (*node1->work_generate_blocking (send2->hash ()))
 							.build ();
-		ASSERT_EQ (nano::process_result::progress, node1->process (*state_change).code);
+		ASSERT_EQ (nano::block_status::progress, node1->process (*state_change));
 
 		auto open = builder
 					.open ()
@@ -3900,7 +3900,7 @@ TEST (rpc, account_info)
 					.sign (key1.prv, key1.pub)
 					.work (*node1->work_generate_blocking (key1.pub))
 					.build ();
-		ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+		ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 		ASSERT_TIMELY (5s, !node1->active.active (*state_change));
 		ASSERT_TIMELY (5s, !node1->active.active (*open));
 	}
@@ -4018,7 +4018,7 @@ TEST (rpc, json_block_output)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node1->work_generate_blocking (latest))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
 	request.put ("action", "block_info");
@@ -4240,7 +4240,7 @@ TEST (rpc, block_info_successor)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node1->work_generate_blocking (latest))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
 	request.put ("action", "block_info");
@@ -4430,7 +4430,7 @@ TEST (rpc, populate_backlog)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node->work_generate_blocking (latest))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send));
 
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -4461,7 +4461,7 @@ TEST (rpc, ledger)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node->work_generate_blocking (latest))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send));
 	auto open = builder
 				.open ()
 				.source (send->hash ())
@@ -4470,7 +4470,7 @@ TEST (rpc, ledger)
 				.sign (key.prv, key.pub)
 				.work (*node->work_generate_blocking (key.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*open));
 	auto time = nano::seconds_since_epoch ();
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -4544,7 +4544,7 @@ TEST (rpc, ledger)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node->work_generate_blocking (send->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, node->process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send2));
 	// When asking for pending, pending amount is taken into account for threshold so the account must show up
 	request.put ("count", 2);
 	request.put ("threshold", (send_amount + send2_amount).convert_to<std::string> ());
@@ -4631,7 +4631,7 @@ TEST (rpc, block_create)
 	boost::property_tree::read_json (block_stream, block_l);
 	auto send_block (nano::deserialize_block_json (block_l));
 	ASSERT_EQ (send->hash (), send_block->hash ());
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
 	boost::property_tree::ptree request1;
 	request1.put ("action", "block_create");
 	request1.put ("type", "open");
@@ -4649,7 +4649,7 @@ TEST (rpc, block_create)
 	boost::property_tree::read_json (block_stream1, block_l);
 	auto open_block (nano::deserialize_block_json (block_l));
 	ASSERT_EQ (open->hash (), open_block->hash ());
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 	request1.put ("representative", key.pub.to_account ());
 	auto response2 (wait_response (system, rpc_ctx, request1));
 	std::string open2_hash (response2.get<std::string> ("hash"));
@@ -4672,7 +4672,7 @@ TEST (rpc, block_create)
 	boost::property_tree::read_json (block_stream4, block_l);
 	auto change_block (nano::deserialize_block_json (block_l));
 	ASSERT_EQ (change->hash (), change_block->hash ());
-	ASSERT_EQ (nano::process_result::progress, node1->process (*change).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*change));
 	auto send2 = builder
 				 .send ()
 				 .previous (send->hash ())
@@ -4681,7 +4681,7 @@ TEST (rpc, block_create)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node1->work_generate_blocking (send->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send2));
 	boost::property_tree::ptree request2;
 	request2.put ("action", "block_create");
 	request2.put ("type", "receive");
@@ -4730,7 +4730,7 @@ TEST (rpc, block_create_state)
 	ASSERT_EQ (nano::block_type::state, state_block->type ());
 	ASSERT_EQ (state_hash, state_block->hash ().to_string ());
 	auto process_result (node->process (*state_block));
-	ASSERT_EQ (nano::process_result::progress, process_result.code);
+	ASSERT_EQ (nano::block_status::progress, process_result);
 }
 
 TEST (rpc, block_create_state_open)
@@ -4766,7 +4766,7 @@ TEST (rpc, block_create_state_open)
 	ASSERT_GT (difficulty, nano::dev::network_params.work.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_0, false, true, false)));
 	ASSERT_TRUE (node->latest (key.pub).is_zero ());
 	auto process_result (node->process (*state_block));
-	ASSERT_EQ (nano::process_result::progress, process_result.code);
+	ASSERT_EQ (nano::block_status::progress, process_result);
 	ASSERT_EQ (state_block->sideband ().details.epoch, nano::epoch::epoch_0);
 	ASSERT_TRUE (state_block->sideband ().details.is_receive);
 	ASSERT_FALSE (node->latest (key.pub).is_zero ());
@@ -4845,7 +4845,7 @@ TEST (rpc, block_create_open_epoch_v2)
 	ASSERT_GT (difficulty, nano::dev::network_params.work.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	ASSERT_TRUE (node->latest (key.pub).is_zero ());
 	auto process_result (node->process (*state_block));
-	ASSERT_EQ (nano::process_result::progress, process_result.code);
+	ASSERT_EQ (nano::block_status::progress, process_result);
 	ASSERT_EQ (state_block->sideband ().details.epoch, nano::epoch::epoch_2);
 	ASSERT_TRUE (state_block->sideband ().details.is_receive);
 	ASSERT_FALSE (node->latest (key.pub).is_zero ());
@@ -4871,7 +4871,7 @@ TEST (rpc, block_create_receive_epoch_v2)
 				.sign (key.prv, key.pub)
 				.work (*node->work_generate_blocking (key.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*open));
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (*node, nano::epoch::epoch_2));
 	auto send_block_2 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, nano::Gxrb_ratio));
 	auto const rpc_ctx = add_rpc (system, node);
@@ -4897,7 +4897,7 @@ TEST (rpc, block_create_receive_epoch_v2)
 	auto difficulty (nano::dev::network_params.work.difficulty (*state_block));
 	ASSERT_GT (difficulty, nano::dev::network_params.work.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, false, true, false)));
 	auto process_result (node->process (*state_block));
-	ASSERT_EQ (nano::process_result::progress, process_result.code);
+	ASSERT_EQ (nano::block_status::progress, process_result);
 	ASSERT_EQ (state_block->sideband ().details.epoch, nano::epoch::epoch_2);
 	ASSERT_TRUE (state_block->sideband ().details.is_receive);
 	ASSERT_FALSE (node->latest (key.pub).is_zero ());
@@ -4924,7 +4924,7 @@ TEST (rpc, block_create_send_epoch_v2)
 				.sign (key.prv, key.pub)
 				.work (*node->work_generate_blocking (key.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*open));
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "block_create");
@@ -4948,7 +4948,7 @@ TEST (rpc, block_create_send_epoch_v2)
 	auto difficulty (nano::dev::network_params.work.difficulty (*state_block));
 	ASSERT_GT (difficulty, nano::dev::network_params.work.threshold (state_block->work_version (), nano::block_details (nano::epoch::epoch_2, true, false, false)));
 	auto process_result (node->process (*state_block));
-	ASSERT_EQ (nano::process_result::progress, process_result.code);
+	ASSERT_EQ (nano::block_status::progress, process_result);
 	ASSERT_EQ (state_block->sideband ().details.epoch, nano::epoch::epoch_2);
 	ASSERT_TRUE (state_block->sideband ().details.is_send);
 	ASSERT_FALSE (node->latest (key.pub).is_zero ());
@@ -5048,7 +5048,7 @@ TEST (rpc, wallet_ledger)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*node1->work_generate_blocking (latest))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send));
 	auto open = builder
 				.open ()
 				.source (send->hash ())
@@ -5057,7 +5057,7 @@ TEST (rpc, wallet_ledger)
 				.sign (key.prv, key.pub)
 				.work (*node1->work_generate_blocking (key.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 	auto time = nano::seconds_since_epoch ();
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
@@ -5221,7 +5221,7 @@ TEST (rpc, confirmation_height_currently_processing)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*system.work.generate (previous_genesis_chain_hash))
 					.build ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 		previous_genesis_chain_hash = send->hash ();
 	}
 
@@ -5343,7 +5343,7 @@ TEST (rpc, block_confirm)
 				 .build_shared ();
 	{
 		auto transaction (node->store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send1));
 	}
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -5850,7 +5850,7 @@ TEST (rpc, block_confirmed)
 					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					 .work (*system.work.generate (latest))
 					 .build ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send1));
 
 		auto open1 = builder
 					 .open ()
@@ -5860,7 +5860,7 @@ TEST (rpc, block_confirmed)
 					 .sign (key.prv, key.pub)
 					 .work (*system.work.generate (key.pub))
 					 .build ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open1).code);
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open1));
 	}
 
 	// This should not be confirmed
@@ -6144,7 +6144,7 @@ TEST (rpc, epoch_upgrade)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared (); // to opened account
-	ASSERT_EQ (nano::process_result::progress, node->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send1));
 	auto send2 = builder
 				 .state ()
 				 .account (nano::dev::genesis_key.pub)
@@ -6155,7 +6155,7 @@ TEST (rpc, epoch_upgrade)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send1->hash ()))
 				 .build_shared (); // to unopened account (pending)
-	ASSERT_EQ (nano::process_result::progress, node->process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send2));
 	auto send3 = builder
 				 .state ()
 				 .account (nano::dev::genesis_key.pub)
@@ -6166,7 +6166,7 @@ TEST (rpc, epoch_upgrade)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send2->hash ()))
 				 .build_shared (); // to burn (0)
-	ASSERT_EQ (nano::process_result::progress, node->process (*send3).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send3));
 	nano::account max_account (std::numeric_limits<nano::uint256_t>::max ());
 	auto send4 = builder
 				 .state ()
@@ -6178,7 +6178,7 @@ TEST (rpc, epoch_upgrade)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send3->hash ()))
 				 .build_shared (); // to max account
-	ASSERT_EQ (nano::process_result::progress, node->process (*send4).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send4));
 	auto open = builder
 				.state ()
 				.account (key1.pub)
@@ -6189,7 +6189,7 @@ TEST (rpc, epoch_upgrade)
 				.sign (key1.prv, key1.pub)
 				.work (*system.work.generate (key1.pub))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*open));
 	// Check accounts epochs
 	{
 		auto transaction (node->store.tx_begin_read ());
@@ -6235,7 +6235,7 @@ TEST (rpc, epoch_upgrade)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (genesis_latest))
 				 .build_shared (); // to burn (0)
-	ASSERT_EQ (nano::process_result::progress, node->process (*send5).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send5));
 	auto send6 = builder
 				 .state ()
 				 .account (nano::dev::genesis_key.pub)
@@ -6246,7 +6246,7 @@ TEST (rpc, epoch_upgrade)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send5->hash ()))
 				 .build_shared (); // to key1 (again)
-	ASSERT_EQ (nano::process_result::progress, node->process (*send6).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send6));
 	auto key1_latest (node->latest (key1.pub));
 	auto send7 = builder
 				 .state ()
@@ -6258,7 +6258,7 @@ TEST (rpc, epoch_upgrade)
 				 .sign (key1.prv, key1.pub)
 				 .work (*system.work.generate (key1_latest))
 				 .build_shared (); // to key3
-	ASSERT_EQ (nano::process_result::progress, node->process (*send7).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send7));
 	{
 		// Check pending entry
 		auto transaction (node->store.tx_begin_read ());
@@ -6307,7 +6307,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared (); // to opened account
-	ASSERT_EQ (nano::process_result::progress, node->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send1));
 	auto send2 = builder
 				 .state ()
 				 .account (nano::dev::genesis_key.pub)
@@ -6318,7 +6318,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send1->hash ()))
 				 .build_shared (); // to unopened account (pending)
-	ASSERT_EQ (nano::process_result::progress, node->process (*send2).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send2));
 	auto send3 = builder
 				 .state ()
 				 .account (nano::dev::genesis_key.pub)
@@ -6329,7 +6329,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send2->hash ()))
 				 .build_shared (); // to burn (0)
-	ASSERT_EQ (nano::process_result::progress, node->process (*send3).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send3));
 	nano::account max_account (std::numeric_limits<nano::uint256_t>::max ());
 	auto send4 = builder
 				 .state ()
@@ -6341,7 +6341,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send3->hash ()))
 				 .build_shared (); // to max account
-	ASSERT_EQ (nano::process_result::progress, node->process (*send4).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send4));
 	auto open = builder
 				.state ()
 				.account (key1.pub)
@@ -6352,7 +6352,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 				.sign (key1.prv, key1.pub)
 				.work (*system.work.generate (key1.pub))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*open));
 	// Check accounts epochs
 	{
 		auto transaction (node->store.tx_begin_read ());
@@ -6399,7 +6399,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (genesis_latest))
 				 .build_shared (); // to burn (0)
-	ASSERT_EQ (nano::process_result::progress, node->process (*send5).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send5));
 	auto send6 = builder
 				 .state ()
 				 .account (nano::dev::genesis_key.pub)
@@ -6410,7 +6410,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send5->hash ()))
 				 .build_shared (); // to key1 (again)
-	ASSERT_EQ (nano::process_result::progress, node->process (*send6).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send6));
 	auto key1_latest (node->latest (key1.pub));
 	auto send7 = builder
 				 .state ()
@@ -6422,7 +6422,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 				 .sign (key1.prv, key1.pub)
 				 .work (*system.work.generate (key1_latest))
 				 .build_shared (); // to key3
-	ASSERT_EQ (nano::process_result::progress, node->process (*send7).code);
+	ASSERT_EQ (nano::block_status::progress, node->process (*send7));
 	{
 		// Check pending entry
 		auto transaction (node->store.tx_begin_read ());
@@ -6471,7 +6471,7 @@ TEST (rpc, account_lazy_start)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*send1).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*send1));
 	auto open = builder
 				.open ()
 				.source (send1->hash ())
@@ -6480,7 +6480,7 @@ TEST (rpc, account_lazy_start)
 				.sign (key.prv, key.pub)
 				.work (*system.work.generate (key.pub))
 				.build_shared ();
-	ASSERT_EQ (nano::process_result::progress, node1->process (*open).code);
+	ASSERT_EQ (nano::block_status::progress, node1->process (*open));
 
 	// Start lazy bootstrap with account
 	nano::node_config node_config = system.default_config ();

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -497,14 +497,14 @@ void nano::generate_cache::enable_all ()
 	account_count = true;
 }
 
-std::string_view nano::to_string (nano::process_result process_result)
+std::string_view nano::to_string (nano::block_status code)
 {
-	return magic_enum::enum_name (process_result);
+	return magic_enum::enum_name (code);
 }
 
-nano::stat::detail nano::to_stat_detail (nano::process_result process_result)
+nano::stat::detail nano::to_stat_detail (nano::block_status code)
 {
-	auto value = magic_enum::enum_cast<nano::stat::detail> (magic_enum::enum_name (process_result));
+	auto value = magic_enum::enum_cast<nano::stat::detail> (magic_enum::enum_name (code));
 	debug_assert (value);
 	return value.value_or (nano::stat::detail{});
 }

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -253,7 +253,7 @@ enum class vote_code
 	indeterminate // Unknown if replay or vote
 };
 
-enum class process_result
+enum class block_status
 {
 	progress, // Hasn't been seen before, signed correctly
 	bad_signature, // Signature was bad, forged or transmission error
@@ -271,14 +271,9 @@ enum class process_result
 	insufficient_work // Insufficient work for this block, even though it passed the minimal validation
 };
 
-std::string_view to_string (process_result);
-nano::stat::detail to_stat_detail (process_result);
+std::string_view to_string (block_status);
+nano::stat::detail to_stat_detail (block_status);
 
-class process_return final
-{
-public:
-	nano::process_result code;
-};
 enum class tally_result
 {
 	vote,

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -72,7 +72,7 @@ public:
 	nano::block_hash block_source (store::transaction const &, nano::block const &);
 	std::pair<nano::block_hash, nano::block_hash> hash_root_random (store::transaction const &) const;
 	std::optional<nano::pending_info> pending_info (store::transaction const & transaction, nano::pending_key const & key) const;
-	nano::process_return process (store::write_transaction const &, nano::block &);
+	nano::block_status process (store::write_transaction const &, nano::block &);
 	bool rollback (store::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
 	bool rollback (store::write_transaction const &, nano::block_hash const &);
 	void update_account (store::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -136,7 +136,7 @@ TEST (ledger, deep_account_compute)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*pool.generate (nano::dev::genesis->hash ()))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 	auto open = builder
 				.open ()
 				.source (send->hash ())
@@ -145,7 +145,7 @@ TEST (ledger, deep_account_compute)
 				.sign (key.prv, key.pub)
 				.work (*pool.generate (key.pub))
 				.build ();
-	ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open));
 	auto sprevious (send->hash ());
 	auto rprevious (open->hash ());
 	for (auto i (0), n (100000); i != n; ++i)
@@ -159,7 +159,7 @@ TEST (ledger, deep_account_compute)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (sprevious))
 					.build ();
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 		sprevious = send->hash ();
 		auto receive = builder
 					   .receive ()
@@ -168,7 +168,7 @@ TEST (ledger, deep_account_compute)
 					   .sign (key.prv, key.pub)
 					   .work (*pool.generate (rprevious))
 					   .build ();
-		ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive).code);
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive));
 		rprevious = receive->hash ();
 		if (i % 100 == 0)
 		{
@@ -278,7 +278,7 @@ TEST (node, fork_storm)
 		for (auto node_i : system.nodes)
 		{
 			auto send_result (node_i->process (*send));
-			ASSERT_EQ (nano::process_result::progress, send_result.code);
+			ASSERT_EQ (nano::block_status::progress, send_result);
 			nano::keypair rep;
 			auto open = builder
 						.open ()
@@ -290,7 +290,7 @@ TEST (node, fork_storm)
 						.build_shared ();
 			node_i->work_generate_blocking (*open);
 			auto open_result (node_i->process (*open));
-			ASSERT_EQ (nano::process_result::progress, open_result.code);
+			ASSERT_EQ (nano::block_status::progress, open_result);
 			auto transaction (node_i->store.tx_begin_read ());
 			node_i->network.flood_block (open);
 		}
@@ -660,7 +660,7 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 						.sign (last_keypair.prv, last_keypair.pub)
 						.work (*system.work.generate (last_open_hash))
 						.build ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 			auto open = builder
 						.open ()
 						.source (send->hash ())
@@ -669,7 +669,7 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 						.sign (key.prv, key.pub)
 						.work (*system.work.generate (key.pub))
 						.build ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open));
 			last_open_hash = open->hash ();
 			last_keypair = key;
 		}
@@ -744,7 +744,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 						.work (*system.work.generate (latest_genesis))
 						.build ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 			auto open = builder
 						.open ()
 						.source (send->hash ())
@@ -753,7 +753,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 						.sign (key.prv, key.pub)
 						.work (*system.work.generate (key.pub))
 						.build_shared ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open));
 			open_blocks.push_back (std::move (open));
 			latest_genesis = send->hash ();
 		}
@@ -826,8 +826,8 @@ TEST (confirmation_height, long_chains)
 				.build ();
 	{
 		auto transaction = node->store.tx_begin_write ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open));
 	}
 
 	// Bulk send from genesis account to destination account
@@ -845,7 +845,7 @@ TEST (confirmation_height, long_chains)
 						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 						.work (*system.work.generate (previous_genesis_chain_hash))
 						.build ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 			auto receive = builder
 						   .receive ()
 						   .previous (previous_destination_chain_hash)
@@ -853,7 +853,7 @@ TEST (confirmation_height, long_chains)
 						   .sign (key1.prv, key1.pub)
 						   .work (*system.work.generate (previous_destination_chain_hash))
 						   .build ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive));
 
 			previous_genesis_chain_hash = send->hash ();
 			previous_destination_chain_hash = receive->hash ();
@@ -895,9 +895,9 @@ TEST (confirmation_height, long_chains)
 
 	{
 		auto transaction = node->store.tx_begin_write ();
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send1).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *receive1).code);
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send2).code);
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send1));
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *receive1));
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send2));
 	}
 
 	// Call block confirm on the existing receive block on the genesis account which will confirm everything underneath on both accounts
@@ -970,7 +970,7 @@ TEST (confirmation_height, dynamic_algorithm)
 		auto transaction = node->store.tx_begin_write ();
 		for (auto const & block : state_blocks)
 		{
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *block).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *block));
 		}
 	}
 
@@ -1031,7 +1031,7 @@ TEST (confirmation_height, dynamic_algorithm_no_transition_while_pending)
 						.build_shared ();
 			latest_genesis = send->hash ();
 			state_blocks.push_back (send);
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 			++num;
 		};
 
@@ -1116,7 +1116,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 						.work (*system.work.generate (latest_genesis))
 						.build ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 			auto open = builder
 						.open ()
 						.source (send->hash ())
@@ -1125,7 +1125,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 						.sign (key.prv, key.pub)
 						.work (*system.work.generate (key.pub))
 						.build_shared ();
-			ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *open).code);
+			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *open));
 			open_blocks.push_back (std::move (open));
 			latest_genesis = send->hash ();
 		}
@@ -1263,7 +1263,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 						.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 						.work (*pool.generate (latest_genesis))
 						.build ();
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send).code);
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send));
 			auto open = builder
 						.open ()
 						.source (send->hash ())
@@ -1272,7 +1272,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 						.sign (key.prv, key.pub)
 						.work (*pool.generate (key.pub))
 						.build_shared ();
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *open).code);
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *open));
 			open_blocks.push_back (std::move (open));
 			latest_genesis = send->hash ();
 		}
@@ -1316,8 +1316,8 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 										 .work (*system.work.generate (send_blocks.back ()->hash ()))
 										 .build_shared ());
 
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *send_blocks.back ()).code);
-			ASSERT_EQ (nano::process_result::progress, ledger.process (transaction, *receive_blocks.back ()).code);
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *send_blocks.back ()));
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *receive_blocks.back ()));
 		}
 	}
 
@@ -1688,7 +1688,7 @@ TEST (telemetry, many_nodes)
 	for (auto node : system.nodes)
 	{
 		auto transaction (node->store.tx_begin_write ());
-		ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 	}
 
 	// This is the node which will request metrics from all other nodes
@@ -1788,7 +1788,7 @@ TEST (node, mass_epoch_upgrader)
 							 .build (ec);
 				ASSERT_FALSE (ec);
 				ASSERT_NE (nullptr, block);
-				ASSERT_EQ (nano::process_result::progress, node.process (*block).code);
+				ASSERT_EQ (nano::block_status::progress, node.process (*block));
 				latest = block->hash ();
 				info.pending_hash = block->hash ();
 			}
@@ -1812,7 +1812,7 @@ TEST (node, mass_epoch_upgrader)
 						 .build (ec);
 			ASSERT_FALSE (ec);
 			ASSERT_NE (nullptr, block);
-			ASSERT_EQ (nano::process_result::progress, node.process (*block).code);
+			ASSERT_EQ (nano::block_status::progress, node.process (*block));
 		}
 		ASSERT_EQ (1 + total_accounts + opened.size (), node.ledger.cache.block_count);
 		ASSERT_EQ (1 + opened.size (), node.ledger.cache.account_count);
@@ -2043,7 +2043,7 @@ TEST (node, aggressive_flooding)
 		for (auto const & block : genesis_blocks)
 		{
 			auto process_result (node_wallet.first->process (*block));
-			ASSERT_TRUE (nano::process_result::progress == process_result.code || nano::process_result::old == process_result.code);
+			ASSERT_TRUE (nano::block_status::progress == process_result || nano::block_status::old == process_result);
 		}
 		ASSERT_EQ (node1.latest (nano::dev::genesis_key.pub), node_wallet.first->latest (nano::dev::genesis_key.pub));
 		ASSERT_EQ (genesis_blocks.back ()->hash (), node_wallet.first->latest (nano::dev::genesis_key.pub));
@@ -2083,7 +2083,7 @@ TEST (node, aggressive_flooding)
 				.build ();
 	}
 	// Processing locally goes through the aggressive block flooding path
-	ASSERT_EQ (nano::process_result::progress, node1.process_local (block).value ().code);
+	ASSERT_EQ (nano::block_status::progress, node1.process_local (block).value ());
 
 	auto all_have_block = [&nodes_wallets] (nano::block_hash const & hash_a) {
 		return std::all_of (nodes_wallets.begin (), nodes_wallets.end (), [hash = hash_a] (auto const & node_wallet) {
@@ -2146,7 +2146,7 @@ TEST (node, wallet_create_block_confirm_conflicts)
 							.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 							.work (*system.work.generate (latest))
 							.build ();
-				ASSERT_EQ (nano::process_result::progress, node->ledger.process (transaction, *send).code);
+				ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, *send));
 				latest = send->hash ();
 			}
 		}

--- a/nano/test_common/ledger.cpp
+++ b/nano/test_common/ledger.cpp
@@ -13,7 +13,7 @@ nano::test::context::ledger_context::ledger_context (std::deque<std::shared_ptr<
 	for (auto const & i : blocks_m)
 	{
 		auto process_result = ledger_m.process (tx, *i);
-		debug_assert (process_result.code == nano::process_result::progress);
+		debug_assert (process_result == nano::block_status::progress);
 	}
 }
 

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -41,7 +41,7 @@ std::shared_ptr<nano::node> nano::test::system::add_node (nano::node_config cons
 	for (auto i : initialization_blocks)
 	{
 		auto result = node->ledger.process (node->store.tx_begin_write (), *i);
-		debug_assert (result.code == nano::process_result::progress);
+		debug_assert (result == nano::block_status::progress);
 	}
 	debug_assert (!node->init_error ());
 	auto wallet = node->wallets.create (nano::random_wallet_id ());
@@ -262,7 +262,7 @@ std::unique_ptr<nano::state_block> nano::test::upgrade_epoch (nano::work_pool & 
 	bool error{ true };
 	if (!ec && epoch)
 	{
-		error = ledger_a.process (transaction, *epoch).code != nano::process_result::progress;
+		error = ledger_a.process (transaction, *epoch) != nano::block_status::progress;
 	}
 
 	return !error ? std::move (epoch) : nullptr;

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -65,7 +65,7 @@ bool nano::test::process (nano::node & node, std::vector<std::shared_ptr<nano::b
 	for (auto & block : blocks)
 	{
 		auto result = node.process (transaction, *block);
-		if (result.code != nano::process_result::progress)
+		if (result != nano::block_status::progress)
 		{
 			return false;
 		}


### PR DESCRIPTION
Remove process_return class which only contained process_result.
Rename process_result to block_status to better indicate its purpose.