### PR TITLE
Allow easy printing ranges of objects

### DIFF
--- a/nano/core_test/object_stream.cpp
+++ b/nano/core_test/object_stream.cpp
@@ -557,3 +557,35 @@ TEST (object_stream, to_json)
 
 	ASSERT_EQ (str, expected);
 }
+
+TEST (object_stream, print_range)
+{
+	std::deque<streamable_object> objects;
+	objects.push_back ({ 1 });
+	objects.push_back ({ 2 });
+	objects.push_back ({ 3 });
+
+	std::stringstream ss1, ss2;
+	ss1 << nano::streamed_range (objects);
+	ss2 << fmt::format ("{}", nano::streamed_range (objects));
+
+	auto expected = trim (R"(
+[
+   {
+      uint256_union_field: "0000000000000000000000000000000000000000000000000000000000000001",
+      block_hash: "0000000000000000000000000000000000000000000000000000000000000000"
+   },
+   {
+      uint256_union_field: "0000000000000000000000000000000000000000000000000000000000000002",
+      block_hash: "0000000000000000000000000000000000000000000000000000000000000000"
+   },
+   {
+      uint256_union_field: "0000000000000000000000000000000000000000000000000000000000000003",
+      block_hash: "0000000000000000000000000000000000000000000000000000000000000000"
+   }
+]
+)");
+
+	ASSERT_EQ (ss1.str (), expected);
+	ASSERT_EQ (ss2.str (), expected);
+}

--- a/nano/lib/object_stream.hpp
+++ b/nano/lib/object_stream.hpp
@@ -281,7 +281,7 @@ public:
 
 	array_stream (array_stream const &) = delete; // Disallow copying
 
-private:
+public:
 	template <class Value>
 	void write_single (Value const & value)
 	{
@@ -290,7 +290,6 @@ private:
 		ctx.end_array_element ();
 	}
 
-public:
 	// Handle `.write (container)`
 	template <class Container>
 	void write (Container const & container)


### PR DESCRIPTION
This is a small addition to logging framework that allows to quickly print a range of objects as an array. From what I heard native support for printing ranges is coming with C++23, until then this should work out of the box with most types in our codebase.

Example usage:
```
node.logger.debug (nano::log::type::tcp_channels, "Channels: {}", nano::streamed_range (channels | std::views::transform ([] (auto const & entry) {
	return entry.channel;
})));
```