### PR TITLE
Simplify the nano::ledger::successor function to make its implementation more obvious.

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -1175,9 +1175,9 @@ TEST (ledger, successor)
 	node1.work_generate_blocking (*send1);
 	auto transaction (node1.store.tx_begin_write ());
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, send1));
-	ASSERT_EQ (*send1, *node1.ledger.successor (transaction, nano::qualified_root (nano::root (0), nano::dev::genesis->hash ())));
-	ASSERT_EQ (*nano::dev::genesis, *node1.ledger.successor (transaction, nano::dev::genesis->qualified_root ()));
-	ASSERT_EQ (nullptr, node1.ledger.successor (transaction, nano::qualified_root (0)));
+	ASSERT_EQ (*send1, *node1.ledger.block (transaction, node1.ledger.successor (transaction, nano::qualified_root (nano::root (0), nano::dev::genesis->hash ())).value ()));
+	ASSERT_EQ (*nano::dev::genesis, *node1.ledger.block (transaction, node1.ledger.successor (transaction, nano::dev::genesis->qualified_root ()).value ()));
+	ASSERT_FALSE (node1.ledger.successor (transaction, nano::qualified_root (0)));
 }
 
 TEST (ledger, fail_change_old)
@@ -4006,8 +4006,8 @@ TEST (ledger, successor_epoch)
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, change));
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, send2));
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, epoch_open));
-	ASSERT_EQ (*change, *node1.ledger.successor (transaction, change->qualified_root ()));
-	ASSERT_EQ (*epoch_open, *node1.ledger.successor (transaction, epoch_open->qualified_root ()));
+	ASSERT_EQ (*change, *node1.ledger.block (transaction, node1.ledger.successor (transaction, change->qualified_root ()).value ()));
+	ASSERT_EQ (*epoch_open, *node1.ledger.block (transaction, node1.ledger.successor (transaction, epoch_open->qualified_root ()).value ()));
 	ASSERT_EQ (nano::epoch::epoch_1, epoch_open->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_0, epoch_open->sideband ().source_epoch); // Not used for epoch state blocks
 }

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -256,7 +256,7 @@ TEST (ledger, process_receive)
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, ledger.account_balance (transaction, key2.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, ledger.weight (key3.pub));
 	ASSERT_FALSE (ledger.rollback (transaction, hash4));
-	ASSERT_TRUE (store.block.successor (transaction, hash2).is_zero ());
+	ASSERT_FALSE (ledger.successor (transaction, hash2));
 	ASSERT_EQ (25, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (25, ledger.account_receivable (transaction, key2.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_balance (transaction, key2.pub));
@@ -3139,7 +3139,7 @@ TEST (ledger, state_rollback_send)
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_FALSE (store.pending.exists (transaction, nano::pending_key (nano::dev::genesis_key.pub, send1->hash ())));
-	ASSERT_TRUE (store.block.successor (transaction, nano::dev::genesis->hash ()).is_zero ());
+	ASSERT_FALSE (ledger.successor (transaction, nano::dev::genesis->hash ()));
 	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
 }
 

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1588,7 +1588,7 @@ int main (int argc, char * const * argv)
 						calculated_representative = block->representative_field ().value ();
 					}
 					// Retrieving successor block hash
-					hash = node->store.block.successor (transaction, hash);
+					hash = node->ledger.successor (transaction, hash).value_or (0);
 					// Retrieving block data
 					if (!hash.is_zero ())
 					{

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -155,7 +155,8 @@ void nano::block_processor::force (std::shared_ptr<nano::block> const & block_a)
 void nano::block_processor::rollback_competitor (store::write_transaction const & transaction, nano::block const & block)
 {
 	auto hash = block.hash ();
-	auto successor = node.ledger.successor (transaction, block.qualified_root ());
+	auto successor_hash = node.ledger.successor (transaction, block.qualified_root ());
+	auto successor = successor_hash ? node.ledger.block (transaction, successor_hash.value ()) : nullptr;
 	if (successor != nullptr && successor->hash () != hash)
 	{
 		// Replace our block with the winner and roll back any dependent blocks

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -376,7 +376,7 @@ void nano::bulk_pull_server::set_current_end ()
 	{
 		node->logger.debug (nano::log::type::bulk_pull_server, "Bulk pull request for block hash: {}", request->start.to_string ());
 
-		current = ascending () ? node->store.block.successor (transaction, request->start.as_block_hash ()) : request->start.as_block_hash ();
+		current = ascending () ? node->ledger.successor (transaction, request->start.as_block_hash ()).value_or (0) : request->start.as_block_hash ();
 		include_start = true;
 	}
 	else

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1956,7 +1956,7 @@ void nano::json_handler::chain (bool successors)
 					entry.put ("", hash.to_string ());
 					blocks.push_back (std::make_pair ("", entry));
 				}
-				hash = successors ? node.store.block.successor (transaction, hash) : block_l->previous ();
+				hash = successors ? node.ledger.successor (transaction, hash).value_or (0) : block_l->previous ();
 			}
 			else
 			{
@@ -2665,7 +2665,7 @@ void nano::json_handler::account_history ()
 					--count;
 				}
 			}
-			hash = reverse ? node.store.block.successor (transaction, hash) : block->previous ();
+			hash = reverse ? node.ledger.successor (transaction, hash).value_or (0) : block->previous ();
 			block = node.ledger.block (transaction, hash);
 		}
 		response_l.add_child ("history", history);
@@ -3698,7 +3698,7 @@ void nano::json_handler::republish ()
 						}
 					}
 				}
-				hash = node.store.block.successor (transaction, hash);
+				hash = node.ledger.successor (transaction, hash).value_or (0);
 			}
 			node.network.flood_block_many (std::move (republish_bundle), nullptr, 25);
 			response_l.put ("success", ""); // obsolete

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -246,24 +246,14 @@ std::pair<std::vector<std::shared_ptr<nano::block>>, std::vector<std::shared_ptr
 			if (block == nullptr && !root.is_zero ())
 			{
 				// Search for block root
-				auto successor (ledger.store.block.successor (transaction, root.as_block_hash ()));
-
-				// Search for account root
-				if (successor.is_zero ())
+				auto successor = ledger.successor (transaction, root.as_block_hash ());
+				if (successor)
 				{
-					auto info = ledger.account_info (transaction, root.as_account ());
-					if (info)
-					{
-						successor = info->open_block;
-					}
-				}
-				if (!successor.is_zero ())
-				{
-					auto successor_block = ledger.block (transaction, successor);
+					auto successor_block = ledger.block (transaction, successor.value ());
 					debug_assert (successor_block != nullptr);
 					block = std::move (successor_block);
 					// 5. Votes in cache for successor
-					auto find_successor_votes (local_votes.votes (root, successor));
+					auto find_successor_votes (local_votes.votes (root, successor.value ()));
 					if (!find_successor_votes.empty ())
 					{
 						cached_votes.insert (cached_votes.end (), find_successor_votes.begin (), find_successor_votes.end ());

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -48,7 +48,7 @@ bool nano::scheduler::priority::activate (nano::account const & account_a, store
 		if (conf_info.height < info->block_count)
 		{
 			debug_assert (conf_info.frontier != info->head);
-			auto hash = conf_info.height == 0 ? info->open_block : node.store.block.successor (transaction, conf_info.frontier);
+			auto hash = conf_info.height == 0 ? info->open_block : node.ledger.successor (transaction, conf_info.frontier).value_or (0);
 			auto block = node.ledger.block (transaction, hash);
 			debug_assert (block != nullptr);
 			if (node.ledger.dependents_confirmed (transaction, *block))

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -693,7 +693,7 @@ nano_qt::block_viewer::block_viewer (nano_qt::wallet & wallet_a) :
 				std::string contents;
 				block_l->serialize_json (contents);
 				block->setPlainText (contents.c_str ());
-				auto successor_l (this->wallet.node.store.block.successor (transaction, hash_l));
+				auto successor_l = this->wallet.node.ledger.successor (transaction, hash_l).value_or (0);
 				successor->setText (successor_l.to_string ().c_str ());
 			}
 			else
@@ -737,13 +737,13 @@ void nano_qt::block_viewer::rebroadcast_action (nano::block_hash const & hash_a)
 	if (block != nullptr)
 	{
 		wallet.node.network.flood_block (block);
-		auto successor (wallet.node.store.block.successor (transaction, hash_a));
-		if (!successor.is_zero ())
+		auto successor = wallet.node.ledger.successor (transaction, hash_a);
+		if (successor)
 		{
 			done = false;
 			wallet.node.workers.add_timed_task (std::chrono::steady_clock::now () + std::chrono::seconds (1), [this, successor] () {
 				this->wallet.application.postEvent (&this->wallet.processor, new eventloop_event ([this, successor] () {
-					rebroadcast_action (successor);
+					rebroadcast_action (successor.value ());
 				}));
 			});
 		}

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1270,12 +1270,22 @@ std::optional<nano::block_hash> nano::ledger::successor (store::transaction cons
 	}
 }
 
+std::optional<nano::block_hash> nano::ledger::successor (store::transaction const & transaction, nano::block_hash const & hash) const noexcept
+{
+	return successor (transaction, { hash, hash });
+}
+
 std::shared_ptr<nano::block> nano::ledger::forked_block (store::transaction const & transaction_a, nano::block const & block_a)
 {
 	debug_assert (!block_exists (transaction_a, block_a.hash ()));
 	auto root (block_a.root ());
 	debug_assert (block_exists (transaction_a, root.as_block_hash ()) || store.account.exists (transaction_a, root.as_account ()));
-	auto result = block (transaction_a, store.block.successor (transaction_a, root.as_block_hash ()));
+	std::shared_ptr<nano::block> result;
+	auto successor_l = successor (transaction_a, root.as_block_hash ());
+	if (successor_l)
+	{
+		result = block (transaction_a, successor_l.value ());
+	}
 	if (result == nullptr)
 	{
 		auto info = account_info (transaction_a, root.as_account ());

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1247,36 +1247,22 @@ void nano::ledger::update_account (store::write_transaction const & transaction_
 
 std::shared_ptr<nano::block> nano::ledger::successor (store::transaction const & transaction_a, nano::qualified_root const & root_a)
 {
-	nano::block_hash successor (0);
-	auto get_from_previous = false;
-	if (root_a.previous ().is_zero ())
+	if (!root_a.previous ().is_zero ())
+	{
+		return block (transaction_a, store.block.successor (transaction_a, root_a.previous ()));
+	}
+	else
 	{
 		auto info = account_info (transaction_a, root_a.root ().as_account ());
 		if (info)
 		{
-			successor = info->open_block;
+			return block (transaction_a, info->open_block);
 		}
 		else
 		{
-			get_from_previous = true;
+			return nullptr;
 		}
 	}
-	else
-	{
-		get_from_previous = true;
-	}
-
-	if (get_from_previous)
-	{
-		successor = store.block.successor (transaction_a, root_a.previous ());
-	}
-	std::shared_ptr<nano::block> result;
-	if (!successor.is_zero ())
-	{
-		result = block (transaction_a, successor);
-	}
-	debug_assert (successor.is_zero () || result != nullptr);
-	return result;
 }
 
 std::shared_ptr<nano::block> nano::ledger::forked_block (store::transaction const & transaction_a, nano::block const & block_a)

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1249,12 +1249,7 @@ std::optional<nano::block_hash> nano::ledger::successor (store::transaction cons
 {
 	if (!root_a.previous ().is_zero ())
 	{
-		auto result = store.block.successor (transaction_a, root_a.previous ());
-		if (result.is_zero ())
-		{
-			return std::nullopt;
-		}
-		return result;
+		return store.block.successor (transaction_a, root_a.previous ());
 	}
 	else
 	{

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1245,22 +1245,27 @@ void nano::ledger::update_account (store::write_transaction const & transaction_
 	}
 }
 
-std::shared_ptr<nano::block> nano::ledger::successor (store::transaction const & transaction_a, nano::qualified_root const & root_a)
+std::optional<nano::block_hash> nano::ledger::successor (store::transaction const & transaction_a, nano::qualified_root const & root_a) const noexcept
 {
 	if (!root_a.previous ().is_zero ())
 	{
-		return block (transaction_a, store.block.successor (transaction_a, root_a.previous ()));
+		auto result = store.block.successor (transaction_a, root_a.previous ());
+		if (result.is_zero ())
+		{
+			return std::nullopt;
+		}
+		return result;
 	}
 	else
 	{
 		auto info = account_info (transaction_a, root_a.root ().as_account ());
 		if (info)
 		{
-			return block (transaction_a, info->open_block);
+			return info.value ().open_block;
 		}
 		else
 		{
-			return nullptr;
+			return std::nullopt;
 		}
 	}
 }

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -52,6 +52,7 @@ public:
 	nano::uint128_t account_receivable (store::transaction const &, nano::account const &, bool = false);
 	nano::uint128_t weight (nano::account const &);
 	std::optional<nano::block_hash> successor (store::transaction const &, nano::qualified_root const &) const noexcept;
+	std::optional<nano::block_hash> successor (store::transaction const & transaction, nano::block_hash const & hash) const noexcept;
 	std::shared_ptr<nano::block> forked_block (store::transaction const &, nano::block const &);
 	std::shared_ptr<nano::block> head_block (store::transaction const &, nano::account const &);
 	bool block_confirmed (store::transaction const &, nano::block_hash const &) const;

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -51,7 +51,7 @@ public:
 	nano::uint128_t account_balance (store::transaction const &, nano::account const &, bool = false);
 	nano::uint128_t account_receivable (store::transaction const &, nano::account const &, bool = false);
 	nano::uint128_t weight (nano::account const &);
-	std::shared_ptr<nano::block> successor (store::transaction const &, nano::qualified_root const &);
+	std::optional<nano::block_hash> successor (store::transaction const &, nano::qualified_root const &) const noexcept;
 	std::shared_ptr<nano::block> forked_block (store::transaction const &, nano::block const &);
 	std::shared_ptr<nano::block> head_block (store::transaction const &, nano::account const &);
 	bool block_confirmed (store::transaction const &, nano::block_hash const &) const;

--- a/nano/store/block.hpp
+++ b/nano/store/block.hpp
@@ -6,6 +6,7 @@
 #include <nano/store/iterator.hpp>
 
 #include <functional>
+#include <optional>
 
 namespace nano
 {
@@ -28,7 +29,7 @@ class block
 public:
 	virtual void put (store::write_transaction const &, nano::block_hash const &, nano::block const &) = 0;
 	virtual void raw_put (store::write_transaction const &, std::vector<uint8_t> const &, nano::block_hash const &) = 0;
-	virtual nano::block_hash successor (store::transaction const &, nano::block_hash const &) const = 0;
+	virtual std::optional<nano::block_hash> successor (store::transaction const &, nano::block_hash const &) const = 0;
 	virtual void successor_clear (store::write_transaction const &, nano::block_hash const &) = 0;
 	virtual std::shared_ptr<nano::block> get (store::transaction const &, nano::block_hash const &) const = 0;
 	virtual std::shared_ptr<nano::block> random (store::transaction const &) = 0;

--- a/nano/store/lmdb/block.cpp
+++ b/nano/store/lmdb/block.cpp
@@ -49,7 +49,7 @@ void nano::store::lmdb::block::raw_put (store::write_transaction const & transac
 	store.release_assert_success (status);
 }
 
-nano::block_hash nano::store::lmdb::block::successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const
+std::optional<nano::block_hash> nano::store::lmdb::block::successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const
 {
 	nano::store::lmdb::db_val value;
 	block_raw_get (transaction_a, hash_a, value);
@@ -66,6 +66,10 @@ nano::block_hash nano::store::lmdb::block::successor (store::transaction const &
 	else
 	{
 		result.clear ();
+	}
+	if (result.is_zero ())
+	{
+		return std::nullopt;
 	}
 	return result;
 }

--- a/nano/store/lmdb/block.hpp
+++ b/nano/store/lmdb/block.hpp
@@ -24,7 +24,7 @@ public:
 	explicit block (nano::store::lmdb::component & store_a);
 	void put (store::write_transaction const & transaction_a, nano::block_hash const & hash_a, nano::block const & block_a) override;
 	void raw_put (store::write_transaction const & transaction_a, std::vector<uint8_t> const & data, nano::block_hash const & hash_a) override;
-	nano::block_hash successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+	std::optional<nano::block_hash> successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 	void successor_clear (store::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 	std::shared_ptr<nano::block> get (store::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 	std::shared_ptr<nano::block> random (store::transaction const & transaction_a) override;

--- a/nano/store/rocksdb/block.cpp
+++ b/nano/store/rocksdb/block.cpp
@@ -49,7 +49,7 @@ void nano::store::rocksdb::block::raw_put (store::write_transaction const & tran
 	store.release_assert_success (status);
 }
 
-nano::block_hash nano::store::rocksdb::block::successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const
+std::optional<nano::block_hash> nano::store::rocksdb::block::successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const
 {
 	nano::store::rocksdb::db_val value;
 	block_raw_get (transaction_a, hash_a, value);
@@ -66,6 +66,10 @@ nano::block_hash nano::store::rocksdb::block::successor (store::transaction cons
 	else
 	{
 		result.clear ();
+	}
+	if (result.is_zero ())
+	{
+		return std::nullopt;
 	}
 	return result;
 }

--- a/nano/store/rocksdb/block.hpp
+++ b/nano/store/rocksdb/block.hpp
@@ -22,7 +22,7 @@ public:
 	explicit block (nano::store::rocksdb::component & store_a);
 	void put (store::write_transaction const & transaction_a, nano::block_hash const & hash_a, nano::block const & block_a) override;
 	void raw_put (store::write_transaction const & transaction_a, std::vector<uint8_t> const & data, nano::block_hash const & hash_a) override;
-	nano::block_hash successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
+	std::optional<nano::block_hash> successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 	void successor_clear (store::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 	std::shared_ptr<nano::block> get (store::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 	std::shared_ptr<nano::block> random (store::transaction const & transaction_a) override;


### PR DESCRIPTION
These changes simplifies the way block successors are accessed.

Usages of store::block::successor are changed to ledger::successor.
ledger::successor returns a std::optional<nano::block_hash> instead of a std::shared_ptr<nano::block> which allows users to determine if they want to load the block.
A convenience overload of ledger::successor is added which takes a block_hash and expands it to a qualified_root.