### PR TITLE
Adding abstraction of iteration over receivable entries

### DIFF
--- a/nano/core_test/bootstrap_ascending.cpp
+++ b/nano/core_test/bootstrap_ascending.cpp
@@ -4,6 +4,7 @@
 #include <nano/lib/tomlconfig.hpp>
 #include <nano/node/bootstrap_ascending/service.hpp>
 #include <nano/node/make_store.hpp>
+#include <nano/secure/ledger.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
@@ -251,7 +252,7 @@ TEST (bootstrap_ascending, trace_base)
 	//	std::cerr << "--------------- Start ---------------\n";
 	ASSERT_EQ (nano::block_status::progress, node0.process (send1));
 	ASSERT_EQ (nano::block_status::progress, node0.process (receive1));
-	ASSERT_EQ (node1.store.pending.begin (node1.store.tx_begin_read (), nano::pending_key{ key.pub, 0 }), node1.store.pending.end ());
+	ASSERT_EQ (node1.ledger.receivable_end (), node1.ledger.receivable_upper_bound (node1.store.tx_begin_read (), key.pub, 0));
 	//	std::cerr << "node0: " << node0.network.endpoint () << std::endl;
 	//	std::cerr << "node1: " << node1.network.endpoint () << std::endl;
 	ASSERT_TIMELY (10s, node1.block (receive1->hash ()) != nullptr);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5654,3 +5654,29 @@ TEST (ledger_receivable, key_two)
 	ASSERT_EQ (ledger.receivable_end (), ++next1);
 	ASSERT_EQ (ledger.receivable_end (), ++next2);
 }
+
+TEST (ledger_receivable, any_none)
+{
+	auto ctx = nano::test::context::ledger_empty ();
+	ASSERT_FALSE (ctx.ledger ().receivable_any (ctx.store ().tx_begin_read (), nano::dev::genesis_key.pub));
+}
+
+TEST (ledger_receivable, any_one)
+{
+	auto ctx = nano::test::context::ledger_empty ();
+	nano::block_builder builder;
+	nano::keypair key;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis_key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*ctx.pool ().generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.store ().tx_begin_write (), send1));
+	ASSERT_TRUE (ctx.ledger ().receivable_any (ctx.store ().tx_begin_read (), nano::dev::genesis_key.pub));
+	ASSERT_FALSE (ctx.ledger ().receivable_any (ctx.store ().tx_begin_read (), key.pub));
+}

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5559,3 +5559,98 @@ TEST (ledger, head_block)
 	auto tx = store.tx_begin_read ();
 	ASSERT_EQ (*nano::dev::genesis, *ledger.head_block (tx, nano::dev::genesis_key.pub));
 }
+
+// Test that nullopt can be returned when there are no receivable entries
+TEST (ledger_receivable, upper_bound_account_none)
+{
+	auto ctx = nano::test::context::ledger_empty ();
+	ASSERT_EQ (ctx.ledger ().receivable_end (), ctx.ledger ().receivable_upper_bound (ctx.store ().tx_begin_read (), 0));
+}
+
+// Test behavior of ledger::receivable_upper_bound when there are receivable entries for multiple accounts
+TEST (ledger_receivable, upper_bound_account_key)
+{
+	auto ctx = nano::test::context::ledger_empty ();
+	nano::block_builder builder;
+	nano::keypair key;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*ctx.pool ().generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.store ().tx_begin_write (), send1));
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio)
+				 .link (nano::dev::genesis_key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*ctx.pool ().generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.store ().tx_begin_write (), send2));
+	auto tx = ctx.store ().tx_begin_read ();
+	auto & ledger = ctx.ledger ();
+	auto next1 = ledger.receivable_upper_bound (tx, nano::dev::genesis_key.pub);
+	auto next2 = ledger.receivable_upper_bound (tx, key.pub);
+	// Depending on which is greater but only one should have a value
+	ASSERT_TRUE (next1 == ledger.receivable_end () xor next2 == ledger.receivable_end ());
+	// The account returned should be after the one we searched for
+	ASSERT_TRUE (next1 == ledger.receivable_end () || next1->first.account == key.pub);
+	ASSERT_TRUE (next2 == ledger.receivable_end () || next2->first.account == nano::dev::genesis_key.pub);
+	auto next3 = ledger.receivable_upper_bound (tx, nano::dev::genesis_key.pub, 0);
+	auto next4 = ledger.receivable_upper_bound (tx, key.pub, 0);
+	// Neither account has more than one receivable
+	ASSERT_TRUE (next3 != ledger.receivable_end () && next4 != ledger.receivable_end ());
+	auto next5 = ledger.receivable_upper_bound (tx, next3->first.account, next3->first.hash);
+	auto next6 = ledger.receivable_upper_bound (tx, next4->first.account, next4->first.hash);
+	ASSERT_TRUE (next5 == ledger.receivable_end () && next6 == ledger.receivable_end ());
+	ASSERT_EQ (ledger.receivable_end (), ++next3);
+	ASSERT_EQ (ledger.receivable_end (), ++next4);
+}
+
+// Test that multiple receivable entries for the same account
+TEST (ledger_receivable, key_two)
+{
+	auto ctx = nano::test::context::ledger_empty ();
+	nano::block_builder builder;
+	nano::keypair key;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*ctx.pool ().generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.store ().tx_begin_write (), send1));
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio)
+				 .link (key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*ctx.pool ().generate (send1->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.store ().tx_begin_write (), send2));
+	auto tx = ctx.store ().tx_begin_read ();
+	auto & ledger = ctx.ledger ();
+	auto next1 = ledger.receivable_upper_bound (tx, key.pub, 0);
+	ASSERT_TRUE (next1 != ledger.receivable_end () && next1->first.account == key.pub);
+	auto next2 = ledger.receivable_upper_bound (tx, key.pub, next1->first.hash);
+	ASSERT_TRUE (next2 != ledger.receivable_end () && next2->first.account == key.pub);
+	ASSERT_NE (next1->first.hash, next2->first.hash);
+	ASSERT_EQ (next2, ++next1);
+	ASSERT_EQ (ledger.receivable_end (), ++next1);
+	ASSERT_EQ (ledger.receivable_end (), ++next2);
+}

--- a/nano/node/bootstrap_ascending/iterators.hpp
+++ b/nano/node/bootstrap_ascending/iterators.hpp
@@ -4,6 +4,11 @@
 
 #include <deque>
 
+namespace nano
+{
+class ledger;
+}
+
 namespace nano::store
 {
 class component;
@@ -21,12 +26,12 @@ public:
 		pending
 	};
 
-	explicit database_iterator (nano::store::component & store, table_type);
+	explicit database_iterator (nano::ledger & ledger, table_type);
 	nano::account operator* () const;
 	void next (nano::store::transaction & tx);
 
 private:
-	nano::store::component & store;
+	nano::ledger & ledger;
 	nano::account current{ 0 };
 	const table_type table;
 };
@@ -34,7 +39,7 @@ private:
 class buffered_iterator
 {
 public:
-	explicit buffered_iterator (nano::store::component & store);
+	explicit buffered_iterator (nano::ledger & ledger);
 	nano::account operator* () const;
 	nano::account next ();
 	// Indicates if a full ledger iteration has taken place e.g. warmed up
@@ -44,7 +49,7 @@ private:
 	void fill ();
 
 private:
-	nano::store::component & store;
+	nano::ledger & ledger;
 	std::deque<nano::account> buffer;
 	bool warmup_m{ true };
 

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -24,7 +24,7 @@ nano::bootstrap_ascending::service::service (nano::node_config & config_a, nano:
 	network{ network_a },
 	stats{ stat_a },
 	accounts{ stats },
-	iterator{ ledger.store },
+	iterator{ ledger },
 	throttle{ compute_throttle_size () },
 	scoring{ config.bootstrap_ascending, config.network_params.network },
 	database_limiter{ config.bootstrap_ascending.database_requests_limit, 1.0 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3051,66 +3051,65 @@ void nano::json_handler::receivable ()
 	{
 		auto offset_counter = offset;
 		boost::property_tree::ptree peers_l;
-		auto transaction (node.store.tx_begin_read ());
+		auto transaction = node.store.tx_begin_read ();
 		// The ptree container is used if there are any children nodes (e.g source/min_version) otherwise the amount container is used.
 		std::vector<std::pair<std::string, boost::property_tree::ptree>> hash_ptree_pairs;
 		std::vector<std::pair<std::string, nano::uint128_t>> hash_amount_pairs;
-		for (auto i (node.store.pending.begin (transaction, nano::pending_key (account, 0))), n (node.store.pending.end ()); i != n && nano::pending_key (i->first).account == account && (should_sort || peers_l.size () < count); ++i)
+		for (auto current = node.ledger.receivable_upper_bound (transaction, account, 0), end = node.ledger.receivable_end (); current != end && (should_sort || peers_l.size () < count); ++current)
 		{
-			nano::pending_key const & key (i->first);
-			if (block_confirmed (node, transaction, key.hash, include_active, include_only_confirmed))
+			auto const & [key, info] = *current;
+			if (include_only_confirmed && !node.ledger.block_confirmed (transaction, key.hash))
 			{
-				if (!should_sort && offset_counter > 0)
+				continue;
+			}
+			if (!should_sort && offset_counter > 0)
+			{
+				--offset_counter;
+				continue;
+			}
+
+			if (simple)
+			{
+				boost::property_tree::ptree entry;
+				entry.put ("", key.hash.to_string ());
+				peers_l.push_back (std::make_pair ("", entry));
+				continue;
+			}
+			if (info.amount.number () < threshold.number ())
+			{
+				continue;
+			}
+			if (source || min_version)
+			{
+				boost::property_tree::ptree pending_tree;
+				pending_tree.put ("amount", info.amount.number ().template convert_to<std::string> ());
+				if (source)
 				{
-					--offset_counter;
-					continue;
+					pending_tree.put ("source", info.source.to_account ());
+				}
+				if (min_version)
+				{
+					pending_tree.put ("min_version", epoch_as_string (info.epoch));
 				}
 
-				if (simple)
+				if (should_sort)
 				{
-					boost::property_tree::ptree entry;
-					entry.put ("", key.hash.to_string ());
-					peers_l.push_back (std::make_pair ("", entry));
+					hash_ptree_pairs.emplace_back (key.hash.to_string (), pending_tree);
 				}
 				else
 				{
-					nano::pending_info const & info (i->second);
-					if (info.amount.number () >= threshold.number ())
-					{
-						if (source || min_version)
-						{
-							boost::property_tree::ptree pending_tree;
-							pending_tree.put ("amount", info.amount.number ().convert_to<std::string> ());
-							if (source)
-							{
-								pending_tree.put ("source", info.source.to_account ());
-							}
-							if (min_version)
-							{
-								pending_tree.put ("min_version", epoch_as_string (info.epoch));
-							}
-
-							if (should_sort)
-							{
-								hash_ptree_pairs.emplace_back (key.hash.to_string (), pending_tree);
-							}
-							else
-							{
-								peers_l.add_child (key.hash.to_string (), pending_tree);
-							}
-						}
-						else
-						{
-							if (should_sort)
-							{
-								hash_amount_pairs.emplace_back (key.hash.to_string (), info.amount.number ());
-							}
-							else
-							{
-								peers_l.put (key.hash.to_string (), info.amount.number ().convert_to<std::string> ());
-							}
-						}
-					}
+					peers_l.add_child (key.hash.to_string (), pending_tree);
+				}
+			}
+			else
+			{
+				if (should_sort)
+				{
+					hash_amount_pairs.emplace_back (key.hash.to_string (), info.amount.number ());
+				}
+				else
+				{
+					peers_l.put (key.hash.to_string (), info.amount.number ().template convert_to<std::string> ());
 				}
 			}
 		}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4238,7 +4238,7 @@ void nano::json_handler::unopened ()
 {
 	auto count (count_optional_impl ());
 	auto threshold (threshold_optional_impl ());
-	nano::account start (1); // exclude burn account by default
+	nano::account start{ 1 }; // exclude burn account by default
 	boost::optional<std::string> account_text (request.get_optional<std::string> ("account"));
 	if (account_text.is_initialized ())
 	{
@@ -4246,48 +4246,28 @@ void nano::json_handler::unopened ()
 	}
 	if (!ec)
 	{
-		auto transaction (node.store.tx_begin_read ());
-		auto iterator (node.store.pending.begin (transaction, nano::pending_key (start, 0)));
-		auto end (node.store.pending.end ());
-		nano::account current_account (start);
-		nano::uint128_t current_account_sum{ 0 };
+		auto transaction = node.store.tx_begin_read ();
+		auto & ledger = node.ledger;
 		boost::property_tree::ptree accounts;
-		while (iterator != end && accounts.size () < count)
+		for (auto iterator = ledger.receivable_upper_bound (transaction, start, 0), end = ledger.receivable_end (); iterator != end && accounts.size () < count;)
 		{
-			nano::pending_key key (iterator->first);
-			nano::account account (key.account);
-			nano::pending_info info (iterator->second);
-			if (node.store.account.exists (transaction, account))
+			auto const & [key, info] = *iterator;
+			nano::account account = key.account;
+			if (!node.store.account.exists (transaction, account))
 			{
-				if (account.number () == std::numeric_limits<nano::uint256_t>::max ())
+				nano::uint128_t current_account_sum{ 0 };
+				while (iterator != end)
 				{
-					break;
+					auto const & [key, info] = *iterator;
+					current_account_sum += info.amount.number ();
+					++iterator;
 				}
-				// Skip existing accounts
-				iterator = node.store.pending.begin (transaction, nano::pending_key (account.number () + 1, 0));
-			}
-			else
-			{
-				if (account != current_account)
+				if (current_account_sum >= threshold.number ())
 				{
-					if (current_account_sum > 0)
-					{
-						if (current_account_sum >= threshold.number ())
-						{
-							accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ());
-						}
-						current_account_sum = 0;
-					}
-					current_account = account;
+					accounts.put (account.to_account (), current_account_sum.convert_to<std::string> ());
 				}
-				current_account_sum += info.amount.number ();
-				++iterator;
 			}
-		}
-		// last one after iterator reaches end
-		if (accounts.size () < count && current_account_sum > 0 && current_account_sum >= threshold.number ())
-		{
-			accounts.put (current_account.to_account (), current_account_sum.convert_to<std::string> ());
+			iterator = ledger.receivable_upper_bound (transaction, account);
 		}
 		response_l.add_child ("accounts", accounts);
 	}

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1248,11 +1248,11 @@ uint32_t nano::wallet::deterministic_check (store::transaction const & transacti
 		else
 		{
 			// Check if there are pending blocks for account
-			for (auto ii (wallets.node.store.pending.begin (block_transaction, nano::pending_key (pair.pub, 0))), nn (wallets.node.store.pending.end ()); ii != nn && nano::pending_key (ii->first).account == pair.pub; ++ii)
+			auto current = wallets.node.ledger.receivable_upper_bound (block_transaction, pair.pub, 0);
+			if (current != wallets.node.ledger.receivable_end ())
 			{
 				index = i;
 				n = i + 64 + (i / 64);
-				break;
 			}
 		}
 	}

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1182,15 +1182,14 @@ bool nano::wallet::search_receivable (store::transaction const & wallet_transact
 			// Don't search pending for watch-only accounts
 			if (!nano::wallet_value (i->second).key.is_zero ())
 			{
-				for (auto j (wallets.node.store.pending.begin (block_transaction, nano::pending_key (account, 0))), k (wallets.node.store.pending.end ()); j != k && nano::pending_key (j->first).account == account; ++j)
+				for (auto i = wallets.node.ledger.receivable_upper_bound (block_transaction, account, 0), n = wallets.node.ledger.receivable_end (); i != n; ++i)
 				{
-					nano::pending_key key (j->first);
-					auto hash (key.hash);
-					nano::pending_info pending (j->second);
-					auto amount (pending.amount.number ());
+					auto const & [key, info] = *i;
+					auto hash = key.hash;
+					auto amount = info.amount.number ();
 					if (wallets.node.config.receive_minimum.number () <= amount)
 					{
-						wallets.node.logger.info (nano::log::type::wallet, "Found a receivable block {} for account {}", hash.to_string (), pending.source.to_account ());
+						wallets.node.logger.info (nano::log::type::wallet, "Found a receivable block {} for account {}", hash.to_string (), info.source.to_account ());
 
 						if (wallets.node.ledger.block_confirmed (block_transaction, hash))
 						{

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -413,7 +413,7 @@ void ledger_processor::epoch_block_impl (nano::state_block & block_a)
 					// Non-exisitng account should have pending entries
 					if (result == nano::block_status::progress)
 					{
-						bool pending_exists = ledger.store.pending.any (transaction, block_a.hashables.account);
+						bool pending_exists = ledger.receivable_any (transaction, block_a.hashables.account);
 						result = pending_exists ? nano::block_status::progress : nano::block_status::gap_epoch_open_pending;
 					}
 				}
@@ -1543,6 +1543,12 @@ uint64_t nano::ledger::height (store::transaction const & transaction, nano::blo
 {
 	auto block_l = block (transaction, hash);
 	return block_l->sideband ().height;
+}
+
+bool nano::ledger::receivable_any (store::transaction const & tx, nano::account const & account) const
+{
+	auto next = receivable_upper_bound (tx, account, 0);
+	return next != receivable_end ();
 }
 
 std::optional<std::pair<nano::pending_key, nano::pending_info>> nano::ledger::receivable_lower_bound (store::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -855,19 +855,11 @@ nano::uint128_t nano::ledger::account_balance (store::transaction const & transa
 
 nano::uint128_t nano::ledger::account_receivable (store::transaction const & transaction_a, nano::account const & account_a, bool only_confirmed_a)
 {
-	nano::uint128_t result (0);
-	nano::account end (account_a.number () + 1);
-	for (auto i (store.pending.begin (transaction_a, nano::pending_key (account_a, 0))), n (store.pending.begin (transaction_a, nano::pending_key (end, 0))); i != n; ++i)
+	nano::uint128_t result{ 0 };
+	for (auto i = receivable_upper_bound (transaction_a, account_a, 0), n = receivable_end (); i != n; ++i)
 	{
-		nano::pending_info const & info (i->second);
-		if (only_confirmed_a)
-		{
-			if (block_confirmed (transaction_a, i->first.hash))
-			{
-				result += info.amount.number ();
-			}
-		}
-		else
+		auto const & [key, info] = *i;
+		if (!only_confirmed_a || block_confirmed (transaction_a, key.hash))
 		{
 			result += info.amount.number ();
 		}

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -87,6 +87,8 @@ public:
 	static nano::epoch version (nano::block const & block);
 	nano::epoch version (store::transaction const & transaction, nano::block_hash const & hash) const;
 	uint64_t height (store::transaction const & transaction, nano::block_hash const & hash) const;
+	// Returns whether there are any receivable entries for 'account'
+	bool receivable_any (store::transaction const & tx, nano::account const & account) const;
 	nano::receivable_iterator receivable_end () const;
 	// Returns the next receivable entry for an account greater than 'account'
 	nano::receivable_iterator receivable_upper_bound (store::transaction const & tx, nano::account const & account) const;

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -5,6 +5,7 @@
 #include <nano/secure/account_info.hpp>
 #include <nano/secure/generate_cache_flags.hpp>
 #include <nano/secure/ledger_cache.hpp>
+#include <nano/secure/pending_info.hpp>
 
 #include <map>
 
@@ -36,6 +37,8 @@ public:
 
 class ledger final
 {
+	friend class receivable_iterator;
+
 public:
 	ledger (nano::store::component &, nano::stats &, nano::ledger_constants & constants, nano::generate_cache_flags const & = nano::generate_cache_flags{});
 	/**
@@ -84,6 +87,11 @@ public:
 	static nano::epoch version (nano::block const & block);
 	nano::epoch version (store::transaction const & transaction, nano::block_hash const & hash) const;
 	uint64_t height (store::transaction const & transaction, nano::block_hash const & hash) const;
+	nano::receivable_iterator receivable_end () const;
+	// Returns the next receivable entry for an account greater than 'account'
+	nano::receivable_iterator receivable_upper_bound (store::transaction const & tx, nano::account const & account) const;
+	// Returns the next receivable entry for the account 'account' with hash greater than 'hash'
+	nano::receivable_iterator receivable_upper_bound (store::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const;
 	static nano::uint128_t const unit;
 	nano::ledger_constants & constants;
 	nano::store::component & store;
@@ -95,6 +103,8 @@ public:
 	bool pruning{ false };
 
 private:
+	// Returns the next receivable entry equal or greater than 'key'
+	std::optional<std::pair<nano::pending_key, nano::pending_info>> receivable_lower_bound (store::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const;
 	void initialize (nano::generate_cache_flags const &);
 };
 

--- a/nano/secure/pending_info.cpp
+++ b/nano/secure/pending_info.cpp
@@ -1,3 +1,4 @@
+#include <nano/secure/ledger.hpp>
 #include <nano/secure/pending_info.hpp>
 
 nano::pending_info::pending_info (nano::account const & source_a, nano::amount const & amount_a, nano::epoch epoch_a) :
@@ -69,4 +70,48 @@ nano::account const & nano::pending_key::key () const
 bool nano::pending_key::operator< (nano::pending_key const & other_a) const
 {
 	return account == other_a.account ? hash < other_a.hash : account < other_a.account;
+}
+
+nano::receivable_iterator::receivable_iterator (nano::ledger const & ledger, nano::store::transaction const & tx, std::optional<std::pair<nano::pending_key, nano::pending_info>> item) :
+	ledger{ &ledger },
+	tx{ &tx },
+	item{ item }
+{
+	if (item.has_value ())
+	{
+		account = item.value ().first.account;
+	}
+}
+
+bool nano::receivable_iterator::operator== (receivable_iterator const & other) const
+{
+	debug_assert (ledger == nullptr || other.ledger == nullptr || ledger == other.ledger);
+	debug_assert (tx == nullptr || other.tx == nullptr || tx == other.tx);
+	debug_assert (account.is_zero () || other.account.is_zero () || account == other.account);
+	return item == other.item;
+}
+
+bool nano::receivable_iterator::operator!= (receivable_iterator const & other) const
+{
+	return !(*this == other);
+}
+
+nano::receivable_iterator & nano::receivable_iterator::operator++ ()
+{
+	item = ledger->receivable_lower_bound (*tx, item.value ().first.account, item.value ().first.hash.number () + 1);
+	if (item && item.value ().first.account != account)
+	{
+		item = std::nullopt;
+	}
+	return *this;
+}
+
+std::pair<nano::pending_key, nano::pending_info> const & nano::receivable_iterator::operator* () const
+{
+	return item.value ();
+}
+
+std::pair<nano::pending_key, nano::pending_info> const * nano::receivable_iterator::operator->() const
+{
+	return &item.value ();
 }

--- a/nano/secure/pending_info.hpp
+++ b/nano/secure/pending_info.hpp
@@ -6,6 +6,16 @@
 
 namespace nano
 {
+class ledger;
+}
+
+namespace nano::store
+{
+class transaction;
+}
+
+namespace nano
+{
 /**
  * Information on an uncollected send
  */
@@ -32,6 +42,25 @@ public:
 	nano::account const & key () const;
 	nano::account account{};
 	nano::block_hash hash{ 0 };
+};
+// This class iterates receivable enttries for an account
+class receivable_iterator
+{
+public:
+	receivable_iterator () = default;
+	receivable_iterator (nano::ledger const & ledger, nano::store::transaction const & tx, std::optional<std::pair<nano::pending_key, nano::pending_info>> item);
+	bool operator== (receivable_iterator const & other) const;
+	bool operator!= (receivable_iterator const & other) const;
+	// Advances to the next receivable entry for the same account
+	receivable_iterator & operator++ ();
+	std::pair<nano::pending_key, nano::pending_info> const & operator* () const;
+	std::pair<nano::pending_key, nano::pending_info> const * operator->() const;
+
+private:
+	nano::ledger const * ledger{ nullptr };
+	nano::store::transaction const * tx{ nullptr };
+	nano::account account{ 0 };
+	std::optional<std::pair<nano::pending_key, nano::pending_info>> item;
 };
 } // namespace nano
 

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -416,11 +416,10 @@ void nano::test::system::generate_receive (nano::node & node_a)
 		auto transaction (node_a.store.tx_begin_read ());
 		nano::account random_account;
 		random_pool::generate_block (random_account.bytes.data (), sizeof (random_account.bytes));
-		auto i (node_a.store.pending.begin (transaction, nano::pending_key (random_account, 0)));
-		if (i != node_a.store.pending.end ())
+		auto item = node_a.ledger.receivable_upper_bound (transaction, random_account);
+		if (item != node_a.ledger.receivable_end ())
 		{
-			nano::pending_key const & send_hash (i->first);
-			send_block = node_a.ledger.block (transaction, send_hash.hash);
+			send_block = node_a.ledger.block (transaction, item->first.hash);
 		}
 	}
 	if (send_block != nullptr)


### PR DESCRIPTION
This series of changes is aimed at decoupling queriers of receivable entries from the implementation of how they're stored. Queries of pending entries fall into three major categories

**Ledger processing**
This is an operation that checks the correctness of source blocks for blocks that receive a balance. If each block that sends a balance inserts an entry into an O(1) unordered_set (destination, block_hash), every receive block can be checked in O(1) time by using the (account, source) fields of blocks that receive. The existence of that value indicates the block is receivable.

**Iterating blocks that can be received by an account.**
This is done by a lot of wallet operations and RPCs related to wallet operations that want to check particular items available to be received for a particular account. A wallet would do this operation when looking for items it could process if wasn't signaled to that event through another means, e.g. websockets.

These operations are currently implemented with sorted queries over a single account searching for values. It might be possible to implement this without a sorted query.

**Iterating accounts that have items to receive**
The "unopened" rpc operates this way, iterating up to a certain number of accounts and summing the amount that can be received.

**Iterating all items**
Epoch upgrades, diagnostic functions

# There are 3 functions that iterate over receivable entries:
ledger.receivable_upper_bound (tx, account) - This will search for the first receivable item for an account strictly greater than "account".
ledger.receivable_upper_bound (tx, account, hash) - This will search for the next receivable item for a particular account greater than "hash". This will return nullopt if iteration goes past items in this account.

Upper_bound is used for the convenience of being able to feed in the current value of an iteration without modification and still iterate entries.

ledger.receivable_lower_bound (tx, account, hash) - This search finds the first item equal to or greater than the items passed in. This is the base function used by upper_bound functions.
