### PR TITLE
Remove usages of frontiers table from ledger_processor block checks

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -820,11 +820,6 @@ TEST (block_store, frontier)
 	auto transaction (store->tx_begin_write ());
 	nano::block_hash hash (100);
 	nano::account account (200);
-	ASSERT_TRUE (store->frontier.get (transaction, hash).is_zero ());
-	store->frontier.put (transaction, hash, account);
-	ASSERT_EQ (account, store->frontier.get (transaction, hash));
-	store->frontier.del (transaction, hash);
-	ASSERT_TRUE (store->frontier.get (transaction, hash).is_zero ());
 }
 
 TEST (block_store, block_replace)


### PR DESCRIPTION
This is the first part of two commits to remove the frontier table from the database. This removes usages of the values in the frontier table from ledger_processor.

The second part https://github.com/nanocurrency/nano-node/pull/4425 will do the database upgrade which can be merged later in the release cycle.