### PR TITLE
Introduce nano-nightly dockerhub registry for live network builds

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -155,6 +155,8 @@ jobs:
     strategy:
       matrix:
         network: ["TEST", "BETA", "LIVE"]
+    env:
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
         with:
@@ -167,10 +169,8 @@ jobs:
           NETWORK: ${{ matrix.network }}
           CI_TAG: ${{ needs.prepare_build.outputs.ci_tag }}
           DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
-      - name: Check if secrets.DOCKER_PASSWORD exists
-        run: echo "DOCKER_PASSWORD_EXISTS=${{ secrets.DOCKER_PASSWORD != '' }}" >> $GITHUB_ENV
       - name: Deploy Docker Hub
-        if: env.DOCKER_PASSWORD_EXISTS == 'true'
+        if: env.DOCKER_PASSWORD != ''
         run: ci/actions/linux/docker-deploy.sh
         env:
           CI_TAG: ${{ needs.prepare_build.outputs.ci_tag }}

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -160,6 +160,7 @@ jobs:
       DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
       DOCKER_USER: ${{ vars.DOCKER_USER }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      IS_RELEASE_BUILD: ${{ github.event.inputs.is_release_build || 'false' }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
         with:

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -156,6 +156,9 @@ jobs:
       matrix:
         network: ["TEST", "BETA", "LIVE"]
     env:
+      CI_TAG: ${{ needs.prepare_build.outputs.ci_tag }}
+      DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
+      DOCKER_USER: ${{ vars.DOCKER_USER }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 #v3.1.0
@@ -167,21 +170,15 @@ jobs:
         run: ci/actions/linux/docker-build.sh
         env:
           NETWORK: ${{ matrix.network }}
-          CI_TAG: ${{ needs.prepare_build.outputs.ci_tag }}
-          DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
       - name: Deploy Docker Hub
         if: env.DOCKER_PASSWORD != ''
         run: ci/actions/linux/docker-deploy.sh
         env:
-          CI_TAG: ${{ needs.prepare_build.outputs.ci_tag }}
           NETWORK: ${{ matrix.network }}
-          DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
-          DOCKER_USER: ${{ vars.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       - name: Deploy Docker (ghcr.io)
         run: ci/actions/linux/ghcr-deploy.sh
         env:
-          CI_TAG: ${{ needs.prepare_build.outputs.ci_tag }}
           NETWORK: ${{ matrix.network }}
           DOCKER_REGISTRY: ghcr.io
           DOCKER_USER: ${{ github.repository_owner }}

--- a/ci/actions/linux/docker-impl/docker-common.sh
+++ b/ci/actions/linux/docker-impl/docker-common.sh
@@ -20,10 +20,8 @@ if [[ "$NETWORK" = "LIVE" ]]; then
     echo "Live"
     if [[ "$IS_RELEASE_BUILD" = "true" ]]; then
         network_tag_suffix=''
-        docker_image_name="${DOCKER_REGISTRY}/nano"
     else
         network_tag_suffix='-nightly'
-        docker_image_name="${DOCKER_REGISTRY}/nano-nightly"
     fi
     network="live"
 elif [[ "$NETWORK" = "BETA" ]]; then

--- a/ci/actions/linux/docker-impl/docker-common.sh
+++ b/ci/actions/linux/docker-impl/docker-common.sh
@@ -18,7 +18,13 @@ fi
 
 if [[ "$NETWORK" = "LIVE" ]]; then
     echo "Live"
-    network_tag_suffix=''
+    if [[ "$IS_RELEASE_BUILD" = "true" ]]; then
+        network_tag_suffix=''
+        docker_image_name="${DOCKER_REGISTRY}/nano"
+    else
+        network_tag_suffix='-nightly'
+        docker_image_name="${DOCKER_REGISTRY}/nano-nightly"
+    fi
     network="live"
 elif [[ "$NETWORK" = "BETA" ]]; then
     echo "Beta"


### PR DESCRIPTION
Currently we create live, beta and test network builds twice a week and each of them is published to docker hub.
On Dockerhub, builds for live network are described as "Nano Production Builds" while it also has non release builds, which may create confusion.

With this pull request, another dockerhub target `nano-nightly` is introduced
- `nanocurrency/nano-nightly` will have all non release builds ( `DB` and `RC` builds)
- `nanocurrency/nano` will only have the official release builds.

**I did the following tests:** 

- DB build (run on `develop` branch with `release_build=='false'`)
Resulting docker tag [gr0vity/nano-nightly:V27.0DB11](
https://hub.docker.com/layers/gr0vity/nano-nightly/V27.0DB11/images/sha256-b35df0cb1f00110a560aee1011a7f08ffc85734afa09ba66a0395463b2330981)
This is the [github runner log](https://github.com/gr0vity-dev/nano-node/actions/runs/8375504090/job/22934768712)



- RC build (run on `releases/v27` branch with `release_build=='false'`)
Resulting docker tag [gr0vity/nano-nightly:V27.0RC1](https://hub.docker.com/layers/gr0vity/nano-nightly/V27.0RC1/images/sha256-6e6d236823a58547dd8d247ef1d9394679385a4484672ff564e2f48e68c26ccc)
This is the [github runner log](https://github.com/gr0vity-dev/nano-node/actions/runs/8376559312/job/22936639511)



- Release build (run on `releases/v27` branch with `release_build=='true'`)
Resulting docker tag [gr0vity/nano:V27.0](https://hub.docker.com/layers/gr0vity/nano/V27.0/images/sha256-045864058355a24f27f544c0f7101d159178edd91ac57fafe71e91b760263ecd)
This is the [github runner log](https://github.com/gr0vity-dev/nano-node/actions/runs/8376601074/job/22936703101)

