### PR TITLE
Remove channel comparison functions

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1096,8 +1096,6 @@ TEST (network, loopback_channel)
 	ASSERT_EQ (channel1.get_node_id (), node1.node_id.pub);
 	ASSERT_EQ (channel1.get_node_id_optional ().value_or (0), node1.node_id.pub);
 	nano::transport::inproc::channel channel2 (node2, node2);
-	ASSERT_EQ (channel1, channel1);
-	ASSERT_FALSE (channel1 == channel2);
 	++node1.network.port;
 	ASSERT_NE (channel1.get_endpoint (), node1.network.endpoint ());
 }

--- a/nano/core_test/rep_crawler.cpp
+++ b/nano/core_test/rep_crawler.cpp
@@ -106,7 +106,7 @@ TEST (rep_crawler, rep_weight)
 	ASSERT_EQ (1, reps.size ());
 	ASSERT_EQ (node.balance (nano::dev::genesis_key.pub), node.ledger.weight (reps[0].account));
 	ASSERT_EQ (nano::dev::genesis_key.pub, reps[0].account);
-	ASSERT_EQ (*channel1, *reps[0].channel);
+	ASSERT_EQ (channel1, reps[0].channel);
 	ASSERT_TRUE (node.rep_crawler.is_pr (channel1));
 	ASSERT_FALSE (node.rep_crawler.is_pr (channel2));
 	ASSERT_TRUE (node.rep_crawler.is_pr (channel3));
@@ -189,7 +189,7 @@ TEST (rep_crawler, rep_remove)
 	ASSERT_EQ (1, reps.size ());
 	ASSERT_EQ (searching_node.minimum_principal_weight () * 2, searching_node.ledger.weight (reps[0].account));
 	ASSERT_EQ (keys_rep1.pub, reps[0].account);
-	ASSERT_EQ (*channel_rep1, *reps[0].channel);
+	ASSERT_EQ (channel_rep1, reps[0].channel);
 
 	// When rep1 disconnects then rep1 should not be found anymore
 	channel_rep1->close ();

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -25,7 +25,7 @@ nano::bootstrap_client::bootstrap_client (std::shared_ptr<nano::node> const & no
 {
 	++node_a->bootstrap_initiator.connections->connections_count;
 	receive_buffer->resize (256);
-	channel->set_endpoint ();
+	channel->update_endpoint ();
 }
 
 nano::bootstrap_client::~bootstrap_client ()

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -26,9 +26,6 @@ public:
 	explicit channel (nano::node &);
 	virtual ~channel () = default;
 
-	virtual std::size_t hash_code () const = 0;
-	virtual bool operator== (nano::transport::channel const &) const = 0;
-
 	void send (nano::message & message_a,
 	std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a = nullptr,
 	nano::transport::buffer_drop_policy policy_a = nano::transport::buffer_drop_policy::limiter,
@@ -147,47 +144,5 @@ protected:
 
 public: // Logging
 	virtual void operator() (nano::object_stream &) const;
-};
-}
-
-namespace std
-{
-template <>
-struct hash<::nano::transport::channel>
-{
-	std::size_t operator() (::nano::transport::channel const & channel_a) const
-	{
-		return channel_a.hash_code ();
-	}
-};
-template <>
-struct equal_to<std::reference_wrapper<::nano::transport::channel const>>
-{
-	bool operator() (std::reference_wrapper<::nano::transport::channel const> const & lhs, std::reference_wrapper<::nano::transport::channel const> const & rhs) const
-	{
-		return lhs.get () == rhs.get ();
-	}
-};
-}
-
-namespace boost
-{
-template <>
-struct hash<::nano::transport::channel>
-{
-	std::size_t operator() (::nano::transport::channel const & channel_a) const
-	{
-		std::hash<::nano::transport::channel> hash;
-		return hash (channel_a);
-	}
-};
-template <>
-struct hash<std::reference_wrapper<::nano::transport::channel const>>
-{
-	std::size_t operator() (std::reference_wrapper<::nano::transport::channel const> const & channel_a) const
-	{
-		std::hash<::nano::transport::channel> hash;
-		return hash (channel_a.get ());
-	}
 };
 }

--- a/nano/node/transport/fake.cpp
+++ b/nano/node/transport/fake.cpp
@@ -26,22 +26,6 @@ void nano::transport::fake::channel::send_buffer (nano::shared_const_buffer cons
 	}
 }
 
-std::size_t nano::transport::fake::channel::hash_code () const
-{
-	std::hash<::nano::endpoint> hash;
-	return hash (endpoint);
-}
-
-bool nano::transport::fake::channel::operator== (nano::transport::channel const & other_a) const
-{
-	return endpoint == other_a.get_endpoint ();
-}
-
-bool nano::transport::fake::channel::operator== (nano::transport::fake::channel const & other_a) const
-{
-	return endpoint == other_a.get_endpoint ();
-}
-
 std::string nano::transport::fake::channel::to_string () const
 {
 	return boost::str (boost::format ("%1%") % endpoint);

--- a/nano/node/transport/fake.hpp
+++ b/nano/node/transport/fake.hpp
@@ -18,16 +18,12 @@ namespace transport
 			explicit channel (nano::node &);
 
 			std::string to_string () const override;
-			std::size_t hash_code () const override;
 
 			void send_buffer (
 			nano::shared_const_buffer const &,
 			std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr,
 			nano::transport::buffer_drop_policy = nano::transport::buffer_drop_policy::limiter,
 			nano::transport::traffic_type = nano::transport::traffic_type::generic) override;
-
-			bool operator== (nano::transport::channel const &) const override;
-			bool operator== (nano::transport::fake::channel const & other_a) const;
 
 			void set_endpoint (nano::endpoint const & endpoint_a)
 			{

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -14,17 +14,6 @@ nano::transport::inproc::channel::channel (nano::node & node, nano::node & desti
 	set_network_version (node.network_params.network.protocol_version);
 }
 
-std::size_t nano::transport::inproc::channel::hash_code () const
-{
-	std::hash<::nano::endpoint> hash;
-	return hash (endpoint);
-}
-
-bool nano::transport::inproc::channel::operator== (nano::transport::channel const & other_a) const
-{
-	return endpoint == other_a.get_endpoint ();
-}
-
 /**
  * Send the buffer to the peer and call the callback function when done. The call never fails.
  * Note that the inbound message visitor will be called before the callback because it is called directly whereas the callback is spawned in the background.

--- a/nano/node/transport/inproc.hpp
+++ b/nano/node/transport/inproc.hpp
@@ -16,17 +16,11 @@ namespace transport
 		{
 		public:
 			explicit channel (nano::node & node, nano::node & destination);
-			std::size_t hash_code () const override;
-			bool operator== (nano::transport::channel const &) const override;
 
 			// TODO: investigate clang-tidy warning about default parameters on virtual/override functions
 			void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::transport::buffer_drop_policy = nano::transport::buffer_drop_policy::limiter, nano::transport::traffic_type = nano::transport::traffic_type::generic) override;
 
 			std::string to_string () const override;
-			bool operator== (nano::transport::inproc::channel const & other_a) const
-			{
-				return endpoint == other_a.get_endpoint ();
-			}
 
 			nano::endpoint get_endpoint () const override
 			{

--- a/nano/node/transport/tcp.cpp
+++ b/nano/node/transport/tcp.cpp
@@ -30,23 +30,6 @@ nano::transport::channel_tcp::~channel_tcp ()
 	}
 }
 
-std::size_t nano::transport::channel_tcp::hash_code () const
-{
-	std::hash<::nano::tcp_endpoint> hash;
-	return hash (get_tcp_endpoint ());
-}
-
-bool nano::transport::channel_tcp::operator== (nano::transport::channel const & other_a) const
-{
-	bool result (false);
-	auto other_l (dynamic_cast<nano::transport::channel_tcp const *> (&other_a));
-	if (other_l != nullptr)
-	{
-		return *this == *other_l;
-	}
-	return result;
-}
-
 void nano::transport::channel_tcp::send_buffer (nano::shared_const_buffer const & buffer_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::transport::buffer_drop_policy policy_a, nano::transport::traffic_type traffic_type)
 {
 	if (auto socket_l = socket.lock ())

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -68,7 +68,15 @@ namespace transport
 
 		std::string to_string () const override;
 
-		void set_endpoint ();
+		void update_endpoint ()
+		{
+			nano::lock_guard<nano::mutex> lk (channel_mutex);
+			debug_assert (endpoint == nano::tcp_endpoint (boost::asio::ip::address_v6::any (), 0)); // Not initialized endpoint value
+			if (auto socket_l = socket.lock ())
+			{
+				endpoint = socket_l->remote_endpoint ();
+			}
+		}
 
 		nano::endpoint get_endpoint () const override
 		{

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -63,17 +63,10 @@ namespace transport
 		channel_tcp (nano::node &, std::weak_ptr<nano::transport::socket>);
 		~channel_tcp () override;
 
-		std::size_t hash_code () const override;
-		bool operator== (nano::transport::channel const &) const override;
-
 		// TODO: investigate clang-tidy warning about default parameters on virtual/override functions//
 		void send_buffer (nano::shared_const_buffer const &, std::function<void (boost::system::error_code const &, std::size_t)> const & = nullptr, nano::transport::buffer_drop_policy = nano::transport::buffer_drop_policy::limiter, nano::transport::traffic_type = nano::transport::traffic_type::generic) override;
 
 		std::string to_string () const override;
-		bool operator== (nano::transport::channel_tcp const & other_a) const
-		{
-			return &node == &other_a.node && socket.lock () == other_a.socket.lock ();
-		}
 
 		void set_endpoint ();
 


### PR DESCRIPTION
Dedicated channel comparison functions are no longer necessary or used. Instead channels have object identity: each allocated channel is a distinct object, with comparison and hashing facilitated by the shared_ptr wrapper.