### PR TITLE
Ledger query simplification

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5363,10 +5363,7 @@ TEST (ledger, pruning_safe_functions)
 	// Safe ledger actions
 	ASSERT_FALSE (ledger.balance (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, ledger.balance (transaction, send2->hash ()).value ());
-	bool error (false);
-	ASSERT_EQ (0, ledger.amount_safe (transaction, send2->hash (), error));
-	ASSERT_TRUE (error);
-	error = false;
+	ASSERT_FALSE (ledger.amount (transaction, send2->hash ()));
 	ASSERT_FALSE (ledger.account (transaction, send1->hash ()));
 	ASSERT_EQ (nano::dev::genesis->account (), ledger.account (transaction, send2->hash ()).value ());
 }

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5371,11 +5371,8 @@ TEST (ledger, pruning_safe_functions)
 	ASSERT_EQ (0, ledger.amount_safe (transaction, send2->hash (), error));
 	ASSERT_TRUE (error);
 	error = false;
-	ASSERT_TRUE (ledger.account_safe (transaction, send1->hash (), error).is_zero ());
-	ASSERT_TRUE (error);
-	error = false;
-	ASSERT_EQ (nano::dev::genesis->account (), ledger.account_safe (transaction, send2->hash (), error));
-	ASSERT_FALSE (error);
+	ASSERT_FALSE (ledger.account (transaction, send1->hash ()));
+	ASSERT_EQ (nano::dev::genesis->account (), ledger.account (transaction, send2->hash ()).value ());
 }
 
 TEST (ledger, hash_root_random)

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5361,13 +5361,9 @@ TEST (ledger, pruning_safe_functions)
 	ASSERT_TRUE (store->block.exists (transaction, nano::dev::genesis->hash ()));
 	ASSERT_TRUE (store->block.exists (transaction, send2->hash ()));
 	// Safe ledger actions
+	ASSERT_FALSE (ledger.balance (transaction, send1->hash ()));
+	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, ledger.balance (transaction, send2->hash ()).value ());
 	bool error (false);
-	ASSERT_EQ (0, ledger.balance_safe (transaction, send1->hash (), error));
-	ASSERT_TRUE (error);
-	error = false;
-	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio * 2, ledger.balance_safe (transaction, send2->hash (), error));
-	ASSERT_FALSE (error);
-	error = false;
 	ASSERT_EQ (0, ledger.amount_safe (transaction, send2->hash (), error));
 	ASSERT_TRUE (error);
 	error = false;

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1494,7 +1494,7 @@ int main (int argc, char * const * argv)
 							bool error_or_pruned (false);
 							if (!state_block.hashables.previous.is_zero ())
 							{
-								prev_balance = node->ledger.balance_safe (transaction, state_block.hashables.previous, error_or_pruned);
+								prev_balance = node->ledger.balance (transaction, state_block.hashables.previous).value_or (0);
 							}
 							if (node->ledger.is_epoch_link (state_block.hashables.link))
 							{
@@ -1518,11 +1518,10 @@ int main (int argc, char * const * argv)
 					}
 					else
 					{
-						bool error_or_pruned (false);
-						auto prev_balance (node->ledger.balance_safe (transaction, block->previous (), error_or_pruned));
-						if (!node->ledger.pruning || !error_or_pruned)
+						auto prev_balance = node->ledger.balance (transaction, block->previous ());
+						if (!node->ledger.pruning || prev_balance)
 						{
-							if (block->balance () < prev_balance)
+							if (block->balance () < prev_balance.value ())
 							{
 								// State send
 								block_details_error = !sideband.details.is_send || sideband.details.is_receive || sideband.details.is_epoch;
@@ -1534,7 +1533,7 @@ int main (int argc, char * const * argv)
 									// State change
 									block_details_error = sideband.details.is_send || sideband.details.is_receive || sideband.details.is_epoch;
 								}
-								else if (block->balance () == prev_balance && node->ledger.is_epoch_link (block->link ()))
+								else if (block->balance () == prev_balance.value () && node->ledger.is_epoch_link (block->link ()))
 								{
 									// State epoch
 									block_details_error = !sideband.details.is_epoch || sideband.details.is_send || sideband.details.is_receive;

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -346,11 +346,10 @@ void nano::bootstrap_attempt_lazy::lazy_block_state (std::shared_ptr<nano::block
 			// In other cases previous block balance required to find out subtype of state block
 			else if (node->ledger.block_or_pruned_exists (transaction, previous))
 			{
-				bool error_or_pruned (false);
-				auto previous_balance (node->ledger.balance_safe (transaction, previous, error_or_pruned));
-				if (!error_or_pruned)
+				auto previous_balance = node->ledger.balance (transaction, previous);
+				if (previous_balance)
 				{
-					if (previous_balance <= balance)
+					if (previous_balance.value () <= balance)
 					{
 						lazy_add (link, retry_limit);
 					}
@@ -423,11 +422,10 @@ void nano::bootstrap_attempt_lazy::lazy_backlog_cleanup ()
 		if (node->ledger.block_or_pruned_exists (transaction, it->first))
 		{
 			auto next_block (it->second);
-			bool error_or_pruned (false);
-			auto balance (node->ledger.balance_safe (transaction, it->first, error_or_pruned));
-			if (!error_or_pruned)
+			auto balance = node->ledger.balance (transaction, it->first);
+			if (balance)
 			{
-				if (balance <= next_block.balance) // balance
+				if (balance.value () <= next_block.balance) // balance
 				{
 					lazy_add (next_block.link, next_block.retry_limit); // link
 				}

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -286,7 +286,7 @@ nano::asc_pull_ack nano::bootstrap_server::process (const store::transaction & t
 		case asc_pull_req::hash_type::block:
 		{
 			// Try to lookup account assuming target is block hash
-			target = ledger.account_safe (transaction, request.target.as_block_hash ());
+			target = ledger.account (transaction, request.target.as_block_hash ()).value_or (0);
 		}
 		break;
 	}

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -166,7 +166,7 @@ void nano::bootstrap_ascending::service::inspect (store::transaction const & tx,
 		break;
 		case nano::block_status::gap_source:
 		{
-			const auto account = block.previous ().is_zero () ? block.account () : ledger.account (tx, block.previous ());
+			const auto account = block.previous ().is_zero () ? block.account () : ledger.account (tx, block.previous ()).value ();
 			const auto source = block.source ().is_zero () ? block.link ().as_block_hash () : block.source ();
 
 			// Mark account as blocked because it is missing the source block

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -132,7 +132,7 @@ void nano::bootstrap_ascending::service::inspect (store::transaction const & tx,
 	{
 		case nano::block_status::progress:
 		{
-			const auto account = ledger.account (tx, hash);
+			const auto account = ledger.account (block);
 			const auto is_send = ledger.is_send (tx, block);
 
 			// If we've inserted any block in to an account, unmark it as blocked

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1214,7 +1214,7 @@ void nano::json_handler::block_confirm ()
 				nano::election_status status{ block_l, 0, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::active_confirmation_height };
 				node.active.recently_cemented.put (status);
 				// Trigger callback for confirmed block
-				auto account (node.ledger.account (transaction, hash));
+				auto account = node.ledger.account (*block_l);
 				bool error_or_pruned (false);
 				auto amount (node.ledger.amount_safe (transaction, hash, error_or_pruned));
 				bool is_state_send (false);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1150,11 +1150,10 @@ void nano::json_handler::block_info ()
 		{
 			nano::account account (block->account ().is_zero () ? block->sideband ().account : block->account ());
 			response_l.put ("block_account", account.to_account ());
-			bool error_or_pruned (false);
-			auto amount (node.ledger.amount_safe (transaction, hash, error_or_pruned));
-			if (!error_or_pruned)
+			auto amount = node.ledger.amount (transaction, hash);
+			if (amount)
 			{
-				response_l.put ("amount", amount.convert_to<std::string> ());
+				response_l.put ("amount", amount.value ().convert_to<std::string> ());
 			}
 			auto balance = node.ledger.balance (*block);
 			response_l.put ("balance", balance.convert_to<std::string> ());
@@ -1215,19 +1214,18 @@ void nano::json_handler::block_confirm ()
 				node.active.recently_cemented.put (status);
 				// Trigger callback for confirmed block
 				auto account = node.ledger.account (*block_l);
-				bool error_or_pruned (false);
-				auto amount (node.ledger.amount_safe (transaction, hash, error_or_pruned));
+				auto amount = node.ledger.amount (transaction, hash);
 				bool is_state_send (false);
 				bool is_state_epoch (false);
-				if (!error_or_pruned)
+				if (amount)
 				{
 					if (auto state = dynamic_cast<nano::state_block *> (block_l.get ()))
 					{
 						is_state_send = node.ledger.is_send (transaction, *state);
-						is_state_epoch = amount == 0 && node.ledger.is_epoch_link (state->link ());
+						is_state_epoch = amount.value () == 0 && node.ledger.is_epoch_link (state->link ());
 					}
 				}
-				node.observers.blocks.notify (status, {}, account, amount, is_state_send, is_state_epoch);
+				node.observers.blocks.notify (status, {}, account, amount ? amount.value () : 0, is_state_send, is_state_epoch);
 			}
 			response_l.put ("started", "1");
 		}
@@ -1309,11 +1307,10 @@ void nano::json_handler::blocks_info ()
 					boost::property_tree::ptree entry;
 					nano::account account (block->account ().is_zero () ? block->sideband ().account : block->account ());
 					entry.put ("block_account", account.to_account ());
-					bool error_or_pruned (false);
-					auto amount (node.ledger.amount_safe (transaction, hash, error_or_pruned));
-					if (!error_or_pruned)
+					auto amount = node.ledger.amount (transaction, hash);
+					if (amount)
 					{
-						entry.put ("amount", amount.convert_to<std::string> ());
+						entry.put ("amount", amount.value ().convert_to<std::string> ());
 					}
 					auto balance = node.ledger.balance (*block);
 					entry.put ("balance", balance.convert_to<std::string> ());
@@ -2395,11 +2392,10 @@ public:
 		tree.put ("type", "send");
 		auto account (block_a.hashables.destination.to_account ());
 		tree.put ("account", account);
-		bool error_or_pruned (false);
-		auto amount (handler.node.ledger.amount_safe (transaction, hash, error_or_pruned).convert_to<std::string> ());
-		if (!error_or_pruned)
+		auto amount = handler.node.ledger.amount (transaction, hash);
+		if (amount)
 		{
-			tree.put ("amount", amount);
+			tree.put ("amount", amount.value ().convert_to<std::string> ());
 		}
 		if (raw)
 		{
@@ -2411,16 +2407,15 @@ public:
 	void receive_block (nano::receive_block const & block_a)
 	{
 		tree.put ("type", "receive");
-		bool error_or_pruned (false);
-		auto amount (handler.node.ledger.amount_safe (transaction, hash, error_or_pruned).convert_to<std::string> ());
-		if (!error_or_pruned)
+		auto amount = handler.node.ledger.amount (transaction, hash);
+		if (amount)
 		{
 			auto source_account = handler.node.ledger.account (transaction, block_a.hashables.source);
 			if (source_account)
 			{
 				tree.put ("account", source_account.value ().to_account ());
 			}
-			tree.put ("amount", amount);
+			tree.put ("amount", amount.value ().convert_to<std::string> ());
 		}
 		if (raw)
 		{
@@ -2445,15 +2440,15 @@ public:
 		if (block_a.hashables.source != handler.node.ledger.constants.genesis->account ())
 		{
 			bool error_or_pruned (false);
-			auto amount (handler.node.ledger.amount_safe (transaction, hash, error_or_pruned).convert_to<std::string> ());
-			if (!error_or_pruned)
+			auto amount = handler.node.ledger.amount (transaction, hash);
+			if (amount)
 			{
 				auto source_account = handler.node.ledger.account (transaction, block_a.hashables.source);
 				if (source_account)
 				{
 					tree.put ("account", source_account.value ().to_account ());
 				}
-				tree.put ("amount", amount);
+				tree.put ("amount", amount.value ().convert_to<std::string> ());
 			}
 		}
 		else

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1232,14 +1232,13 @@ void nano::node::process_confirmed_data (store::transaction const & transaction_
 	}
 	// Faster amount calculation
 	auto previous (block_a->previous ());
-	bool error (false);
-	auto previous_balance (ledger.balance_safe (transaction_a, previous, error));
+	auto previous_balance = ledger.balance (transaction_a, previous);
 	auto block_balance = ledger.balance (*block_a);
 	if (hash_a != ledger.constants.genesis->account ())
 	{
-		if (!error)
+		if (previous_balance)
 		{
-			amount_a = block_balance > previous_balance ? block_balance - previous_balance : previous_balance - block_balance;
+			amount_a = block_balance > previous_balance.value () ? block_balance - previous_balance.value () : previous_balance.value () - block_balance;
 		}
 		else
 		{

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -51,8 +51,8 @@ bool nano::scheduler::priority::activate (nano::account const & account_a, store
 			debug_assert (block != nullptr);
 			if (node.ledger.dependents_confirmed (transaction, *block))
 			{
-				auto const balance = node.ledger.balance (transaction, hash);
-				auto const previous_balance = node.ledger.balance (transaction, conf_info.frontier);
+				auto const balance = node.ledger.balance (transaction, hash).value ();
+				auto const previous_balance = node.ledger.balance (transaction, conf_info.frontier).value_or (0);
 				auto const balance_priority = std::max (balance, previous_balance);
 
 				node.stats.inc (nano::stat::type::election_scheduler, nano::stat::detail::activated);

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -521,26 +521,29 @@ public:
 	{
 		type = "Send";
 		account = block_a.hashables.destination;
-		bool error_or_pruned (false);
-		amount = ledger.amount_safe (transaction, block_a.hash (), error_or_pruned);
-		if (error_or_pruned)
+		auto amount_l = ledger.amount (transaction, block_a.hash ());
+		if (!amount_l)
 		{
 			type = "Send (pruned)";
+		}
+		else
+		{
+			amount = amount_l.value ();
 		}
 	}
 	void receive_block (nano::receive_block const & block_a)
 	{
 		type = "Receive";
 		auto account_l = ledger.account (transaction, block_a.hashables.source);
-		bool error_or_pruned = false;
-		amount = ledger.amount_safe (transaction, block_a.hash (), error_or_pruned);
-		if (!account_l || error_or_pruned)
+		auto amount_l = ledger.amount (transaction, block_a.hash ());
+		if (!account_l || !amount_l)
 		{
 			type = "Receive (pruned)";
 		}
 		else
 		{
 			account = account_l.value ();
+			amount = amount_l.value ();
 		}
 	}
 	void open_block (nano::open_block const & block_a)
@@ -548,16 +551,16 @@ public:
 		type = "Receive";
 		if (block_a.hashables.source != ledger.constants.genesis->account ())
 		{
-			bool error_or_pruned (false);
 			auto account_l = ledger.account (transaction, block_a.hashables.source);
-			amount = ledger.amount_safe (transaction, block_a.hash (), error_or_pruned);
-			if (!account_l || error_or_pruned)
+			auto amount_l = ledger.amount (transaction, block_a.hash ());
+			if (!account_l || !amount_l)
 			{
 				type = "Receive (pruned)";
 			}
 			else
 			{
 				account = account_l.value ();
+				amount = amount_l.value ();
 			}
 		}
 		else

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -531,12 +531,16 @@ public:
 	void receive_block (nano::receive_block const & block_a)
 	{
 		type = "Receive";
-		bool error_or_pruned (false);
-		account = ledger.account_safe (transaction, block_a.hashables.source, error_or_pruned);
+		auto account_l = ledger.account (transaction, block_a.hashables.source);
+		bool error_or_pruned = false;
 		amount = ledger.amount_safe (transaction, block_a.hash (), error_or_pruned);
-		if (error_or_pruned)
+		if (!account_l || error_or_pruned)
 		{
 			type = "Receive (pruned)";
+		}
+		else
+		{
+			account = account_l.value ();
 		}
 	}
 	void open_block (nano::open_block const & block_a)
@@ -545,11 +549,15 @@ public:
 		if (block_a.hashables.source != ledger.constants.genesis->account ())
 		{
 			bool error_or_pruned (false);
-			account = ledger.account_safe (transaction, block_a.hashables.source, error_or_pruned);
+			auto account_l = ledger.account (transaction, block_a.hashables.source);
 			amount = ledger.amount_safe (transaction, block_a.hash (), error_or_pruned);
-			if (error_or_pruned)
+			if (!account_l || error_or_pruned)
 			{
 				type = "Receive (pruned)";
+			}
+			else
+			{
+				account = account_l.value ();
 			}
 		}
 		else
@@ -596,10 +604,14 @@ public:
 			else
 			{
 				type = "Receive";
-				account = ledger.account_safe (transaction, block_a.hashables.link.as_block_hash (), error_or_pruned);
-				if (error_or_pruned)
+				auto account_l = ledger.account (transaction, block_a.hashables.link.as_block_hash ());
+				if (!account_l)
 				{
 					type = "Receive (pruned)";
+				}
+				else
+				{
+					account = account_l.value ();
 				}
 			}
 			amount = balance - previous_balance;
@@ -609,7 +621,7 @@ public:
 	nano::ledger & ledger;
 	std::string type;
 	nano::uint128_t amount;
-	nano::account account;
+	nano::account account{ 0 };
 };
 }
 

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -575,9 +575,8 @@ public:
 	void state_block (nano::state_block const & block_a)
 	{
 		auto balance (block_a.hashables.balance.number ());
-		bool error_or_pruned (false);
-		auto previous_balance (ledger.balance_safe (transaction, block_a.hashables.previous, error_or_pruned));
-		if (error_or_pruned)
+		auto previous_balance = ledger.balance (transaction, block_a.hashables.previous);
+		if (!previous_balance)
 		{
 			type = "Unknown (pruned)";
 			amount = 0;
@@ -586,7 +585,7 @@ public:
 		else if (balance < previous_balance)
 		{
 			type = "Send";
-			amount = previous_balance - balance;
+			amount = previous_balance.value () - balance;
 			account = block_a.hashables.link.as_account ();
 		}
 		else
@@ -614,7 +613,7 @@ public:
 					account = account_l.value ();
 				}
 			}
-			amount = balance - previous_balance;
+			amount = balance - previous_balance.value ();
 		}
 	}
 	nano::store::transaction const & transaction;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1171,6 +1171,10 @@ nano::uint128_t nano::ledger::amount (store::transaction const & transaction_a, 
 {
 	auto block_l = block (transaction_a, hash_a);
 	auto block_balance (balance (transaction_a, hash_a));
+	if (block_l->previous ().is_zero ())
+	{
+		return block_balance;
+	}
 	auto previous_balance (balance (transaction_a, block_l->previous ()));
 	return block_balance > previous_balance ? block_balance - previous_balance : previous_balance - block_balance;
 }
@@ -1180,6 +1184,10 @@ nano::uint128_t nano::ledger::amount_safe (store::transaction const & transactio
 	auto block_l = block (transaction_a, hash_a);
 	debug_assert (block_l);
 	auto block_balance (balance (transaction_a, hash_a));
+	if (block_l->previous ().is_zero ())
+	{
+		return block_balance;
+	}
 	auto previous_balance (balance_safe (transaction_a, block_l->previous (), error_a));
 	return error_a ? 0 : block_balance > previous_balance ? block_balance - previous_balance
 														  : previous_balance - block_balance;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -63,7 +63,7 @@ public:
 	{
 		auto hash (block_a.hash ());
 		auto amount (ledger.amount (transaction, hash));
-		auto destination_account (ledger.account (transaction, hash));
+		auto destination_account = ledger.account (block_a);
 		// Pending account entry can be incorrect if source block was pruned. But it's not affecting correct ledger processing
 		[[maybe_unused]] bool is_pruned (false);
 		auto source_account (ledger.account_safe (transaction, block_a.hashables.source, is_pruned));
@@ -83,7 +83,7 @@ public:
 	{
 		auto hash (block_a.hash ());
 		auto amount (ledger.amount (transaction, hash));
-		auto destination_account (ledger.account (transaction, hash));
+		auto destination_account = ledger.account (block_a);
 		// Pending account entry can be incorrect if source block was pruned. But it's not affecting correct ledger processing
 		[[maybe_unused]] bool is_pruned (false);
 		auto source_account (ledger.account_safe (transaction, block_a.hashables.source, is_pruned));
@@ -99,7 +99,7 @@ public:
 	{
 		auto hash (block_a.hash ());
 		auto rep_block (ledger.representative (transaction, block_a.hashables.previous));
-		auto account (ledger.account (transaction, block_a.hashables.previous));
+		auto account = ledger.account (block_a);
 		auto info = ledger.account_info (transaction, account);
 		debug_assert (info);
 		auto balance (ledger.balance (transaction, block_a.hashables.previous));

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -65,15 +65,14 @@ public:
 		auto amount (ledger.amount (transaction, hash));
 		auto destination_account = ledger.account (block_a);
 		// Pending account entry can be incorrect if source block was pruned. But it's not affecting correct ledger processing
-		[[maybe_unused]] bool is_pruned (false);
-		auto source_account (ledger.account_safe (transaction, block_a.hashables.source, is_pruned));
+		auto source_account = ledger.account (transaction, block_a.hashables.source);
 		auto info = ledger.account_info (transaction, destination_account);
 		debug_assert (info);
 		ledger.cache.rep_weights.representation_add (info->representative, 0 - amount);
 		nano::account_info new_info (block_a.hashables.previous, info->representative, info->open_block, ledger.balance (transaction, block_a.hashables.previous), nano::seconds_since_epoch (), info->block_count - 1, nano::epoch::epoch_0);
 		ledger.update_account (transaction, destination_account, *info, new_info);
 		ledger.store.block.del (transaction, hash);
-		ledger.store.pending.put (transaction, nano::pending_key (destination_account, block_a.hashables.source), { source_account, amount, nano::epoch::epoch_0 });
+		ledger.store.pending.put (transaction, nano::pending_key (destination_account, block_a.hashables.source), { source_account.value_or (0), amount, nano::epoch::epoch_0 });
 		ledger.store.frontier.del (transaction, hash);
 		ledger.store.frontier.put (transaction, block_a.hashables.previous, destination_account);
 		ledger.store.block.successor_clear (transaction, block_a.hashables.previous);
@@ -84,14 +83,12 @@ public:
 		auto hash (block_a.hash ());
 		auto amount (ledger.amount (transaction, hash));
 		auto destination_account = ledger.account (block_a);
-		// Pending account entry can be incorrect if source block was pruned. But it's not affecting correct ledger processing
-		[[maybe_unused]] bool is_pruned (false);
-		auto source_account (ledger.account_safe (transaction, block_a.hashables.source, is_pruned));
+		auto source_account = ledger.account (transaction, block_a.hashables.source);
 		ledger.cache.rep_weights.representation_add (block_a.representative (), 0 - amount);
 		nano::account_info new_info;
 		ledger.update_account (transaction, destination_account, new_info, new_info);
 		ledger.store.block.del (transaction, hash);
-		ledger.store.pending.put (transaction, nano::pending_key (destination_account, block_a.hashables.source), { source_account, amount, nano::epoch::epoch_0 });
+		ledger.store.pending.put (transaction, nano::pending_key (destination_account, block_a.hashables.source), { source_account.value_or (0), amount, nano::epoch::epoch_0 });
 		ledger.store.frontier.del (transaction, hash);
 		ledger.stats.inc (nano::stat::type::rollback, nano::stat::detail::open);
 	}
@@ -156,9 +153,8 @@ public:
 		else if (!block_a.hashables.link.is_zero () && !ledger.is_epoch_link (block_a.hashables.link))
 		{
 			// Pending account entry can be incorrect if source block was pruned. But it's not affecting correct ledger processing
-			[[maybe_unused]] bool is_pruned (false);
-			auto source_account (ledger.account_safe (transaction, block_a.hashables.link.as_block_hash (), is_pruned));
-			nano::pending_info pending_info (source_account, block_a.hashables.balance.number () - balance, block_a.sideband ().source_epoch);
+			auto source_account = ledger.account (transaction, block_a.hashables.link.as_block_hash ());
+			nano::pending_info pending_info (source_account.value_or (0), block_a.hashables.balance.number () - balance, block_a.sideband ().source_epoch);
 			ledger.store.pending.put (transaction, nano::pending_key (block_a.hashables.account, block_a.hashables.link.as_block_hash ()), pending_info);
 			ledger.stats.inc (nano::stat::type::rollback, nano::stat::detail::receive);
 		}
@@ -1109,7 +1105,7 @@ nano::uint128_t nano::ledger::weight (nano::account const & account_a)
 bool nano::ledger::rollback (store::write_transaction const & transaction_a, nano::block_hash const & block_a, std::vector<std::shared_ptr<nano::block>> & list_a)
 {
 	debug_assert (block_exists (transaction_a, block_a));
-	auto account_l (account (transaction_a, block_a));
+	auto account_l = account (transaction_a, block_a).value ();
 	auto block_account_height (height (transaction_a, block_a));
 	rollback_visitor rollback (transaction_a, *this, list_a);
 	auto error (false);
@@ -1144,7 +1140,7 @@ bool nano::ledger::rollback (store::write_transaction const & transaction_a, nan
 	return rollback (transaction_a, block_a, rollback_list);
 }
 
-nano::account nano::ledger::account (nano::block const & block) const
+nano::account nano::ledger::account (nano::block const & block)
 {
 	debug_assert (block.has_sideband ());
 	nano::account result (block.account ());
@@ -1156,45 +1152,14 @@ nano::account nano::ledger::account (nano::block const & block) const
 	return result;
 }
 
-nano::account nano::ledger::account (store::transaction const & transaction, nano::block_hash const & hash) const
+std::optional<nano::account> nano::ledger::account (store::transaction const & transaction, nano::block_hash const & hash) const
 {
 	auto block_l = block (transaction, hash);
-	debug_assert (block_l != nullptr);
+	if (!block_l)
+	{
+		return std::nullopt;
+	}
 	return account (*block_l);
-}
-
-nano::account nano::ledger::account_safe (store::transaction const & transaction_a, nano::block_hash const & hash_a, bool & error_a) const
-{
-	if (!pruning)
-	{
-		return account (transaction_a, hash_a);
-	}
-	else
-	{
-		auto block_l = block (transaction_a, hash_a);
-		if (block_l != nullptr)
-		{
-			return account (*block_l);
-		}
-		else
-		{
-			error_a = true;
-			return 0;
-		}
-	}
-}
-
-nano::account nano::ledger::account_safe (store::transaction const & transaction, nano::block_hash const & hash) const
-{
-	auto block_l = block (transaction, hash);
-	if (block_l)
-	{
-		return account (*block_l);
-	}
-	else
-	{
-		return { 0 };
-	}
 }
 
 std::optional<nano::account_info> nano::ledger::account_info (store::transaction const & transaction, nano::account const & account) const

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -40,9 +40,7 @@ public:
 	 */
 	std::optional<nano::account> account (store::transaction const &, nano::block_hash const &) const;
 	std::optional<nano::account_info> account_info (store::transaction const & transaction, nano::account const & account) const;
-	nano::uint128_t amount (store::transaction const &, nano::block_hash const &);
-	/** Safe for previous block, but block hash_a must exist */
-	nano::uint128_t amount_safe (store::transaction const &, nano::block_hash const & hash_a, bool &) const;
+	std::optional<nano::uint128_t> amount (store::transaction const &, nano::block_hash const &);
 	static nano::uint128_t balance (nano::block const & block);
 	std::optional<nano::uint128_t> balance (store::transaction const &, nano::block_hash const &) const;
 	std::shared_ptr<nano::block> block (store::transaction const & transaction, nano::block_hash const & hash) const;

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -44,8 +44,7 @@ public:
 	/** Safe for previous block, but block hash_a must exist */
 	nano::uint128_t amount_safe (store::transaction const &, nano::block_hash const & hash_a, bool &) const;
 	static nano::uint128_t balance (nano::block const & block);
-	nano::uint128_t balance (store::transaction const &, nano::block_hash const &) const;
-	nano::uint128_t balance_safe (store::transaction const &, nano::block_hash const &, bool &) const;
+	std::optional<nano::uint128_t> balance (store::transaction const &, nano::block_hash const &) const;
 	std::shared_ptr<nano::block> block (store::transaction const & transaction, nano::block_hash const & hash) const;
 	bool block_exists (store::transaction const & transaction, nano::block_hash const & hash) const;
 	nano::uint128_t account_balance (store::transaction const &, nano::account const &, bool = false);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -33,18 +33,13 @@ public:
 	/**
 	 * Return account containing hash, expects that block hash exists in ledger
 	 */
-	nano::account account (nano::block const & block) const;
-	nano::account account (store::transaction const &, nano::block_hash const &) const;
+	static nano::account account (nano::block const & block);
+	/**
+	 * Returns the account for a given hash
+	 * Returns std::nullopt if the block doesn't exist or has been pruned
+	 */
+	std::optional<nano::account> account (store::transaction const &, nano::block_hash const &) const;
 	std::optional<nano::account_info> account_info (store::transaction const & transaction, nano::account const & account) const;
-	/**
-	 * For non-prunning nodes same as `ledger::account()`
-	 * For prunning nodes ensures that block hash exists, otherwise returns zero account
-	 */
-	nano::account account_safe (store::transaction const &, nano::block_hash const &, bool &) const;
-	/**
-	 * Return account containing hash, returns zero account if account can not be found
-	 */
-	nano::account account_safe (store::transaction const &, nano::block_hash const &) const;
 	nano::uint128_t amount (store::transaction const &, nano::block_hash const &);
 	/** Safe for previous block, but block hash_a must exist */
 	nano::uint128_t amount_safe (store::transaction const &, nano::block_hash const & hash_a, bool &) const;


### PR DESCRIPTION
This PR merges the ledger::account/balance/amount variants in to a single function for each, returning an optional associated value.

The major advantage is a simplification in the nano::ledger interface and increased type-checking in values returned.  Previously there were separate functions for assumed-correct function calls protected with debug_assert, and variants permitted to fail that returned error codes or sentinel values.

These changes replace each account/amount/balance with functions that return std::optional values for each associated type. Variants that used assumed-correct functions simply call std::optional::value, which does runtime value checking which increases correctness safety. Variants that used _safe variants or checked sentinel values are replaced with std::optional bool conversion checks and operate the same way.