### PR TITLE
Blocks.hpp recompile time reduction

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>

--- a/nano/core_test/backlog.cpp
+++ b/nano/core_test/backlog.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/active_transactions.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stream.hpp>
 #include <nano/node/common.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/lmdbconfig.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/stats.hpp>

--- a/nano/core_test/blockprocessor.cpp
+++ b/nano/core_test/blockprocessor.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blockbuilders.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/secure/common.hpp>

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/bootstrap/block_deserializer.hpp>
 #include <nano/node/bootstrap/bootstrap_frontier.hpp>
 #include <nano/node/bootstrap/bootstrap_lazy.hpp>

--- a/nano/core_test/bootstrap_ascending.cpp
+++ b/nano/core_test/bootstrap_ascending.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/tomlconfig.hpp>

--- a/nano/core_test/bootstrap_server.cpp
+++ b/nano/core_test/bootstrap_server.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/make_store.hpp>

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/transport/inproc.hpp>

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -1,4 +1,4 @@
-
+#include <nano/lib/blocks.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/frontiers_confirmation.cpp
+++ b/nano/core_test/frontiers_confirmation.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/active_transactions.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/threading.hpp>

--- a/nano/core_test/memory_pool.cpp
+++ b/nano/core_test/memory_pool.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/memory.hpp>
 #include <nano/node/active_transactions.hpp>
 #include <nano/secure/common.hpp>

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stream.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/network.hpp>

--- a/nano/core_test/message_deserializer.cpp
+++ b/nano/core_test/message_deserializer.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/transport/message_deserializer.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/scheduler/component.hpp>

--- a/nano/core_test/network_filter.cpp
+++ b/nano/core_test/network_filter.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stream.hpp>
 #include <nano/node/common.hpp>
 #include <nano/secure/common.hpp>

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/node/election.hpp>

--- a/nano/core_test/optimistic_scheduler.cpp
+++ b/nano/core_test/optimistic_scheduler.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/election.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/work.hpp>

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/request_aggregator.hpp>
 #include <nano/node/transport/inproc.hpp>

--- a/nano/core_test/scheduler_buckets.cpp
+++ b/nano/core_test/scheduler_buckets.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/scheduler/buckets.hpp>
 #include <nano/secure/common.hpp>
 

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/test_common/network.hpp>

--- a/nano/core_test/unchecked_map.cpp
+++ b/nano/core_test/unchecked_map.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blockbuilders.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/node/unchecked_map.hpp>
 #include <nano/secure/common.hpp>

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/vote_processor.hpp>

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/voting.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/store/lmdb/wallet_value.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/store/versioning.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -1,4 +1,5 @@
 #include <nano/core_test/fakes/websocket_client.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/test_common/network.hpp>

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   block_sideband.cpp
   block_type.hpp
   block_type.cpp
+  block_uniquer.hpp
   blockbuilders.hpp
   blockbuilders.cpp
   blocks.hpp

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -21,6 +21,10 @@ add_library(
   ${platform_sources}
   asio.hpp
   asio.cpp
+  block_sideband.hpp
+  block_sideband.cpp
+  block_type.hpp
+  block_type.cpp
   blockbuilders.hpp
   blockbuilders.cpp
   blocks.hpp

--- a/nano/lib/block_sideband.hpp
+++ b/nano/lib/block_sideband.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <nano/lib/block_type.hpp>
+#include <nano/lib/epoch.hpp>
+#include <nano/lib/numbers.hpp>
+#include <nano/lib/stream.hpp>
+#include <nano/lib/timer.hpp>
+
+#include <cstdint>
+
+namespace nano
+{
+class object_stream;
+}
+
+namespace nano
+{
+class block_details
+{
+	static_assert (std::is_same<std::underlying_type<nano::epoch>::type, uint8_t> (), "Epoch enum is not the proper type");
+	static_assert (static_cast<uint8_t> (nano::epoch::max) < (1 << 5), "Epoch max is too large for the sideband");
+
+public:
+	block_details () = default;
+	block_details (nano::epoch const epoch_a, bool const is_send_a, bool const is_receive_a, bool const is_epoch_a);
+	static constexpr size_t size ()
+	{
+		return 1;
+	}
+	bool operator== (block_details const & other_a) const;
+	void serialize (nano::stream &) const;
+	bool deserialize (nano::stream &);
+	nano::epoch epoch{ nano::epoch::epoch_0 };
+	bool is_send{ false };
+	bool is_receive{ false };
+	bool is_epoch{ false };
+
+private:
+	uint8_t packed () const;
+	void unpack (uint8_t);
+
+public: // Logging
+	void operator() (nano::object_stream &) const;
+};
+
+std::string state_subtype (nano::block_details const);
+
+class block_sideband final
+{
+public:
+	block_sideband () = default;
+	block_sideband (nano::account const &, nano::block_hash const &, nano::amount const &, uint64_t const, nano::seconds_t const local_timestamp, nano::block_details const &, nano::epoch const source_epoch_a);
+	block_sideband (nano::account const &, nano::block_hash const &, nano::amount const &, uint64_t const, nano::seconds_t const local_timestamp, nano::epoch const epoch_a, bool const is_send, bool const is_receive, bool const is_epoch, nano::epoch const source_epoch_a);
+	void serialize (nano::stream &, nano::block_type) const;
+	bool deserialize (nano::stream &, nano::block_type);
+	static size_t size (nano::block_type);
+	nano::block_hash successor{ 0 };
+	nano::account account{};
+	nano::amount balance{ 0 };
+	uint64_t height{ 0 };
+	uint64_t timestamp{ 0 };
+	nano::block_details details;
+	nano::epoch source_epoch{ nano::epoch::epoch_0 };
+
+public: // Logging
+	void operator() (nano::object_stream &) const;
+};
+} // namespace nano

--- a/nano/lib/block_sideband.hpp
+++ b/nano/lib/block_sideband.hpp
@@ -7,6 +7,7 @@
 #include <nano/lib/timer.hpp>
 
 #include <cstdint>
+#include <memory>
 
 namespace nano
 {

--- a/nano/lib/block_type.cpp
+++ b/nano/lib/block_type.cpp
@@ -1,0 +1,13 @@
+#include <nano/lib/block_type.hpp>
+
+#include <magic_enum.hpp>
+
+std::string_view nano::to_string (nano::block_type type)
+{
+	return magic_enum::enum_name (type);
+}
+
+void nano::serialize_block_type (nano::stream & stream, const nano::block_type & type)
+{
+	nano::write (stream, type);
+}

--- a/nano/lib/block_type.hpp
+++ b/nano/lib/block_type.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <nano/lib/stream.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace nano
+{
+enum class block_type : uint8_t
+{
+	invalid = 0,
+	not_a_block = 1,
+	send = 2,
+	receive = 3,
+	open = 4,
+	change = 5,
+	state = 6
+};
+
+std::string_view to_string (block_type);
+/**
+ * Serialize block type as an 8-bit value
+ */
+void serialize_block_type (nano::stream &, nano::block_type const &);
+} // namespace nano

--- a/nano/lib/block_uniquer.hpp
+++ b/nano/lib/block_uniquer.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+#include <nano/lib/uniquer.hpp>
+
+namespace nano
+{
+class block;
+using block_uniquer = nano::uniquer<nano::uint256_union, nano::block>;
+}

--- a/nano/lib/blockbuilders.cpp
+++ b/nano/lib/blockbuilders.cpp
@@ -1,4 +1,7 @@
 #include <nano/lib/blockbuilders.hpp>
+#include <nano/lib/blocks.hpp>
+#include <nano/lib/errors.hpp>
+#include <nano/lib/utility.hpp>
 
 #include <unordered_map>
 

--- a/nano/lib/blockbuilders.hpp
+++ b/nano/lib/blockbuilders.hpp
@@ -1,8 +1,17 @@
 #pragma once
 
-#include <nano/lib/blocks.hpp>
+#include <nano/lib/numbers.hpp>
 
 #include <memory>
+
+namespace nano
+{
+class change_block;
+class send_block;
+class state_block;
+class open_block;
+class receive_block;
+}
 
 namespace nano
 {

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -13,6 +13,12 @@
 #include <cryptopp/words.h>
 #include <magic_enum.hpp>
 
+size_t constexpr nano::send_block::size;
+size_t constexpr nano::receive_block::size;
+size_t constexpr nano::open_block::size;
+size_t constexpr nano::change_block::size;
+size_t constexpr nano::state_block::size;
+
 /** Compare blocks, first by type, then content. This is an optimization over dynamic_cast, which is very slow on some platforms. */
 namespace
 {

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -1443,11 +1443,6 @@ std::shared_ptr<nano::block> nano::deserialize_block_json (boost::property_tree:
 	return result;
 }
 
-void nano::serialize_block_type (nano::stream & stream, const nano::block_type & type)
-{
-	nano::write (stream, type);
-}
-
 void nano::serialize_block (nano::stream & stream_a, nano::block const & block_a)
 {
 	nano::serialize_block_type (stream_a, block_a.type ());
@@ -1985,9 +1980,4 @@ void nano::block_sideband::operator() (nano::object_stream & obs) const
 	obs.write ("timestamp", timestamp);
 	obs.write ("source_epoch", source_epoch);
 	obs.write ("details", details);
-}
-
-std::string_view nano::to_string (nano::block_type type)
-{
-	return magic_enum::enum_name (type);
 }

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -83,8 +83,6 @@ public: // Logging
 	virtual void operator() (nano::object_stream &) const;
 };
 
-using block_list_t = std::vector<std::shared_ptr<nano::block>>;
-
 class send_hashables
 {
 public:

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/crypto/blake2/blake2.h>
 #include <nano/lib/block_sideband.hpp>
+#include <nano/lib/block_uniquer.hpp>
 #include <nano/lib/epoch.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/numbers.hpp>
@@ -9,7 +10,6 @@
 #include <nano/lib/optional_ptr.hpp>
 #include <nano/lib/stream.hpp>
 #include <nano/lib/timer.hpp>
-#include <nano/lib/uniquer.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/lib/work.hpp>
 
@@ -377,8 +377,6 @@ public:
 	virtual void state_block (nano::state_block &) = 0;
 	virtual ~mutable_block_visitor () = default;
 };
-
-using block_uniquer = nano::uniquer<nano::uint256_union, nano::block>;
 
 std::shared_ptr<nano::block> deserialize_block (nano::stream &);
 std::shared_ptr<nano::block> deserialize_block (nano::stream &, nano::block_type, nano::block_uniquer * = nullptr);

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -1,26 +1,23 @@
 #pragma once
 
-#include <nano/crypto/blake2/blake2.h>
 #include <nano/lib/block_sideband.hpp>
 #include <nano/lib/block_uniquer.hpp>
+#include <nano/lib/config.hpp>
 #include <nano/lib/epoch.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/numbers.hpp>
-#include <nano/lib/object_stream.hpp>
 #include <nano/lib/optional_ptr.hpp>
 #include <nano/lib/stream.hpp>
-#include <nano/lib/timer.hpp>
-#include <nano/lib/utility.hpp>
-#include <nano/lib/work.hpp>
 
 #include <boost/property_tree/ptree_fwd.hpp>
 
-#include <unordered_map>
+typedef struct blake2b_state__ blake2b_state;
 
 namespace nano
 {
 class block_visitor;
 class mutable_block_visitor;
+class object_stream;
 
 class block
 {

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -1,3 +1,4 @@
+#include <nano/crypto/blake2/blake2.h>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/logging.hpp>

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -1,3 +1,4 @@
+#include <nano/crypto/blake2/blake2.h>
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/epoch.hpp>

--- a/nano/load_test/entry.cpp
+++ b/nano/load_test/entry.cpp
@@ -4,6 +4,7 @@
 #include <nano/boost/beast/core/flat_buffer.hpp>
 #include <nano/boost/beast/http.hpp>
 #include <nano/boost/process/child.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/threading.hpp>

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/cli.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/utility.hpp>

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/node/active_transactions.hpp>
 #include <nano/node/confirmation_height_processor.hpp>

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/node/blockprocessor.hpp>

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/secure/common.hpp>
 
@@ -10,6 +9,13 @@
 #include <optional>
 #include <thread>
 
+namespace nano
+{
+class block;
+class node;
+class write_database_queue;
+}
+
 namespace nano::store
 {
 class write_transaction;
@@ -17,8 +23,6 @@ class write_transaction;
 
 namespace nano
 {
-class node;
-class write_database_queue;
 
 enum class block_source
 {

--- a/nano/node/bootstrap/block_deserializer.hpp
+++ b/nano/node/bootstrap/block_deserializer.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <nano/lib/blocks.hpp>
+#include <nano/lib/block_type.hpp>
+
+#include <boost/system/error_code.hpp>
 
 #include <memory>
 #include <vector>

--- a/nano/node/bootstrap/bootstrap_attempt.cpp
+++ b/nano/node/bootstrap/bootstrap_attempt.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/bootstrap/bootstrap.hpp>
 #include <nano/node/bootstrap/bootstrap_attempt.hpp>
 #include <nano/node/bootstrap/bootstrap_bulk_push.hpp>

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/bootstrap/block_deserializer.hpp>
 #include <nano/node/bootstrap/bootstrap.hpp>
 #include <nano/node/bootstrap/bootstrap_bulk_pull.hpp>

--- a/nano/node/bootstrap/bootstrap_bulk_push.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/bootstrap/bootstrap_attempt.hpp>
 #include <nano/node/bootstrap/bootstrap_bulk_push.hpp>
 #include <nano/node/bootstrap/bootstrap_legacy.hpp>

--- a/nano/node/bootstrap/bootstrap_frontier.hpp
+++ b/nano/node/bootstrap/bootstrap_frontier.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <nano/lib/numbers.hpp>
+
 #include <deque>
 #include <future>
+#include <memory>
 
 namespace nano
 {

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/bootstrap/bootstrap.hpp>
 #include <nano/node/bootstrap/bootstrap_lazy.hpp>
 #include <nano/node/common.hpp>

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/bootstrap/bootstrap_server.hpp>
 #include <nano/node/transport/channel.hpp>

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stats_enums.hpp>
 #include <nano/node/blockprocessor.hpp>
 #include <nano/node/bootstrap_ascending/service.hpp>

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/cli.hpp>
 #include <nano/lib/tlsconfig.hpp>
 #include <nano/lib/tomlconfig.hpp>

--- a/nano/node/confirmation_height_bounded.cpp
+++ b/nano/node/confirmation_height_bounded.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/node/confirmation_height_bounded.hpp>
 #include <nano/node/write_database_queue.hpp>

--- a/nano/node/confirmation_height_processor.cpp
+++ b/nano/node/confirmation_height_processor.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/thread_roles.hpp>
 #include <nano/lib/utility.hpp>
@@ -238,4 +239,9 @@ nano::block_hash nano::confirmation_height_processor::current () const
 {
 	nano::lock_guard<nano::mutex> lk (mutex);
 	return original_block ? original_block->hash () : 0;
+}
+
+std::reference_wrapper<nano::block_hash const> nano::confirmation_height_processor::block_wrapper::hash () const
+{
+	return block->hash ();
 }

--- a/nano/node/confirmation_height_processor.hpp
+++ b/nano/node/confirmation_height_processor.hpp
@@ -65,10 +65,7 @@ private:
 		{
 		}
 
-		std::reference_wrapper<nano::block_hash const> hash () const
-		{
-			return block->hash ();
-		}
+		std::reference_wrapper<nano::block_hash const> hash () const;
 
 		std::shared_ptr<nano::block> block;
 	};

--- a/nano/node/confirmation_height_unbounded.cpp
+++ b/nano/node/confirmation_height_unbounded.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/node/confirmation_height_unbounded.hpp>
 #include <nano/node/write_database_queue.hpp>

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/nodeconfig.hpp>

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/network.hpp>

--- a/nano/node/epoch_upgrader.cpp
+++ b/nano/node/epoch_upgrader.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/node/epoch_upgrader.hpp>
 #include <nano/node/node.hpp>

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/json_error_response.hpp>
 #include <nano/lib/timer.hpp>

--- a/nano/node/local_block_broadcaster.cpp
+++ b/nano/node/local_block_broadcaster.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/blockprocessor.hpp>
@@ -167,4 +168,9 @@ std::unique_ptr<nano::container_info_component> nano::local_block_broadcaster::c
 	auto composite = std::make_unique<container_info_composite> (name);
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "local", local_blocks.size (), sizeof (decltype (local_blocks)::value_type) }));
 	return composite;
+}
+
+nano::block_hash nano::local_block_broadcaster::local_entry::hash () const
+{
+	return block->hash ();
 }

--- a/nano/node/local_block_broadcaster.hpp
+++ b/nano/node/local_block_broadcaster.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <nano/lib/blocks.hpp>
 #include <nano/lib/locks.hpp>
 #include <nano/lib/processing_queue.hpp>
 #include <nano/node/bandwidth_limiter.hpp>
@@ -66,10 +65,7 @@ private:
 		std::chrono::steady_clock::time_point const arrival;
 		mutable std::chrono::steady_clock::time_point last_broadcast{}; // Not part of any index
 
-		nano::block_hash hash () const
-		{
-			return block->hash ();
-		}
+		nano::block_hash hash () const;
 	};
 
 	// clang-format off

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -2,7 +2,6 @@
 
 #include <nano/lib/asio.hpp>
 #include <nano/lib/block_uniquer.hpp>
-#include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/jsonconfig.hpp>

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/asio.hpp>
+#include <nano/lib/block_uniquer.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/errors.hpp>

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool_shuffle.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/bootstrap_ascending/service.hpp>

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stream.hpp>
 #include <nano/lib/tomlconfig.hpp>
 #include <nano/lib/utility.hpp>

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/block_uniquer.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/stats.hpp>

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/lib/rpcconfig.hpp>

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/node/active_transactions.hpp>
 #include <nano/node/common.hpp>

--- a/nano/node/scheduler/optimistic.cpp
+++ b/nano/node/scheduler/optimistic.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/tomlconfig.hpp>
 #include <nano/node/node.hpp>

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/priority.hpp>

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/node/network.hpp>

--- a/nano/node/unchecked_map.cpp
+++ b/nano/node/unchecked_map.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/locks.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/stats_enums.hpp>

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/network.hpp>

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/election.hpp>

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -1,6 +1,7 @@
 #include <nano/boost/asio/bind_executor.hpp>
 #include <nano/boost/asio/dispatch.hpp>
 #include <nano/boost/asio/strand.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/tlsconfig.hpp>
 #include <nano/lib/work.hpp>

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <nano/lib/blocks.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/work.hpp>
 #include <nano/node/common.hpp>
@@ -20,6 +19,7 @@
 
 namespace nano
 {
+class block;
 class wallets;
 class logger;
 class vote;

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/qt/qt.hpp>
 

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/make_store.hpp>
 #include <nano/qt/qt.hpp>
 #include <nano/test_common/network.hpp>

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
 #include <nano/rpc_test/common.hpp>

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1,5 +1,6 @@
 #include <nano/boost/beast/core/flat_buffer.hpp>
 #include <nano/boost/beast/http.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/rpcconfig.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/threading.hpp>

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/timer.hpp>
@@ -16,12 +17,6 @@
 #include <crypto/ed25519-donna/ed25519.h>
 #include <cryptopp/words.h>
 #include <magic_enum.hpp>
-
-size_t constexpr nano::send_block::size;
-size_t constexpr nano::receive_block::size;
-size_t constexpr nano::open_block::size;
-size_t constexpr nano::change_block::size;
-size_t constexpr nano::state_block::size;
 
 nano::networks nano::network_constants::active_network = nano::networks::ACTIVE_NETWORK;
 

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -2,7 +2,6 @@
 
 #include <nano/crypto/blake2/blake2.h>
 #include <nano/lib/blockbuilders.hpp>
-#include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/epoch.hpp>
 #include <nano/lib/numbers.hpp>

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/rep_weights.hpp>
 #include <nano/lib/stats.hpp>

--- a/nano/secure/network_filter.cpp
+++ b/nano/secure/network_filter.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/locks.hpp>
 #include <nano/lib/stream.hpp>
 #include <nano/secure/common.hpp>

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -2,6 +2,8 @@
 #include <nano/secure/utility.hpp>
 #include <nano/secure/working.hpp>
 
+#include <boost/system/error_code.hpp>
+
 #include <random>
 
 static std::vector<std::filesystem::path> all_unique_paths;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/node/election.hpp>

--- a/nano/slow_test/vote_cache.cpp
+++ b/nano/slow_test/vote_cache.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/test_common/rate_observer.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/slow_test/vote_processor.cpp
+++ b/nano/slow_test/vote_processor.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/store/CMakeLists.txt
+++ b/nano/store/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(
   component.hpp
   confirmation_height.hpp
   db_val.hpp
+  db_val_impl.hpp
   iterator.hpp
   iterator_impl.hpp
   final.hpp

--- a/nano/store/block.hpp
+++ b/nano/store/block.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/block_sideband.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/store/component.hpp>

--- a/nano/store/block.hpp
+++ b/nano/store/block.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <nano/lib/block_sideband.hpp>
-#include <nano/lib/blocks.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/store/component.hpp>
 #include <nano/store/iterator.hpp>
@@ -10,6 +9,7 @@
 
 namespace nano
 {
+class block;
 class block_hash;
 }
 namespace nano::store

--- a/nano/store/component.cpp
+++ b/nano/store/component.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/store/account.hpp>
 #include <nano/store/block.hpp>

--- a/nano/store/db_val.hpp
+++ b/nano/store/db_val.hpp
@@ -9,6 +9,11 @@
 
 #include <cstddef>
 
+namespace nano
+{
+class block;
+}
+
 namespace nano::store
 {
 /**
@@ -92,15 +97,7 @@ public:
 		static_assert (std::is_standard_layout<nano::endpoint_key>::value, "Standard layout is required");
 	}
 
-	db_val (std::shared_ptr<nano::block> const & val_a) :
-		buffer (std::make_shared<std::vector<uint8_t>> ())
-	{
-		{
-			nano::vectorstream stream (*buffer);
-			nano::serialize_block (stream, *val_a);
-		}
-		convert_buffer_to_value ();
-	}
+	db_val (std::shared_ptr<nano::block> const & val_a);
 
 	db_val (uint64_t val_a) :
 		buffer (std::make_shared<std::vector<uint8_t>> ())
@@ -209,16 +206,7 @@ public:
 		return result;
 	}
 
-	explicit operator block_w_sideband () const
-	{
-		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (data ()), size ());
-		nano::store::block_w_sideband block_w_sideband;
-		block_w_sideband.block = (nano::deserialize_block (stream));
-		auto error = block_w_sideband.sideband.deserialize (stream, block_w_sideband.block->type ());
-		release_assert (!error);
-		block_w_sideband.block->sideband_set (block_w_sideband.sideband);
-		return block_w_sideband;
-	}
+	explicit operator block_w_sideband () const;
 
 	explicit operator std::nullptr_t () const
 	{
@@ -230,12 +218,7 @@ public:
 		return no_value::dummy;
 	}
 
-	explicit operator std::shared_ptr<nano::block> () const
-	{
-		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (data ()), size ());
-		std::shared_ptr<nano::block> result (nano::deserialize_block (stream));
-		return result;
-	}
+	explicit operator std::shared_ptr<nano::block> () const;
 
 	template <typename Block>
 	std::shared_ptr<Block> convert_to_block () const

--- a/nano/store/db_val_impl.hpp
+++ b/nano/store/db_val_impl.hpp
@@ -1,0 +1,33 @@
+#include <nano/lib/blocks.hpp>
+#include <nano/store/db_val.hpp>
+
+template <typename T>
+nano::store::db_val<T>::db_val (std::shared_ptr<nano::block> const & val_a) :
+	buffer (std::make_shared<std::vector<uint8_t>> ())
+{
+	{
+		nano::vectorstream stream (*buffer);
+		nano::serialize_block (stream, *val_a);
+	}
+	convert_buffer_to_value ();
+}
+
+template <typename T>
+nano::store::db_val<T>::operator std::shared_ptr<nano::block> () const
+{
+	nano::bufferstream stream (reinterpret_cast<uint8_t const *> (data ()), size ());
+	std::shared_ptr<nano::block> result (nano::deserialize_block (stream));
+	return result;
+}
+
+template <typename T>
+nano::store::db_val<T>::operator nano::store::block_w_sideband () const
+{
+	nano::bufferstream stream (reinterpret_cast<uint8_t const *> (data ()), size ());
+	nano::store::block_w_sideband block_w_sideband;
+	block_w_sideband.block = (nano::deserialize_block (stream));
+	auto error = block_w_sideband.sideband.deserialize (stream, block_w_sideband.block->type ());
+	release_assert (!error);
+	block_w_sideband.block->sideband_set (block_w_sideband.sideband);
+	return block_w_sideband;
+}

--- a/nano/store/lmdb/block.cpp
+++ b/nano/store/lmdb/block.cpp
@@ -1,4 +1,5 @@
 #include <nano/secure/parallel_traversal.hpp>
+#include <nano/store/db_val_impl.hpp>
 #include <nano/store/lmdb/block.hpp>
 #include <nano/store/lmdb/lmdb.hpp>
 

--- a/nano/store/lmdb/lmdb_env.cpp
+++ b/nano/store/lmdb/lmdb_env.cpp
@@ -1,6 +1,8 @@
 #include <nano/lib/utility.hpp>
 #include <nano/store/lmdb/lmdb_env.hpp>
 
+#include <boost/system/error_code.hpp>
+
 nano::store::lmdb::env::env (bool & error_a, std::filesystem::path const & path_a, nano::store::lmdb::env::options options_a)
 {
 	init (error_a, path_a, options_a);

--- a/nano/store/rocksdb/block.cpp
+++ b/nano/store/rocksdb/block.cpp
@@ -1,4 +1,5 @@
 #include <nano/secure/parallel_traversal.hpp>
+#include <nano/store/db_val_impl.hpp>
 #include <nano/store/rocksdb/block.hpp>
 #include <nano/store/rocksdb/rocksdb.hpp>
 

--- a/nano/store/rocksdb/rocksdb.cpp
+++ b/nano/store/rocksdb/rocksdb.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/rocksdbconfig.hpp>
 #include <nano/store/rocksdb/iterator.hpp>
 #include <nano/store/rocksdb/rocksdb.hpp>

--- a/nano/store/versioning.hpp
+++ b/nano/store/versioning.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <nano/lib/blocks.hpp>
 #include <nano/secure/common.hpp>
 
 struct MDB_val;

--- a/nano/test_common/chains.cpp
+++ b/nano/test_common/chains.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/test_common/chains.hpp>
 
 using namespace std::chrono_literals;

--- a/nano/test_common/chains.hpp
+++ b/nano/test_common/chains.hpp
@@ -8,6 +8,11 @@
 #include <memory>
 #include <vector>
 
+namespace nano
+{
+using block_list_t = std::vector<std::shared_ptr<nano::block>>;
+}
+
 /*
  * Helper functions to deal with common chain setup scenarios
  */

--- a/nano/test_common/ledger.cpp
+++ b/nano/test_common/ledger.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/node/make_store.hpp>
 #include <nano/node/node.hpp>
 #include <nano/test_common/ledger.hpp>

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/node/common.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/manual.hpp>
 #include <nano/node/scheduler/priority.hpp>


### PR DESCRIPTION
This reduces the recompilation time of modifying nano/lib/blocks.hpp by removing inclusion of the file by other headers and including the file directly in other implementation files.

Previous speed: 211 files recompiled in 3m 30s 
New speed: 109 files recompiled in 2m 00s