### PR TITLE
Encapsulate ledger cache counts

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -902,9 +902,10 @@ TEST (block_store, cemented_count_cache)
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto transaction (store->tx_begin_write ());
-	nano::ledger_cache ledger_cache{ store->rep_weight };
-	store->initialize (transaction, ledger_cache, nano::dev::constants);
-	ASSERT_EQ (1, ledger_cache.cemented_count);
+	nano::stats stats;
+	nano::ledger ledger (*store, stats, nano::dev::constants);
+	store->initialize (transaction, ledger.cache, nano::dev::constants);
+	ASSERT_EQ (1, ledger.cemented_count ());
 }
 
 TEST (block_store, block_random)

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -661,8 +661,8 @@ TEST (bootstrap_processor, push_diamond_pruning)
 		ASSERT_TRUE (node1->store.pruned.exists (transaction, open->hash ()));
 		ASSERT_TRUE (node1->ledger.block_exists (transaction, send2->hash ()));
 		ASSERT_TRUE (node1->ledger.block_exists (transaction, receive->hash ()));
-		ASSERT_EQ (2, node1->ledger.cache.pruned_count);
-		ASSERT_EQ (5, node1->ledger.cache.block_count);
+		ASSERT_EQ (2, node1->ledger.pruned_count ());
+		ASSERT_EQ (5, node1->ledger.block_count ());
 	}
 
 	// 2nd bootstrap
@@ -973,22 +973,22 @@ TEST (bootstrap_processor, lazy_hash_pruning)
 	ASSERT_TIMELY (5s, node1->block_confirmed (change1->hash ()));
 	ASSERT_TIMELY (5s, node1->block_confirmed (change2->hash ()));
 	ASSERT_TIMELY (5s, node1->active.empty ());
-	ASSERT_EQ (5, node1->ledger.cache.block_count);
-	ASSERT_EQ (5, node1->ledger.cache.cemented_count);
+	ASSERT_EQ (5, node1->ledger.block_count ());
+	ASSERT_EQ (5, node1->ledger.cemented_count ());
 
 	// Pruning action
 	node1->ledger_pruning (2, false);
-	ASSERT_EQ (9, node0->ledger.cache.block_count);
-	ASSERT_EQ (0, node0->ledger.cache.pruned_count);
-	ASSERT_EQ (5, node1->ledger.cache.block_count);
-	ASSERT_EQ (3, node1->ledger.cache.pruned_count);
+	ASSERT_EQ (9, node0->ledger.block_count ());
+	ASSERT_EQ (0, node0->ledger.pruned_count ());
+	ASSERT_EQ (5, node1->ledger.block_count ());
+	ASSERT_EQ (3, node1->ledger.pruned_count ());
 
 	// Start lazy bootstrap with last block in chain known
 	nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	node1->bootstrap_initiator.bootstrap_lazy (receive3->hash (), true);
 
 	// Check processed blocks
-	ASSERT_TIMELY_EQ (5s, node1->ledger.cache.block_count, 9);
+	ASSERT_TIMELY_EQ (5s, node1->ledger.block_count (), 9);
 	ASSERT_TIMELY (5s, node1->balance (key2.pub) != 0);
 	ASSERT_TIMELY (5s, !node1->bootstrap_initiator.in_progress ());
 }
@@ -1369,14 +1369,14 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	// Confirm last block to prune previous
 	ASSERT_TRUE (nano::test::start_elections (system, *node1, { send1, send2, open, state_open }, true));
 	ASSERT_TIMELY (5s, nano::test::confirmed (*node1, { send2, open, state_open }));
-	ASSERT_EQ (5, node1->ledger.cache.block_count);
-	ASSERT_EQ (5, node1->ledger.cache.cemented_count);
+	ASSERT_EQ (5, node1->ledger.block_count ());
+	ASSERT_EQ (5, node1->ledger.cemented_count ());
 
 	// Pruning action, send1 should get pruned
-	ASSERT_EQ (0, node1->ledger.cache.pruned_count);
+	ASSERT_EQ (0, node1->ledger.pruned_count ());
 	node1->ledger_pruning (2, false);
-	ASSERT_EQ (1, node1->ledger.cache.pruned_count);
-	ASSERT_EQ (5, node1->ledger.cache.block_count);
+	ASSERT_EQ (1, node1->ledger.pruned_count ());
+	ASSERT_EQ (5, node1->ledger.block_count ());
 	ASSERT_TRUE (node1->ledger.store.pruned.exists (node1->ledger.store.tx_begin_read (), send1->hash ()));
 	ASSERT_TRUE (nano::test::exists (*node1, { send2, open, state_open }));
 
@@ -1392,7 +1392,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	ASSERT_TIMELY (5s, lazy_attempt->stopped || lazy_attempt->requeued_pulls >= 4);
 
 	// Some blocks cannot be retrieved from pruned node
-	ASSERT_EQ (1, node2->ledger.cache.block_count);
+	ASSERT_EQ (1, node2->ledger.block_count ());
 	ASSERT_TRUE (nano::test::block_or_pruned_none_exists (*node2, { send1, send2, open, state_open }));
 	{
 		auto transaction (node2->store.tx_begin_read ());
@@ -1401,7 +1401,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 
 	// Insert missing block
 	node2->process_active (send1);
-	ASSERT_TIMELY_EQ (5s, 3, node2->ledger.cache.block_count);
+	ASSERT_TIMELY_EQ (5s, 3, node2->ledger.block_count ());
 	ASSERT_TIMELY (5s, nano::test::exists (*node2, { send1, send2 }));
 	ASSERT_TRUE (nano::test::block_or_pruned_none_exists (*node2, { open, state_open }));
 }
@@ -2050,18 +2050,18 @@ TEST (bulk, genesis_pruning)
 
 	ASSERT_TRUE (nano::test::start_elections (system, *node1, { send1 }, true));
 	ASSERT_TIMELY (5s, node1->active.active (send2->qualified_root ()));
-	ASSERT_EQ (0, node1->ledger.cache.pruned_count);
+	ASSERT_EQ (0, node1->ledger.pruned_count ());
 
 	ASSERT_TRUE (nano::test::start_elections (system, *node1, { send2 }, true));
 	ASSERT_TIMELY (5s, node1->active.active (send3->qualified_root ()));
-	ASSERT_EQ (0, node1->ledger.cache.pruned_count);
+	ASSERT_EQ (0, node1->ledger.pruned_count ());
 
 	ASSERT_TRUE (nano::test::start_elections (system, *node1, { send3 }, true));
 	ASSERT_TIMELY (5s, nano::test::confirmed (*node1, { send3 }));
 
 	node1->ledger_pruning (2, false);
-	ASSERT_EQ (2, node1->ledger.cache.pruned_count);
-	ASSERT_EQ (4, node1->ledger.cache.block_count);
+	ASSERT_EQ (2, node1->ledger.pruned_count ());
+	ASSERT_EQ (4, node1->ledger.block_count ());
 	ASSERT_TRUE (node1->ledger.store.pruned.exists (node1->ledger.store.tx_begin_read (), send1->hash ()));
 	ASSERT_FALSE (nano::test::exists (*node1, { send1 }));
 	ASSERT_TRUE (node1->ledger.store.pruned.exists (node1->ledger.store.tx_begin_read (), send2->hash ()));
@@ -2077,7 +2077,7 @@ TEST (bulk, genesis_pruning)
 	ASSERT_TIMELY (5s, !node2->bootstrap_initiator.in_progress ());
 
 	// node2 still missing blocks
-	ASSERT_EQ (1, node2->ledger.cache.block_count);
+	ASSERT_EQ (1, node2->ledger.block_count ());
 	{
 		auto transaction (node2->store.tx_begin_write ());
 		node2->unchecked.clear ();
@@ -2086,7 +2086,7 @@ TEST (bulk, genesis_pruning)
 	// Insert pruned blocks
 	node2->process_active (send1);
 	node2->process_active (send2);
-	ASSERT_TIMELY_EQ (5s, 3, node2->ledger.cache.block_count);
+	ASSERT_TIMELY_EQ (5s, 3, node2->ledger.block_count ());
 
 	// New bootstrap to sync up everything
 	ASSERT_TIMELY_EQ (5s, node2->bootstrap_initiator.connections->connections_count, 0);

--- a/nano/core_test/confirming_set.cpp
+++ b/nano/core_test/confirming_set.cpp
@@ -46,7 +46,7 @@ TEST (confirming_set, process_one)
 	std::unique_lock lock{ mutex };
 	ASSERT_TRUE (condition.wait_for (lock, 5s, [&] () { return count == 1; }));
 	ASSERT_EQ (1, ctx.stats ().count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
-	ASSERT_EQ (2, ctx.ledger ().cache.cemented_count);
+	ASSERT_EQ (2, ctx.ledger ().cemented_count ());
 }
 
 TEST (confirming_set, process_multiple)
@@ -64,7 +64,7 @@ TEST (confirming_set, process_multiple)
 	std::unique_lock lock{ mutex };
 	ASSERT_TRUE (condition.wait_for (lock, 5s, [&] () { return count == 2; }));
 	ASSERT_EQ (2, ctx.stats ().count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
-	ASSERT_EQ (3, ctx.ledger ().cache.cemented_count);
+	ASSERT_EQ (3, ctx.ledger ().cemented_count ());
 }
 
 TEST (confirmation_callback, observer_callbacks)
@@ -109,7 +109,7 @@ TEST (confirmation_callback, observer_callbacks)
 	ASSERT_TIMELY_EQ (5s, 2, node->ledger.stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
 
 	ASSERT_EQ (2, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
-	ASSERT_EQ (3, node->ledger.cache.cemented_count);
+	ASSERT_EQ (3, node->ledger.cemented_count ());
 	ASSERT_EQ (0, node->active.election_winner_details_size ());
 }
 
@@ -188,7 +188,7 @@ TEST (confirmation_callback, confirmed_history)
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out));
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out));
 	ASSERT_EQ (2, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
-	ASSERT_EQ (3, node->ledger.cache.cemented_count);
+	ASSERT_EQ (3, node->ledger.cemented_count ());
 	ASSERT_EQ (0, node->active.election_winner_details_size ());
 }
 
@@ -251,7 +251,7 @@ TEST (confirmation_callback, dependent_election)
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out));
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_conf_height, nano::stat::dir::out));
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out));
-	ASSERT_EQ (4, node->ledger.cache.cemented_count);
+	ASSERT_EQ (4, node->ledger.cemented_count ());
 
 	ASSERT_EQ (0, node->active.election_winner_details_size ());
 }

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -99,7 +99,7 @@ TEST (conflicts, add_two)
 	// create 2 new accounts, that receive 1 raw each, all blocks are force confirmed
 	auto [send1, open1] = nano::test::setup_new_account (system, *node, 1, gk, key1, gk.pub, true);
 	auto [send2, open2] = nano::test::setup_new_account (system, *node, 1, gk, key2, gk.pub, true);
-	ASSERT_EQ (5, node->ledger.cache.cemented_count);
+	ASSERT_EQ (5, node->ledger.cemented_count ());
 
 	// send 1 raw to account key3 from key1
 	auto send_a = nano::state_block_builder ()

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -238,13 +238,13 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 					   .work (*system.work.generate (open1->hash ()))
 					   .build ();
 	ASSERT_EQ (nano::block_status::progress, node1.process (send2));
-	ASSERT_TIMELY_EQ (5s, node1.ledger.cache.block_count, 4);
+	ASSERT_TIMELY_EQ (5s, node1.ledger.block_count (), 4);
 
 	node_config.peering_port = system.get_available_port ();
 	auto & node2 = *system.add_node (node_config);
 
 	system.wallet (1)->insert_adhoc (key1.prv);
-	ASSERT_TIMELY_EQ (10s, node2.ledger.cache.block_count, 4);
+	ASSERT_TIMELY_EQ (10s, node2.ledger.block_count (), 4);
 
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, (election = node1.active.election (send1->qualified_root ())) != nullptr);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -56,7 +56,7 @@ TEST (ledger, genesis_balance)
 	ASSERT_EQ (nano::dev::constants.genesis_amount, balance);
 	auto info = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info);
-	ASSERT_EQ (1, ledger.cache.account_count);
+	ASSERT_EQ (1, ledger.account_count ());
 	// Frontier time should have been updated when genesis balance was added
 	ASSERT_GE (nano::seconds_since_epoch (), info->modified);
 	ASSERT_LT (nano::seconds_since_epoch () - info->modified, 10);
@@ -189,7 +189,7 @@ TEST (ledger, process_send)
 	ASSERT_FALSE (ledger.pending_info (transaction, nano::pending_key (key2.pub, hash1)));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.account_receivable (transaction, key2.pub));
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, process_receive)
@@ -272,7 +272,7 @@ TEST (ledger, process_receive)
 	ASSERT_TRUE (pending1);
 	ASSERT_EQ (nano::dev::genesis_key.pub, pending1->source);
 	ASSERT_EQ (25, pending1->amount.number ());
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, rollback_receiver)
@@ -320,7 +320,7 @@ TEST (ledger, rollback_receiver)
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 	ASSERT_EQ (0, ledger.weight (key3.pub));
 	ASSERT_FALSE (ledger.account_info (transaction, key2.pub));
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 	ASSERT_FALSE (ledger.pending_info (transaction, nano::pending_key{ key2.pub, hash1 }));
 }
 
@@ -1626,7 +1626,7 @@ TEST (ledger, fail_open_fork_previous)
 				  .work (*pool.generate (key1.pub))
 				  .build ();
 	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, block4));
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, fail_open_account_mismatch)
@@ -1657,7 +1657,7 @@ TEST (ledger, fail_open_account_mismatch)
 				  .work (*pool.generate (badkey.pub))
 				  .build ();
 	ASSERT_NE (nano::block_status::progress, ledger.process (transaction, block2));
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, fail_receive_old)
@@ -2265,7 +2265,7 @@ TEST (ledger, bootstrap_rep_weight)
 					.build ();
 		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send));
 	}
-	ASSERT_EQ (2, ledger.cache.block_count);
+	ASSERT_EQ (2, ledger.block_count ());
 	{
 		ledger.bootstrap_weight_max_blocks = 3;
 		ledger.bootstrap_weights[key2.pub] = 1000;
@@ -2286,7 +2286,7 @@ TEST (ledger, bootstrap_rep_weight)
 					.build ();
 		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send));
 	}
-	ASSERT_EQ (3, ledger.cache.block_count);
+	ASSERT_EQ (3, ledger.block_count ());
 	ASSERT_EQ (0, ledger.weight (key2.pub));
 }
 
@@ -2452,7 +2452,7 @@ TEST (ledger, state_send_receive)
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, receive1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_FALSE (ledger.pending_info (transaction, nano::pending_key{ nano::dev::genesis_key.pub, send1->hash () }));
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 	ASSERT_EQ (3, receive2->sideband ().height);
 	ASSERT_FALSE (receive2->is_send ());
 	ASSERT_TRUE (receive2->is_receive ());
@@ -2588,7 +2588,7 @@ TEST (ledger, state_open)
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.balance (transaction, open1->hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.amount (transaction, open1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
-	ASSERT_EQ (ledger.cache.account_count, store.account.count (transaction));
+	ASSERT_EQ (ledger.account_count (), store.account.count (transaction));
 	ASSERT_EQ (1, open2->sideband ().height);
 	ASSERT_FALSE (open2->is_send ());
 	ASSERT_TRUE (open2->is_receive ());
@@ -2918,7 +2918,7 @@ TEST (ledger, state_state_open_fork)
 				 .build ();
 	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, open2));
 	ASSERT_EQ (open1->root (), open2->root ());
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, state_open_previous_fail)
@@ -3195,7 +3195,7 @@ TEST (ledger, state_rollback_send)
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_FALSE (ledger.pending_info (transaction, nano::pending_key{ nano::dev::genesis_key.pub, send1->hash () }));
 	ASSERT_FALSE (ledger.successor (transaction, nano::dev::genesis->hash ()));
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, state_rollback_receive)
@@ -3237,7 +3237,7 @@ TEST (ledger, state_rollback_receive)
 	ASSERT_FALSE (ledger.block_exists (transaction, receive1->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis_key.pub));
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, state_rollback_received_send)
@@ -3280,7 +3280,7 @@ TEST (ledger, state_rollback_received_send)
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.account_balance (transaction, key.pub));
 	ASSERT_EQ (0, ledger.weight (key.pub));
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, state_rep_change_rollback)
@@ -3349,7 +3349,7 @@ TEST (ledger, state_open_rollback)
 	ASSERT_TRUE (info);
 	ASSERT_EQ (nano::dev::genesis_key.pub, info->source);
 	ASSERT_EQ (nano::Gxrb_ratio, info->amount.number ());
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, state_send_change_rollback)
@@ -3377,7 +3377,7 @@ TEST (ledger, state_send_change_rollback)
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (rep.pub));
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, state_receive_change_rollback)
@@ -3416,7 +3416,7 @@ TEST (ledger, state_receive_change_rollback)
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (rep.pub));
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, epoch_blocks_v1_general)
@@ -3932,7 +3932,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, epoch4));
 	ASSERT_EQ (nano::epoch::epoch_2, epoch4->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_0, epoch4->sideband ().source_epoch); // Not used for epoch blocks
-	ASSERT_EQ (store.account.count (transaction), ledger.cache.account_count);
+	ASSERT_EQ (store.account.count (transaction), ledger.account_count ());
 }
 
 TEST (ledger, epoch_blocks_fork)
@@ -4794,12 +4794,12 @@ TEST (ledger, cache)
 		auto genesis_weight = nano::dev::constants.genesis_amount - i;
 		auto pruned_count = i;
 
-		auto cache_check = [&, i] (nano::ledger_cache const & cache_a) {
-			ASSERT_EQ (account_count, cache_a.account_count);
-			ASSERT_EQ (block_count, cache_a.block_count);
-			ASSERT_EQ (cemented_count, cache_a.cemented_count);
-			ASSERT_EQ (genesis_weight, cache_a.rep_weights.representation_get (nano::dev::genesis_key.pub));
-			ASSERT_EQ (pruned_count, cache_a.pruned_count);
+		auto cache_check = [&, i] (nano::ledger const & ledger) {
+			ASSERT_EQ (account_count, ledger.account_count ());
+			ASSERT_EQ (block_count, ledger.block_count ());
+			ASSERT_EQ (cemented_count, ledger.cemented_count ());
+			ASSERT_EQ (genesis_weight, ledger.cache.rep_weights.representation_get (nano::dev::genesis_key.pub));
+			ASSERT_EQ (pruned_count, ledger.pruned_count ());
 		};
 
 		nano::keypair key;
@@ -4829,8 +4829,8 @@ TEST (ledger, cache)
 
 		++block_count;
 		--genesis_weight;
-		cache_check (ledger.cache);
-		cache_check (nano::ledger (store, stats, nano::dev::constants).cache);
+		cache_check (ledger);
+		cache_check (nano::ledger (store, stats, nano::dev::constants));
 
 		{
 			auto transaction (store.tx_begin_write ());
@@ -4839,47 +4839,36 @@ TEST (ledger, cache)
 
 		++block_count;
 		++account_count;
-		cache_check (ledger.cache);
-		cache_check (nano::ledger (store, stats, nano::dev::constants).cache);
+		cache_check (ledger);
+		cache_check (nano::ledger (store, stats, nano::dev::constants));
 
 		{
 			auto transaction (store.tx_begin_write ());
-			nano::confirmation_height_info height;
-			ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, height));
-			++height.height;
-			height.frontier = send->hash ();
-			ledger.store.confirmation_height.put (transaction, nano::dev::genesis_key.pub, height);
+			ledger.confirm (transaction, send->hash ());
 			ASSERT_TRUE (ledger.block_confirmed (transaction, send->hash ()));
-			++ledger.cache.cemented_count;
 		}
 
 		++cemented_count;
-		cache_check (ledger.cache);
-		cache_check (nano::ledger (store, stats, nano::dev::constants).cache);
+		cache_check (ledger);
+		cache_check (nano::ledger (store, stats, nano::dev::constants));
 
 		{
 			auto transaction (store.tx_begin_write ());
-			nano::confirmation_height_info height;
-			ledger.store.confirmation_height.get (transaction, key.pub, height);
-			height.height += 1;
-			height.frontier = open->hash ();
-			ledger.store.confirmation_height.put (transaction, key.pub, height);
+			ledger.confirm (transaction, open->hash ());
 			ASSERT_TRUE (ledger.block_confirmed (transaction, open->hash ()));
-			++ledger.cache.cemented_count;
 		}
 
 		++cemented_count;
-		cache_check (ledger.cache);
-		cache_check (nano::ledger (store, stats, nano::dev::constants).cache);
+		cache_check (ledger);
+		cache_check (nano::ledger (store, stats, nano::dev::constants));
 
 		{
 			auto transaction (store.tx_begin_write ());
-			ledger.store.pruned.put (transaction, open->hash ());
-			++ledger.cache.pruned_count;
+			ledger.pruning_action (transaction, open->hash (), 1);
 		}
 		++pruned_count;
-		cache_check (ledger.cache);
-		cache_check (nano::ledger (store, stats, nano::dev::constants).cache);
+		cache_check (ledger);
+		cache_check (nano::ledger (store, stats, nano::dev::constants));
 	}
 }
 
@@ -4962,9 +4951,9 @@ TEST (ledger, pruning_action)
 	ASSERT_EQ (1, ledger.pruning_action (transaction, send2->hash (), 1));
 	ASSERT_TRUE (store->pruned.exists (transaction, send2->hash ()));
 	ASSERT_FALSE (store->block.exists (transaction, send2->hash ()));
-	ASSERT_EQ (store->account.count (transaction), ledger.cache.account_count);
-	ASSERT_EQ (store->pruned.count (transaction), ledger.cache.pruned_count);
-	ASSERT_EQ (store->block.count (transaction), ledger.cache.block_count - ledger.cache.pruned_count);
+	ASSERT_EQ (store->account.count (transaction), ledger.account_count ());
+	ASSERT_EQ (store->pruned.count (transaction), ledger.pruned_count ());
+	ASSERT_EQ (store->block.count (transaction), ledger.block_count () - ledger.pruned_count ());
 }
 
 TEST (ledger, pruning_large_chain)
@@ -5016,8 +5005,8 @@ TEST (ledger, pruning_large_chain)
 	ASSERT_TRUE (store->pruned.exists (transaction, last_hash));
 	ASSERT_TRUE (store->block.exists (transaction, nano::dev::genesis->hash ()));
 	ASSERT_FALSE (store->block.exists (transaction, last_hash));
-	ASSERT_EQ (store->pruned.count (transaction), ledger.cache.pruned_count);
-	ASSERT_EQ (store->block.count (transaction), ledger.cache.block_count - ledger.cache.pruned_count);
+	ASSERT_EQ (store->pruned.count (transaction), ledger.pruned_count ());
+	ASSERT_EQ (store->block.count (transaction), ledger.block_count () - ledger.pruned_count ());
 	ASSERT_EQ (send_receive_pairs * 2, store->pruned.count (transaction));
 	ASSERT_EQ (1, store->block.count (transaction)); // Genesis
 }
@@ -5094,8 +5083,8 @@ TEST (ledger, pruning_source_rollback)
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive1));
 	ASSERT_FALSE (ledger.pending_info (transaction, nano::pending_key{ nano::dev::genesis_key.pub, send1->hash () }));
-	ASSERT_EQ (2, ledger.cache.pruned_count);
-	ASSERT_EQ (5, ledger.cache.block_count);
+	ASSERT_EQ (2, ledger.pruned_count ());
+	ASSERT_EQ (5, ledger.block_count ());
 	// Rollback receive block
 	ASSERT_FALSE (ledger.rollback (transaction, receive1->hash ()));
 	auto info2 = ledger.pending_info (transaction, nano::pending_key (nano::dev::genesis_key.pub, send1->hash ()));
@@ -5106,8 +5095,8 @@ TEST (ledger, pruning_source_rollback)
 	// Process receive block again
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive1));
 	ASSERT_FALSE (ledger.pending_info (transaction, nano::pending_key{ nano::dev::genesis_key.pub, send1->hash () }));
-	ASSERT_EQ (2, ledger.cache.pruned_count);
-	ASSERT_EQ (5, ledger.cache.block_count);
+	ASSERT_EQ (2, ledger.pruned_count ());
+	ASSERT_EQ (5, ledger.block_count ());
 }
 
 TEST (ledger, pruning_source_rollback_legacy)
@@ -5182,8 +5171,8 @@ TEST (ledger, pruning_source_rollback_legacy)
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive1));
 	ASSERT_FALSE (ledger.pending_info (transaction, nano::pending_key{ nano::dev::genesis_key.pub, send1->hash () }));
-	ASSERT_EQ (2, ledger.cache.pruned_count);
-	ASSERT_EQ (5, ledger.cache.block_count);
+	ASSERT_EQ (2, ledger.pruned_count ());
+	ASSERT_EQ (5, ledger.block_count ());
 	// Rollback receive block
 	ASSERT_FALSE (ledger.rollback (transaction, receive1->hash ()));
 	auto info3 = ledger.pending_info (transaction, nano::pending_key (nano::dev::genesis_key.pub, send1->hash ()));
@@ -5194,8 +5183,8 @@ TEST (ledger, pruning_source_rollback_legacy)
 	// Process receive block again
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive1));
 	ASSERT_FALSE (ledger.pending_info (transaction, nano::pending_key{ nano::dev::genesis_key.pub, send1->hash () }));
-	ASSERT_EQ (2, ledger.cache.pruned_count);
-	ASSERT_EQ (5, ledger.cache.block_count);
+	ASSERT_EQ (2, ledger.pruned_count ());
+	ASSERT_EQ (5, ledger.block_count ());
 	// Receiving pruned block (open)
 	auto open1 = builder
 				 .open ()
@@ -5207,8 +5196,8 @@ TEST (ledger, pruning_source_rollback_legacy)
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open1));
 	ASSERT_FALSE (ledger.pending_info (transaction, nano::pending_key{ key1.pub, send2->hash () }));
-	ASSERT_EQ (2, ledger.cache.pruned_count);
-	ASSERT_EQ (6, ledger.cache.block_count);
+	ASSERT_EQ (2, ledger.pruned_count ());
+	ASSERT_EQ (6, ledger.block_count ());
 	// Rollback open block
 	ASSERT_FALSE (ledger.rollback (transaction, open1->hash ()));
 	auto info4 = ledger.pending_info (transaction, nano::pending_key (key1.pub, send2->hash ()));
@@ -5219,8 +5208,8 @@ TEST (ledger, pruning_source_rollback_legacy)
 	// Process open block again
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open1));
 	ASSERT_FALSE (ledger.pending_info (transaction, nano::pending_key{ key1.pub, send2->hash () }));
-	ASSERT_EQ (2, ledger.cache.pruned_count);
-	ASSERT_EQ (6, ledger.cache.block_count);
+	ASSERT_EQ (2, ledger.pruned_count ());
+	ASSERT_EQ (6, ledger.block_count ());
 }
 
 TEST (ledger, pruning_process_error)
@@ -5246,8 +5235,8 @@ TEST (ledger, pruning_process_error)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send1));
-	ASSERT_EQ (0, ledger.cache.pruned_count);
-	ASSERT_EQ (2, ledger.cache.block_count);
+	ASSERT_EQ (0, ledger.pruned_count ());
+	ASSERT_EQ (2, ledger.block_count ());
 	// Pruning action for latest block (not valid action)
 	ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 1));
 	ASSERT_FALSE (store->block.exists (transaction, send1->hash ()));
@@ -5266,8 +5255,8 @@ TEST (ledger, pruning_process_error)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::block_status::gap_previous, ledger.process (transaction, send2));
-	ASSERT_EQ (1, ledger.cache.pruned_count);
-	ASSERT_EQ (2, ledger.cache.block_count);
+	ASSERT_EQ (1, ledger.pruned_count ());
+	ASSERT_EQ (2, ledger.block_count ());
 }
 
 TEST (ledger, pruning_legacy_blocks)
@@ -5350,10 +5339,10 @@ TEST (ledger, pruning_legacy_blocks)
 	ASSERT_FALSE (store->block.exists (transaction, open1->hash ()));
 	ASSERT_TRUE (store->pruned.exists (transaction, open1->hash ()));
 	ASSERT_TRUE (store->block.exists (transaction, send3->hash ()));
-	ASSERT_EQ (4, ledger.cache.pruned_count);
-	ASSERT_EQ (7, ledger.cache.block_count);
-	ASSERT_EQ (store->pruned.count (transaction), ledger.cache.pruned_count);
-	ASSERT_EQ (store->block.count (transaction), ledger.cache.block_count - ledger.cache.pruned_count);
+	ASSERT_EQ (4, ledger.pruned_count ());
+	ASSERT_EQ (7, ledger.block_count ());
+	ASSERT_EQ (store->pruned.count (transaction), ledger.pruned_count ());
+	ASSERT_EQ (store->block.count (transaction), ledger.block_count () - ledger.pruned_count ());
 }
 
 TEST (ledger, pruning_safe_functions)

--- a/nano/core_test/ledger_confirm.cpp
+++ b/nano/core_test/ledger_confirm.cpp
@@ -48,7 +48,7 @@ TEST (ledger_confirm, single)
 	ASSERT_TRUE (node->ledger.rollback (transaction, latest1));
 	ASSERT_TRUE (node->ledger.rollback (transaction, send1->hash ()));
 	ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
-	ASSERT_EQ (2, node->ledger.cache.cemented_count);
+	ASSERT_EQ (2, node->ledger.cemented_count ());
 }
 
 TEST (ledger_confirm, multiple_accounts)
@@ -193,7 +193,7 @@ TEST (ledger_confirm, multiple_accounts)
 	auto confirmed = node->ledger.confirm (transaction, receive3->hash ());
 	ASSERT_EQ (10, confirmed.size ());
 	ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
-	ASSERT_EQ (11, node->ledger.cache.cemented_count);
+	ASSERT_EQ (11, node->ledger.cemented_count ());
 
 	ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive3->hash ()));
 	ASSERT_EQ (4, node->ledger.account_info (transaction, nano::dev::genesis_key.pub).value ().block_count);
@@ -343,7 +343,7 @@ TEST (ledger_confirm, send_receive_between_2_accounts)
 	auto confirmed = node->ledger.confirm (transaction, receive4->hash ());
 	ASSERT_EQ (10, confirmed.size ());
 	ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
-	ASSERT_EQ (11, node->ledger.cache.cemented_count);
+	ASSERT_EQ (11, node->ledger.cemented_count ());
 
 	ASSERT_TRUE (node->ledger.block_confirmed (transaction, receive4->hash ()));
 	ASSERT_EQ (7, node->ledger.account_info (transaction, nano::dev::genesis_key.pub).value ().block_count);
@@ -440,7 +440,7 @@ TEST (ledger_confirm, send_receive_self)
 	ASSERT_EQ (8, node->ledger.account_info (transaction, nano::dev::genesis_key.pub).value ().block_count);
 	ASSERT_EQ (7, node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub).value ().height);
 	ASSERT_EQ (receive3->hash (), node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub).value ().frontier);
-	ASSERT_EQ (7, node->ledger.cache.cemented_count);
+	ASSERT_EQ (7, node->ledger.cemented_count ());
 }
 
 TEST (ledger_confirm, all_block_types)
@@ -660,7 +660,7 @@ TEST (ledger_confirm, all_block_types)
 	auto confirmed = node->ledger.confirm (transaction, state_send2->hash ());
 	ASSERT_EQ (15, confirmed.size ());
 	ASSERT_EQ (15, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
-	ASSERT_EQ (16, node->ledger.cache.cemented_count);
+	ASSERT_EQ (16, node->ledger.cemented_count ());
 
 	ASSERT_TRUE (node->ledger.block_confirmed (transaction, state_send2->hash ()));
 	nano::confirmation_height_info confirmation_height_info;
@@ -749,7 +749,7 @@ TEST (ledger_confirm, observers)
 	node1->ledger.confirm (transaction, send1->hash ());
 	ASSERT_TRUE (node1->ledger.block_confirmed (transaction, send1->hash ()));
 	ASSERT_EQ (1, node1->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
-	ASSERT_EQ (2, node1->ledger.cache.cemented_count);
+	ASSERT_EQ (2, node1->ledger.cemented_count ());
 }
 
 TEST (ledger_confirm, election_winner_details_clearing_node_process_confirmed)

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -277,9 +277,9 @@ TEST (node, auto_bootstrap)
 	ASSERT_TIMELY (10s, !node1->bootstrap_initiator.in_progress ());
 	ASSERT_TRUE (node1->ledger.block_or_pruned_exists (send1->hash ()));
 	// Wait block receive
-	ASSERT_TIMELY_EQ (5s, node1->ledger.cache.block_count, 3);
+	ASSERT_TIMELY_EQ (5s, node1->ledger.block_count (), 3);
 	// Confirmation for all blocks
-	ASSERT_TIMELY_EQ (5s, node1->ledger.cache.cemented_count, 3);
+	ASSERT_TIMELY_EQ (5s, node1->ledger.cemented_count (), 3);
 }
 
 TEST (node, auto_bootstrap_reverse)
@@ -427,7 +427,7 @@ TEST (node, search_receivable_pruned)
 	// Confirmation
 	ASSERT_TIMELY (10s, node1->active.empty () && node2->active.empty ());
 	ASSERT_TIMELY (5s, node1->ledger.block_confirmed (node1->store.tx_begin_read (), send2->hash ()));
-	ASSERT_TIMELY_EQ (5s, node2->ledger.cache.cemented_count, 3);
+	ASSERT_TIMELY_EQ (5s, node2->ledger.cemented_count (), 3);
 	system.wallet (0)->store.erase (node1->wallets.tx_begin_write (), nano::dev::genesis_key.pub);
 
 	// Pruning
@@ -435,7 +435,7 @@ TEST (node, search_receivable_pruned)
 		auto transaction (node2->store.tx_begin_write ());
 		ASSERT_EQ (1, node2->ledger.pruning_action (transaction, send1->hash (), 1));
 	}
-	ASSERT_EQ (1, node2->ledger.cache.pruned_count);
+	ASSERT_EQ (1, node2->ledger.pruned_count ());
 	ASSERT_TRUE (node2->ledger.block_or_pruned_exists (send1->hash ())); // true for pruned
 
 	// Receive pruned block
@@ -1277,7 +1277,7 @@ TEST (node, DISABLED_broadcast_elected)
 		auto election (node->active.election (block->qualified_root ()));
 		ASSERT_NE (nullptr, election);
 		election->force_confirm ();
-		ASSERT_TIMELY_EQ (5s, 4, node->ledger.cache.cemented_count)
+		ASSERT_TIMELY_EQ (5s, 4, node->ledger.cemented_count ())
 	}
 
 	system.wallet (0)->insert_adhoc (rep_big.prv);
@@ -1592,7 +1592,7 @@ TEST (node, unconfirmed_send)
 	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
 	ASSERT_TIMELY (5s, node2.block_confirmed (send3->hash ()));
 	ASSERT_TIMELY (5s, node1.block_confirmed (send3->hash ()));
-	ASSERT_TIMELY_EQ (5s, node2.ledger.cache.cemented_count, 7);
+	ASSERT_TIMELY_EQ (5s, node2.ledger.cemented_count (), 7);
 	ASSERT_TIMELY_EQ (5s, node1.balance (nano::dev::genesis_key.pub), nano::dev::constants.genesis_amount);
 }
 
@@ -1914,7 +1914,7 @@ TEST (node, local_votes_cache)
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node.active.election (send2->qualified_root ()));
 	election->force_confirm ();
-	ASSERT_TIMELY_EQ (3s, node.ledger.cache.cemented_count, 3);
+	ASSERT_TIMELY_EQ (3s, node.ledger.cemented_count (), 3);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::confirm_req message1{ nano::dev::network_params.network, send1->hash (), send1->root () };
 	nano::confirm_req message2{ nano::dev::network_params.network, send2->hash (), send2->root () };
@@ -3081,7 +3081,7 @@ TEST (node, rollback_vote_self)
 	// Process and mark the first 2 blocks as confirmed to allow voting
 	ASSERT_TRUE (nano::test::process (node, { send1, open }));
 	ASSERT_TRUE (nano::test::start_elections (system, node, { send1, open }, true));
-	ASSERT_TIMELY_EQ (5s, node.ledger.cache.cemented_count, 3);
+	ASSERT_TIMELY_EQ (5s, node.ledger.cemented_count (), 3);
 
 	// wait until the rep weights have caught up with the weight transfer
 	ASSERT_TIMELY_EQ (5s, nano::dev::constants.genesis_amount / 2, node.weight (key.pub));
@@ -3363,7 +3363,7 @@ TEST (node, dependency_graph)
 		{ key3_receive->hash (), { key3_open->hash (), key1_send2->hash () } },
 		{ key3_epoch->hash (), { key3_receive->hash () } },
 	};
-	ASSERT_EQ (node.ledger.cache.block_count - 2, dependency_graph.size ());
+	ASSERT_EQ (node.ledger.block_count () - 2, dependency_graph.size ());
 
 	// Start an election for the first block of the dependency graph, and ensure all blocks are eventually confirmed
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -3389,9 +3389,9 @@ TEST (node, dependency_graph)
 		});
 
 		EXPECT_FALSE (error);
-		return error || node.ledger.cache.cemented_count == node.ledger.cache.block_count;
+		return error || node.ledger.cemented_count () == node.ledger.block_count ();
 	}));
-	ASSERT_EQ (node.ledger.cache.cemented_count, node.ledger.cache.block_count);
+	ASSERT_EQ (node.ledger.cemented_count (), node.ledger.block_count ());
 	ASSERT_TIMELY (5s, node.active.empty ());
 }
 
@@ -3558,8 +3558,8 @@ TEST (node, dependency_graph_frontier)
 	ASSERT_TIMELY (10s, node2.active.active (gen_send1->qualified_root ()));
 	node1.start_election (gen_send1);
 
-	ASSERT_TIMELY_EQ (15s, node1.ledger.cache.cemented_count, node1.ledger.cache.block_count);
-	ASSERT_TIMELY_EQ (15s, node2.ledger.cache.cemented_count, node2.ledger.cache.block_count);
+	ASSERT_TIMELY_EQ (15s, node1.ledger.cemented_count (), node1.ledger.block_count ());
+	ASSERT_TIMELY_EQ (15s, node2.ledger.cemented_count (), node2.ledger.block_count ());
 }
 
 namespace nano
@@ -3733,11 +3733,11 @@ TEST (node, pruning_automatic)
 	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
 
 	// Check pruning result
-	ASSERT_EQ (3, node1.ledger.cache.block_count);
-	ASSERT_TIMELY_EQ (5s, node1.ledger.cache.pruned_count, 1);
+	ASSERT_EQ (3, node1.ledger.block_count ());
+	ASSERT_TIMELY_EQ (5s, node1.ledger.pruned_count (), 1);
 	ASSERT_TIMELY_EQ (5s, node1.store.pruned.count (node1.store.tx_begin_read ()), 1);
-	ASSERT_EQ (1, node1.ledger.cache.pruned_count);
-	ASSERT_EQ (3, node1.ledger.cache.block_count);
+	ASSERT_EQ (1, node1.ledger.pruned_count ());
+	ASSERT_EQ (3, node1.ledger.block_count ());
 
 	ASSERT_TRUE (nano::test::block_or_pruned_all_exists (node1, { nano::dev::genesis, send1, send2 }));
 }
@@ -3784,19 +3784,19 @@ TEST (node, pruning_age)
 	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
 
 	// Three blocks in total, nothing pruned yet
-	ASSERT_EQ (0, node1.ledger.cache.pruned_count);
-	ASSERT_EQ (3, node1.ledger.cache.block_count);
+	ASSERT_EQ (0, node1.ledger.pruned_count ());
+	ASSERT_EQ (3, node1.ledger.block_count ());
 
 	// Pruning with default age 1 day
 	node1.ledger_pruning (1, true);
-	ASSERT_EQ (0, node1.ledger.cache.pruned_count);
-	ASSERT_EQ (3, node1.ledger.cache.block_count);
+	ASSERT_EQ (0, node1.ledger.pruned_count ());
+	ASSERT_EQ (3, node1.ledger.block_count ());
 
 	// Pruning with max age 0
 	node1.config.max_pruning_age = std::chrono::seconds{ 0 };
 	node1.ledger_pruning (1, true);
-	ASSERT_EQ (1, node1.ledger.cache.pruned_count);
-	ASSERT_EQ (3, node1.ledger.cache.block_count);
+	ASSERT_EQ (1, node1.ledger.pruned_count ());
+	ASSERT_EQ (3, node1.ledger.block_count ());
 
 	ASSERT_TRUE (nano::test::block_or_pruned_all_exists (node1, { nano::dev::genesis, send1, send2 }));
 }
@@ -3845,19 +3845,19 @@ TEST (node, pruning_depth)
 	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
 
 	// Three blocks in total, nothing pruned yet
-	ASSERT_EQ (0, node1.ledger.cache.pruned_count);
-	ASSERT_EQ (3, node1.ledger.cache.block_count);
+	ASSERT_EQ (0, node1.ledger.pruned_count ());
+	ASSERT_EQ (3, node1.ledger.block_count ());
 
 	// Pruning with default depth (unlimited)
 	node1.ledger_pruning (1, true);
-	ASSERT_EQ (0, node1.ledger.cache.pruned_count);
-	ASSERT_EQ (3, node1.ledger.cache.block_count);
+	ASSERT_EQ (0, node1.ledger.pruned_count ());
+	ASSERT_EQ (3, node1.ledger.block_count ());
 
 	// Pruning with max depth 1
 	node1.config.max_pruning_depth = 1;
 	node1.ledger_pruning (1, true);
-	ASSERT_EQ (1, node1.ledger.cache.pruned_count);
-	ASSERT_EQ (3, node1.ledger.cache.block_count);
+	ASSERT_EQ (1, node1.ledger.pruned_count ());
+	ASSERT_EQ (3, node1.ledger.block_count ());
 
 	ASSERT_TRUE (nano::test::block_or_pruned_all_exists (node1, { nano::dev::genesis, send1, send2 }));
 }

--- a/nano/core_test/rep_crawler.cpp
+++ b/nano/core_test/rep_crawler.cpp
@@ -252,7 +252,7 @@ TEST (rep_crawler, recently_confirmed)
 {
 	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
-	ASSERT_EQ (1, node1.ledger.cache.block_count);
+	ASSERT_EQ (1, node1.ledger.block_count ());
 	auto const block = nano::dev::genesis;
 	node1.active.recently_confirmed.put (block->qualified_root (), block->hash ());
 	auto & node2 (*system.add_node ());

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -293,7 +293,7 @@ TEST (request_aggregator, split)
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node.active.election (blocks.back ()->qualified_root ()));
 	election->force_confirm ();
-	ASSERT_TIMELY_EQ (5s, max_vbh + 2, node.ledger.cache.cemented_count);
+	ASSERT_TIMELY_EQ (5s, max_vbh + 2, node.ledger.cemented_count ());
 	ASSERT_EQ (max_vbh + 1, request.size ());
 	auto client = std::make_shared<nano::transport::socket> (node);
 	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1186,7 +1186,7 @@ TEST (wallet, search_receivable)
 	wallet.insert_adhoc (nano::dev::genesis_key.prv);
 
 	// Pending search should create the receive block
-	ASSERT_EQ (2, node.ledger.cache.block_count);
+	ASSERT_EQ (2, node.ledger.block_count ());
 	ASSERT_FALSE (wallet.search_receivable (wallet.wallets.tx_begin_read ()));
 	ASSERT_TIMELY_EQ (3s, node.balance (nano::dev::genesis_key.pub), nano::dev::constants.genesis_amount);
 	auto receive_hash = node.ledger.latest (node.store.tx_begin_read (), nano::dev::genesis_key.pub);
@@ -1220,12 +1220,12 @@ TEST (wallet, receive_pruned)
 	auto send2 = wallet1.send_action (nano::dev::genesis_key.pub, key.pub, 1, 1);
 
 	// Pruning
-	ASSERT_TIMELY_EQ (5s, node2.ledger.cache.cemented_count, 3);
+	ASSERT_TIMELY_EQ (5s, node2.ledger.cemented_count (), 3);
 	{
 		auto transaction = node2.store.tx_begin_write ();
 		ASSERT_EQ (1, node2.ledger.pruning_action (transaction, send1->hash (), 2));
 	}
-	ASSERT_EQ (1, node2.ledger.cache.pruned_count);
+	ASSERT_EQ (1, node2.ledger.pruned_count ());
 	ASSERT_TRUE (node2.ledger.block_or_pruned_exists (send1->hash ()));
 	ASSERT_FALSE (node2.ledger.block_exists (node2.store.tx_begin_read (), send1->hash ()));
 
@@ -1234,5 +1234,5 @@ TEST (wallet, receive_pruned)
 	auto open1 = wallet2.receive_action (send1->hash (), key.pub, amount, send1->destination (), 1);
 	ASSERT_NE (nullptr, open1);
 	ASSERT_EQ (amount, node2.ledger.balance (node2.store.tx_begin_read (), open1->hash ()));
-	ASSERT_TIMELY_EQ (5s, node2.ledger.cache.cemented_count, 4);
+	ASSERT_TIMELY_EQ (5s, node2.ledger.cemented_count (), 4);
 }

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -243,7 +243,7 @@ TEST (wallets, search_receivable)
 		wallet->insert_adhoc (nano::dev::genesis_key.prv);
 
 		// Pending search should create the receive block
-		ASSERT_EQ (2, node.ledger.cache.block_count);
+		ASSERT_EQ (2, node.ledger.block_count ());
 		if (search_all)
 		{
 			node.wallets.search_receivable_all ();

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -169,7 +169,7 @@ int main (int argc, char * const * argv)
 				auto const & hardcoded = bootstrap_weights.second;
 				auto const hardcoded_height = bootstrap_weights.first;
 				auto const ledger_unfiltered = node->ledger.cache.rep_weights.get_rep_amounts ();
-				auto const ledger_height = node->ledger.cache.block_count.load ();
+				auto const ledger_height = node->ledger.block_count ();
 
 				auto get_total = [] (decltype (bootstrap_weights.second) const & reps) -> nano::uint128_union {
 					return std::accumulate (reps.begin (), reps.end (), nano::uint128_t{ 0 }, [] (auto sum, auto const & rep) { return sum + rep.second; });
@@ -327,7 +327,7 @@ int main (int argc, char * const * argv)
 			node_flags.generate_cache.block_count = true;
 			nano::inactive_node inactive_node (data_path, node_flags);
 			auto node = inactive_node.node;
-			std::cout << boost::str (boost::format ("Block count: %1%\n") % node->ledger.cache.block_count);
+			std::cout << boost::str (boost::format ("Block count: %1%\n") % node->ledger.block_count ());
 		}
 		else if (vm.count ("debug_bootstrap_generate"))
 		{
@@ -448,7 +448,7 @@ int main (int argc, char * const * argv)
 			nano::update_flags (node_flags, vm);
 			node_flags.generate_cache.account_count = true;
 			nano::inactive_node inactive_node (data_path, node_flags);
-			std::cout << boost::str (boost::format ("Frontier count: %1%\n") % inactive_node.node->ledger.cache.account_count);
+			std::cout << boost::str (boost::format ("Frontier count: %1%\n") % inactive_node.node->ledger.account_count ());
 		}
 		else if (vm.count ("debug_profile_kdf"))
 		{
@@ -987,14 +987,14 @@ int main (int argc, char * const * argv)
 				blocks.pop_front ();
 			}
 			nano::timer<std::chrono::seconds> timer_l (nano::timer_state::started);
-			while (node->ledger.cache.block_count != max_blocks + 1)
+			while (node->ledger.block_count () != max_blocks + 1)
 			{
 				std::this_thread::sleep_for (std::chrono::milliseconds (10));
 				// Message each 15 seconds
 				if (timer_l.after_deadline (std::chrono::seconds (15)))
 				{
 					timer_l.restart ();
-					std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked), %3% remaining") % node->ledger.cache.block_count % node->unchecked.count () % node->block_processor.size ()) << std::endl;
+					std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked), %3% remaining") % node->ledger.block_count () % node->unchecked.count () % node->block_processor.size ()) << std::endl;
 				}
 			}
 
@@ -1002,7 +1002,7 @@ int main (int argc, char * const * argv)
 			auto time (std::chrono::duration_cast<std::chrono::microseconds> (end - begin).count ());
 			node->stop ();
 			std::cout << boost::str (boost::format ("%|1$ 12d| us \n%2% blocks per second\n") % time % (max_blocks * 1000000 / time));
-			release_assert (node->ledger.cache.block_count == max_blocks + 1);
+			release_assert (node->ledger.block_count () == max_blocks + 1);
 		}
 		else if (vm.count ("debug_profile_votes"))
 		{
@@ -1202,12 +1202,12 @@ int main (int argc, char * const * argv)
 				node1->block_processor.add (block);
 			}
 			auto iteration (0);
-			while (node1->ledger.cache.block_count != count * 2 + 1)
+			while (node1->ledger.block_count () != count * 2 + 1)
 			{
 				std::this_thread::sleep_for (std::chrono::milliseconds (500));
 				if (++iteration % 60 == 0)
 				{
-					std::cout << boost::str (boost::format ("%1% blocks processed\n") % node1->ledger.cache.block_count);
+					std::cout << boost::str (boost::format ("%1% blocks processed\n") % node1->ledger.block_count ());
 				}
 			}
 			// Confirm blocks for node1
@@ -1215,12 +1215,12 @@ int main (int argc, char * const * argv)
 			{
 				node1->confirming_set.add (block->hash ());
 			}
-			while (node1->ledger.cache.cemented_count != node1->ledger.cache.block_count)
+			while (node1->ledger.cemented_count () != node1->ledger.block_count ())
 			{
 				std::this_thread::sleep_for (std::chrono::milliseconds (500));
 				if (++iteration % 60 == 0)
 				{
-					std::cout << boost::str (boost::format ("%1% blocks cemented\n") % node1->ledger.cache.cemented_count);
+					std::cout << boost::str (boost::format ("%1% blocks cemented\n") % node1->ledger.cemented_count ());
 				}
 			}
 
@@ -1250,12 +1250,12 @@ int main (int argc, char * const * argv)
 				node2->block_processor.add (block);
 				blocks.pop_front ();
 			}
-			while (node2->ledger.cache.block_count != count * 2 + 1)
+			while (node2->ledger.block_count () != count * 2 + 1)
 			{
 				std::this_thread::sleep_for (std::chrono::milliseconds (500));
 				if (++iteration % 60 == 0)
 				{
-					std::cout << boost::str (boost::format ("%1% blocks processed\n") % node2->ledger.cache.block_count);
+					std::cout << boost::str (boost::format ("%1% blocks processed\n") % node2->ledger.block_count ());
 				}
 			}
 			// Insert representative
@@ -1274,12 +1274,12 @@ int main (int argc, char * const * argv)
 			auto begin (std::chrono::high_resolution_clock::now ());
 			std::cout << boost::str (boost::format ("Starting confirming %1% frontiers (test node)\n") % (count + 1));
 			// Wait for full frontiers confirmation
-			while (node2->ledger.cache.cemented_count != node2->ledger.cache.block_count)
+			while (node2->ledger.cemented_count () != node2->ledger.block_count ())
 			{
 				std::this_thread::sleep_for (std::chrono::milliseconds (25));
 				if (++iteration % 1200 == 0)
 				{
-					std::cout << boost::str (boost::format ("%1% blocks confirmed\n") % node2->ledger.cache.cemented_count);
+					std::cout << boost::str (boost::format ("%1% blocks confirmed\n") % node2->ledger.cemented_count ());
 				}
 			}
 			auto end (std::chrono::high_resolution_clock::now ());
@@ -1793,7 +1793,7 @@ int main (int argc, char * const * argv)
 				nano::inactive_node inactive_node (data_path, node_flags);
 				auto source_node = inactive_node.node;
 				auto transaction (source_node->store.tx_begin_read ());
-				block_count = source_node->ledger.cache.block_count;
+				block_count = source_node->ledger.block_count ();
 				std::cout << boost::str (boost::format ("Performing bootstrap emulation, %1% blocks in ledger...") % block_count) << std::endl;
 				for (auto i (source_node->store.account.begin (transaction)), n (source_node->store.account.end ()); i != n; ++i)
 				{
@@ -1824,7 +1824,7 @@ int main (int argc, char * const * argv)
 				}
 			}
 			nano::timer<std::chrono::seconds> timer_l (nano::timer_state::started);
-			while (node.node->ledger.cache.block_count != block_count)
+			while (node.node->ledger.block_count () != block_count)
 			{
 				std::this_thread::sleep_for (std::chrono::milliseconds (500));
 				// Add epoch open blocks again if required
@@ -1839,7 +1839,7 @@ int main (int argc, char * const * argv)
 				if (timer_l.after_deadline (std::chrono::seconds (60)))
 				{
 					timer_l.restart ();
-					std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked)") % node.node->ledger.cache.block_count % node.node->unchecked.count ()) << std::endl;
+					std::cout << boost::str (boost::format ("%1% (%2%) blocks processed (unchecked)") % node.node->ledger.block_count () % node.node->unchecked.count ()) << std::endl;
 				}
 			}
 
@@ -1849,7 +1849,7 @@ int main (int argc, char * const * argv)
 			auto seconds (time / us_in_second);
 			nano::remove_temporary_directories ();
 			std::cout << boost::str (boost::format ("%|1$ 12d| seconds \n%2% blocks per second") % seconds % (block_count * us_in_second / time)) << std::endl;
-			release_assert (node.node->ledger.cache.block_count == block_count);
+			release_assert (node.node->ledger.block_count () == block_count);
 		}
 		else if (vm.count ("debug_peers"))
 		{
@@ -1868,7 +1868,7 @@ int main (int argc, char * const * argv)
 			node_flags.generate_cache.cemented_count = true;
 			nano::update_flags (node_flags, vm);
 			nano::inactive_node node (data_path, node_flags);
-			std::cout << "Total cemented block count: " << node.node->ledger.cache.cemented_count << std::endl;
+			std::cout << "Total cemented block count: " << node.node->ledger.cemented_count () << std::endl;
 		}
 		else if (vm.count ("debug_prune"))
 		{

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -111,7 +111,7 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 	recently_cemented.put (status);
 	auto transaction = node.store.tx_begin_read ();
 	notify_observers (transaction, status, votes);
-	bool cemented_bootstrap_count_reached = node.ledger.cache.cemented_count >= node.ledger.bootstrap_weight_max_blocks;
+	bool cemented_bootstrap_count_reached = node.ledger.cemented_count () >= node.ledger.bootstrap_weight_max_blocks;
 	bool was_active = status.type == nano::election_status_type::active_confirmed_quorum || status.type == nano::election_status_type::active_confirmation_height;
 
 	// Next-block activations are only done for blocks with previously active elections

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -485,7 +485,7 @@ std::size_t nano::bootstrap_ascending::service::compute_throttle_size () const
 {
 	// Scales logarithmically with ledger block
 	// Returns: config.throttle_coefficient * sqrt(block_count)
-	std::size_t size_new = config.bootstrap_ascending.throttle_coefficient * std::sqrt (ledger.cache.block_count.load ());
+	std::size_t size_new = config.bootstrap_ascending.throttle_coefficient * std::sqrt (ledger.block_count ());
 	return size_new == 0 ? 16 : size_new;
 }
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1446,13 +1446,13 @@ void nano::json_handler::block_account ()
 
 void nano::json_handler::block_count ()
 {
-	response_l.put ("count", std::to_string (node.ledger.cache.block_count));
+	response_l.put ("count", std::to_string (node.ledger.block_count ()));
 	response_l.put ("unchecked", std::to_string (node.unchecked.count ()));
-	response_l.put ("cemented", std::to_string (node.ledger.cache.cemented_count));
+	response_l.put ("cemented", std::to_string (node.ledger.cemented_count ()));
 	if (node.flags.enable_pruning)
 	{
-		response_l.put ("full", std::to_string (node.ledger.cache.block_count - node.ledger.cache.pruned_count));
-		response_l.put ("pruned", std::to_string (node.ledger.cache.pruned_count));
+		response_l.put ("full", std::to_string (node.ledger.block_count () - node.ledger.pruned_count ()));
+		response_l.put ("pruned", std::to_string (node.ledger.pruned_count ()));
 	}
 	response_errors ();
 }
@@ -2351,7 +2351,7 @@ void nano::json_handler::frontiers ()
 
 void nano::json_handler::account_count ()
 {
-	auto size (node.ledger.cache.account_count.load ());
+	auto size (node.ledger.account_count ());
 	response_l.put ("count", std::to_string (size));
 	response_errors ();
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -422,10 +422,10 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 			ledger.bootstrap_weight_max_blocks = bootstrap_weights.first;
 
 			logger.info (nano::log::type::node, "Initial bootstrap height: {}", ledger.bootstrap_weight_max_blocks);
-			logger.info (nano::log::type::node, "Current ledger height:    {}", ledger.cache.block_count.load ());
+			logger.info (nano::log::type::node, "Current ledger height:    {}", ledger.block_count ());
 
 			// Use bootstrap weights if initial bootstrap is not completed
-			const bool use_bootstrap_weight = ledger.cache.block_count < bootstrap_weights.first;
+			const bool use_bootstrap_weight = ledger.block_count () < bootstrap_weights.first;
 			if (use_bootstrap_weight)
 			{
 				logger.info (nano::log::type::node, "Using predefined representative weights, since block count is less than bootstrap threshold");
@@ -827,7 +827,7 @@ void nano::node::ongoing_bootstrap ()
 	}
 	// Differential bootstrap with max age (75% of all legacy attempts)
 	uint32_t frontiers_age (std::numeric_limits<uint32_t>::max ());
-	auto bootstrap_weight_reached (ledger.cache.block_count >= ledger.bootstrap_weight_max_blocks);
+	auto bootstrap_weight_reached (ledger.block_count () >= ledger.bootstrap_weight_max_blocks);
 	auto previous_bootstrap_count (stats.count (nano::stat::type::bootstrap, nano::stat::detail::initiate, nano::stat::dir::out) + stats.count (nano::stat::type::bootstrap, nano::stat::detail::initiate_legacy_age, nano::stat::dir::out));
 	/*
 	- Maximum value for 25% of attempts or if block count is below preconfigured value (initial bootstrap not finished)
@@ -1025,7 +1025,7 @@ void nano::node::ledger_pruning (uint64_t const batch_size_a, bool bootstrap_wei
 
 void nano::node::ongoing_ledger_pruning ()
 {
-	auto bootstrap_weight_reached (ledger.cache.block_count >= ledger.bootstrap_weight_max_blocks);
+	auto bootstrap_weight_reached (ledger.block_count () >= ledger.bootstrap_weight_max_blocks);
 	ledger_pruning (flags.block_processor_batch_size != 0 ? flags.block_processor_batch_size : 2 * 1024, bootstrap_weight_reached);
 	auto const ledger_pruning_interval (bootstrap_weight_reached ? config.max_pruning_age : std::min (config.max_pruning_age, std::chrono::seconds (15 * 60)));
 	auto this_l (shared ());
@@ -1352,15 +1352,15 @@ nano::telemetry_data nano::node::local_telemetry () const
 {
 	nano::telemetry_data telemetry_data;
 	telemetry_data.node_id = node_id.pub;
-	telemetry_data.block_count = ledger.cache.block_count;
-	telemetry_data.cemented_count = ledger.cache.cemented_count;
+	telemetry_data.block_count = ledger.block_count ();
+	telemetry_data.cemented_count = ledger.cemented_count ();
 	telemetry_data.bandwidth_cap = config.bandwidth_limit;
 	telemetry_data.protocol_version = network_params.network.protocol_version;
 	telemetry_data.uptime = std::chrono::duration_cast<std::chrono::seconds> (std::chrono::steady_clock::now () - startup_time).count ();
 	telemetry_data.unchecked_count = unchecked.count ();
 	telemetry_data.genesis_block = network_params.ledger.genesis->hash ();
 	telemetry_data.peer_count = nano::narrow_cast<decltype (telemetry_data.peer_count)> (network.size ());
-	telemetry_data.account_count = ledger.cache.account_count;
+	telemetry_data.account_count = ledger.account_count ();
 	telemetry_data.major_version = nano::get_major_node_version ();
 	telemetry_data.minor_version = nano::get_minor_node_version ();
 	telemetry_data.patch_version = nano::get_patch_node_version ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -554,7 +554,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (no
 {
 	auto composite = std::make_unique<container_info_composite> (name);
 	composite->add_component (collect_container_info (node.work, "work"));
-	composite->add_component (collect_container_info (node.ledger, "ledger"));
+	composite->add_component (node.ledger.collect_container_info ("ledger"));
 	composite->add_component (collect_container_info (node.active, "active"));
 	composite->add_component (collect_container_info (node.bootstrap_initiator, "bootstrap_initiator"));
 	composite->add_component (node.tcp_listener->collect_container_info ("tcp_listener"));

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -939,9 +939,9 @@ std::string nano_qt::status::text ()
 	size_t cemented (0);
 	std::string count_string;
 	{
-		auto size (wallet.wallet_m->wallets.node.ledger.cache.block_count.load ());
+		auto size (wallet.wallet_m->wallets.node.ledger.block_count ());
 		unchecked = wallet.wallet_m->wallets.node.unchecked.count ();
-		cemented = wallet.wallet_m->wallets.node.ledger.cache.cemented_count.load ();
+		cemented = wallet.wallet_m->wallets.node.ledger.cemented_count ();
 		count_string = std::to_string (size);
 	}
 
@@ -979,8 +979,8 @@ std::string nano_qt::status::text ()
 
 	if (wallet.node.flags.enable_pruning)
 	{
-		count_string += ", Full: " + std::to_string (wallet.wallet_m->wallets.node.ledger.cache.block_count - wallet.wallet_m->wallets.node.ledger.cache.pruned_count);
-		count_string += ", Pruned: " + std::to_string (wallet.wallet_m->wallets.node.ledger.cache.pruned_count);
+		count_string += ", Full: " + std::to_string (wallet.wallet_m->wallets.node.ledger.block_count () - wallet.wallet_m->wallets.node.ledger.pruned_count ());
+		count_string += ", Pruned: " + std::to_string (wallet.wallet_m->wallets.node.ledger.pruned_count ());
 	}
 
 	result += count_string.c_str ();

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6599,7 +6599,7 @@ TEST (rpc, receive_pruned)
 		auto transaction (node2->store.tx_begin_write ());
 		ASSERT_EQ (2, node2->ledger.pruning_action (transaction, send2->hash (), 1));
 	}
-	ASSERT_EQ (2, node2->ledger.cache.pruned_count);
+	ASSERT_EQ (2, node2->ledger.pruned_count ());
 	ASSERT_TRUE (node2->ledger.block_or_pruned_exists (send1->hash ()));
 	ASSERT_FALSE (node2->ledger.block_exists (node2->store.tx_begin_read (), send1->hash ()));
 	ASSERT_TRUE (node2->ledger.block_or_pruned_exists (send2->hash ()));

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1600,6 +1600,26 @@ nano::receivable_iterator nano::ledger::receivable_upper_bound (store::transacti
 	return nano::receivable_iterator{ *this, tx, result };
 }
 
+uint64_t nano::ledger::cemented_count () const
+{
+	return cache.cemented_count;
+}
+
+uint64_t nano::ledger::block_count () const
+{
+	return cache.block_count;
+}
+
+uint64_t nano::ledger::account_count () const
+{
+	return cache.account_count;
+}
+
+uint64_t nano::ledger::pruned_count () const
+{
+	return cache.pruned_count;
+}
+
 nano::uncemented_info::uncemented_info (nano::block_hash const & cemented_frontier, nano::block_hash const & frontier, nano::account const & account) :
 	cemented_frontier (cemented_frontier), frontier (frontier), account (account)
 {

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1605,12 +1605,12 @@ nano::uncemented_info::uncemented_info (nano::block_hash const & cemented_fronti
 {
 }
 
-std::unique_ptr<nano::container_info_component> nano::collect_container_info (ledger & ledger, std::string const & name)
+std::unique_ptr<nano::container_info_component> nano::ledger::collect_container_info (std::string const & name) const
 {
-	auto count = ledger.bootstrap_weights.size ();
-	auto sizeof_element = sizeof (decltype (ledger.bootstrap_weights)::value_type);
+	auto count = bootstrap_weights.size ();
+	auto sizeof_element = sizeof (decltype (bootstrap_weights)::value_type);
 	auto composite = std::make_unique<container_info_composite> (name);
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "bootstrap_weights", count, sizeof_element }));
-	composite->add_component (ledger.cache.rep_weights.collect_container_info ("rep_weights"));
+	composite->add_component (cache.rep_weights.collect_container_info ("rep_weights"));
 	return composite;
 }

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -103,6 +103,7 @@ public:
 	nano::receivable_iterator receivable_upper_bound (store::transaction const & tx, nano::account const & account) const;
 	// Returns the next receivable entry for the account 'account' with hash greater than 'hash'
 	nano::receivable_iterator receivable_upper_bound (store::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const;
+	std::unique_ptr<container_info_component> collect_container_info (std::string const & name) const;
 	static nano::uint128_t const unit;
 	nano::ledger_constants & constants;
 	nano::store::component & store;
@@ -119,6 +120,4 @@ private:
 	void initialize (nano::generate_cache_flags const &);
 	void confirm (nano::store::write_transaction const & transaction, nano::block const & block);
 };
-
-std::unique_ptr<container_info_component> collect_container_info (ledger & ledger, std::string const & name);
 }

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -104,6 +104,10 @@ public:
 	// Returns the next receivable entry for the account 'account' with hash greater than 'hash'
 	nano::receivable_iterator receivable_upper_bound (store::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const;
 	std::unique_ptr<container_info_component> collect_container_info (std::string const & name) const;
+	uint64_t cemented_count () const;
+	uint64_t block_count () const;
+	uint64_t account_count () const;
+	uint64_t pruned_count () const;
 	static nano::uint128_t const unit;
 	nano::ledger_constants & constants;
 	nano::store::component & store;

--- a/nano/secure/ledger_cache.hpp
+++ b/nano/secure/ledger_cache.hpp
@@ -8,12 +8,26 @@
 
 namespace nano
 {
+class ledger;
+}
+namespace nano::store
+{
+class component;
+}
+
+namespace nano
+{
 /* Holds an in-memory cache of various counts */
 class ledger_cache
 {
+	friend class store::component;
+	friend class ledger;
+
 public:
 	explicit ledger_cache (nano::store::rep_weight & rep_weight_store_a, nano::uint128_t min_rep_weight_a = 0);
 	nano::rep_weights rep_weights;
+
+private:
 	std::atomic<uint64_t> cemented_count{ 0 };
 	std::atomic<uint64_t> block_count{ 0 };
 	std::atomic<uint64_t> pruned_count{ 0 };

--- a/nano/secure/rep_weights.cpp
+++ b/nano/secure/rep_weights.cpp
@@ -126,7 +126,7 @@ std::size_t nano::rep_weights::size () const
 	return rep_amounts.size ();
 }
 
-std::unique_ptr<nano::container_info_component> nano::rep_weights::collect_container_info (std::string const & name)
+std::unique_ptr<nano::container_info_component> nano::rep_weights::collect_container_info (std::string const & name) const
 {
 	size_t rep_amounts_count;
 

--- a/nano/secure/rep_weights.hpp
+++ b/nano/secure/rep_weights.hpp
@@ -29,7 +29,7 @@ public:
 	/* Only use this method when loading rep weights from the database table */
 	void copy_from (rep_weights & other_a);
 	size_t size () const;
-	std::unique_ptr<container_info_component> collect_container_info (std::string const &);
+	std::unique_ptr<container_info_component> collect_container_info (std::string const &) const;
 
 private:
 	mutable nano::mutex mutex;

--- a/nano/slow_test/bootstrap.cpp
+++ b/nano/slow_test/bootstrap.cpp
@@ -169,10 +169,10 @@ TEST (bootstrap_ascending, profile)
 		}
 	});*/
 
-	std::cout << "server count: " << server->ledger.cache.block_count << std::endl;
+	std::cout << "server count: " << server->ledger.block_count () << std::endl;
 
 	nano::test::rate_observer rate;
-	rate.observe ("count", [&] () { return client->ledger.cache.block_count.load (); });
+	rate.observe ("count", [&] () { return client->ledger.block_count (); });
 	rate.observe ("unchecked", [&] () { return client->unchecked.count (); });
 	rate.observe ("block_processor", [&] () { return client->block_processor.size (); });
 	rate.observe ("priority", [&] () { return client->ascendboot.priority_size (); });

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -709,12 +709,12 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 		cemented_count += i->second.height;
 	}
 
-	ASSERT_EQ (cemented_count, node->ledger.cache.cemented_count);
+	ASSERT_EQ (cemented_count, node->ledger.cemented_count ());
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_accounts * 2 - 2);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in), num_accounts * 2 - 2);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), 0);
 
-	ASSERT_TIMELY_EQ (40s, (node->ledger.cache.cemented_count - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (40s, (node->ledger.cemented_count () - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
 	ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 }
 
@@ -777,7 +777,7 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	ASSERT_GE (num_confirmed_bounded, nano::confirmation_height::unbounded_cutoff);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), num_blocks_to_confirm - num_confirmed_bounded);
 
-	ASSERT_TIMELY_EQ (60s, (node->ledger.cache.cemented_count - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (60s, (node->ledger.cemented_count () - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
 
 	auto transaction = node->store.tx_begin_read ();
 	size_t cemented_count = 0;
@@ -787,9 +787,9 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	}
 
 	ASSERT_EQ (num_blocks_to_confirm + 1, cemented_count);
-	ASSERT_EQ (cemented_count, node->ledger.cache.cemented_count);
+	ASSERT_EQ (cemented_count, node->ledger.cemented_count ());
 
-	ASSERT_TIMELY_EQ (20s, (node->ledger.cache.cemented_count - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (20s, (node->ledger.cemented_count () - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
 
 	ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 }
@@ -931,12 +931,12 @@ TEST (confirmation_height, long_chains)
 		cemented_count += i->second.height;
 	}
 
-	ASSERT_EQ (cemented_count, node->ledger.cache.cemented_count);
+	ASSERT_EQ (cemented_count, node->ledger.cemented_count ());
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_blocks * 2 + 2);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in), num_blocks * 2 + 2);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), 0);
 
-	ASSERT_TIMELY_EQ (40s, (node->ledger.cache.cemented_count - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
+	ASSERT_TIMELY_EQ (40s, (node->ledger.cemented_count () - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out));
 	ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 }
 
@@ -976,11 +976,11 @@ TEST (confirmation_height, dynamic_algorithm)
 	}
 
 	node->confirming_set.add (state_blocks.front ()->hash ());
-	ASSERT_TIMELY_EQ (20s, node->ledger.cache.cemented_count, 2);
+	ASSERT_TIMELY_EQ (20s, node->ledger.cemented_count (), 2);
 
 	node->confirming_set.add (latest_genesis->hash ());
 
-	ASSERT_TIMELY_EQ (20s, node->ledger.cache.cemented_count, num_blocks + 1);
+	ASSERT_TIMELY_EQ (20s, node->ledger.cemented_count (), num_blocks + 1);
 
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_blocks);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in), 1);
@@ -1094,7 +1094,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 	}
 
 	system.deadline_set (200s);
-	while ((node->ledger.cache.cemented_count - 1) != node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out))
+	while ((node->ledger.cemented_count () - 1) != node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out))
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -1107,10 +1107,10 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 	}
 
 	ASSERT_EQ (num_blocks_to_confirm + 1, cemented_count);
-	ASSERT_EQ (cemented_count, node->ledger.cache.cemented_count);
+	ASSERT_EQ (cemented_count, node->ledger.cemented_count ());
 
 	system.deadline_set (60s);
-	while ((node->ledger.cache.cemented_count - 1) != node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out))
+	while ((node->ledger.cemented_count () - 1) != node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::all, nano::stat::dir::out))
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -1264,7 +1264,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 	}
 
 	ASSERT_EQ (num_blocks_to_confirm + 1, cemented_count);
-	ASSERT_EQ (cemented_count, ledger.cache.cemented_count);
+	ASSERT_EQ (cemented_count, ledger.cemented_count ());
 }
 
 }
@@ -1471,7 +1471,7 @@ TEST (telemetry, under_load)
 	std::thread thread1 (thread_func, nano::dev::genesis_key, latest_genesis, nano::dev::constants.genesis_amount - num_blocks);
 	std::thread thread2 (thread_func, key, latest_key, num_blocks);
 
-	ASSERT_TIMELY_EQ (200s, node1->ledger.cache.block_count, num_blocks * 2 + 3);
+	ASSERT_TIMELY_EQ (200s, node1->ledger.block_count (), num_blocks * 2 + 3);
 
 	thread1.join ();
 	thread2.join ();
@@ -1702,8 +1702,8 @@ TEST (node, mass_epoch_upgrader)
 				info.pending_hash = block->hash ();
 			}
 		}
-		ASSERT_EQ (1 + total_accounts, node.ledger.cache.block_count);
-		ASSERT_EQ (1, node.ledger.cache.account_count);
+		ASSERT_EQ (1 + total_accounts, node.ledger.block_count ());
+		ASSERT_EQ (1, node.ledger.account_count ());
 
 		// Receive for half of accounts
 		for (auto const & info : opened)
@@ -1723,32 +1723,32 @@ TEST (node, mass_epoch_upgrader)
 			ASSERT_NE (nullptr, block);
 			ASSERT_EQ (nano::block_status::progress, node.process (block));
 		}
-		ASSERT_EQ (1 + total_accounts + opened.size (), node.ledger.cache.block_count);
-		ASSERT_EQ (1 + opened.size (), node.ledger.cache.account_count);
+		ASSERT_EQ (1 + total_accounts + opened.size (), node.ledger.block_count ());
+		ASSERT_EQ (1 + opened.size (), node.ledger.account_count ());
 
 		nano::keypair epoch_signer (nano::dev::genesis_key);
 
-		auto const block_count_before = node.ledger.cache.block_count.load ();
+		auto const block_count_before = node.ledger.block_count ();
 		auto const total_to_upgrade = 1 + total_accounts;
 		std::cout << "Mass upgrading " << total_to_upgrade << " accounts" << std::endl;
-		while (node.ledger.cache.block_count != block_count_before + total_to_upgrade)
+		while (node.ledger.block_count () != block_count_before + total_to_upgrade)
 		{
-			auto const pre_upgrade = node.ledger.cache.block_count.load ();
+			auto const pre_upgrade = node.ledger.block_count ();
 			auto upgrade_count = std::min<size_t> (batch_size, block_count_before + total_to_upgrade - pre_upgrade);
 			ASSERT_FALSE (node.epoch_upgrader.start (epoch_signer.prv, nano::epoch::epoch_1, upgrade_count, threads));
 			// Already ongoing - should fail
 			ASSERT_TRUE (node.epoch_upgrader.start (epoch_signer.prv, nano::epoch::epoch_1, upgrade_count, threads));
 			system.deadline_set (60s);
-			while (node.ledger.cache.block_count != pre_upgrade + upgrade_count)
+			while (node.ledger.block_count () != pre_upgrade + upgrade_count)
 			{
 				ASSERT_NO_ERROR (system.poll ());
 				std::this_thread::sleep_for (200ms);
-				std::cout << node.ledger.cache.block_count - block_count_before << " / " << total_to_upgrade << std::endl;
+				std::cout << node.ledger.block_count () - block_count_before << " / " << total_to_upgrade << std::endl;
 			}
 			std::this_thread::sleep_for (50ms);
 		}
 		auto expected_blocks = block_count_before + total_accounts + 1;
-		ASSERT_EQ (expected_blocks, node.ledger.cache.block_count);
+		ASSERT_EQ (expected_blocks, node.ledger.block_count ());
 		// Check upgrade
 		{
 			auto transaction (node.store.tx_begin_read ());
@@ -1794,7 +1794,7 @@ TEST (node, mass_block_new)
 		{
 			node.process_active (block);
 		}
-		ASSERT_TIMELY_EQ (200s, node.ledger.cache.block_count, next_block_count);
+		ASSERT_TIMELY_EQ (200s, node.ledger.block_count (), next_block_count);
 		next_block_count += num_blocks;
 		while (node.block_processor.size () > 0)
 		{
@@ -1971,7 +1971,7 @@ TEST (node, aggressive_flooding)
 
 	ASSERT_TIMELY (!nano::slow_instrumentation () ? 10s : 40s, all_received ());
 
-	ASSERT_TIMELY_EQ (!nano::slow_instrumentation () ? 10s : 40s, node1.ledger.cache.block_count, 1 + 2 * nodes_wallets.size ());
+	ASSERT_TIMELY_EQ (!nano::slow_instrumentation () ? 10s : 40s, node1.ledger.block_count (), 1 + 2 * nodes_wallets.size ());
 
 	// Wait until the main node sees all representatives
 	ASSERT_TIMELY_EQ (!nano::slow_instrumentation () ? 10s : 40s, node1.rep_crawler.principal_representatives ().size (), nodes_wallets.size ());
@@ -2008,7 +2008,7 @@ TEST (node, aggressive_flooding)
 
 	// All blocks: genesis + (send+open) for each representative + 2 local blocks
 	// The main node only sees all blocks if other nodes are flooding their PR's open block to all other PRs
-	ASSERT_EQ (1 + 2 * nodes_wallets.size () + 2, node1.ledger.cache.block_count);
+	ASSERT_EQ (1 + 2 * nodes_wallets.size () + 2, node1.ledger.block_count ());
 }
 
 TEST (node, send_single_many_peers)
@@ -2166,7 +2166,7 @@ TEST (system, block_sequence)
 			std::string message;
 			for (auto i : system.nodes)
 			{
-				message += boost::str (boost::format ("N:%1% b:%2% c:%3% a:%4% s:%5% p:%6%\n") % std::to_string (i->network.port) % std::to_string (i->ledger.cache.block_count) % std::to_string (i->ledger.cache.cemented_count) % std::to_string (i->active.size ()) % std::to_string (i->scheduler.priority.size ()) % std::to_string (i->network.size ()));
+				message += boost::str (boost::format ("N:%1% b:%2% c:%3% a:%4% s:%5% p:%6%\n") % std::to_string (i->network.port) % std::to_string (i->ledger.block_count ()) % std::to_string (i->ledger.cemented_count ()) % std::to_string (i->active.size ()) % std::to_string (i->scheduler.priority.size ()) % std::to_string (i->network.size ()));
 				nano::lock_guard<nano::mutex> lock{ i->active.mutex };
 				for (auto const & j : i->active.roots)
 				{

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -610,7 +610,7 @@ void nano::test::system::generate_mass_activity (uint32_t count_a, nano::node & 
 		{
 			auto now (std::chrono::steady_clock::now ());
 			auto us (std::chrono::duration_cast<std::chrono::microseconds> (now - previous).count ());
-			auto count = node_a.ledger.cache.block_count.load ();
+			auto count = node_a.ledger.block_count ();
 			std::cerr << boost::str (boost::format ("Mass activity iteration %1% us %2% us/t %3% block count: %4%\n") % i % us % (us / 256) % count);
 			previous = now;
 		}


### PR DESCRIPTION
This is a cleanup PR for encapsulating the various ledger counts in ledger_cache which get new ledger accessors.