### PR TITLE
Store full votes in vote cache

### DIFF
--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -365,7 +365,7 @@ TEST (inactive_votes_cache, existing_vote)
 	ASSERT_EQ (send->hash (), last_vote1.hash);
 	ASSERT_EQ (nano::vote::timestamp_min * 1, last_vote1.timestamp);
 	// Attempt to change vote with inactive_votes_cache
-	node.vote_cache.vote (vote1);
+	node.vote_cache.insert (vote1);
 	auto cached = node.vote_cache.find (send->hash ());
 	ASSERT_EQ (1, cached.size ());
 	for (auto const & cached_vote : cached)
@@ -1535,7 +1535,7 @@ TEST (active_transactions, allow_limited_overflow)
 	{
 		// Non-final vote, so it stays in the AEC without getting confirmed
 		auto vote = nano::test::make_vote (nano::dev::genesis_key, { block });
-		node.vote_cache.vote (vote);
+		node.vote_cache.insert (vote);
 	}
 
 	// Ensure active elections overfill AEC only up to normal + hinted limit
@@ -1573,7 +1573,7 @@ TEST (active_transactions, allow_limited_overflow_adapt)
 	{
 		// Non-final vote, so it stays in the AEC without getting confirmed
 		auto vote = nano::test::make_vote (nano::dev::genesis_key, { block });
-		node.vote_cache.vote (vote);
+		node.vote_cache.insert (vote);
 	}
 
 	// Ensure hinted election amount is bounded by hinted limit

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -235,7 +235,7 @@ TEST (active_transactions, keep_local)
 	// ASSERT_EQ (1, node.scheduler.size ());
 }
 
-TEST (active_transactions, inactive_votes_cache)
+TEST (inactive_votes_cache, basic)
 {
 	nano::test::system system (1);
 	auto & node = *system.nodes[0];
@@ -259,7 +259,7 @@ TEST (active_transactions, inactive_votes_cache)
 /**
  * This test case confirms that a non final vote cannot cause an election to become confirmed
  */
-TEST (active_transactions, inactive_votes_cache_non_final)
+TEST (inactive_votes_cache, non_final)
 {
 	nano::test::system system (1);
 	auto & node = *system.nodes[0];
@@ -285,7 +285,7 @@ TEST (active_transactions, inactive_votes_cache_non_final)
 	ASSERT_FALSE (election->confirmed ());
 }
 
-TEST (active_transactions, inactive_votes_cache_fork)
+TEST (inactive_votes_cache, fork)
 {
 	nano::test::system system{ 1 };
 	auto & node = *system.nodes[0];
@@ -325,7 +325,7 @@ TEST (active_transactions, inactive_votes_cache_fork)
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
 }
 
-TEST (active_transactions, inactive_votes_cache_existing_vote)
+TEST (inactive_votes_cache, existing_vote)
 {
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
@@ -365,12 +365,13 @@ TEST (active_transactions, inactive_votes_cache_existing_vote)
 	ASSERT_EQ (send->hash (), last_vote1.hash);
 	ASSERT_EQ (nano::vote::timestamp_min * 1, last_vote1.timestamp);
 	// Attempt to change vote with inactive_votes_cache
-	nano::unique_lock<nano::mutex> active_lock (node.active.mutex);
-	node.vote_cache.vote (send->hash (), vote1);
-	auto cache = node.vote_cache.find (send->hash ());
-	ASSERT_TRUE (cache);
-	ASSERT_EQ (1, cache->voters ().size ());
-	cache->fill (election);
+	node.vote_cache.vote (vote1);
+	auto cached = node.vote_cache.find (send->hash ());
+	ASSERT_EQ (1, cached.size ());
+	for (auto const & cached_vote : cached)
+	{
+		node.active.vote (cached_vote);
+	}
 	// Check that election data is not changed
 	ASSERT_EQ (2, election->votes ().size ());
 	auto last_vote2 (election->votes ()[key.pub]);
@@ -380,7 +381,7 @@ TEST (active_transactions, inactive_votes_cache_existing_vote)
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
 }
 
-TEST (active_transactions, inactive_votes_cache_multiple_votes)
+TEST (inactive_votes_cache, multiple_votes)
 {
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
@@ -426,8 +427,7 @@ TEST (active_transactions, inactive_votes_cache_multiple_votes)
 	auto vote2 = nano::test::make_vote (nano::dev::genesis_key, { send1 }, 0, 0);
 	node.vote_processor.vote (vote2, std::make_shared<nano::transport::inproc::channel> (node, node));
 
-	ASSERT_TIMELY (5s, node.vote_cache.find (send1->hash ()));
-	ASSERT_TIMELY_EQ (5s, node.vote_cache.find (send1->hash ())->voters ().size (), 2);
+	ASSERT_TIMELY_EQ (5s, node.vote_cache.find (send1->hash ()).size (), 2);
 	ASSERT_EQ (1, node.vote_cache.size ());
 	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
 	std::shared_ptr<nano::election> election;
@@ -436,7 +436,7 @@ TEST (active_transactions, inactive_votes_cache_multiple_votes)
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
 }
 
-TEST (active_transactions, inactive_votes_cache_election_start)
+TEST (inactive_votes_cache, election_start)
 {
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
@@ -528,8 +528,7 @@ TEST (active_transactions, inactive_votes_cache_election_start)
 	// A late block arrival also checks the inactive votes cache
 	ASSERT_TRUE (node.active.empty ());
 	auto send4_cache (node.vote_cache.find (send4->hash ()));
-	ASSERT_TRUE (send4_cache);
-	ASSERT_EQ (3, send4_cache->voters ().size ());
+	ASSERT_EQ (3, send4_cache.size ());
 	node.process_active (send3);
 	// An election is started for send6 but does not
 	ASSERT_FALSE (node.block_confirmed_or_being_confirmed (send3->hash ()));
@@ -982,8 +981,7 @@ TEST (active_transactions, fork_replacement_tally)
 	node1.vote_processor.vote (vote, std::make_shared<nano::transport::inproc::channel> (node1, node1));
 	node1.vote_processor.flush ();
 	// ensure vote arrives before the block
-	ASSERT_TIMELY (5s, node1.vote_cache.find (send_last->hash ()));
-	ASSERT_TIMELY_EQ (5s, 1, node1.vote_cache.find (send_last->hash ())->size ());
+	ASSERT_TIMELY_EQ (5s, 1, node1.vote_cache.find (send_last->hash ()).size ());
 	node1.network.publish_filter.clear ();
 	node2.network.flood_block (send_last);
 	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) > 1);
@@ -1537,7 +1535,7 @@ TEST (active_transactions, allow_limited_overflow)
 	{
 		// Non-final vote, so it stays in the AEC without getting confirmed
 		auto vote = nano::test::make_vote (nano::dev::genesis_key, { block });
-		node.vote_cache.vote (block->hash (), vote);
+		node.vote_cache.vote (vote);
 	}
 
 	// Ensure active elections overfill AEC only up to normal + hinted limit
@@ -1575,7 +1573,7 @@ TEST (active_transactions, allow_limited_overflow_adapt)
 	{
 		// Non-final vote, so it stays in the AEC without getting confirmed
 		auto vote = nano::test::make_vote (nano::dev::genesis_key, { block });
-		node.vote_cache.vote (block->hash (), vote);
+		node.vote_cache.vote (vote);
 	}
 
 	// Ensure hinted election amount is bounded by hinted limit

--- a/nano/core_test/vote_cache.cpp
+++ b/nano/core_test/vote_cache.cpp
@@ -42,7 +42,7 @@ TEST (vote_cache, construction)
 	ASSERT_EQ (0, vote_cache.size ());
 	ASSERT_TRUE (vote_cache.empty ());
 	auto hash1 = nano::test::random_hash ();
-	ASSERT_FALSE (vote_cache.find (hash1));
+	ASSERT_TRUE (vote_cache.find (hash1).empty ());
 }
 
 /*
@@ -57,16 +57,12 @@ TEST (vote_cache, insert_one_hash)
 	auto rep1 = create_rep (7);
 	auto hash1 = nano::test::random_hash ();
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1024 * 1024);
-	vote_cache.vote (vote1->hashes.front (), vote1);
+	vote_cache.vote (vote1);
 	ASSERT_EQ (1, vote_cache.size ());
 
 	auto peek1 = vote_cache.find (hash1);
-	ASSERT_TRUE (peek1);
-	ASSERT_EQ (peek1->hash (), hash1);
-	ASSERT_EQ (peek1->voters ().size (), 1);
-	ASSERT_EQ (peek1->voters ().front ().representative, rep1.pub); // account
-	ASSERT_EQ (peek1->voters ().front ().timestamp, 1024 * 1024); // timestamp
-	ASSERT_EQ (peek1->tally (), 7);
+	ASSERT_EQ (peek1.size (), 1);
+	ASSERT_EQ (peek1.front (), vote1);
 
 	auto tops = vote_cache.top (0);
 	ASSERT_EQ (tops.size (), 1);
@@ -92,17 +88,17 @@ TEST (vote_cache, insert_one_hash_many_votes)
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1 * 1024 * 1024);
 	auto vote2 = nano::test::make_vote (rep2, { hash1 }, 2 * 1024 * 1024);
 	auto vote3 = nano::test::make_vote (rep3, { hash1 }, 3 * 1024 * 1024);
-	vote_cache.vote (vote1->hashes.front (), vote1);
-	vote_cache.vote (vote2->hashes.front (), vote2);
-	vote_cache.vote (vote3->hashes.front (), vote3);
+	vote_cache.vote (vote1);
+	vote_cache.vote (vote2);
+	vote_cache.vote (vote3);
 
-	// We have 3 votes but for a single hash, so just one entry in vote cache
 	ASSERT_EQ (1, vote_cache.size ());
 	auto peek1 = vote_cache.find (hash1);
-	ASSERT_TRUE (peek1);
-	ASSERT_EQ (peek1->voters ().size (), 3);
-	// Tally must be the sum of rep weights
-	ASSERT_EQ (peek1->tally (), 7 + 9 + 11);
+	ASSERT_EQ (peek1.size (), 3);
+	// Verify each vote is present
+	ASSERT_TRUE (std::find (peek1.begin (), peek1.end (), vote1) != peek1.end ());
+	ASSERT_TRUE (std::find (peek1.begin (), peek1.end (), vote2) != peek1.end ());
+	ASSERT_TRUE (std::find (peek1.begin (), peek1.end (), vote3) != peek1.end ());
 
 	auto tops = vote_cache.top (0);
 	ASSERT_EQ (tops.size (), 1);
@@ -136,14 +132,14 @@ TEST (vote_cache, insert_many_hashes_many_votes)
 	auto vote3 = nano::test::make_vote (rep3, { hash3 }, 1024 * 1024);
 	auto vote4 = nano::test::make_vote (rep4, { hash1 }, 1024 * 1024);
 	// Insert first 3 votes in cache
-	vote_cache.vote (vote1->hashes.front (), vote1);
-	vote_cache.vote (vote2->hashes.front (), vote2);
-	vote_cache.vote (vote3->hashes.front (), vote3);
+	vote_cache.vote (vote1);
+	vote_cache.vote (vote2);
+	vote_cache.vote (vote3);
 	// Ensure all of those are properly inserted
 	ASSERT_EQ (3, vote_cache.size ());
-	ASSERT_TRUE (vote_cache.find (hash1));
-	ASSERT_TRUE (vote_cache.find (hash2));
-	ASSERT_TRUE (vote_cache.find (hash3));
+	ASSERT_EQ (1, vote_cache.find (hash1).size ());
+	ASSERT_EQ (1, vote_cache.find (hash2).size ());
+	ASSERT_EQ (1, vote_cache.find (hash3).size ());
 
 	// Ensure that first entry in queue is the one for hash3 (rep3 has the highest weight of the first 3 reps)
 	auto tops1 = vote_cache.top (0);
@@ -151,14 +147,12 @@ TEST (vote_cache, insert_many_hashes_many_votes)
 	ASSERT_EQ (tops1[0].hash, hash3);
 	ASSERT_EQ (tops1[0].tally, 11);
 
-	auto peek1 = vote_cache.find (tops1[0].hash);
-	ASSERT_TRUE (peek1);
-	ASSERT_EQ (peek1->voters ().size (), 1);
-	ASSERT_EQ (peek1->tally (), 11);
-	ASSERT_EQ (peek1->hash (), hash3);
+	auto peek1 = vote_cache.find (hash3);
+	ASSERT_EQ (peek1.size (), 1);
+	ASSERT_EQ (peek1.front (), vote3);
 
 	// Now add a vote from rep4 with the highest voting weight
-	vote_cache.vote (vote4->hashes.front (), vote4);
+	vote_cache.vote (vote4);
 
 	// Ensure that the first entry in queue is now the one for hash1 (rep1 + rep4 tally weight)
 	auto tops2 = vote_cache.top (0);
@@ -166,31 +160,26 @@ TEST (vote_cache, insert_many_hashes_many_votes)
 	ASSERT_EQ (tops2[0].hash, hash1);
 	ASSERT_EQ (tops2[0].tally, 7 + 13);
 
-	auto pop1 = vote_cache.find (tops2[0].hash);
-	ASSERT_TRUE (pop1);
-	ASSERT_EQ ((*pop1).voters ().size (), 2);
-	ASSERT_EQ ((*pop1).tally (), 7 + 13);
-	ASSERT_EQ ((*pop1).hash (), hash1);
+	auto pop1 = vote_cache.find (hash1);
+	ASSERT_EQ (pop1.size (), 2);
+	ASSERT_TRUE (std::find (pop1.begin (), pop1.end (), vote1) != pop1.end ());
+	ASSERT_TRUE (std::find (pop1.begin (), pop1.end (), vote4) != pop1.end ());
 
 	// The next entry in queue should be hash3 (rep3 tally weight)
 	ASSERT_EQ (tops2[1].hash, hash3);
 	ASSERT_EQ (tops2[1].tally, 11);
 
-	auto pop2 = vote_cache.find (tops2[1].hash);
-	ASSERT_EQ ((*pop2).voters ().size (), 1);
-	ASSERT_EQ ((*pop2).tally (), 11);
-	ASSERT_EQ ((*pop2).hash (), hash3);
-	ASSERT_TRUE (vote_cache.find (hash3));
+	auto pop2 = vote_cache.find (hash3);
+	ASSERT_EQ (pop2.size (), 1);
+	ASSERT_EQ (pop2.front (), vote3);
 
 	// And last one should be hash2 with rep2 tally weight
 	ASSERT_EQ (tops2[2].hash, hash2);
 	ASSERT_EQ (tops2[2].tally, 9);
 
-	auto pop3 = vote_cache.find (tops2[2].hash);
-	ASSERT_EQ ((*pop3).voters ().size (), 1);
-	ASSERT_EQ ((*pop3).tally (), 9);
-	ASSERT_EQ ((*pop3).hash (), hash2);
-	ASSERT_TRUE (vote_cache.find (hash2));
+	auto pop3 = vote_cache.find (hash2);
+	ASSERT_EQ (pop3.size (), 1);
+	ASSERT_EQ (pop3.front (), vote2);
 }
 
 /*
@@ -206,8 +195,8 @@ TEST (vote_cache, insert_duplicate)
 	auto rep1 = create_rep (9);
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1 * 1024 * 1024);
 	auto vote2 = nano::test::make_vote (rep1, { hash1 }, 1 * 1024 * 1024);
-	vote_cache.vote (vote1->hashes.front (), vote1);
-	vote_cache.vote (vote2->hashes.front (), vote2);
+	vote_cache.vote (vote1);
+	vote_cache.vote (vote2);
 	ASSERT_EQ (1, vote_cache.size ());
 }
 
@@ -223,18 +212,15 @@ TEST (vote_cache, insert_newer)
 	auto hash1 = nano::test::random_hash ();
 	auto rep1 = create_rep (9);
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1 * 1024 * 1024);
-	vote_cache.vote (vote1->hashes.front (), vote1);
+	vote_cache.vote (vote1);
 	auto peek1 = vote_cache.find (hash1);
-	ASSERT_TRUE (peek1);
+	ASSERT_EQ (peek1.size (), 1);
+	ASSERT_EQ (peek1.front (), vote1);
 	auto vote2 = nano::test::make_final_vote (rep1, { hash1 });
-	vote_cache.vote (vote2->hashes.front (), vote2);
+	vote_cache.vote (vote2);
 	auto peek2 = vote_cache.find (hash1);
-	ASSERT_TRUE (peek2);
-	ASSERT_EQ (1, vote_cache.size ());
-	ASSERT_EQ (1, peek2->voters ().size ());
-	// Second entry should have timestamp greater than the first one
-	ASSERT_GT (peek2->voters ().front ().timestamp, peek1->voters ().front ().timestamp);
-	ASSERT_EQ (peek2->voters ().front ().timestamp, std::numeric_limits<uint64_t>::max ()); // final timestamp
+	ASSERT_EQ (peek2.size (), 1);
+	ASSERT_EQ (peek2.front (), vote2); // vote2 should replace vote1 as it has a higher timestamp
 }
 
 /*
@@ -249,16 +235,15 @@ TEST (vote_cache, insert_older)
 	auto hash1 = nano::test::random_hash ();
 	auto rep1 = create_rep (9);
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 2 * 1024 * 1024);
-	vote_cache.vote (vote1->hashes.front (), vote1);
+	vote_cache.vote (vote1);
 	auto peek1 = vote_cache.find (hash1);
-	ASSERT_TRUE (peek1);
+	ASSERT_EQ (peek1.size (), 1);
+	ASSERT_EQ (peek1.front (), vote1);
 	auto vote2 = nano::test::make_vote (rep1, { hash1 }, 1 * 1024 * 1024);
-	vote_cache.vote (vote2->hashes.front (), vote2);
+	vote_cache.vote (vote2);
 	auto peek2 = vote_cache.find (hash1);
-	ASSERT_TRUE (peek2);
-	ASSERT_EQ (1, vote_cache.size ());
-	ASSERT_EQ (1, peek2->voters ().size ());
-	ASSERT_EQ (peek2->voters ().front ().timestamp, peek1->voters ().front ().timestamp); // timestamp2 == timestamp1
+	ASSERT_EQ (peek2.size (), 1);
+	ASSERT_EQ (peek2.front (), vote1); // vote1 should still be in cache as it has a higher timestamp
 }
 
 /*
@@ -280,24 +265,24 @@ TEST (vote_cache, erase)
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1024 * 1024);
 	auto vote2 = nano::test::make_vote (rep2, { hash2 }, 1024 * 1024);
 	auto vote3 = nano::test::make_vote (rep3, { hash3 }, 1024 * 1024);
-	vote_cache.vote (vote1->hashes.front (), vote1);
-	vote_cache.vote (vote2->hashes.front (), vote2);
-	vote_cache.vote (vote3->hashes.front (), vote3);
+	vote_cache.vote (vote1);
+	vote_cache.vote (vote2);
+	vote_cache.vote (vote3);
 	ASSERT_EQ (3, vote_cache.size ());
 	ASSERT_FALSE (vote_cache.empty ());
-	ASSERT_TRUE (vote_cache.find (hash1));
-	ASSERT_TRUE (vote_cache.find (hash2));
-	ASSERT_TRUE (vote_cache.find (hash3));
+	ASSERT_FALSE (vote_cache.find (hash1).empty ());
+	ASSERT_FALSE (vote_cache.find (hash2).empty ());
+	ASSERT_FALSE (vote_cache.find (hash3).empty ());
 	vote_cache.erase (hash2);
 	ASSERT_EQ (2, vote_cache.size ());
-	ASSERT_TRUE (vote_cache.find (hash1));
-	ASSERT_FALSE (vote_cache.find (hash2));
-	ASSERT_TRUE (vote_cache.find (hash3));
+	ASSERT_FALSE (vote_cache.find (hash1).empty ());
+	ASSERT_TRUE (vote_cache.find (hash2).empty ());
+	ASSERT_FALSE (vote_cache.find (hash3).empty ());
 	vote_cache.erase (hash1);
 	vote_cache.erase (hash3);
-	ASSERT_FALSE (vote_cache.find (hash1));
-	ASSERT_FALSE (vote_cache.find (hash2));
-	ASSERT_FALSE (vote_cache.find (hash3));
+	ASSERT_TRUE (vote_cache.find (hash1).empty ());
+	ASSERT_TRUE (vote_cache.find (hash2).empty ());
+	ASSERT_TRUE (vote_cache.find (hash3).empty ());
 	ASSERT_TRUE (vote_cache.empty ());
 }
 
@@ -319,7 +304,7 @@ TEST (vote_cache, overfill)
 		auto rep1 = create_rep (count - n);
 		auto hash1 = nano::test::random_hash ();
 		auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1024 * 1024);
-		vote_cache.vote (vote1->hashes.front (), vote1);
+		vote_cache.vote (vote1);
 	}
 	ASSERT_LT (vote_cache.size (), count);
 	// Check that oldest votes are dropped first
@@ -343,7 +328,7 @@ TEST (vote_cache, overfill_entry)
 	{
 		auto rep1 = create_rep (9);
 		auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1024 * 1024);
-		vote_cache.vote (vote1->hashes.front (), vote1);
+		vote_cache.vote (vote1);
 	}
 	ASSERT_EQ (1, vote_cache.size ());
 }
@@ -359,9 +344,9 @@ TEST (vote_cache, age_cutoff)
 	auto hash1 = nano::test::random_hash ();
 	auto rep1 = create_rep (9);
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 3);
-	vote_cache.vote (vote1->hashes.front (), vote1);
+	vote_cache.vote (vote1);
 	ASSERT_EQ (1, vote_cache.size ());
-	ASSERT_TRUE (vote_cache.find (hash1));
+	ASSERT_FALSE (vote_cache.find (hash1).empty ());
 
 	auto tops1 = vote_cache.top (0);
 	ASSERT_EQ (tops1.size (), 1);

--- a/nano/core_test/vote_cache.cpp
+++ b/nano/core_test/vote_cache.cpp
@@ -57,7 +57,7 @@ TEST (vote_cache, insert_one_hash)
 	auto rep1 = create_rep (7);
 	auto hash1 = nano::test::random_hash ();
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1024 * 1024);
-	vote_cache.vote (vote1);
+	vote_cache.insert (vote1);
 	ASSERT_EQ (1, vote_cache.size ());
 
 	auto peek1 = vote_cache.find (hash1);
@@ -88,9 +88,9 @@ TEST (vote_cache, insert_one_hash_many_votes)
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1 * 1024 * 1024);
 	auto vote2 = nano::test::make_vote (rep2, { hash1 }, 2 * 1024 * 1024);
 	auto vote3 = nano::test::make_vote (rep3, { hash1 }, 3 * 1024 * 1024);
-	vote_cache.vote (vote1);
-	vote_cache.vote (vote2);
-	vote_cache.vote (vote3);
+	vote_cache.insert (vote1);
+	vote_cache.insert (vote2);
+	vote_cache.insert (vote3);
 
 	ASSERT_EQ (1, vote_cache.size ());
 	auto peek1 = vote_cache.find (hash1);
@@ -132,9 +132,9 @@ TEST (vote_cache, insert_many_hashes_many_votes)
 	auto vote3 = nano::test::make_vote (rep3, { hash3 }, 1024 * 1024);
 	auto vote4 = nano::test::make_vote (rep4, { hash1 }, 1024 * 1024);
 	// Insert first 3 votes in cache
-	vote_cache.vote (vote1);
-	vote_cache.vote (vote2);
-	vote_cache.vote (vote3);
+	vote_cache.insert (vote1);
+	vote_cache.insert (vote2);
+	vote_cache.insert (vote3);
 	// Ensure all of those are properly inserted
 	ASSERT_EQ (3, vote_cache.size ());
 	ASSERT_EQ (1, vote_cache.find (hash1).size ());
@@ -152,7 +152,7 @@ TEST (vote_cache, insert_many_hashes_many_votes)
 	ASSERT_EQ (peek1.front (), vote3);
 
 	// Now add a vote from rep4 with the highest voting weight
-	vote_cache.vote (vote4);
+	vote_cache.insert (vote4);
 
 	// Ensure that the first entry in queue is now the one for hash1 (rep1 + rep4 tally weight)
 	auto tops2 = vote_cache.top (0);
@@ -195,8 +195,8 @@ TEST (vote_cache, insert_duplicate)
 	auto rep1 = create_rep (9);
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1 * 1024 * 1024);
 	auto vote2 = nano::test::make_vote (rep1, { hash1 }, 1 * 1024 * 1024);
-	vote_cache.vote (vote1);
-	vote_cache.vote (vote2);
+	vote_cache.insert (vote1);
+	vote_cache.insert (vote2);
 	ASSERT_EQ (1, vote_cache.size ());
 }
 
@@ -212,12 +212,12 @@ TEST (vote_cache, insert_newer)
 	auto hash1 = nano::test::random_hash ();
 	auto rep1 = create_rep (9);
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1 * 1024 * 1024);
-	vote_cache.vote (vote1);
+	vote_cache.insert (vote1);
 	auto peek1 = vote_cache.find (hash1);
 	ASSERT_EQ (peek1.size (), 1);
 	ASSERT_EQ (peek1.front (), vote1);
 	auto vote2 = nano::test::make_final_vote (rep1, { hash1 });
-	vote_cache.vote (vote2);
+	vote_cache.insert (vote2);
 	auto peek2 = vote_cache.find (hash1);
 	ASSERT_EQ (peek2.size (), 1);
 	ASSERT_EQ (peek2.front (), vote2); // vote2 should replace vote1 as it has a higher timestamp
@@ -235,12 +235,12 @@ TEST (vote_cache, insert_older)
 	auto hash1 = nano::test::random_hash ();
 	auto rep1 = create_rep (9);
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 2 * 1024 * 1024);
-	vote_cache.vote (vote1);
+	vote_cache.insert (vote1);
 	auto peek1 = vote_cache.find (hash1);
 	ASSERT_EQ (peek1.size (), 1);
 	ASSERT_EQ (peek1.front (), vote1);
 	auto vote2 = nano::test::make_vote (rep1, { hash1 }, 1 * 1024 * 1024);
-	vote_cache.vote (vote2);
+	vote_cache.insert (vote2);
 	auto peek2 = vote_cache.find (hash1);
 	ASSERT_EQ (peek2.size (), 1);
 	ASSERT_EQ (peek2.front (), vote1); // vote1 should still be in cache as it has a higher timestamp
@@ -265,9 +265,9 @@ TEST (vote_cache, erase)
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1024 * 1024);
 	auto vote2 = nano::test::make_vote (rep2, { hash2 }, 1024 * 1024);
 	auto vote3 = nano::test::make_vote (rep3, { hash3 }, 1024 * 1024);
-	vote_cache.vote (vote1);
-	vote_cache.vote (vote2);
-	vote_cache.vote (vote3);
+	vote_cache.insert (vote1);
+	vote_cache.insert (vote2);
+	vote_cache.insert (vote3);
 	ASSERT_EQ (3, vote_cache.size ());
 	ASSERT_FALSE (vote_cache.empty ());
 	ASSERT_FALSE (vote_cache.find (hash1).empty ());
@@ -304,7 +304,7 @@ TEST (vote_cache, overfill)
 		auto rep1 = create_rep (count - n);
 		auto hash1 = nano::test::random_hash ();
 		auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1024 * 1024);
-		vote_cache.vote (vote1);
+		vote_cache.insert (vote1);
 	}
 	ASSERT_LT (vote_cache.size (), count);
 	// Check that oldest votes are dropped first
@@ -328,7 +328,7 @@ TEST (vote_cache, overfill_entry)
 	{
 		auto rep1 = create_rep (9);
 		auto vote1 = nano::test::make_vote (rep1, { hash1 }, 1024 * 1024);
-		vote_cache.vote (vote1);
+		vote_cache.insert (vote1);
 	}
 	ASSERT_EQ (1, vote_cache.size ());
 }
@@ -344,7 +344,7 @@ TEST (vote_cache, age_cutoff)
 	auto hash1 = nano::test::random_hash ();
 	auto rep1 = create_rep (9);
 	auto vote1 = nano::test::make_vote (rep1, { hash1 }, 3);
-	vote_cache.vote (vote1);
+	vote_cache.insert (vote1);
 	ASSERT_EQ (1, vote_cache.size ());
 	ASSERT_FALSE (vote_cache.find (hash1).empty ());
 

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -549,26 +549,29 @@ std::shared_ptr<nano::block> nano::active_transactions::winner (nano::block_hash
 	return result;
 }
 
-void nano::active_transactions::erase (nano::block const & block_a)
+bool nano::active_transactions::erase (nano::block const & block_a)
 {
-	erase (block_a.qualified_root ());
+	return erase (block_a.qualified_root ());
 }
 
-void nano::active_transactions::erase (nano::qualified_root const & root_a)
+bool nano::active_transactions::erase (nano::qualified_root const & root_a)
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	auto root_it (roots.get<tag_root> ().find (root_a));
 	if (root_it != roots.get<tag_root> ().end ())
 	{
 		cleanup_election (lock, root_it->election);
+		return true;
 	}
+	return false;
 }
 
-void nano::active_transactions::erase_hash (nano::block_hash const & hash_a)
+bool nano::active_transactions::erase_hash (nano::block_hash const & hash_a)
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	[[maybe_unused]] auto erased (blocks.erase (hash_a));
 	debug_assert (erased == 1);
+	return erased == 1;
 }
 
 void nano::active_transactions::erase_oldest ()

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -480,27 +480,10 @@ std::unordered_map<nano::block_hash, nano::vote_code> nano::active_transactions:
 		}
 	}
 
-	if (!process.empty ())
+	for (auto const & [block_hash, election] : process)
 	{
-		bool processed = false;
-
-		for (auto const & [block_hash, election] : process)
-		{
-			auto const vote_result = election->vote (vote->account, vote->timestamp (), block_hash, source);
-			results[block_hash] = vote_result;
-
-			processed |= (vote_result == nano::vote_code::vote);
-		}
-
-		// Republish vote if it is new and the node does not host a principal representative (or close to)
-		if (processed)
-		{
-			auto const reps (node.wallets.reps ());
-			if (!reps.have_half_rep () && !reps.exists (vote->account))
-			{
-				node.network.flood_vote (vote, 0.5f);
-			}
-		}
+		auto const vote_result = election->vote (vote->account, vote->timestamp (), block_hash, source);
+		results[block_hash] = vote_result;
 	}
 
 	// All hashes should have their result set

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -164,8 +164,9 @@ public:
 	std::shared_ptr<nano::block> winner (nano::block_hash const &) const;
 	// Returns a list of elections sorted by difficulty
 	std::vector<std::shared_ptr<nano::election>> list_active (std::size_t = std::numeric_limits<std::size_t>::max ());
-	void erase (nano::block const &);
-	void erase_hash (nano::block_hash const &);
+	bool erase (nano::block const &);
+	bool erase (nano::qualified_root const &);
+	bool erase_hash (nano::block_hash const &);
 	void erase_oldest ();
 	bool empty () const;
 	std::size_t size () const;
@@ -193,7 +194,6 @@ private:
 	void trim ();
 	void request_loop ();
 	void request_confirm (nano::unique_lock<nano::mutex> &);
-	void erase (nano::qualified_root const &);
 	// Erase all blocks from active and, if not confirmed, clear digests from network filters
 	void cleanup_election (nano::unique_lock<nano::mutex> & lock_a, std::shared_ptr<nano::election>);
 	nano::stat::type completion_type (nano::election const & election) const;

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -199,11 +199,6 @@ private:
 	nano::stat::type completion_type (nano::election const & election) const;
 	// Returns a list of elections sorted by difficulty, mutex must be locked
 	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t) const;
-	/**
-	 * Checks if vote passes minimum representative weight threshold and adds it to inactive vote cache
-	 * TODO: Should be moved to `vote_cache` class
-	 */
-	void add_vote_cache (nano::block_hash const & hash, std::shared_ptr<nano::vote> vote);
 	void activate_successors (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block);
 	void notify_observers (nano::store::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes);
 

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -152,7 +152,7 @@ public:
 	 */
 	nano::election_insertion_result insert (std::shared_ptr<nano::block> const &, nano::election_behavior = nano::election_behavior::normal);
 	// Distinguishes replay votes, cannot be determined if the block is not in any election
-	std::unordered_map<nano::block_hash, nano::vote_code> vote (std::shared_ptr<nano::vote> const &);
+	std::unordered_map<nano::block_hash, nano::vote_code> vote (std::shared_ptr<nano::vote> const &, nano::vote_source = nano::vote_source::live);
 	// Is the root of this block in the roots container
 	bool active (nano::block const &) const;
 	bool active (nano::qualified_root const &) const;
@@ -189,6 +189,10 @@ public:
 	void add_election_winner_details (nano::block_hash const &, std::shared_ptr<nano::election> const &);
 	std::shared_ptr<nano::election> remove_election_winner_details (nano::block_hash const &);
 
+public: // Events
+	using vote_processed_event_t = nano::observer_set<std::shared_ptr<nano::vote> const &, nano::vote_source, std::unordered_map<nano::block_hash, nano::vote_code> const &>;
+	vote_processed_event_t vote_processed;
+
 private:
 	// Erase elections if we're over capacity
 	void trim ();
@@ -201,6 +205,7 @@ private:
 	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t) const;
 	void activate_successors (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block);
 	void notify_observers (nano::store::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes);
+	bool trigger_vote_cache (nano::block_hash);
 
 private: // Dependencies
 	nano::node & node;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -221,6 +221,21 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 		vote_cache.observe (vote, source, results);
 	});
 
+	// Republish vote if it is new and the node does not host a principal representative (or close to)
+	active.vote_processed.add ([this] (std::shared_ptr<nano::vote> const & vote, nano::vote_source source, std::unordered_map<nano::block_hash, nano::vote_code> const & results) {
+		bool processed = std::any_of (results.begin (), results.end (), [] (auto const & result) {
+			return result.second == nano::vote_code::vote;
+		});
+		if (processed)
+		{
+			auto const reps = wallets.reps ();
+			if (!reps.have_half_rep () && !reps.exists (vote->account))
+			{
+				network.flood_vote (vote, 0.5f);
+			}
+		}
+	});
+
 	if (!init_error ())
 	{
 		// Notify election schedulers when AEC frees election slot

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -217,6 +217,10 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 		scheduler.optimistic.activate (account, account_info, conf_info);
 	});
 
+	active.vote_processed.add ([this] (std::shared_ptr<nano::vote> const & vote, nano::vote_source source, std::unordered_map<nano::block_hash, nano::vote_code> const & results) {
+		vote_cache.observe (vote, source, results);
+	});
+
 	if (!init_error ())
 	{
 		// Notify election schedulers when AEC frees election slot

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -244,13 +244,12 @@ std::vector<nano::vote_cache::top_entry> nano::vote_cache::top (const nano::uint
 			cleanup ();
 		}
 
-		for (auto & entry : cache.get<tag_tally> ())
+		for (auto & entry : cache)
 		{
-			if (entry.tally () < min_tally)
+			if (entry.tally () >= min_tally)
 			{
-				break;
+				results.push_back ({ entry.hash (), entry.tally (), entry.final_tally () });
 			}
-			results.push_back ({ entry.hash (), entry.tally (), entry.final_tally () });
 		}
 	}
 

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -4,15 +4,15 @@
 #include <nano/node/vote_cache.hpp>
 
 /*
- * entry
+ * entvote_cache_entryry
  */
 
-nano::vote_cache::entry::entry (const nano::block_hash & hash) :
+nano::vote_cache_entry::vote_cache_entry (const nano::block_hash & hash) :
 	hash_m{ hash }
 {
 }
 
-bool nano::vote_cache::entry::vote (const nano::account & representative, const uint64_t & timestamp, const nano::uint128_t & rep_weight, std::size_t max_voters)
+bool nano::vote_cache_entry::vote (const nano::account & representative, const uint64_t & timestamp, const nano::uint128_t & rep_weight, std::size_t max_voters)
 {
 	bool updated = vote_impl (representative, timestamp, rep_weight, max_voters);
 	if (updated)
@@ -22,7 +22,7 @@ bool nano::vote_cache::entry::vote (const nano::account & representative, const 
 	return updated;
 }
 
-bool nano::vote_cache::entry::vote_impl (const nano::account & representative, const uint64_t & timestamp, const nano::uint128_t & rep_weight, std::size_t max_voters)
+bool nano::vote_cache_entry::vote_impl (const nano::account & representative, const uint64_t & timestamp, const nano::uint128_t & rep_weight, std::size_t max_voters)
 {
 	auto existing = std::find_if (voters_m.begin (), voters_m.end (), [&representative] (auto const & item) { return item.representative == representative; });
 	if (existing != voters_m.end ())
@@ -64,7 +64,7 @@ bool nano::vote_cache::entry::vote_impl (const nano::account & representative, c
 	}
 }
 
-std::size_t nano::vote_cache::entry::fill (std::shared_ptr<nano::election> const & election) const
+std::size_t nano::vote_cache_entry::fill (std::shared_ptr<nano::election> const & election) const
 {
 	std::size_t inserted = 0;
 	for (const auto & entry : voters_m)
@@ -78,32 +78,32 @@ std::size_t nano::vote_cache::entry::fill (std::shared_ptr<nano::election> const
 	return inserted;
 }
 
-std::size_t nano::vote_cache::entry::size () const
+std::size_t nano::vote_cache_entry::size () const
 {
 	return voters_m.size ();
 }
 
-nano::block_hash nano::vote_cache::entry::hash () const
+nano::block_hash nano::vote_cache_entry::hash () const
 {
 	return hash_m;
 }
 
-nano::uint128_t nano::vote_cache::entry::tally () const
+nano::uint128_t nano::vote_cache_entry::tally () const
 {
 	return tally_m;
 }
 
-nano::uint128_t nano::vote_cache::entry::final_tally () const
+nano::uint128_t nano::vote_cache_entry::final_tally () const
 {
 	return final_tally_m;
 }
 
-std::vector<nano::vote_cache::entry::voter_entry> nano::vote_cache::entry::voters () const
+std::vector<nano::vote_cache_entry::voter_entry> nano::vote_cache_entry::voters () const
 {
 	return voters_m;
 }
 
-std::chrono::steady_clock::time_point nano::vote_cache::entry::last_vote () const
+std::chrono::steady_clock::time_point nano::vote_cache_entry::last_vote () const
 {
 	return last_vote_m;
 }

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -284,8 +284,23 @@ void nano::vote_cache::cleanup ()
 
 std::unique_ptr<nano::container_info_component> nano::vote_cache::collect_container_info (const std::string & name) const
 {
+	nano::lock_guard<nano::mutex> guard{ mutex };
+
+	auto count_unique_votes = [this] () {
+		std::unordered_set<std::shared_ptr<nano::vote>> votes;
+		for (auto const & entry : cache)
+		{
+			for (auto const & vote : entry.votes ())
+			{
+				votes.insert (vote);
+			}
+		}
+		return votes.size ();
+	};
+
 	auto composite = std::make_unique<container_info_composite> (name);
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "cache", size (), sizeof (ordered_cache::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "cache", cache.size (), sizeof (ordered_cache::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "unique", count_unique_votes (), sizeof (nano::vote) }));
 	return composite;
 }
 

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -106,9 +106,14 @@ public:
 	/**
 	 * Adds a new vote to cache
 	 */
-	void vote (
+	void insert (
 	std::shared_ptr<nano::vote> const & vote,
-	std::function<bool (nano::block_hash const &)> const & filter = [] (nano::block_hash const &) { return true; });
+	std::function<bool (nano::block_hash const &)> filter = [] (nano::block_hash const &) { return true; });
+
+	/**
+	 * Should be called for every processed vote, filters which votes should be added to cache
+	 */
+	void observe (std::shared_ptr<nano::vote> const & vote, nano::vote_source source, std::unordered_map<nano::block_hash, nano::vote_code>);
 
 	/**
 	 * Tries to find an entry associated with block hash

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -41,53 +41,55 @@ public:
 	std::chrono::seconds age_cutoff{ 5 * 60 };
 };
 
+/**
+ * Stores votes associated with a single block hash
+ */
+class vote_cache_entry final
+{
+public:
+	struct voter_entry
+	{
+		nano::account representative;
+		uint64_t timestamp;
+	};
+
+public:
+	explicit vote_cache_entry (nano::block_hash const & hash);
+
+	/**
+	 * Adds a vote into a list, checks for duplicates and updates timestamp if new one is greater
+	 * @return true if current tally changed, false otherwise
+	 */
+	bool vote (nano::account const & representative, uint64_t const & timestamp, nano::uint128_t const & rep_weight, std::size_t max_voters);
+
+	/**
+	 * Inserts votes stored in this entry into an election
+	 */
+	std::size_t fill (std::shared_ptr<nano::election> const & election) const;
+
+	std::size_t size () const;
+	nano::block_hash hash () const;
+	nano::uint128_t tally () const;
+	nano::uint128_t final_tally () const;
+	std::vector<voter_entry> voters () const;
+	std::chrono::steady_clock::time_point last_vote () const;
+
+private:
+	bool vote_impl (nano::account const & representative, uint64_t const & timestamp, nano::uint128_t const & rep_weight, std::size_t max_voters);
+
+	nano::block_hash const hash_m;
+	std::vector<voter_entry> voters_m;
+
+	nano::uint128_t tally_m{ 0 };
+	nano::uint128_t final_tally_m{ 0 };
+
+	std::chrono::steady_clock::time_point last_vote_m{};
+};
+
 class vote_cache final
 {
 public:
-	/**
-	 * Stores votes associated with a single block hash
-	 */
-	class entry final
-	{
-	public:
-		struct voter_entry
-		{
-			nano::account representative;
-			uint64_t timestamp;
-		};
-
-	public:
-		explicit entry (nano::block_hash const & hash);
-
-		/**
-		 * Adds a vote into a list, checks for duplicates and updates timestamp if new one is greater
-		 * @return true if current tally changed, false otherwise
-		 */
-		bool vote (nano::account const & representative, uint64_t const & timestamp, nano::uint128_t const & rep_weight, std::size_t max_voters);
-
-		/**
-		 * Inserts votes stored in this entry into an election
-		 */
-		std::size_t fill (std::shared_ptr<nano::election> const & election) const;
-
-		std::size_t size () const;
-		nano::block_hash hash () const;
-		nano::uint128_t tally () const;
-		nano::uint128_t final_tally () const;
-		std::vector<voter_entry> voters () const;
-		std::chrono::steady_clock::time_point last_vote () const;
-
-	private:
-		bool vote_impl (nano::account const & representative, uint64_t const & timestamp, nano::uint128_t const & rep_weight, std::size_t max_voters);
-
-		nano::block_hash const hash_m;
-		std::vector<voter_entry> voters_m;
-
-		nano::uint128_t tally_m{ 0 };
-		nano::uint128_t final_tally_m{ 0 };
-
-		std::chrono::steady_clock::time_point last_vote_m{};
-	};
+	using entry = vote_cache_entry;
 
 public:
 	explicit vote_cache (vote_cache_config const &, nano::stats &);

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -106,7 +106,9 @@ public:
 	/**
 	 * Adds a new vote to cache
 	 */
-	void vote (std::shared_ptr<nano::vote> const & vote, std::function<bool (nano::block_hash const &)> const & filter);
+	void vote (
+	std::shared_ptr<nano::vote> const & vote,
+	std::function<bool (nano::block_hash const &)> const & filter = [] (nano::block_hash const &) { return true; });
 
 	/**
 	 * Tries to find an entry associated with block hash

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -38,8 +38,8 @@ public:
 	nano::error serialize (nano::tomlconfig & toml) const;
 
 public:
-	std::size_t max_size{ 1024 * 128 };
-	std::size_t max_voters{ 128 };
+	std::size_t max_size{ 1024 * 64 };
+	std::size_t max_voters{ 64 };
 	std::chrono::seconds age_cutoff{ 15 * 60 };
 };
 

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -164,7 +164,6 @@ private:
 	// clang-format off
 	class tag_sequenced {};
 	class tag_hash {};
-	class tag_tally {};
 	// clang-format on
 
 	// clang-format off
@@ -172,9 +171,7 @@ private:
 	mi::indexed_by<
 		mi::hashed_unique<mi::tag<tag_hash>,
 			mi::const_mem_fun<entry, nano::block_hash, &entry::hash>>,
-		mi::sequenced<mi::tag<tag_sequenced>>,
-		mi::ordered_non_unique<mi::tag<tag_tally>,
-			mi::const_mem_fun<entry, nano::uint128_t, &entry::tally>, std::greater<>> // DESC
+		mi::sequenced<mi::tag<tag_sequenced>>
 	>>;
 	// clang-format on
 	ordered_cache cache;

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -38,7 +38,7 @@ public:
 public:
 	std::size_t max_size{ 1024 * 128 };
 	std::size_t max_voters{ 128 };
-	std::chrono::seconds age_cutoff{ 5 * 60 };
+	std::chrono::seconds age_cutoff{ 15 * 60 };
 };
 
 /**

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -10,8 +10,6 @@
 #include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
 
-#include <boost/format.hpp>
-
 #include <chrono>
 
 using namespace std::chrono_literals;
@@ -161,12 +159,12 @@ void nano::vote_processor::verify_votes (decltype (votes) const & votes_a)
 	}
 }
 
-nano::vote_code nano::vote_processor::vote_blocking (std::shared_ptr<nano::vote> const & vote_a, std::shared_ptr<nano::transport::channel> const & channel_a, bool validated)
+nano::vote_code nano::vote_processor::vote_blocking (std::shared_ptr<nano::vote> const & vote, std::shared_ptr<nano::transport::channel> const & channel, bool validated)
 {
 	auto result = nano::vote_code::invalid;
-	if (validated || !vote_a->validate ())
+	if (validated || !vote->validate ())
 	{
-		auto vote_results = active.vote (vote_a);
+		auto vote_results = active.vote (vote);
 
 		// Aggregate results for individual hashes
 		bool replay = false;
@@ -184,7 +182,7 @@ nano::vote_code nano::vote_processor::vote_blocking (std::shared_ptr<nano::vote>
 	stats.inc (nano::stat::type::vote, to_stat_detail (result));
 
 	logger.trace (nano::log::type::vote_processor, nano::log::detail::vote_processed,
-	nano::log::arg{ "vote", vote_a },
+	nano::log::arg{ "vote", vote },
 	nano::log::arg{ "result", result });
 
 	return result;

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -176,7 +176,7 @@ nano::vote_code nano::vote_processor::vote_blocking (std::shared_ptr<nano::vote>
 		}
 		result = replay ? nano::vote_code::replay : (processed ? nano::vote_code::vote : nano::vote_code::indeterminate);
 
-		observers.vote.notify (vote_a, channel_a, result);
+		observers.vote.notify (vote, channel, result);
 	}
 
 	stats.inc (nano::stat::type::vote, to_stat_detail (result));

--- a/nano/secure/vote.cpp
+++ b/nano/secure/vote.cpp
@@ -137,6 +137,11 @@ std::chrono::milliseconds nano::vote::duration () const
 	return std::chrono::milliseconds{ 1u << (duration_bits () + 4) };
 }
 
+bool nano::vote::is_final () const
+{
+	return is_final_timestamp (timestamp_m);
+}
+
 void nano::vote::serialize_json (boost::property_tree::ptree & tree) const
 {
 	tree.put ("account", account.to_account ());

--- a/nano/secure/vote.hpp
+++ b/nano/secure/vote.hpp
@@ -47,6 +47,7 @@ public:
 	uint64_t timestamp () const;
 	uint8_t duration_bits () const;
 	std::chrono::milliseconds duration () const;
+	bool is_final () const;
 
 	static uint64_t constexpr timestamp_mask = { 0xffff'ffff'ffff'fff0ULL };
 	static nano::seconds_t constexpr timestamp_max = { 0xffff'ffff'ffff'fff0ULL };


### PR DESCRIPTION
Currently vote cache stores in compressed format, keeping the representative, block hash and timestamp fields, but without the signature. This modifies the behaviour to store full votes, so that upon hinted election activation those votes can be immediately rebroadcasted. In V26 the votes were rebroadcasted only if the vote arrived after election was already active, since there was no way to rebroadcast a previously seen votes without having their signature. 
Another modification is that the vote cache, for each cached block hash, **now stores 64 votes with the highest voting weight**. This is in contrast to previous behaviour where cache stored first 128 votes (above principal rep weight) that were observed. With current live network rep distribution this should be irrelevant, but I think it's nice to have.
The total vote cache size is also **reduced from a maximum of 128k hashes to 64k**. The age cutoff for entries is increased **from 5 minutes to 15 minutes**.
Yet another behaviour change is that votes for active elections are also cached, so that if a particular election is dropped before getting confirmed and later rescheduled, it won't have to collect all the votes from scratch.

During testing (thanks @gr0vity-dev as always) we couldn't observe a significant difference between this branch and V26 in synthetic tests. However, I believe that this will at least partially improve vote propagation on live network under conditions similar to that observed during the recent stress test.