### PR TITLE
CLI option to merge new node config changes into current config

### DIFF
--- a/nano/lib/tomlconfig.cpp
+++ b/nano/lib/tomlconfig.cpp
@@ -186,6 +186,31 @@ void nano::tomlconfig::erase_default_values (tomlconfig & defaults_a)
 	erase_defaults (defaults_l.get_tree (), self.get_tree (), get_tree ());
 }
 
+void nano::tomlconfig::merge_defaults (std::shared_ptr<cpptoml::table> const & base, std::shared_ptr<cpptoml::table> const & defaults)
+{
+	debug_assert (defaults != nullptr);
+
+	for (auto & item : *defaults)
+	{
+		std::string const & key = item.first;
+		if (!base->contains (key))
+		{
+			base->insert (key, item.second);
+		}
+		else
+		{
+			// If the key is present in both, and is a table, merge them recursively
+			auto value = item.second;
+			if (value->is_table ())
+			{
+				auto child_base = base->get_table (key);
+				auto child_defaults = defaults->get_table (key);
+				merge_defaults (child_base, child_defaults);
+			}
+		}
+	}
+}
+
 std::string nano::tomlconfig::to_string (bool comment_values)
 {
 	std::stringstream ss, ss_processed;

--- a/nano/lib/tomlconfig.hpp
+++ b/nano/lib/tomlconfig.hpp
@@ -48,6 +48,7 @@ public:
 	std::shared_ptr<cpptoml::array> create_array (std::string const & key, boost::optional<char const *> documentation_a);
 	void erase_default_values (tomlconfig & defaults_a);
 	std::string to_string (bool comment_values);
+	void merge_defaults (std::shared_ptr<cpptoml::table> const & base, std::shared_ptr<cpptoml::table> const & defaults);
 
 	/** Set value for the given key. Any existing value will be overwritten. */
 	template <typename T>

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -62,6 +62,7 @@ void nano::add_node_options (boost::program_options::options_description & descr
 	("migrate_database_lmdb_to_rocksdb", "Migrates LMDB database to RocksDB")
 	("diagnostics", "Run internal diagnostics")
 	("generate_config", boost::program_options::value<std::string> (), "Write configuration to stdout, populated with defaults suitable for this system. Pass the configuration type node, rpc or log. See also use_defaults.")
+	("update_config", boost::program_options::value<std::string> (), "Reads the current node configuration and updates it with missing keys and values and delete keys that are no longer used. Updated configuration is written to stdout.")
 	("key_create", "Generates a adhoc random keypair and prints it to stdout")
 	("key_expand", "Derive public key and account number from <key>")
 	("wallet_add_adhoc", "Insert <key> in to <wallet>")
@@ -709,6 +710,34 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 			{
 				std::cout << toml.to_string (true) << std::endl;
 			}
+		}
+	}
+	else if (vm.count ("update_config"))
+	{
+		nano::tomlconfig default_toml;
+		nano::tomlconfig current_toml;
+		nano::network_params network_params{ nano::network_constants::active_network };
+		nano::daemon_config default_config{ data_path, network_params };
+
+		std::vector<std::string> config_overrides;
+		nano::daemon_config current_config{ data_path, network_params };
+		auto error = nano::read_node_config_toml (data_path, current_config, config_overrides);
+		if (error)
+		{
+			std::cerr << "Could not read existing config file\n";
+			ec = nano::error_cli::invalid_arguments;
+		}
+		else
+		{
+			current_config.serialize_toml (current_toml);
+
+			// Remove keys that have the same value as in default_config
+			current_toml.erase_default_values (default_toml);
+
+			// Insert new default keys and values
+			current_toml.merge_defaults (current_toml.get_tree (), default_toml.get_tree ());
+
+			std::cout << current_toml.to_string (false) << std::endl;
 		}
 	}
 	else if (vm.count ("diagnostics"))


### PR DESCRIPTION
The node config options are constantly changing with each new version of the node. New ones are added and old ones are removed. As a node operator it's not easy to keep your config file up to date because it currently needs to be done manually.
This PR adds a new CLI option called "update_config" that will read the current configuration file and find all non-default values. It will then insert them into a fresh default node configuration, and output it to the console.