### PR TITLE
Rename block::hash(blake2b_state&) overload to block::generate_hash(blake2b_state&)

### DIFF
--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -101,7 +101,7 @@ nano::block_hash nano::block::generate_hash () const
 	blake2b_state hash_l;
 	auto status (blake2b_init (&hash_l, sizeof (result.bytes)));
 	debug_assert (status == 0);
-	hash (hash_l);
+	generate_hash (hash_l);
 	status = blake2b_final (&hash_l, result.bytes.data (), sizeof (result.bytes));
 	debug_assert (status == 0);
 	return result;
@@ -359,7 +359,7 @@ void nano::send_block::visit (nano::mutable_block_visitor & visitor_a)
 	visitor_a.send_block (*this);
 }
 
-void nano::send_block::hash (blake2b_state & hash_a) const
+void nano::send_block::generate_hash (blake2b_state & hash_a) const
 {
 	hashables.hash (hash_a);
 }
@@ -754,7 +754,7 @@ nano::open_block::open_block (bool & error_a, boost::property_tree::ptree const 
 	}
 }
 
-void nano::open_block::hash (blake2b_state & hash_a) const
+void nano::open_block::generate_hash (blake2b_state & hash_a) const
 {
 	hashables.hash (hash_a);
 }
@@ -1025,7 +1025,7 @@ nano::change_block::change_block (bool & error_a, boost::property_tree::ptree co
 	}
 }
 
-void nano::change_block::hash (blake2b_state & hash_a) const
+void nano::change_block::generate_hash (blake2b_state & hash_a) const
 {
 	hashables.hash (hash_a);
 }
@@ -1322,7 +1322,7 @@ nano::state_block::state_block (bool & error_a, boost::property_tree::ptree cons
 	}
 }
 
-void nano::state_block::hash (blake2b_state & hash_a) const
+void nano::state_block::generate_hash (blake2b_state & hash_a) const
 {
 	nano::uint256_union preamble (static_cast<uint64_t> (nano::block_type::state));
 	blake2b_update (&hash_a, preamble.bytes.data (), preamble.bytes.size ());
@@ -1788,7 +1788,7 @@ nano::receive_block::receive_block (bool & error_a, boost::property_tree::ptree 
 	}
 }
 
-void nano::receive_block::hash (blake2b_state & hash_a) const
+void nano::receive_block::generate_hash (blake2b_state & hash_a) const
 {
 	hashables.hash (hash_a);
 }

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -30,7 +30,6 @@ public:
 	void sideband_set (nano::block_sideband const &);
 	bool has_sideband () const;
 	std::string to_json () const;
-	virtual void hash (blake2b_state &) const = 0;
 	virtual uint64_t block_work () const = 0;
 	virtual void block_work_set (uint64_t) = 0;
 	// Previous block or account number for open blocks
@@ -84,6 +83,7 @@ public: // Direct access to the block fields or nullopt if the block type does n
 	virtual std::optional<nano::block_hash> source_field () const;
 
 protected:
+	virtual void generate_hash (blake2b_state &) const = 0;
 	mutable nano::block_hash cached_hash{ 0 };
 	/**
 	 * Contextual details about a block, some fields may or may not be set depending on block type.
@@ -121,8 +121,6 @@ public:
 	send_block (bool &, nano::stream &);
 	send_block (bool &, boost::property_tree::ptree const &);
 	virtual ~send_block () = default;
-	using nano::block::hash;
-	void hash (blake2b_state &) const override;
 	uint64_t block_work () const override;
 	void block_work_set (uint64_t) override;
 	nano::root const & root () const override;
@@ -151,6 +149,9 @@ public: // Send block fields
 
 public: // Logging
 	void operator() (nano::object_stream &) const override;
+
+protected:
+	void generate_hash (blake2b_state &) const override;
 };
 
 class receive_hashables
@@ -174,8 +175,6 @@ public:
 	receive_block (bool &, nano::stream &);
 	receive_block (bool &, boost::property_tree::ptree const &);
 	virtual ~receive_block () = default;
-	using nano::block::hash;
-	void hash (blake2b_state &) const override;
 	uint64_t block_work () const override;
 	void block_work_set (uint64_t) override;
 	nano::root const & root () const override;
@@ -203,6 +202,9 @@ public: // Receive block fields
 
 public: // Logging
 	void operator() (nano::object_stream &) const override;
+
+protected:
+	void generate_hash (blake2b_state &) const override;
 };
 
 class open_hashables
@@ -228,8 +230,6 @@ public:
 	open_block (bool &, nano::stream &);
 	open_block (bool &, boost::property_tree::ptree const &);
 	virtual ~open_block () = default;
-	using nano::block::hash;
-	void hash (blake2b_state &) const override;
 	uint64_t block_work () const override;
 	void block_work_set (uint64_t) override;
 	nano::root const & root () const override;
@@ -259,6 +259,9 @@ public: // Open block fields
 
 public: // Logging
 	void operator() (nano::object_stream &) const override;
+
+protected:
+	void generate_hash (blake2b_state &) const override;
 };
 
 class change_hashables
@@ -282,8 +285,6 @@ public:
 	change_block (bool &, nano::stream &);
 	change_block (bool &, boost::property_tree::ptree const &);
 	virtual ~change_block () = default;
-	using nano::block::hash;
-	void hash (blake2b_state &) const override;
 	uint64_t block_work () const override;
 	void block_work_set (uint64_t) override;
 	nano::root const & root () const override;
@@ -311,6 +312,9 @@ public: // Change block fields
 
 public: // Logging
 	void operator() (nano::object_stream &) const override;
+
+protected:
+	void generate_hash (blake2b_state &) const override;
 };
 
 class state_hashables
@@ -347,8 +351,6 @@ public:
 	state_block (bool &, nano::stream &);
 	state_block (bool &, boost::property_tree::ptree const &);
 	virtual ~state_block () = default;
-	using nano::block::hash;
-	void hash (blake2b_state &) const override;
 	uint64_t block_work () const override;
 	void block_work_set (uint64_t) override;
 	nano::root const & root () const override;
@@ -379,6 +381,9 @@ public: // State block fields
 
 public: // Logging
 	void operator() (nano::object_stream &) const override;
+
+protected:
+	void generate_hash (blake2b_state &) const override;
 };
 
 class block_visitor


### PR DESCRIPTION
Fix annoyance where a debugger may not perform overload resolution correctly. With lldb asking the debugger to calculate a block hash will fail, likely because it doesn't follow overload resolution through inheritance.

Previously it would give:
(lldb) p send1->hash()
error: <user expression 0>:1:13: too few arguments to function call, expected 1, have 0
send1->hash()

Now it correctly prints:
(lldb) p send1->hash()
(const nano::block_hash) {
  nano::uint256_union = {
     = {
      bytes = (__elems_ = "|\U00000012/<\xa60\x85&\xbf\U0000007f`\xf3\xde|\xe2V-)\x88\xc5w\x97\x89\U0000007f\U000000127\xee :\x88\xb9\t")
      chars = (__elems_ = "|\U00000012/<\xa60\x85&\xbf\U0000007f`\xf3\xde|\xe2V-)\x88\xc5w\x97\x89\U0000007f\U000000127\xee :\x88\xb9\t")
...