### PR TITLE
Networking cleanup continued

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -759,7 +759,7 @@ TEST (network, peer_max_tcp_attempts)
 		node->network.merge_peer (node2->network.endpoint ());
 	}
 	ASSERT_EQ (0, node->network.size ());
-	ASSERT_TRUE (node->network.tcp_channels.reachout (nano::endpoint (node->network.endpoint ().address (), system.get_available_port ())));
+	ASSERT_TRUE (node->network.tcp_channels.track_reachout (nano::endpoint (node->network.endpoint ().address (), system.get_available_port ())));
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_max_per_ip, nano::stat::dir::out));
 }
 #endif
@@ -779,11 +779,11 @@ namespace transport
 		{
 			auto address (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0x7f000001 + i))); // 127.0.0.1 hex
 			nano::endpoint endpoint (address, system.get_available_port ());
-			ASSERT_FALSE (node->network.tcp_channels.reachout (endpoint));
+			ASSERT_FALSE (node->network.tcp_channels.track_reachout (endpoint));
 		}
 		ASSERT_EQ (0, node->network.size ());
 		ASSERT_EQ (0, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_max_per_subnetwork, nano::stat::dir::out));
-		ASSERT_TRUE (node->network.tcp_channels.reachout (nano::endpoint (boost::asio::ip::make_address_v6 ("::ffff:127.0.0.1"), system.get_available_port ())));
+		ASSERT_TRUE (node->network.tcp_channels.track_reachout (nano::endpoint (boost::asio::ip::make_address_v6 ("::ffff:127.0.0.1"), system.get_available_port ())));
 		ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_max_per_subnetwork, nano::stat::dir::out));
 	}
 }
@@ -974,7 +974,7 @@ TEST (network, tcp_no_connect_excluded_peers)
 	ASSERT_EQ (nullptr, node0->network.find_node_id (node1->get_node_id ()));
 
 	// Should not actively reachout to excluded peers
-	ASSERT_TRUE (node0->network.reachout (node1->network.endpoint (), true));
+	ASSERT_TRUE (node0->network.track_reachout (node1->network.endpoint ()));
 
 	// Erasing from excluded peers should allow a connection
 	node0->network.excluded_peers.remove (endpoint1_tcp);

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -759,7 +759,7 @@ TEST (network, peer_max_tcp_attempts)
 		node->network.merge_peer (node2->network.endpoint ());
 	}
 	ASSERT_EQ (0, node->network.size ());
-	ASSERT_TRUE (node->network.tcp_channels.track_reachout (nano::endpoint (node->network.endpoint ().address (), system.get_available_port ())));
+	ASSERT_FALSE (node->network.tcp_channels.track_reachout (nano::endpoint (node->network.endpoint ().address (), system.get_available_port ())));
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_max_per_ip, nano::stat::dir::out));
 }
 #endif
@@ -779,11 +779,11 @@ namespace transport
 		{
 			auto address (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0x7f000001 + i))); // 127.0.0.1 hex
 			nano::endpoint endpoint (address, system.get_available_port ());
-			ASSERT_FALSE (node->network.tcp_channels.track_reachout (endpoint));
+			ASSERT_TRUE (node->network.tcp_channels.track_reachout (endpoint));
 		}
 		ASSERT_EQ (0, node->network.size ());
 		ASSERT_EQ (0, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_max_per_subnetwork, nano::stat::dir::out));
-		ASSERT_TRUE (node->network.tcp_channels.track_reachout (nano::endpoint (boost::asio::ip::make_address_v6 ("::ffff:127.0.0.1"), system.get_available_port ())));
+		ASSERT_FALSE (node->network.tcp_channels.track_reachout (nano::endpoint (boost::asio::ip::make_address_v6 ("::ffff:127.0.0.1"), system.get_available_port ())));
 		ASSERT_EQ (1, node->stats.count (nano::stat::type::tcp, nano::stat::detail::tcp_max_per_subnetwork, nano::stat::dir::out));
 	}
 }
@@ -974,7 +974,7 @@ TEST (network, tcp_no_connect_excluded_peers)
 	ASSERT_EQ (nullptr, node0->network.find_node_id (node1->get_node_id ()));
 
 	// Should not actively reachout to excluded peers
-	ASSERT_TRUE (node0->network.track_reachout (node1->network.endpoint ()));
+	ASSERT_FALSE (node0->network.track_reachout (node1->network.endpoint ()));
 
 	// Erasing from excluded peers should allow a connection
 	node0->network.excluded_peers.remove (endpoint1_tcp);

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1080,7 +1080,7 @@ TEST (network, cleanup_purge)
 	ASSERT_EQ (1, node1.network.size ());
 
 	node1.network.cleanup (std::chrono::steady_clock::now ());
-	ASSERT_EQ (0, node1.network.size ());
+	ASSERT_TIMELY_EQ (5s, 0, node1.network.size ());
 }
 
 TEST (network, loopback_channel)

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -217,18 +217,18 @@ TEST (peer_container, reachout)
 	auto outer_node1 = nano::test::add_outer_node (system);
 	ASSERT_NE (nullptr, nano::test::establish_tcp (system, node1, outer_node1->network.endpoint ()));
 	// Make sure having been contacted by them already indicates we shouldn't reach out
-	ASSERT_TRUE (node1.network.reachout (outer_node1->network.endpoint ()));
+	ASSERT_TRUE (node1.network.track_reachout (outer_node1->network.endpoint ()));
 	auto outer_node2 = nano::test::add_outer_node (system);
-	ASSERT_FALSE (node1.network.reachout (outer_node2->network.endpoint ()));
+	ASSERT_FALSE (node1.network.track_reachout (outer_node2->network.endpoint ()));
 	ASSERT_NE (nullptr, nano::test::establish_tcp (system, node1, outer_node2->network.endpoint ()));
 	// Reaching out to them once should signal we shouldn't reach out again.
-	ASSERT_TRUE (node1.network.reachout (outer_node2->network.endpoint ()));
+	ASSERT_TRUE (node1.network.track_reachout (outer_node2->network.endpoint ()));
 	// Make sure we don't purge new items
 	node1.network.cleanup (std::chrono::steady_clock::now () - std::chrono::seconds (10));
-	ASSERT_TRUE (node1.network.reachout (outer_node2->network.endpoint ()));
+	ASSERT_TRUE (node1.network.track_reachout (outer_node2->network.endpoint ()));
 	// Make sure we purge old items
 	node1.network.cleanup (std::chrono::steady_clock::now () + std::chrono::seconds (10));
-	ASSERT_FALSE (node1.network.reachout (outer_node2->network.endpoint ()));
+	ASSERT_FALSE (node1.network.track_reachout (outer_node2->network.endpoint ()));
 }
 
 // This test is similar to network.filter_invalid_version_using with the difference that

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -217,19 +217,19 @@ TEST (peer_container, reachout)
 	auto outer_node1 = nano::test::add_outer_node (system);
 	ASSERT_NE (nullptr, nano::test::establish_tcp (system, node1, outer_node1->network.endpoint ()));
 	// Make sure having been contacted by them already indicates we shouldn't reach out
-	ASSERT_TRUE (node1.network.track_reachout (outer_node1->network.endpoint ()));
+	ASSERT_FALSE (node1.network.track_reachout (outer_node1->network.endpoint ()));
 	auto outer_node2 = nano::test::add_outer_node (system);
-	ASSERT_FALSE (node1.network.track_reachout (outer_node2->network.endpoint ()));
+	ASSERT_TRUE (node1.network.track_reachout (outer_node2->network.endpoint ()));
 	ASSERT_NE (nullptr, nano::test::establish_tcp (system, node1, outer_node2->network.endpoint ()));
 	// Reaching out to them once should signal we shouldn't reach out again.
-	ASSERT_TRUE (node1.network.track_reachout (outer_node2->network.endpoint ()));
+	ASSERT_FALSE (node1.network.track_reachout (outer_node2->network.endpoint ()));
 	// Make sure we don't purge new items
 	node1.network.cleanup (std::chrono::steady_clock::now () - std::chrono::seconds (10));
-	ASSERT_TRUE (node1.network.track_reachout (outer_node2->network.endpoint ()));
+	ASSERT_FALSE (node1.network.track_reachout (outer_node2->network.endpoint ()));
 	// Make sure we purge old items
 	node1.network.cleanup (std::chrono::steady_clock::now () + std::chrono::seconds (10));
 	ASSERT_TIMELY (5s, node1.network.empty ());
-	ASSERT_FALSE (node1.network.track_reachout (outer_node2->network.endpoint ()));
+	ASSERT_TRUE (node1.network.track_reachout (outer_node2->network.endpoint ()));
 }
 
 // This test is similar to network.filter_invalid_version_using with the difference that

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -228,6 +228,7 @@ TEST (peer_container, reachout)
 	ASSERT_TRUE (node1.network.track_reachout (outer_node2->network.endpoint ()));
 	// Make sure we purge old items
 	node1.network.cleanup (std::chrono::steady_clock::now () + std::chrono::seconds (10));
+	ASSERT_TIMELY (5s, node1.network.empty ());
 	ASSERT_FALSE (node1.network.track_reachout (outer_node2->network.endpoint ()));
 }
 

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -420,7 +420,7 @@ TEST (socket, drop_policy)
 		});
 
 		auto client = std::make_shared<nano::transport::socket> (*node);
-		nano::transport::channel_tcp channel{ *node, client };
+		auto channel = std::make_shared<nano::transport::channel_tcp> (*node, client);
 		nano::test::counted_completion write_completion (static_cast<unsigned> (total_message_count));
 
 		client->async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), listener->endpoint ().port ()),
@@ -428,7 +428,7 @@ TEST (socket, drop_policy)
 			for (int i = 0; i < total_message_count; i++)
 			{
 				std::vector<uint8_t> buff (1);
-				channel.send_buffer (
+				channel->send_buffer (
 				nano::shared_const_buffer (std::move (buff)), [&write_completion, client] (boost::system::error_code const & ec, size_t size_a) mutable {
 					client.reset ();
 					write_completion.increment ();

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -56,6 +56,7 @@ enum class type
 	tcp,
 	tcp_server,
 	tcp_listener,
+	tcp_channels,
 	prunning,
 	conf_processor_bounded,
 	conf_processor_unbounded,

--- a/nano/lib/random.hpp
+++ b/nano/lib/random.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <random>
+
+namespace nano
+{
+/**
+ * Not safe for any crypto related code, use for non-crypto PRNG only.
+ */
+class random_generator final
+{
+public:
+	/// Generate a random number in the range [min, max)
+	auto random (auto min, auto max)
+	{
+		release_assert (min < max);
+		std::uniform_int_distribution<decltype (min)> dist (min, max - 1);
+		return dist (rng);
+	}
+
+	/// Generate a random number in the range [0, max)
+	auto random (auto max)
+	{
+		return random (decltype (max){ 0 }, max);
+	}
+
+private:
+	std::random_device device;
+	std::default_random_engine rng{ device () };
+};
+}

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -71,7 +71,6 @@ enum class detail : uint8_t
 	ok,
 	loop,
 	loop_cleanup,
-	loop_keepalive,
 	total,
 	process,
 	processed,
@@ -216,6 +215,11 @@ enum class detail : uint8_t
 	invalid_asc_pull_ack_message,
 	message_size_too_big,
 	outdated_version,
+
+	// network
+	loop_keepalive,
+	loop_reachout,
+	merge_peer,
 
 	// tcp
 	tcp_accept_success,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -24,6 +24,7 @@ enum class type : uint8_t
 	http_callback,
 	ipc,
 	tcp,
+	tcp_channels,
 	channel,
 	socket,
 	confirmation_height,

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -118,9 +118,6 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::network_reachout:
 			thread_role_name_string = "Net reachout";
 			break;
-		case nano::thread_role::name::tcp_keepalive:
-			thread_role_name_string = "Tcp keepalive";
-			break;
 		default:
 			debug_assert (false && "nano::thread_role::get_string unhandled thread role");
 	}

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -115,6 +115,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::network_keepalive:
 			thread_role_name_string = "Net keepalive";
 			break;
+		case nano::thread_role::name::network_reachout:
+			thread_role_name_string = "Net reachout";
+			break;
 		case nano::thread_role::name::tcp_keepalive:
 			thread_role_name_string = "Tcp keepalive";
 			break;

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -115,6 +115,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::network_keepalive:
 			thread_role_name_string = "Net keepalive";
 			break;
+		case nano::thread_role::name::tcp_keepalive:
+			thread_role_name_string = "Tcp keepalive";
+			break;
 		default:
 			debug_assert (false && "nano::thread_role::get_string unhandled thread role");
 	}

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -48,7 +48,6 @@ enum class name
 	network_cleanup,
 	network_keepalive,
 	network_reachout,
-	tcp_keepalive,
 };
 
 /*

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -47,6 +47,7 @@ enum class name
 	rep_tiers,
 	network_cleanup,
 	network_keepalive,
+	tcp_keepalive,
 };
 
 /*

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -47,6 +47,7 @@ enum class name
 	rep_tiers,
 	network_cleanup,
 	network_keepalive,
+	network_reachout,
 	tcp_keepalive,
 };
 

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -48,6 +48,11 @@ void nano::network::start ()
 		run_keepalive ();
 	});
 
+	reachout_thread = std::thread ([this] () {
+		nano::thread_role::set (nano::thread_role::name::network_reachout);
+		run_reachout ();
+	});
+
 	if (!node.flags.disable_tcp_realtime)
 	{
 		tcp_channels.start ();
@@ -86,6 +91,10 @@ void nano::network::stop ()
 	if (cleanup_thread.joinable ())
 	{
 		cleanup_thread.join ();
+	}
+	if (reachout_thread.joinable ())
+	{
+		reachout_thread.join ();
 	}
 
 	port = 0;
@@ -126,12 +135,11 @@ void nano::network::run_cleanup ()
 	while (!stopped)
 	{
 		condition.wait_for (lock, node.network_params.network.is_dev_network () ? 1s : 5s);
-		lock.unlock ();
-
 		if (stopped)
 		{
 			return;
 		}
+		lock.unlock ();
 
 		node.stats.inc (nano::stat::type::network, nano::stat::detail::loop_cleanup);
 
@@ -154,17 +162,51 @@ void nano::network::run_keepalive ()
 	while (!stopped)
 	{
 		condition.wait_for (lock, node.network_params.network.keepalive_period);
-		lock.unlock ();
-
 		if (stopped)
 		{
 			return;
 		}
+		lock.unlock ();
 
 		node.stats.inc (nano::stat::type::network, nano::stat::detail::loop_keepalive);
 
 		flood_keepalive (0.75f);
 		flood_keepalive_self (0.25f);
+
+		lock.lock ();
+	}
+}
+
+void nano::network::run_reachout ()
+{
+	nano::unique_lock<nano::mutex> lock{ mutex };
+	while (!stopped)
+	{
+		condition.wait_for (lock, node.network_params.network.merge_period);
+		if (stopped)
+		{
+			return;
+		}
+		lock.unlock ();
+
+		node.stats.inc (nano::stat::type::network, nano::stat::detail::loop_reachout);
+
+		auto keepalive = tcp_channels.sample_keepalive ();
+		if (keepalive)
+		{
+			for (auto const & peer : keepalive->peers)
+			{
+				if (stopped)
+				{
+					return;
+				}
+
+				merge_peer (peer);
+
+				// Throttle reachout attempts
+				std::this_thread::sleep_for (node.network_params.network.merge_period);
+			}
+		}
 
 		lock.lock ();
 	}
@@ -413,8 +455,9 @@ void nano::network::merge_peer (nano::endpoint const & peer_a)
 {
 	if (!track_reachout (peer_a))
 	{
-		std::weak_ptr<nano::node> node_w (node.shared ());
-		node.network.tcp_channels.start_tcp (peer_a);
+		node.stats.inc (nano::stat::type::network, nano::stat::detail::merge_peer);
+
+		tcp_channels.start_tcp (peer_a);
 	}
 }
 

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -455,7 +455,7 @@ void nano::network::merge_peers (std::array<nano::endpoint, 8> const & peers_a)
 
 void nano::network::merge_peer (nano::endpoint const & peer_a)
 {
-	if (!track_reachout (peer_a))
+	if (track_reachout (peer_a))
 	{
 		node.stats.inc (nano::stat::type::network, nano::stat::detail::merge_peer);
 
@@ -484,12 +484,11 @@ bool nano::network::not_a_peer (nano::endpoint const & endpoint_a, bool allow_lo
 bool nano::network::track_reachout (nano::endpoint const & endpoint_a)
 {
 	// Don't contact invalid IPs
-	bool error = not_a_peer (endpoint_a, node.config.allow_local_peers);
-	if (!error)
+	if (not_a_peer (endpoint_a, node.config.allow_local_peers))
 	{
-		error = tcp_channels.track_reachout (endpoint_a);
+		return false;
 	}
-	return error;
+	return tcp_channels.track_reachout (endpoint_a);
 }
 
 std::deque<std::shared_ptr<nano::transport::channel>> nano::network::list (std::size_t count_a, uint8_t minimum_version_a, bool include_tcp_temporary_channels_a)

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -173,6 +173,8 @@ void nano::network::run_keepalive ()
 		flood_keepalive (0.75f);
 		flood_keepalive_self (0.25f);
 
+		tcp_channels.keepalive ();
+
 		lock.lock ();
 	}
 }

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -411,7 +411,7 @@ void nano::network::merge_peers (std::array<nano::endpoint, 8> const & peers_a)
 
 void nano::network::merge_peer (nano::endpoint const & peer_a)
 {
-	if (!reachout (peer_a, node.config.allow_local_peers))
+	if (!track_reachout (peer_a))
 	{
 		std::weak_ptr<nano::node> node_w (node.shared ());
 		node.network.tcp_channels.start_tcp (peer_a);
@@ -436,13 +436,13 @@ bool nano::network::not_a_peer (nano::endpoint const & endpoint_a, bool allow_lo
 	return result;
 }
 
-bool nano::network::reachout (nano::endpoint const & endpoint_a, bool allow_local_peers)
+bool nano::network::track_reachout (nano::endpoint const & endpoint_a)
 {
 	// Don't contact invalid IPs
-	bool error = not_a_peer (endpoint_a, allow_local_peers);
+	bool error = not_a_peer (endpoint_a, node.config.allow_local_peers);
 	if (!error)
 	{
-		error = tcp_channels.reachout (endpoint_a);
+		error = tcp_channels.track_reachout (endpoint_a);
 	}
 	return error;
 }

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -111,6 +111,7 @@ private:
 	void run_processing ();
 	void run_cleanup ();
 	void run_keepalive ();
+	void run_reachout ();
 	void process_message (nano::message const &, std::shared_ptr<nano::transport::channel> const &);
 
 private: // Dependencies
@@ -137,6 +138,7 @@ private:
 	std::vector<boost::thread> processing_threads; // Using boost::thread to enable increased stack size
 	std::thread cleanup_thread;
 	std::thread keepalive_thread;
+	std::thread reachout_thread;
 
 public:
 	static unsigned const broadcast_interval_ms = 10;

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -78,9 +78,9 @@ public:
 	void send_keepalive_self (std::shared_ptr<nano::transport::channel> const &);
 	std::shared_ptr<nano::transport::channel> find_node_id (nano::account const &);
 	std::shared_ptr<nano::transport::channel> find_channel (nano::endpoint const &);
-	bool not_a_peer (nano::endpoint const &, bool);
-	// Should we reach out to this endpoint with a keepalive message
-	bool reachout (nano::endpoint const &, bool = false);
+	bool not_a_peer (nano::endpoint const &, bool allow_local_peers);
+	// Should we reach out to this endpoint with a keepalive message? If yes, register a new reachout attempt
+	bool track_reachout (nano::endpoint const &);
 	std::deque<std::shared_ptr<nano::transport::channel>> list (std::size_t max_count = 0, uint8_t = 0, bool = true);
 	std::deque<std::shared_ptr<nano::transport::channel>> list_non_pr (std::size_t);
 	// Desired fanout for a given scale

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1120,7 +1120,7 @@ void nano::node::add_initial_peers ()
 	for (auto i (store.peer.begin (transaction)), n (store.peer.end ()); i != n; ++i)
 	{
 		nano::endpoint endpoint (boost::asio::ip::address_v6 (i->first.address_bytes ()), i->first.port ());
-		if (!network.track_reachout (endpoint))
+		if (network.track_reachout (endpoint))
 		{
 			network.tcp_channels.start_tcp (endpoint);
 		}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -684,7 +684,6 @@ void nano::node::stop ()
 	generator.stop ();
 	final_generator.stop ();
 	confirmation_height_processor.stop ();
-	network.stop ();
 	telemetry.stop ();
 	websocket.stop ();
 	bootstrap_server.stop ();
@@ -696,6 +695,8 @@ void nano::node::stop ()
 	epoch_upgrader.stop ();
 	workers.stop ();
 	local_block_broadcaster.stop ();
+	network.stop (); // Stop network last to avoid killing in-use sockets
+
 	// work pool is not stopped on purpose due to testing setup
 }
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1120,7 +1120,7 @@ void nano::node::add_initial_peers ()
 	for (auto i (store.peer.begin (transaction)), n (store.peer.end ()); i != n; ++i)
 	{
 		nano::endpoint endpoint (boost::asio::ip::address_v6 (i->first.address_bytes ()), i->first.port ());
-		if (!network.reachout (endpoint, config.allow_local_peers))
+		if (!network.track_reachout (endpoint))
 		{
 			network.tcp_channels.start_tcp (endpoint);
 		}

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -41,6 +41,8 @@ public:
 	nano::transport::traffic_type = nano::transport::traffic_type::generic)
 	= 0;
 
+	virtual void close () = 0;
+
 	virtual std::string to_string () const = 0;
 	virtual nano::endpoint get_endpoint () const = 0;
 	virtual nano::tcp_endpoint get_tcp_endpoint () const = 0;
@@ -50,6 +52,7 @@ public:
 	{
 		return false;
 	}
+
 	virtual bool alive () const
 	{
 		return true;

--- a/nano/node/transport/fake.hpp
+++ b/nano/node/transport/fake.hpp
@@ -49,7 +49,7 @@ namespace transport
 				return nano::transport::transport_type::fake;
 			}
 
-			void close ()
+			void close () override
 			{
 				closed = true;
 			}

--- a/nano/node/transport/inproc.hpp
+++ b/nano/node/transport/inproc.hpp
@@ -43,6 +43,11 @@ namespace transport
 				return nano::transport::transport_type::loopback;
 			}
 
+			void close () override
+			{
+				// Can't be closed
+			}
+
 		private:
 			nano::node & destination;
 			nano::endpoint const endpoint;

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -469,7 +469,7 @@ bool nano::transport::tcp_channels::max_ip_or_subnetwork_connections (nano::tcp_
 	return max_ip_connections (endpoint_a) || max_subnetwork_connections (endpoint_a);
 }
 
-bool nano::transport::tcp_channels::reachout (nano::endpoint const & endpoint_a)
+bool nano::transport::tcp_channels::track_reachout (nano::endpoint const & endpoint_a)
 {
 	auto tcp_endpoint (nano::transport::map_endpoint_to_tcp (endpoint_a));
 	// Don't overload single IP

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -308,7 +308,7 @@ nano::tcp_endpoint nano::transport::tcp_channels::bootstrap_peer ()
 		if (i->channel->get_network_version () >= node.network_params.network.protocol_version_min)
 		{
 			result = nano::transport::map_endpoint_to_tcp (i->channel->get_peering_endpoint ());
-			channels.get<last_bootstrap_attempt_tag> ().modify (i, [] (channel_tcp_wrapper & wrapper_a) {
+			channels.get<last_bootstrap_attempt_tag> ().modify (i, [] (channel_entry & wrapper_a) {
 				wrapper_a.channel->set_last_bootstrap_attempt (std::chrono::steady_clock::now ());
 			});
 			i = n;
@@ -601,7 +601,7 @@ void nano::transport::tcp_channels::modify (std::shared_ptr<nano::transport::cha
 	auto existing (channels.get<endpoint_tag> ().find (channel_a->get_tcp_endpoint ()));
 	if (existing != channels.get<endpoint_tag> ().end ())
 	{
-		channels.get<endpoint_tag> ().modify (existing, [modify_callback = std::move (modify_callback_a)] (channel_tcp_wrapper & wrapper_a) {
+		channels.get<endpoint_tag> ().modify (existing, [modify_callback = std::move (modify_callback_a)] (channel_entry & wrapper_a) {
 			modify_callback (wrapper_a.channel);
 		});
 	}
@@ -613,7 +613,7 @@ void nano::transport::tcp_channels::update (nano::tcp_endpoint const & endpoint_
 	auto existing (channels.get<endpoint_tag> ().find (endpoint_a));
 	if (existing != channels.get<endpoint_tag> ().end ())
 	{
-		channels.get<endpoint_tag> ().modify (existing, [] (channel_tcp_wrapper & wrapper_a) {
+		channels.get<endpoint_tag> ().modify (existing, [] (channel_entry & wrapper_a) {
 			wrapper_a.channel->set_last_packet_sent (std::chrono::steady_clock::now ());
 		});
 	}

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -131,16 +131,34 @@ nano::transport::tcp_channels::tcp_channels (nano::node & node, std::function<vo
 {
 }
 
+nano::transport::tcp_channels::~tcp_channels ()
+{
+	// All threads must be stopped before destruction
+	debug_assert (!keepalive_thread.joinable ());
+}
+
 void nano::transport::tcp_channels::start ()
 {
-	ongoing_keepalive ();
 	ongoing_merge (0);
+
+	keepalive_thread = std::thread ([this] () {
+		nano::thread_role::set (nano::thread_role::name::tcp_keepalive);
+		run_keepalive ();
+	});
 }
 
 void nano::transport::tcp_channels::stop ()
 {
-	stopped = true;
-	nano::unique_lock<nano::mutex> lock{ mutex };
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		stopped = true;
+	}
+	condition.notify_all ();
+
+	if (keepalive_thread.joinable ())
+	{
+		keepalive_thread.join ();
+	}
 
 	message_manager.stop ();
 
@@ -158,6 +176,26 @@ void nano::transport::tcp_channels::stop ()
 		}
 	}
 	channels.clear ();
+}
+
+// TODO: Merge with keepalive in network class
+void nano::transport::tcp_channels::run_keepalive ()
+{
+	nano::unique_lock<nano::mutex> lock{ mutex };
+	while (!stopped)
+	{
+		condition.wait_for (lock, node.network_params.network.keepalive_period);
+		if (stopped)
+		{
+			return;
+		}
+		lock.unlock ();
+
+		node.stats.inc (nano::stat::type::tcp_channels, nano::stat::detail::loop_keepalive);
+		keepalive ();
+
+		lock.lock ();
+	}
 }
 
 bool nano::transport::tcp_channels::insert (std::shared_ptr<nano::transport::channel_tcp> const & channel_a, std::shared_ptr<nano::transport::socket> const & socket_a, std::shared_ptr<nano::transport::tcp_server> const & server_a)
@@ -485,33 +523,29 @@ void nano::transport::tcp_channels::purge (std::chrono::steady_clock::time_point
 	channels.get<version_tag> ().erase (channels.get<version_tag> ().begin (), lower_bound);
 }
 
-void nano::transport::tcp_channels::ongoing_keepalive ()
+void nano::transport::tcp_channels::keepalive ()
 {
 	nano::keepalive message{ node.network_params.network };
 	node.network.random_fill (message.peers);
+
 	nano::unique_lock<nano::mutex> lock{ mutex };
+
+	auto const cutoff_time = std::chrono::steady_clock::now () - node.network_params.network.keepalive_period;
+
 	// Wake up channels
 	std::vector<std::shared_ptr<nano::transport::channel_tcp>> send_list;
-	auto keepalive_sent_cutoff (channels.get<last_packet_sent_tag> ().lower_bound (std::chrono::steady_clock::now () - node.network_params.network.keepalive_period));
+	auto keepalive_sent_cutoff (channels.get<last_packet_sent_tag> ().lower_bound (cutoff_time));
 	for (auto i (channels.get<last_packet_sent_tag> ().begin ()); i != keepalive_sent_cutoff; ++i)
 	{
 		send_list.push_back (i->channel);
 	}
+
 	lock.unlock ();
+
 	for (auto & channel : send_list)
 	{
 		channel->send (message);
 	}
-	std::weak_ptr<nano::node> node_w (node.shared ());
-	node.workers.add_timed_task (std::chrono::steady_clock::now () + node.network_params.network.keepalive_period, [node_w] () {
-		if (auto node_l = node_w.lock ())
-		{
-			if (!node_l->network.tcp_channels.stopped)
-			{
-				node_l->network.tcp_channels.ongoing_keepalive ();
-			}
-		}
-	});
 }
 
 void nano::transport::tcp_channels::ongoing_merge (size_t channel_index)

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -150,7 +150,13 @@ void nano::transport::tcp_channels::stop ()
 
 	message_manager.stop ();
 
-	// Close all TCP sockets
+	close ();
+}
+
+void nano::transport::tcp_channels::close ()
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+
 	for (auto const & channel : channels)
 	{
 		if (channel.socket)
@@ -163,6 +169,7 @@ void nano::transport::tcp_channels::stop ()
 			channel.response_server->stop ();
 		}
 	}
+
 	channels.clear ();
 }
 

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -168,7 +168,7 @@ namespace transport
 		nano::tcp_message_manager message_manager;
 
 	private:
-		class channel_tcp_wrapper final
+		class channel_entry final
 		{
 		public:
 			std::shared_ptr<nano::transport::channel_tcp> channel;
@@ -176,7 +176,7 @@ namespace transport
 			std::shared_ptr<nano::transport::tcp_server> response_server;
 
 		public:
-			channel_tcp_wrapper (std::shared_ptr<nano::transport::channel_tcp> channel_a, std::shared_ptr<nano::transport::socket> socket_a, std::shared_ptr<nano::transport::tcp_server> server_a) :
+			channel_entry (std::shared_ptr<nano::transport::channel_tcp> channel_a, std::shared_ptr<nano::transport::socket> socket_a, std::shared_ptr<nano::transport::tcp_server> server_a) :
 				channel (std::move (channel_a)), socket (std::move (socket_a)), response_server (std::move (server_a))
 			{
 			}
@@ -211,7 +211,7 @@ namespace transport
 			}
 		};
 
-		class tcp_endpoint_attempt final
+		class attempt_entry final
 		{
 		public:
 			nano::tcp_endpoint endpoint;
@@ -220,7 +220,7 @@ namespace transport
 			std::chrono::steady_clock::time_point last_attempt{ std::chrono::steady_clock::now () };
 
 		public:
-			explicit tcp_endpoint_attempt (nano::tcp_endpoint const & endpoint_a) :
+			explicit attempt_entry (nano::tcp_endpoint const & endpoint_a) :
 				endpoint (endpoint_a),
 				address (nano::transport::ipv4_address_or_ipv6_subnet (endpoint_a.address ())),
 				subnetwork (nano::transport::map_address_to_subnetwork (endpoint_a.address ()))
@@ -241,35 +241,35 @@ namespace transport
 		// clang-format on
 
 		// clang-format off
-		boost::multi_index_container<channel_tcp_wrapper,
+		boost::multi_index_container<channel_entry,
 		mi::indexed_by<
 			mi::random_access<mi::tag<random_access_tag>>,
 			mi::ordered_non_unique<mi::tag<last_bootstrap_attempt_tag>,
-				mi::const_mem_fun<channel_tcp_wrapper, std::chrono::steady_clock::time_point, &channel_tcp_wrapper::last_bootstrap_attempt>>,
+				mi::const_mem_fun<channel_entry, std::chrono::steady_clock::time_point, &channel_entry::last_bootstrap_attempt>>,
 			mi::hashed_unique<mi::tag<endpoint_tag>,
-				mi::const_mem_fun<channel_tcp_wrapper, nano::tcp_endpoint, &channel_tcp_wrapper::endpoint>>,
+				mi::const_mem_fun<channel_entry, nano::tcp_endpoint, &channel_entry::endpoint>>,
 			mi::hashed_non_unique<mi::tag<node_id_tag>,
-				mi::const_mem_fun<channel_tcp_wrapper, nano::account, &channel_tcp_wrapper::node_id>>,
+				mi::const_mem_fun<channel_entry, nano::account, &channel_entry::node_id>>,
 			mi::ordered_non_unique<mi::tag<last_packet_sent_tag>,
-				mi::const_mem_fun<channel_tcp_wrapper, std::chrono::steady_clock::time_point, &channel_tcp_wrapper::last_packet_sent>>,
+				mi::const_mem_fun<channel_entry, std::chrono::steady_clock::time_point, &channel_entry::last_packet_sent>>,
 			mi::ordered_non_unique<mi::tag<version_tag>,
-				mi::const_mem_fun<channel_tcp_wrapper, uint8_t, &channel_tcp_wrapper::network_version>>,
+				mi::const_mem_fun<channel_entry, uint8_t, &channel_entry::network_version>>,
 			mi::hashed_non_unique<mi::tag<ip_address_tag>,
-				mi::const_mem_fun<channel_tcp_wrapper, boost::asio::ip::address, &channel_tcp_wrapper::ip_address>>,
+				mi::const_mem_fun<channel_entry, boost::asio::ip::address, &channel_entry::ip_address>>,
 			mi::hashed_non_unique<mi::tag<subnetwork_tag>,
-				mi::const_mem_fun<channel_tcp_wrapper, boost::asio::ip::address, &channel_tcp_wrapper::subnetwork>>>>
+				mi::const_mem_fun<channel_entry, boost::asio::ip::address, &channel_entry::subnetwork>>>>
 		channels;
 
-		boost::multi_index_container<tcp_endpoint_attempt,
+		boost::multi_index_container<attempt_entry,
 		mi::indexed_by<
 			mi::hashed_unique<mi::tag<endpoint_tag>,
-				mi::member<tcp_endpoint_attempt, nano::tcp_endpoint, &tcp_endpoint_attempt::endpoint>>,
+				mi::member<attempt_entry, nano::tcp_endpoint, &attempt_entry::endpoint>>,
 			mi::hashed_non_unique<mi::tag<ip_address_tag>,
-				mi::member<tcp_endpoint_attempt, boost::asio::ip::address, &tcp_endpoint_attempt::address>>,
+				mi::member<attempt_entry, boost::asio::ip::address, &attempt_entry::address>>,
 			mi::hashed_non_unique<mi::tag<subnetwork_tag>,
-				mi::member<tcp_endpoint_attempt, boost::asio::ip::address, &tcp_endpoint_attempt::subnetwork>>,
+				mi::member<attempt_entry, boost::asio::ip::address, &attempt_entry::subnetwork>>,
 			mi::ordered_non_unique<mi::tag<last_attempt_tag>,
-				mi::member<tcp_endpoint_attempt, std::chrono::steady_clock::time_point, &tcp_endpoint_attempt::last_attempt>>>>
+				mi::member<attempt_entry, std::chrono::steady_clock::time_point, &attempt_entry::last_attempt>>>>
 		attempts;
 		// clang-format on
 

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -145,7 +145,6 @@ namespace transport
 		std::shared_ptr<nano::transport::channel_tcp> find_node_id (nano::account const &);
 		// Get the next peer for attempting a tcp connection
 		nano::tcp_endpoint bootstrap_peer ();
-		void receive ();
 		void process_messages ();
 		void process_message (nano::message const &, nano::tcp_endpoint const &, nano::account const &, std::shared_ptr<nano::transport::socket> const &);
 		bool max_ip_connections (nano::tcp_endpoint const & endpoint_a);

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/random.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/transport/channel.hpp>
 #include <nano/node/transport/transport.hpp>
@@ -283,7 +284,7 @@ namespace transport
 		nano::condition_variable condition;
 		mutable nano::mutex mutex;
 
-		std::default_random_engine rng;
+		mutable nano::random_generator rng;
 	};
 } // namespace transport
 } // namespace nano

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -150,8 +150,8 @@ namespace transport
 		bool max_ip_connections (nano::tcp_endpoint const & endpoint_a);
 		bool max_subnetwork_connections (nano::tcp_endpoint const & endpoint_a);
 		bool max_ip_or_subnetwork_connections (nano::tcp_endpoint const & endpoint_a);
-		// Should we reach out to this endpoint with a keepalive message
-		bool reachout (nano::endpoint const &);
+		// Should we reach out to this endpoint with a keepalive message? If yes, register a new reachout attempt
+		bool track_reachout (nano::endpoint const &);
 		std::unique_ptr<container_info_component> collect_container_info (std::string const &);
 		void purge (std::chrono::steady_clock::time_point const &);
 		void ongoing_keepalive ();

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -158,6 +158,7 @@ namespace transport
 		void list (std::deque<std::shared_ptr<nano::transport::channel>> &, uint8_t = 0, bool = true);
 		void modify (std::shared_ptr<nano::transport::channel_tcp> const &, std::function<void (std::shared_ptr<nano::transport::channel_tcp> const &)>);
 		void update (nano::tcp_endpoint const &);
+		void keepalive ();
 		std::optional<nano::keepalive> sample_keepalive ();
 
 		// Connection start
@@ -166,10 +167,6 @@ namespace transport
 
 	private: // Dependencies
 		nano::node & node;
-
-	private:
-		void run_keepalive ();
-		void keepalive ();
 
 	public:
 		nano::tcp_message_manager message_manager;
@@ -286,7 +283,6 @@ namespace transport
 		std::atomic<bool> stopped{ false };
 		nano::condition_variable condition;
 		mutable nano::mutex mutex;
-		std::thread keepalive_thread;
 
 		std::default_random_engine rng;
 	};

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -172,6 +172,9 @@ namespace transport
 		nano::tcp_message_manager message_manager;
 
 	private:
+		void close ();
+
+	private:
 		class channel_entry final
 		{
 		public:

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -11,6 +11,7 @@
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index_container.hpp>
 
+#include <random>
 #include <thread>
 #include <unordered_set>
 
@@ -154,12 +155,11 @@ namespace transport
 		bool track_reachout (nano::endpoint const &);
 		std::unique_ptr<container_info_component> collect_container_info (std::string const &);
 		void purge (std::chrono::steady_clock::time_point const &);
-		void ongoing_keepalive ();
-		void ongoing_merge (size_t channel_index);
-		void ongoing_merge (size_t channel_index, nano::keepalive keepalive, size_t peer_index);
 		void list (std::deque<std::shared_ptr<nano::transport::channel>> &, uint8_t = 0, bool = true);
 		void modify (std::shared_ptr<nano::transport::channel_tcp> const &, std::function<void (std::shared_ptr<nano::transport::channel_tcp> const &)>);
 		void update (nano::tcp_endpoint const &);
+		std::optional<nano::keepalive> sample_keepalive ();
+
 		// Connection start
 		void start_tcp (nano::endpoint const &);
 		void start_tcp_receive_node_id (std::shared_ptr<nano::transport::channel_tcp> const &, nano::endpoint const &, std::shared_ptr<std::vector<uint8_t>> const &);
@@ -287,6 +287,8 @@ namespace transport
 		nano::condition_variable condition;
 		mutable nano::mutex mutex;
 		std::thread keepalive_thread;
+
+		std::default_random_engine rng;
 	};
 } // namespace transport
 } // namespace nano

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -796,6 +796,14 @@ void nano::transport::tcp_server::set_last_keepalive (nano::keepalive const & me
 	}
 }
 
+std::optional<nano::keepalive> nano::transport::tcp_server::pop_last_keepalive ()
+{
+	std::lock_guard<nano::mutex> lock{ mutex };
+	auto result = last_keepalive;
+	last_keepalive = std::nullopt;
+	return result;
+}
+
 bool nano::transport::tcp_server::to_bootstrap_connection ()
 {
 	auto node = this->node.lock ();

--- a/nano/node/transport/tcp_server.hpp
+++ b/nano/node/transport/tcp_server.hpp
@@ -63,6 +63,7 @@ public:
 
 	void timeout ();
 	void set_last_keepalive (nano::keepalive const & message);
+	std::optional<nano::keepalive> pop_last_keepalive ();
 
 	std::shared_ptr<nano::transport::socket> const socket;
 	std::weak_ptr<nano::node> const node;
@@ -73,7 +74,6 @@ public:
 	nano::tcp_endpoint remote_endpoint{ boost::asio::ip::address_v6::any (), 0 };
 	nano::account remote_node_id{};
 	std::chrono::steady_clock::time_point last_telemetry_req{};
-	std::optional<nano::keepalive> last_keepalive;
 
 private:
 	void send_handshake_response (nano::node_id_handshake::query_payload const & query, bool v2);
@@ -90,9 +90,10 @@ private:
 	bool is_bootstrap_connection () const;
 	bool is_realtime_connection () const;
 
+private:
+	bool const allow_bootstrap;
 	std::shared_ptr<nano::transport::message_deserializer> message_deserializer;
-
-	bool allow_bootstrap;
+	std::optional<nano::keepalive> last_keepalive;
 
 private:
 	class handshake_message_visitor : public nano::message_visitor


### PR DESCRIPTION
This PR focuses on cleanup of `tcp_channels` class. It eliminates some obvious inefficiencies (the `update` function), offloads peer reachout loop to a dedicated thread and fixes shutdown bug.