### PR TITLE
Removing unconfirmed_frontiers command line option.

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5530,41 +5530,6 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	ASSERT_EQ (rocksdb_store.final_vote.get (rocksdb_transaction, nano::root (send->previous ()))[0], nano::block_hash (2));
 }
 
-TEST (ledger, unconfirmed_frontiers)
-{
-	auto ctx = nano::test::context::ledger_empty ();
-	auto & ledger = ctx.ledger ();
-	auto & store = ctx.store ();
-	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
-
-	auto unconfirmed_frontiers = ledger.unconfirmed_frontiers ();
-	ASSERT_TRUE (unconfirmed_frontiers.empty ());
-
-	nano::state_block_builder builder;
-	nano::keypair key;
-	auto const latest = ledger.latest (store.tx_begin_read (), nano::dev::genesis_key.pub);
-	auto send = builder.make_block ()
-				.account (nano::dev::genesis_key.pub)
-				.previous (latest)
-				.representative (nano::dev::genesis_key.pub)
-				.balance (nano::dev::constants.genesis_amount - 100)
-				.link (key.pub)
-				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*pool.generate (latest))
-				.build ();
-
-	ASSERT_EQ (nano::block_status::progress, ledger.process (store.tx_begin_write (), send));
-
-	unconfirmed_frontiers = ledger.unconfirmed_frontiers ();
-	ASSERT_EQ (unconfirmed_frontiers.size (), 1);
-	ASSERT_EQ (unconfirmed_frontiers.begin ()->first, 1);
-	nano::uncemented_info uncemented_info1{ latest, send->hash (), nano::dev::genesis_key.pub };
-	auto uncemented_info2 = unconfirmed_frontiers.begin ()->second;
-	ASSERT_EQ (uncemented_info1.account, uncemented_info2.account);
-	ASSERT_EQ (uncemented_info1.cemented_frontier, uncemented_info2.cemented_frontier);
-	ASSERT_EQ (uncemented_info1.frontier, uncemented_info2.frontier);
-}
-
 TEST (ledger, is_send_genesis)
 {
 	auto ctx = nano::test::context::ledger_empty ();

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1993,20 +1993,6 @@ int main (int argc, char * const * argv)
 				output_account_version_number (i, unopened_account_version_totals[i]);
 			}
 		}
-		else if (vm.count ("debug_unconfirmed_frontiers"))
-		{
-			auto inactive_node = nano::default_inactive_node (data_path, vm);
-			auto node = inactive_node->node;
-
-			auto unconfirmed_frontiers = node->ledger.unconfirmed_frontiers ();
-			std::cout << "Account: Height delta | Frontier | Confirmed frontier\n";
-			for (auto const & [height_delta, unconfirmed_info] : unconfirmed_frontiers)
-			{
-				std::cout << (boost::format ("%1%: %2% %3% %4%\n") % unconfirmed_info.account.to_account () % height_delta % unconfirmed_info.frontier.to_string () % unconfirmed_info.cemented_frontier.to_string ()).str ();
-			}
-
-			std::cout << "\nNumber of unconfirmed frontiers: " << unconfirmed_frontiers.size () << std::endl;
-		}
 		else if (vm.count ("version"))
 		{
 			std::cout << "Version " << NANO_VERSION_STRING << "\n"

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -27,15 +27,6 @@ class pending_info;
 class pending_key;
 class stats;
 
-class uncemented_info
-{
-public:
-	uncemented_info (nano::block_hash const & cemented_frontier, nano::block_hash const & frontier, nano::account const & account);
-	nano::block_hash cemented_frontier;
-	nano::block_hash frontier;
-	nano::account account;
-};
-
 class ledger final
 {
 	friend class receivable_iterator;
@@ -90,7 +81,6 @@ public:
 	std::shared_ptr<nano::block> find_receive_block_by_send_hash (store::transaction const & transaction, nano::account const & destination, nano::block_hash const & send_block_hash);
 	nano::account const & epoch_signer (nano::link const &) const;
 	nano::link const & epoch_link (nano::epoch) const;
-	std::multimap<uint64_t, uncemented_info, std::greater<>> unconfirmed_frontiers () const;
 	bool migrate_lmdb_to_rocksdb (std::filesystem::path const &) const;
 	bool bootstrap_weight_reached () const;
 	static nano::epoch version (nano::block const & block);


### PR DESCRIPTION
When unconfirmed blocks are moved in to memory this information will not be queryable outside the node process.