### PR TITLE
Block cemented callback simplify

### DIFF
--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1444,8 +1444,9 @@ TEST (confirmation_height, pending_observer_callbacks)
 
 		node->confirmation_height_processor.add (send1);
 
-		// Confirm the callback is not called under this circumstance because there is no election information
-		ASSERT_TIMELY (10s, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out) == 1 && node->ledger.stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out) == 1);
+		// Callback is performed for all blocks that are confirmed
+		ASSERT_TIMELY_EQ (5s, 2, node->stats.count (nano::stat::type::http_callback, nano::stat::detail::http_callback, nano::stat::dir::out))
+		ASSERT_TIMELY_EQ (5s, 2, node->ledger.stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
 
 		ASSERT_EQ (2, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
 		ASSERT_EQ (2, node->stats.count (nano::stat::type::confirmation_height, get_stats_detail (mode_a), nano::stat::dir::in));
@@ -1528,7 +1529,8 @@ TEST (confirmation_height, callback_confirmed_history)
 		ASSERT_TIMELY_EQ (10s, node->active.size (), 0);
 		ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out), 1);
 
-		ASSERT_EQ (1, node->active.recently_cemented.list ().size ());
+		// Each block that's confirmed is in the recently_cemented history
+		ASSERT_EQ (2, node->active.recently_cemented.list ().size ());
 		ASSERT_TRUE (node->active.empty ());
 
 		// Confirm the callback is not called under this circumstance

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -160,7 +160,6 @@ public:
 	bool empty () const;
 	std::size_t size () const;
 	bool publish (std::shared_ptr<nano::block> const &);
-	boost::optional<nano::election_status_type> confirm_block (std::shared_ptr<nano::block> const &);
 	void block_cemented_callback (std::shared_ptr<nano::block> const &);
 	void block_already_cemented_callback (nano::block_hash const &);
 
@@ -177,7 +176,7 @@ public:
 
 	std::size_t election_winner_details_size ();
 	void add_election_winner_details (nano::block_hash const &, std::shared_ptr<nano::election> const &);
-	void remove_election_winner_details (nano::block_hash const &);
+	std::shared_ptr<nano::election> remove_election_winner_details (nano::block_hash const &);
 
 private:
 	// Erase elections if we're over capacity
@@ -195,11 +194,6 @@ private:
 	 * TODO: Should be moved to `vote_cache` class
 	 */
 	void add_vote_cache (nano::block_hash const & hash, std::shared_ptr<nano::vote> vote);
-	boost::optional<nano::election_status_type> election_status (std::shared_ptr<nano::block> const & block);
-	void process_inactive_confirmation (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block);
-	void process_active_confirmation (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block, nano::election_status_type status);
-	void handle_final_votes_confirmation (std::shared_ptr<nano::block> const & block, nano::store::read_transaction const & transaction, nano::election_status_type status);
-	void handle_confirmation (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block, std::shared_ptr<nano::election> election, nano::election_status_type status);
 	void activate_successors (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block);
 	void notify_observers (nano::store::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes);
 

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -146,8 +146,7 @@ public: // Interface
 	bool publish (std::shared_ptr<nano::block> const & block_a);
 	// Confirm this block if quorum is met
 	void confirm_if_quorum (nano::unique_lock<nano::mutex> &);
-	boost::optional<nano::election_status_type> try_confirm (nano::block_hash const & hash);
-	nano::election_status set_status_type (nano::election_status_type status_type);
+	void try_confirm (nano::block_hash const & hash);
 
 	/**
 	 * Broadcasts vote for the current winner of this election
@@ -173,7 +172,7 @@ private:
 	bool confirmed_locked () const;
 	nano::election_extended_status current_status_locked () const;
 	// lock_a does not own the mutex on return
-	void confirm_once (nano::unique_lock<nano::mutex> & lock_a, nano::election_status_type = nano::election_status_type::active_confirmed_quorum);
+	void confirm_once (nano::unique_lock<nano::mutex> & lock_a);
 	bool broadcast_block_predicate () const;
 	void broadcast_block (nano::confirmation_solicitor &);
 	void send_confirm_req (nano::confirmation_solicitor &);
@@ -217,7 +216,7 @@ private: // Constants
 	friend class confirmation_solicitor;
 
 public: // Only used in tests
-	void force_confirm (nano::election_status_type = nano::election_status_type::active_confirmed_quorum);
+	void force_confirm ();
 	std::unordered_map<nano::account, nano::vote_info> votes () const;
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks () const;
 

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -360,14 +360,14 @@ class election_status final
 {
 public:
 	std::shared_ptr<nano::block> winner;
-	nano::amount tally;
-	nano::amount final_tally;
-	std::chrono::milliseconds election_end;
-	std::chrono::milliseconds election_duration;
-	unsigned confirmation_request_count;
-	unsigned block_count;
-	unsigned voter_count;
-	election_status_type type;
+	nano::amount tally{ 0 };
+	nano::amount final_tally{ 0 };
+	std::chrono::milliseconds election_end{ std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()) };
+	std::chrono::milliseconds election_duration{ std::chrono::duration_values<std::chrono::milliseconds>::zero () };
+	unsigned confirmation_request_count{ 0 };
+	unsigned block_count{ 0 };
+	unsigned voter_count{ 0 };
+	election_status_type type{ nano::election_status_type::inactive_confirmation_height };
 };
 
 nano::wallet_id random_wallet_id ();


### PR DESCRIPTION
Simplifies and merges logic that was spread across multiple functions and coupled with nano::election.

Behaviour changed with respect to callbacks that were *not* called for confirmed blocks in certain circumstances. This was a purely synthetic case where an election was explicitly confirmed in code but didn't have an associated election. In other cases where there was no election yet the block was confirmed indirectly, the callbacks were still called. This behaviour change calls the callback for all blocks that are confirmed.

Behaviour changed with respect to entries in the recently_cemented list. Previously blocks implicitly confirmed were not placed in this list yet were reported through callbacks. This behaviour was arbitrary and could be confusing. Now all blocks that are reported through callbacks are placed in the recently_cemented list.