### PR TITLE
Show `receivable` and `weight` for unopened accounts in `account_info`rpc

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -624,6 +624,24 @@ void nano::json_handler::account_info ()
 		auto info (account_info_impl (transaction, account));
 		nano::confirmation_height_info confirmation_height_info;
 		node.store.confirmation_height.get (transaction, account, confirmation_height_info);
+		if (weight)
+		{
+			auto account_weight (node.ledger.weight (account));
+			response_l.put ("weight", account_weight.convert_to<std::string> ());
+		}
+		if (receivable)
+		{
+			auto account_receivable = node.ledger.account_receivable (transaction, account);
+			response_l.put ("pending", account_receivable.convert_to<std::string> ());
+			response_l.put ("receivable", account_receivable.convert_to<std::string> ());
+
+			if (include_confirmed)
+			{
+				auto account_receivable = node.ledger.account_receivable (transaction, account, true);
+				response_l.put ("confirmed_pending", account_receivable.convert_to<std::string> ());
+				response_l.put ("confirmed_receivable", account_receivable.convert_to<std::string> ());
+			}
+		}
 		if (!ec)
 		{
 			response_l.put ("frontier", info.head.to_string ());
@@ -690,24 +708,6 @@ void nano::json_handler::account_info ()
 					}
 
 					response_l.put ("confirmed_representative", confirmed_representative.to_account ());
-				}
-			}
-			if (weight)
-			{
-				auto account_weight (node.ledger.weight_exact (transaction, account));
-				response_l.put ("weight", account_weight.convert_to<std::string> ());
-			}
-			if (receivable)
-			{
-				auto account_receivable = node.ledger.account_receivable (transaction, account);
-				response_l.put ("pending", account_receivable.convert_to<std::string> ());
-				response_l.put ("receivable", account_receivable.convert_to<std::string> ());
-
-				if (include_confirmed)
-				{
-					auto account_receivable = node.ledger.account_receivable (transaction, account, true);
-					response_l.put ("confirmed_pending", account_receivable.convert_to<std::string> ());
-					response_l.put ("confirmed_receivable", account_receivable.convert_to<std::string> ());
 				}
 			}
 		}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -169,18 +169,12 @@ void nano::json_handler::response_errors ()
 	}
 	if (ec)
 	{
-		boost::property_tree::ptree response_error;
-		response_error.put ("error", ec.message ());
-		std::stringstream ostream;
-		boost::property_tree::write_json (ostream, response_error);
-		response (ostream.str ());
+		response_l.put ("error", ec.message ());
 	}
-	else
-	{
-		std::stringstream ostream;
-		boost::property_tree::write_json (ostream, response_l);
-		response (ostream.str ());
-	}
+
+	std::stringstream ostream;
+	boost::property_tree::write_json (ostream, response_l);
+	response (ostream.str ());
 }
 
 std::shared_ptr<nano::wallet> nano::json_handler::wallet_impl ()


### PR DESCRIPTION
Currently when an account is not opened,  the rpc command `account_info` returns an error `Account not found`.
Even if we provide the `receivable` or `weight` flags, the receivable blocks or the delegated weight is not shown.

```json
{
  "action": "account_info",
  "account": "nano_1dckaox4wondc4dtsn9fnw1wzgehb8q9agx4e6rch43kaadrobciepmbjcd3",
  "receivable": "true",
  "weight" : "true"
}
```
returns
```json
{
    "error": "Account not found"
}
```

Even though it has receivable blocks.
This pull request allows ordinary response keys to coexist with an error key
The responsefor the example above would look like this:
```json
{
    "error": "Account not found",
    "pending": "1100000000000000000000000000000",
    "receivable": "1100000000000000000000000000000",
    "weight": "0"
}
```

All the rpc unit tests are passing. There is no test that explicitly prohibits this behavior.
This change in behavior is probably not be wanted, but it greatly simplified the rpc requests required for nanobrowse explorer.
