### PR TITLE
Update minimum OSX deployment target to 13.3 which is required by the OSX 14.4 SDK.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 # OSX compatibility needs to be set before project is declared
 set(CMAKE_OSX_DEPLOYMENT_TARGET
-    12
+    13.3
     CACHE STRING "")
 
 project(nano-node)


### PR DESCRIPTION
Fixes error:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.4.sdk/usr/include/c++/v1/__format/formatter_floating_point.h:66:32: error: 'to_chars' is unavailable: introduced in macOS 13.3