### PR TITLE
Node shutdown reliability improvements

### DIFF
--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -254,6 +254,7 @@ namespace transport
 		attempts;
 		// clang-format on
 		std::atomic<bool> stopped{ false };
+		std::unordered_map<nano::transport::socket *, std::weak_ptr<nano::transport::socket>> connecting;
 
 		friend class network_peer_max_tcp_attempts_subnetwork_Test;
 	};


### PR DESCRIPTION
Cleans up connections waiting to connect when tcp_channels::stop is called which would otherwise leave waiting connection attempts in the io_context queue.
Wait for vote_generator thread to start before returning from vote_generator::start which may run in to an issue where an immediate call to vote_generator::stop would find a non-joinable thread.