### PR TITLE
Header reduction for election, vote_generator, vote_spacing, and active_transactions

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/manual.hpp>

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/bootstrap/block_deserializer.hpp>
 #include <nano/node/bootstrap/bootstrap_frontier.hpp>
 #include <nano/node/bootstrap/bootstrap_lazy.hpp>

--- a/nano/core_test/confirmation_height.cpp
+++ b/nano/core_test/confirmation_height.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/make_store.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
+#include <nano/node/election.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/transport/inproc.hpp>

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -2,6 +2,7 @@
 #include <nano/lib/logging.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/threading.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/make_store.hpp>
 #include <nano/node/scheduler/component.hpp>

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2,6 +2,7 @@
 #include <nano/lib/config.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/node/election.hpp>
+#include <nano/node/local_vote_history.hpp>
 #include <nano/node/make_store.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/manual.hpp>

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -9,6 +9,7 @@
 #include <nano/node/scheduler/priority.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/node/transport/inproc.hpp>
+#include <nano/node/vote_generator.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/logging.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/local_vote_history.hpp>
 #include <nano/node/make_store.hpp>

--- a/nano/core_test/optimistic_scheduler.cpp
+++ b/nano/core_test/optimistic_scheduler.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/rep_crawler.cpp
+++ b/nano/core_test/rep_crawler.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/logging.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/repcrawler.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/node/transport/inproc.hpp>

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
+#include <nano/node/election.hpp>
 #include <nano/node/request_aggregator.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/local_vote_history.hpp>
 #include <nano/node/request_aggregator.hpp>

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/election.hpp>
+#include <nano/node/local_vote_history.hpp>
 #include <nano/node/request_aggregator.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
+#include <nano/node/election.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/vote_processor.hpp>

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -1,7 +1,8 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/local_vote_history.hpp>
-#include <nano/node/voting.hpp>
+#include <nano/node/vote_generator.hpp>
+#include <nano/node/vote_spacing.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/common.hpp>
+#include <nano/node/local_vote_history.hpp>
 #include <nano/node/voting.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1,6 +1,7 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/thread_runner.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/store/lmdb/wallet_value.hpp>

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1,6 +1,7 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/thread_runner.hpp>
+#include <nano/node/election.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/store/lmdb/wallet_value.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/election.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/store/versioning.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/store/versioning.hpp>

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -1,5 +1,6 @@
 #include <nano/core_test/fakes/websocket_client.hpp>
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/test_common/network.hpp>

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -389,4 +389,12 @@ struct hash<std::reference_wrapper<::nano::block_hash const>>
 		return hash (hash_a);
 	}
 };
+template <>
+struct hash<::nano::root>
+{
+	size_t operator() (::nano::root const & value_a) const
+	{
+		return std::hash<::nano::root> () (value_a);
+	}
+};
 }

--- a/nano/lib/processing_queue.hpp
+++ b/nano/lib/processing_queue.hpp
@@ -108,7 +108,7 @@ public:
 	}
 
 public: // Container info
-	std::unique_ptr<container_info_component> collect_container_info (std::string const & name)
+	std::unique_ptr<container_info_component> collect_container_info (std::string const & name) const
 	{
 		nano::lock_guard<nano::mutex> guard{ mutex };
 

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -4,6 +4,7 @@
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/nano_node/daemon.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/cli.hpp>
 #include <nano/node/daemonconfig.hpp>
 #include <nano/node/ipc/ipc_server.hpp>

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -166,11 +166,13 @@ add_library(
   unchecked_map.hpp
   vote_cache.hpp
   vote_cache.cpp
+  vote_generator.hpp
+  vote_generator.cpp
   vote_processor.hpp
   vote_processor.cpp
+  vote_spacing.hpp
+  vote_spacing.cpp
   vote_with_weight_info.hpp
-  voting.hpp
-  voting.cpp
   wallet.hpp
   wallet.cpp
   websocket.hpp

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -98,6 +98,8 @@ add_library(
   json_handler.cpp
   local_block_broadcaster.cpp
   local_block_broadcaster.hpp
+  local_vote_history.cpp
+  local_vote_history.hpp
   make_store.hpp
   make_store.cpp
   network.hpp

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(
   distributed_work_factory.cpp
   election.hpp
   election.cpp
+  election_behavior.hpp
   election_insertion_result.hpp
   epoch_upgrader.hpp
   epoch_upgrader.cpp
@@ -164,6 +165,7 @@ add_library(
   vote_cache.cpp
   vote_processor.hpp
   vote_processor.cpp
+  vote_with_weight_info.hpp
   voting.hpp
   voting.cpp
   wallet.hpp

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(
   election.cpp
   election_behavior.hpp
   election_insertion_result.hpp
+  election_status.hpp
   epoch_upgrader.hpp
   epoch_upgrader.cpp
   ipc/action_handler.hpp

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -53,8 +53,9 @@ public: // Tests
 
 private:
 	// clang-format off
-	class tag_root {};
 	class tag_hash {};
+	class tag_root {};
+	class tag_sequence {};
 
 	using ordered_recent_confirmations = boost::multi_index_container<entry_t,
 	mi::indexed_by<

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -5,7 +5,6 @@
 #include <nano/node/election_insertion_result.hpp>
 #include <nano/node/election_status.hpp>
 #include <nano/node/vote_with_weight_info.hpp>
-#include <nano/node/voting.hpp>
 #include <nano/secure/common.hpp>
 
 #include <boost/multi_index/hashed_index.hpp>
@@ -17,6 +16,7 @@
 #include <condition_variable>
 #include <deque>
 #include <memory>
+#include <thread>
 #include <unordered_map>
 
 namespace mi = boost::multi_index;
@@ -32,7 +32,14 @@ class election;
 class vote;
 class confirmation_height_processor;
 class stats;
+}
+namespace nano::store
+{
+class read_transaction;
+}
 
+namespace nano
+{
 class recently_confirmed_cache final
 {
 public:

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include <nano/lib/numbers.hpp>
-#include <nano/node/election.hpp>
+#include <nano/node/election_behavior.hpp>
 #include <nano/node/election_insertion_result.hpp>
+#include <nano/node/vote_with_weight_info.hpp>
 #include <nano/node/voting.hpp>
 #include <nano/secure/common.hpp>
 

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -3,6 +3,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/node/election_behavior.hpp>
 #include <nano/node/election_insertion_result.hpp>
+#include <nano/node/election_status.hpp>
 #include <nano/node/vote_with_weight_info.hpp>
 #include <nano/node/voting.hpp>
 #include <nano/secure/common.hpp>

--- a/nano/node/backlog_population.cpp
+++ b/nano/node/backlog_population.cpp
@@ -2,7 +2,9 @@
 #include <nano/node/backlog_population.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/scheduler/priority.hpp>
+#include <nano/store/account.hpp>
 #include <nano/store/component.hpp>
+#include <nano/store/confirmation_height.hpp>
 
 nano::backlog_population::backlog_population (const config & config_a, nano::store::component & store_a, nano::stats & stats_a) :
 	config_m{ config_a },

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/timer.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/blockprocessor.hpp>
 #include <nano/node/local_vote_history.hpp>
 #include <nano/node/node.hpp>

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -2,6 +2,7 @@
 #include <nano/lib/threading.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/node/blockprocessor.hpp>
+#include <nano/node/local_vote_history.hpp>
 #include <nano/node/node.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/store/component.hpp>

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
+#include <nano/node/local_vote_history.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -4,6 +4,7 @@
 #include <nano/node/local_vote_history.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node.hpp>
+#include <nano/node/vote_generator.hpp>
 #include <nano/secure/ledger.hpp>
 
 #include <boost/format.hpp>

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/local_vote_history.hpp>

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -2,10 +2,10 @@
 
 #include <nano/lib/id_dispenser.hpp>
 #include <nano/lib/logging.hpp>
+#include <nano/lib/stats_enums.hpp>
 #include <nano/node/election_behavior.hpp>
+#include <nano/node/election_status.hpp>
 #include <nano/node/vote_with_weight_info.hpp>
-#include <nano/secure/common.hpp>
-#include <nano/store/component.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -13,6 +13,7 @@
 
 namespace nano
 {
+class block;
 class channel;
 class confirmation_solicitor;
 class inactive_cache_information;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -2,6 +2,8 @@
 
 #include <nano/lib/id_dispenser.hpp>
 #include <nano/lib/logging.hpp>
+#include <nano/node/election_behavior.hpp>
+#include <nano/node/vote_with_weight_info.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/store/component.hpp>
 
@@ -22,34 +24,6 @@ public:
 	std::chrono::steady_clock::time_point time;
 	uint64_t timestamp;
 	nano::block_hash hash;
-};
-
-class vote_with_weight_info final
-{
-public:
-	nano::account representative;
-	std::chrono::steady_clock::time_point time;
-	uint64_t timestamp;
-	nano::block_hash hash;
-	nano::uint128_t weight;
-};
-
-enum class election_behavior
-{
-	normal,
-	/**
-	 * Hinted elections:
-	 * - shorter timespan
-	 * - limited space inside AEC
-	 */
-	hinted,
-	/**
-	 * Optimistic elections:
-	 * - shorter timespan
-	 * - limited space inside AEC
-	 * - more frequent confirmation requests
-	 */
-	optimistic,
 };
 
 nano::stat::detail to_stat_detail (nano::election_behavior);

--- a/nano/node/election_behavior.hpp
+++ b/nano/node/election_behavior.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace nano
+{
+enum class election_behavior
+{
+	normal,
+	/**
+	 * Hinted elections:
+	 * - shorter timespan
+	 * - limited space inside AEC
+	 */
+	hinted,
+	/**
+	 * Optimistic elections:
+	 * - shorter timespan
+	 * - limited space inside AEC
+	 * - more frequent confirmation requests
+	 */
+	optimistic,
+};
+}

--- a/nano/node/election_status.hpp
+++ b/nano/node/election_status.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+
+#include <chrono>
+#include <memory>
+
+namespace nano
+{
+class block;
+}
+
+namespace nano
+{
+/* Defines the possible states for an election to stop in */
+enum class election_status_type : uint8_t
+{
+	ongoing = 0,
+	active_confirmed_quorum = 1,
+	active_confirmation_height = 2,
+	inactive_confirmation_height = 3,
+	stopped = 5
+};
+
+/* Holds a summary of an election */
+class election_status final
+{
+public:
+	std::shared_ptr<nano::block> winner;
+	nano::amount tally{ 0 };
+	nano::amount final_tally{ 0 };
+	std::chrono::milliseconds election_end{ std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()) };
+	std::chrono::milliseconds election_duration{ std::chrono::duration_values<std::chrono::milliseconds>::zero () };
+	unsigned confirmation_request_count{ 0 };
+	unsigned block_count{ 0 };
+	unsigned voter_count{ 0 };
+	election_status_type type{ nano::election_status_type::inactive_confirmation_height };
+};
+}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2,6 +2,7 @@
 #include <nano/lib/config.hpp>
 #include <nano/lib/json_error_response.hpp>
 #include <nano/lib/timer.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/bootstrap/bootstrap_lazy.hpp>
 #include <nano/node/bootstrap_ascending/service.hpp>
 #include <nano/node/common.hpp>

--- a/nano/node/local_vote_history.cpp
+++ b/nano/node/local_vote_history.cpp
@@ -1,0 +1,115 @@
+#include <nano/node/local_vote_history.hpp>
+#include <nano/secure/common.hpp>
+#include <nano/secure/vote.hpp>
+
+bool nano::local_vote_history::consistency_check (nano::root const & root_a) const
+{
+	auto & history_by_root (history.get<tag_root> ());
+	auto const range (history_by_root.equal_range (root_a));
+	// All cached votes for a root must be for the same hash, this is actively enforced in local_vote_history::add
+	auto consistent_same = std::all_of (range.first, range.second, [hash = range.first->hash] (auto const & info_a) { return info_a.hash == hash; });
+	std::vector<nano::account> accounts;
+	std::transform (range.first, range.second, std::back_inserter (accounts), [] (auto const & info_a) { return info_a.vote->account; });
+	std::sort (accounts.begin (), accounts.end ());
+	// All cached votes must be unique by account, this is actively enforced in local_vote_history::add
+	auto consistent_unique = accounts.size () == std::unique (accounts.begin (), accounts.end ()) - accounts.begin ();
+	auto result = consistent_same && consistent_unique;
+	debug_assert (result);
+	return result;
+}
+
+void nano::local_vote_history::add (nano::root const & root_a, nano::block_hash const & hash_a, std::shared_ptr<nano::vote> const & vote_a)
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	clean ();
+	auto add_vote (true);
+	auto & history_by_root (history.get<tag_root> ());
+	// Erase any vote that is not for this hash, or duplicate by account, and if new timestamp is higher
+	auto range (history_by_root.equal_range (root_a));
+	for (auto i (range.first); i != range.second;)
+	{
+		if (i->hash != hash_a || (vote_a->account == i->vote->account && i->vote->timestamp () <= vote_a->timestamp ()))
+		{
+			i = history_by_root.erase (i);
+		}
+		else if (vote_a->account == i->vote->account && i->vote->timestamp () > vote_a->timestamp ())
+		{
+			add_vote = false;
+			++i;
+		}
+		else
+		{
+			++i;
+		}
+	}
+	// Do not add new vote to cache if representative account is same and timestamp is lower
+	if (add_vote)
+	{
+		auto result (history_by_root.emplace (root_a, hash_a, vote_a));
+		(void)result;
+		debug_assert (result.second);
+	}
+	debug_assert (consistency_check (root_a));
+}
+
+void nano::local_vote_history::erase (nano::root const & root_a)
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	auto & history_by_root (history.get<tag_root> ());
+	auto range (history_by_root.equal_range (root_a));
+	history_by_root.erase (range.first, range.second);
+}
+
+std::vector<std::shared_ptr<nano::vote>> nano::local_vote_history::votes (nano::root const & root_a) const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	std::vector<std::shared_ptr<nano::vote>> result;
+	auto range (history.get<tag_root> ().equal_range (root_a));
+	std::transform (range.first, range.second, std::back_inserter (result), [] (auto const & entry) { return entry.vote; });
+	return result;
+}
+
+std::vector<std::shared_ptr<nano::vote>> nano::local_vote_history::votes (nano::root const & root_a, nano::block_hash const & hash_a, bool const is_final_a) const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	std::vector<std::shared_ptr<nano::vote>> result;
+	auto range (history.get<tag_root> ().equal_range (root_a));
+	// clang-format off
+	nano::transform_if (range.first, range.second, std::back_inserter (result),
+		[&hash_a, is_final_a](auto const & entry) { return entry.hash == hash_a && (!is_final_a || entry.vote->timestamp () == std::numeric_limits<uint64_t>::max ()); },
+		[](auto const & entry) { return entry.vote; });
+	// clang-format on
+	return result;
+}
+
+bool nano::local_vote_history::exists (nano::root const & root_a) const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return history.get<tag_root> ().find (root_a) != history.get<tag_root> ().end ();
+}
+
+void nano::local_vote_history::clean ()
+{
+	debug_assert (constants.max_cache > 0);
+	auto & history_by_sequence (history.get<tag_sequence> ());
+	while (history_by_sequence.size () > constants.max_cache)
+	{
+		history_by_sequence.erase (history_by_sequence.begin ());
+	}
+}
+
+std::size_t nano::local_vote_history::size () const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return history.size ();
+}
+
+std::unique_ptr<nano::container_info_component> nano::local_vote_history::collect_container_info (std::string const & name) const
+{
+	std::size_t history_count = size ();
+	auto sizeof_element = sizeof (decltype (history)::value_type);
+	auto composite = std::make_unique<container_info_composite> (name);
+	/* This does not currently loop over each element inside the cache to get the sizes of the votes inside history*/
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "history", history_count, sizeof_element }));
+	return composite;
+}

--- a/nano/node/local_vote_history.hpp
+++ b/nano/node/local_vote_history.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <nano/lib/locks.hpp>
+#include <nano/lib/numbers.hpp>
+
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index_container.hpp>
+
+#include <memory>
+#include <vector>
+
+namespace mi = boost::multi_index;
+
+namespace nano
+{
+class container_info_component;
+class vote;
+class voting_constants;
+}
+
+namespace nano
+{
+class local_vote_history final
+{
+	class local_vote final
+	{
+	public:
+		local_vote (nano::root const & root_a, nano::block_hash const & hash_a, std::shared_ptr<nano::vote> const & vote_a) :
+			root (root_a),
+			hash (hash_a),
+			vote (vote_a)
+		{
+		}
+		nano::root root;
+		nano::block_hash hash;
+		std::shared_ptr<nano::vote> vote;
+	};
+
+public:
+	local_vote_history (nano::voting_constants const & constants) :
+		constants{ constants }
+	{
+	}
+	void add (nano::root const & root_a, nano::block_hash const & hash_a, std::shared_ptr<nano::vote> const & vote_a);
+	void erase (nano::root const & root_a);
+
+	std::vector<std::shared_ptr<nano::vote>> votes (nano::root const & root_a, nano::block_hash const & hash_a, bool const is_final_a = false) const;
+	bool exists (nano::root const &) const;
+	std::size_t size () const;
+
+	std::unique_ptr<container_info_component> collect_container_info (std::string const & name) const;
+
+private:
+	// clang-format off
+	boost::multi_index_container<local_vote,
+	mi::indexed_by<
+		mi::hashed_non_unique<mi::tag<class tag_root>,
+			mi::member<local_vote, nano::root, &local_vote::root>>,
+		mi::sequenced<mi::tag<class tag_sequence>>>>
+	history;
+	// clang-format on
+
+	nano::voting_constants const & constants;
+	void clean ();
+	std::vector<std::shared_ptr<nano::vote>> votes (nano::root const & root_a) const;
+	// Only used in Debug
+	bool consistency_check (nano::root const &) const;
+	mutable nano::mutex mutex;
+
+	friend class local_vote_history_basic_Test;
+};
+}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -5,6 +5,7 @@
 #include <nano/node/common.hpp>
 #include <nano/node/daemonconfig.hpp>
 #include <nano/node/make_store.hpp>
+#include <nano/node/local_vote_history.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/hinted.hpp>
@@ -171,7 +172,8 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	warmed_up (0),
 	block_processor (*this, write_database_queue),
 	online_reps (ledger, config),
-	history{ config.network_params.voting },
+	history_impl{ std::make_unique<nano::local_vote_history> (config.network_params.voting) },
+	history{ *history_impl },
 	vote_uniquer{},
 	confirmation_height_processor (ledger, write_database_queue, config.conf_height_processor_batch_min_time, logger, node_initialized_latch, flags.confirmation_height_processor_mode),
 	vote_cache{ config.vote_cache, stats },
@@ -537,7 +539,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (no
 	composite->add_component (node.rep_crawler.collect_container_info ("rep_crawler"));
 	composite->add_component (node.block_processor.collect_container_info ("block_processor"));
 	composite->add_component (collect_container_info (node.online_reps, "online_reps"));
-	composite->add_component (collect_container_info (node.history, "history"));
+	composite->add_component (node.history.collect_container_info ("history"));
 	composite->add_component (node.block_uniquer.collect_container_info ("block_uniquer"));
 	composite->add_component (node.vote_uniquer.collect_container_info ("vote_uniquer"));
 	composite->add_component (collect_container_info (node.confirmation_height_processor, "confirmation_height_processor"));

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -6,7 +6,6 @@
 #include <nano/lib/stats.hpp>
 #include <nano/lib/thread_pool.hpp>
 #include <nano/lib/work.hpp>
-#include <nano/node/active_transactions.hpp>
 #include <nano/node/backlog_population.hpp>
 #include <nano/node/bandwidth_limiter.hpp>
 #include <nano/node/blockprocessor.hpp>
@@ -47,6 +46,7 @@
 
 namespace nano
 {
+class active_transactions;
 namespace rocksdb
 {
 } // Declare a namespace rocksdb inside nano so all references to the rocksdb library need to be globally scoped e.g. ::rocksdb::Slice
@@ -160,23 +160,24 @@ public:
 	std::filesystem::path application_path;
 	nano::node_observers observers;
 	nano::port_mapping port_mapping;
+	nano::block_processor block_processor;
+	nano::confirmation_height_processor confirmation_height_processor;
+	std::unique_ptr<nano::active_transactions> active_impl;
+	nano::active_transactions & active;
 	nano::online_reps online_reps;
 	nano::rep_crawler rep_crawler;
 	nano::rep_tiers rep_tiers;
 	nano::vote_processor vote_processor;
 	unsigned warmed_up;
-	nano::block_processor block_processor;
 	std::unique_ptr<nano::local_vote_history> history_impl;
 	nano::local_vote_history & history;
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer;
-	nano::confirmation_height_processor confirmation_height_processor;
 	nano::vote_cache vote_cache;
 	std::unique_ptr<nano::vote_generator> generator_impl;
 	nano::vote_generator & generator;
 	std::unique_ptr<nano::vote_generator> final_generator_impl;
 	nano::vote_generator & final_generator;
-	nano::active_transactions active;
 
 private: // Placed here to maintain initialization order
 	std::unique_ptr<nano::scheduler::component> scheduler_impl;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -166,7 +166,8 @@ public:
 	nano::vote_processor vote_processor;
 	unsigned warmed_up;
 	nano::block_processor block_processor;
-	nano::local_vote_history history;
+	std::unique_ptr<nano::local_vote_history> history_impl;
+	nano::local_vote_history & history;
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer;
 	nano::confirmation_height_processor confirmation_height_processor;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -16,7 +16,6 @@
 #include <nano/node/bootstrap_ascending/service.hpp>
 #include <nano/node/confirmation_height_processor.hpp>
 #include <nano/node/distributed_work_factory.hpp>
-#include <nano/node/election.hpp>
 #include <nano/node/epoch_upgrader.hpp>
 #include <nano/node/local_block_broadcaster.hpp>
 #include <nano/node/network.hpp>

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -172,8 +172,10 @@ public:
 	nano::vote_uniquer vote_uniquer;
 	nano::confirmation_height_processor confirmation_height_processor;
 	nano::vote_cache vote_cache;
-	nano::vote_generator generator;
-	nano::vote_generator final_generator;
+	std::unique_ptr<nano::vote_generator> generator_impl;
+	nano::vote_generator & generator;
+	std::unique_ptr<nano::vote_generator> final_generator_impl;
+	nano::vote_generator & final_generator;
 	nano::active_transactions active;
 
 private: // Placed here to maintain initialization order

--- a/nano/node/node_observers.hpp
+++ b/nano/node/node_observers.hpp
@@ -7,6 +7,7 @@
 
 namespace nano
 {
+class election_status;
 class telemetry;
 class node_observers final
 {

--- a/nano/node/node_observers.hpp
+++ b/nano/node/node_observers.hpp
@@ -2,8 +2,8 @@
 
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/utility.hpp>
-#include <nano/node/active_transactions.hpp>
 #include <nano/node/transport/transport.hpp>
+#include <nano/node/vote_with_weight_info.hpp>
 
 namespace nano
 {

--- a/nano/node/node_observers.hpp
+++ b/nano/node/node_observers.hpp
@@ -9,6 +9,14 @@ namespace nano
 {
 class election_status;
 class telemetry;
+}
+namespace nano::transport
+{
+class channel;
+}
+
+namespace nano
+{
 class node_observers final
 {
 public:

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -1,3 +1,4 @@
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/repcrawler.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -2,6 +2,7 @@
 #include <nano/lib/stats.hpp>
 #include <nano/node/active_transactions.hpp>
 #include <nano/node/common.hpp>
+#include <nano/node/local_vote_history.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/request_aggregator.hpp>

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -6,7 +6,7 @@
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/request_aggregator.hpp>
-#include <nano/node/voting.hpp>
+#include <nano/node/vote_generator.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/store/component.hpp>

--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -1,5 +1,7 @@
 #include <nano/lib/stats.hpp>
 #include <nano/lib/tomlconfig.hpp>
+#include <nano/node/active_transactions.hpp>
+#include <nano/node/election_behavior.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/hinted.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/node/scheduler/manual.cpp
+++ b/nano/node/scheduler/manual.cpp
@@ -1,3 +1,4 @@
+#include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/manual.hpp>
 

--- a/nano/node/scheduler/manual.cpp
+++ b/nano/node/scheduler/manual.cpp
@@ -1,3 +1,4 @@
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/manual.hpp>

--- a/nano/node/scheduler/manual.hpp
+++ b/nano/node/scheduler/manual.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <nano/lib/locks.hpp>
 #include <nano/lib/numbers.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/election_behavior.hpp>
 
 #include <boost/optional.hpp>
 

--- a/nano/node/scheduler/optimistic.cpp
+++ b/nano/node/scheduler/optimistic.cpp
@@ -1,6 +1,8 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/tomlconfig.hpp>
+#include <nano/node/active_transactions.hpp>
+#include <nano/node/election_behavior.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/optimistic.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/buckets.hpp>

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/buckets.hpp>
 #include <nano/node/scheduler/priority.hpp>

--- a/nano/node/scheduler/priority.hpp
+++ b/nano/node/scheduler/priority.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <nano/lib/numbers.hpp>
-#include <nano/node/active_transactions.hpp>
 
 #include <boost/optional.hpp>
 
@@ -16,6 +15,7 @@ namespace nano
 class block;
 class container_info_component;
 class node;
+class stats;
 }
 namespace nano::store
 {

--- a/nano/node/scheduler/priority.hpp
+++ b/nano/node/scheduler/priority.hpp
@@ -17,6 +17,10 @@ class block;
 class container_info_component;
 class node;
 }
+namespace nano::store
+{
+class transaction;
+}
 
 namespace nano::scheduler
 {

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/tomlconfig.hpp>
+#include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/vote_cache.hpp>
 

--- a/nano/node/vote_spacing.cpp
+++ b/nano/node/vote_spacing.cpp
@@ -1,0 +1,39 @@
+#include <nano/node/vote_spacing.hpp>
+
+void nano::vote_spacing::trim ()
+{
+	recent.get<tag_time> ().erase (recent.get<tag_time> ().begin (), recent.get<tag_time> ().upper_bound (std::chrono::steady_clock::now () - delay));
+}
+
+bool nano::vote_spacing::votable (nano::root const & root_a, nano::block_hash const & hash_a) const
+{
+	bool result = true;
+	for (auto range = recent.get<tag_root> ().equal_range (root_a); result && range.first != range.second; ++range.first)
+	{
+		auto & item = *range.first;
+		result = hash_a == item.hash || item.time < std::chrono::steady_clock::now () - delay;
+	}
+	return result;
+}
+
+void nano::vote_spacing::flag (nano::root const & root_a, nano::block_hash const & hash_a)
+{
+	trim ();
+	auto now = std::chrono::steady_clock::now ();
+	auto existing = recent.get<tag_root> ().find (root_a);
+	if (existing != recent.end ())
+	{
+		recent.get<tag_root> ().modify (existing, [now] (entry & entry) {
+			entry.time = now;
+		});
+	}
+	else
+	{
+		recent.insert ({ root_a, now, hash_a });
+	}
+}
+
+std::size_t nano::vote_spacing::size () const
+{
+	return recent.size ();
+}

--- a/nano/node/vote_spacing.hpp
+++ b/nano/node/vote_spacing.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index_container.hpp>
+
+#include <chrono>
+
+namespace mi = boost::multi_index;
+
+namespace nano
+{
+class vote_spacing final
+{
+	class entry
+	{
+	public:
+		nano::root root;
+		std::chrono::steady_clock::time_point time;
+		nano::block_hash hash;
+	};
+
+	boost::multi_index_container<entry,
+	mi::indexed_by<
+	mi::hashed_non_unique<mi::tag<class tag_root>,
+	mi::member<entry, nano::root, &entry::root>>,
+	mi::ordered_non_unique<mi::tag<class tag_time>,
+	mi::member<entry, std::chrono::steady_clock::time_point, &entry::time>>>>
+	recent;
+	std::chrono::milliseconds const delay;
+	void trim ();
+
+public:
+	vote_spacing (std::chrono::milliseconds const & delay) :
+		delay{ delay }
+	{
+	}
+	bool votable (nano::root const & root_a, nano::block_hash const & hash_a) const;
+	void flag (nano::root const & root_a, nano::block_hash const & hash_a);
+	std::size_t size () const;
+};
+}

--- a/nano/node/vote_with_weight_info.hpp
+++ b/nano/node/vote_with_weight_info.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+
+#include <chrono>
+
+namespace nano
+{
+class vote_with_weight_info final
+{
+public:
+	nano::account representative;
+	std::chrono::steady_clock::time_point time;
+	uint64_t timestamp;
+	nano::block_hash hash;
+	nano::uint128_t weight;
+};
+}

--- a/nano/node/voting.cpp
+++ b/nano/node/voting.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/utility.hpp>
+#include <nano/node/local_vote_history.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/transport/inproc.hpp>
@@ -48,118 +49,6 @@ void nano::vote_spacing::flag (nano::root const & root_a, nano::block_hash const
 std::size_t nano::vote_spacing::size () const
 {
 	return recent.size ();
-}
-
-bool nano::local_vote_history::consistency_check (nano::root const & root_a) const
-{
-	auto & history_by_root (history.get<tag_root> ());
-	auto const range (history_by_root.equal_range (root_a));
-	// All cached votes for a root must be for the same hash, this is actively enforced in local_vote_history::add
-	auto consistent_same = std::all_of (range.first, range.second, [hash = range.first->hash] (auto const & info_a) { return info_a.hash == hash; });
-	std::vector<nano::account> accounts;
-	std::transform (range.first, range.second, std::back_inserter (accounts), [] (auto const & info_a) { return info_a.vote->account; });
-	std::sort (accounts.begin (), accounts.end ());
-	// All cached votes must be unique by account, this is actively enforced in local_vote_history::add
-	auto consistent_unique = accounts.size () == std::unique (accounts.begin (), accounts.end ()) - accounts.begin ();
-	auto result = consistent_same && consistent_unique;
-	debug_assert (result);
-	return result;
-}
-
-void nano::local_vote_history::add (nano::root const & root_a, nano::block_hash const & hash_a, std::shared_ptr<nano::vote> const & vote_a)
-{
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	clean ();
-	auto add_vote (true);
-	auto & history_by_root (history.get<tag_root> ());
-	// Erase any vote that is not for this hash, or duplicate by account, and if new timestamp is higher
-	auto range (history_by_root.equal_range (root_a));
-	for (auto i (range.first); i != range.second;)
-	{
-		if (i->hash != hash_a || (vote_a->account == i->vote->account && i->vote->timestamp () <= vote_a->timestamp ()))
-		{
-			i = history_by_root.erase (i);
-		}
-		else if (vote_a->account == i->vote->account && i->vote->timestamp () > vote_a->timestamp ())
-		{
-			add_vote = false;
-			++i;
-		}
-		else
-		{
-			++i;
-		}
-	}
-	// Do not add new vote to cache if representative account is same and timestamp is lower
-	if (add_vote)
-	{
-		auto result (history_by_root.emplace (root_a, hash_a, vote_a));
-		(void)result;
-		debug_assert (result.second);
-	}
-	debug_assert (consistency_check (root_a));
-}
-
-void nano::local_vote_history::erase (nano::root const & root_a)
-{
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	auto & history_by_root (history.get<tag_root> ());
-	auto range (history_by_root.equal_range (root_a));
-	history_by_root.erase (range.first, range.second);
-}
-
-std::vector<std::shared_ptr<nano::vote>> nano::local_vote_history::votes (nano::root const & root_a) const
-{
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	std::vector<std::shared_ptr<nano::vote>> result;
-	auto range (history.get<tag_root> ().equal_range (root_a));
-	std::transform (range.first, range.second, std::back_inserter (result), [] (auto const & entry) { return entry.vote; });
-	return result;
-}
-
-std::vector<std::shared_ptr<nano::vote>> nano::local_vote_history::votes (nano::root const & root_a, nano::block_hash const & hash_a, bool const is_final_a) const
-{
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	std::vector<std::shared_ptr<nano::vote>> result;
-	auto range (history.get<tag_root> ().equal_range (root_a));
-	// clang-format off
-	nano::transform_if (range.first, range.second, std::back_inserter (result),
-		[&hash_a, is_final_a](auto const & entry) { return entry.hash == hash_a && (!is_final_a || entry.vote->timestamp () == std::numeric_limits<uint64_t>::max ()); },
-		[](auto const & entry) { return entry.vote; });
-	// clang-format on
-	return result;
-}
-
-bool nano::local_vote_history::exists (nano::root const & root_a) const
-{
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	return history.get<tag_root> ().find (root_a) != history.get<tag_root> ().end ();
-}
-
-void nano::local_vote_history::clean ()
-{
-	debug_assert (constants.max_cache > 0);
-	auto & history_by_sequence (history.get<tag_sequence> ());
-	while (history_by_sequence.size () > constants.max_cache)
-	{
-		history_by_sequence.erase (history_by_sequence.begin ());
-	}
-}
-
-std::size_t nano::local_vote_history::size () const
-{
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	return history.size ();
-}
-
-std::unique_ptr<nano::container_info_component> nano::collect_container_info (nano::local_vote_history & history, std::string const & name)
-{
-	std::size_t history_count = history.size ();
-	auto sizeof_element = sizeof (decltype (history.history)::value_type);
-	auto composite = std::make_unique<container_info_composite> (name);
-	/* This does not currently loop over each element inside the cache to get the sizes of the votes inside history*/
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "history", history_count, sizeof_element }));
-	return composite;
 }
 
 nano::vote_generator::vote_generator (nano::node_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_processor & vote_processor_a, nano::local_vote_history & history_a, nano::network & network_a, nano::stats & stats_a, nano::logger & logger_a, bool is_final_a) :

--- a/nano/node/voting.hpp
+++ b/nano/node/voting.hpp
@@ -22,9 +22,10 @@ namespace mi = boost::multi_index;
 
 namespace nano
 {
-class node;
 class ledger;
+class local_vote_history;
 class network;
+class node;
 class node_config;
 class stats;
 class vote_processor;
@@ -63,57 +64,6 @@ public:
 	void flag (nano::root const & root_a, nano::block_hash const & hash_a);
 	std::size_t size () const;
 };
-
-class local_vote_history final
-{
-	class local_vote final
-	{
-	public:
-		local_vote (nano::root const & root_a, nano::block_hash const & hash_a, std::shared_ptr<nano::vote> const & vote_a) :
-			root (root_a),
-			hash (hash_a),
-			vote (vote_a)
-		{
-		}
-		nano::root root;
-		nano::block_hash hash;
-		std::shared_ptr<nano::vote> vote;
-	};
-
-public:
-	local_vote_history (nano::voting_constants const & constants) :
-		constants{ constants }
-	{
-	}
-	void add (nano::root const & root_a, nano::block_hash const & hash_a, std::shared_ptr<nano::vote> const & vote_a);
-	void erase (nano::root const & root_a);
-
-	std::vector<std::shared_ptr<nano::vote>> votes (nano::root const & root_a, nano::block_hash const & hash_a, bool const is_final_a = false) const;
-	bool exists (nano::root const &) const;
-	std::size_t size () const;
-
-private:
-	// clang-format off
-	boost::multi_index_container<local_vote,
-	mi::indexed_by<
-		mi::hashed_non_unique<mi::tag<class tag_root>,
-			mi::member<local_vote, nano::root, &local_vote::root>>,
-		mi::sequenced<mi::tag<class tag_sequence>>>>
-	history;
-	// clang-format on
-
-	nano::voting_constants const & constants;
-	void clean ();
-	std::vector<std::shared_ptr<nano::vote>> votes (nano::root const & root_a) const;
-	// Only used in Debug
-	bool consistency_check (nano::root const &) const;
-	mutable nano::mutex mutex;
-
-	friend std::unique_ptr<container_info_component> collect_container_info (local_vote_history & history, std::string const & name);
-	friend class local_vote_history_basic_Test;
-};
-
-std::unique_ptr<container_info_component> collect_container_info (local_vote_history & history, std::string const & name);
 
 class vote_generator final
 {

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -5,6 +5,7 @@
 #include <nano/lib/logging.hpp>
 #include <nano/lib/tlsconfig.hpp>
 #include <nano/lib/work.hpp>
+#include <nano/node/election_status.hpp>
 #include <nano/node/node_observers.hpp>
 #include <nano/node/transport/channel.hpp>
 #include <nano/node/wallet.hpp>

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -3,7 +3,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/work.hpp>
 #include <nano/node/common.hpp>
-#include <nano/node/election.hpp>
+#include <nano/node/vote_with_weight_info.hpp>
 #include <nano/node/websocket_stream.hpp>
 #include <nano/node/websocketconfig.hpp>
 #include <nano/secure/common.hpp>

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
+#include <nano/node/vote_with_weight_info.hpp>
 #include <nano/qt/qt.hpp>
 #include <nano/secure/ledger.hpp>
 

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
+#include <nano/node/election_status.hpp>
 #include <nano/node/vote_with_weight_info.hpp>
 #include <nano/qt/qt.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -4,6 +4,7 @@
 #include <nano/lib/rpcconfig.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/threading.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/json_handler.hpp>

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -4,6 +4,7 @@
 #include <nano/lib/rpcconfig.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/threading.hpp>
+#include <nano/node/election.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/json_handler.hpp>
 #include <nano/node/node_rpc_config.hpp>

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -345,30 +345,5 @@ enum class confirmation_height_mode
 	bounded
 };
 
-/* Defines the possible states for an election to stop in */
-enum class election_status_type : uint8_t
-{
-	ongoing = 0,
-	active_confirmed_quorum = 1,
-	active_confirmation_height = 2,
-	inactive_confirmation_height = 3,
-	stopped = 5
-};
-
-/* Holds a summary of an election */
-class election_status final
-{
-public:
-	std::shared_ptr<nano::block> winner;
-	nano::amount tally{ 0 };
-	nano::amount final_tally{ 0 };
-	std::chrono::milliseconds election_end{ std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()) };
-	std::chrono::milliseconds election_duration{ std::chrono::duration_values<std::chrono::milliseconds>::zero () };
-	unsigned confirmation_request_count{ 0 };
-	unsigned block_count{ 0 };
-	unsigned voter_count{ 0 };
-	election_status_type type{ nano::election_status_type::inactive_confirmation_height };
-};
-
 nano::wallet_id random_wallet_id ();
 }

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -73,14 +73,6 @@ struct hash<::nano::qualified_root>
 		return std::hash<::nano::qualified_root> () (value_a);
 	}
 };
-template <>
-struct hash<::nano::root>
-{
-	size_t operator() (::nano::root const & value_a) const
-	{
-		return std::hash<::nano::root> () (value_a);
-	}
-};
 }
 namespace nano
 {

--- a/nano/secure/vote.hpp
+++ b/nano/secure/vote.hpp
@@ -12,6 +12,11 @@
 
 namespace nano
 {
+class object_stream;
+}
+
+namespace nano
+{
 class vote final
 {
 public:

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -2,6 +2,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/thread_runner.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/make_store.hpp>
 #include <nano/node/scheduler/component.hpp>

--- a/nano/slow_test/vote_cache.cpp
+++ b/nano/slow_test/vote_cache.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/test_common/rate_observer.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/test_common/ledger.hpp
+++ b/nano/test_common/ledger.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/stats.hpp>
+#include <nano/lib/work.hpp>
 #include <nano/secure/ledger.hpp>
 
 namespace nano

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -1,5 +1,6 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/common.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -1,5 +1,6 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/manual.hpp>

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -1,5 +1,6 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
+#include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/manual.hpp>
 #include <nano/node/scheduler/priority.hpp>


### PR DESCRIPTION
Changing election.hpp
Before:
[118/118] Linking CXX executable rpc_test
ninja  1208.77s user 85.03s system 875% cpu 2:27.78 total
After:
[39/39] Linking CXX executable rpc_test
ninja  338.18s user 25.74s system 714% cpu 50.953 total

Changing voting.hpp
Before:
[117/117] Linking CXX executable rpc_test
ninja  1262.92s user 87.90s system 869% cpu 2:35.28 total
After:
[16/16] Linking CXX executable nano_node
ninja  98.05s user 11.24s system 377% cpu 28.917 total

Changing active_transactions.hpp
Before:
[116/116] Linking CXX executable rpc_test
ninja  1194.40s user 83.30s system 860% cpu 2:28.51 total
After:
[49/49] Linking CXX executable rpc_test
ninja  465.39s user 35.25s system 762% cpu 1:05.67 total