### PR TITLE
Use ledger::confirm

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -480,7 +480,6 @@ TEST (block_store, frontier_retrieval)
 	nano::account account1{};
 	nano::account_info info1 (0, 0, 0, 0, 0, 0, nano::epoch::epoch_0);
 	auto transaction (store->tx_begin_write ());
-	store->confirmation_height.put (transaction, account1, { 0, nano::block_hash (0) });
 	store->account.put (transaction, account1, info1);
 	nano::account_info info2;
 	store->account.get (transaction, account1, info2);
@@ -604,10 +603,6 @@ TEST (block_store, latest_find)
 	nano::account account2 (3);
 	nano::block_hash hash2 (4);
 	auto transaction (store->tx_begin_write ());
-	store->confirmation_height.put (transaction, account1, { 0, nano::block_hash (0) });
-	store->account.put (transaction, account1, { hash1, account1, hash1, 100, 0, 300, nano::epoch::epoch_0 });
-	store->confirmation_height.put (transaction, account2, { 0, nano::block_hash (0) });
-	store->account.put (transaction, account2, { hash2, account2, hash2, 200, 0, 400, nano::epoch::epoch_0 });
 	auto first (store->account.begin (transaction));
 	auto second (store->account.begin (transaction));
 	++second;
@@ -768,7 +763,6 @@ TEST (block_store, latest_exists)
 	nano::account two (2);
 	nano::account_info info;
 	auto transaction (store->tx_begin_write ());
-	store->confirmation_height.put (transaction, two, { 0, nano::block_hash (0) });
 	store->account.put (transaction, two, info);
 	nano::account one (1);
 	ASSERT_FALSE (store->account.exists (transaction, one));
@@ -786,7 +780,6 @@ TEST (block_store, large_iteration)
 		nano::account account;
 		nano::random_pool::generate_block (account.bytes.data (), account.bytes.size ());
 		accounts1.insert (account);
-		store->confirmation_height.put (transaction, account, { 0, nano::block_hash (0) });
 		store->account.put (transaction, account, nano::account_info ());
 	}
 	std::unordered_set<nano::account> accounts2;
@@ -889,7 +882,6 @@ TEST (block_store, account_count)
 		auto transaction (store->tx_begin_write ());
 		ASSERT_EQ (0, store->account.count (transaction));
 		nano::account account (200);
-		store->confirmation_height.put (transaction, account, { 0, nano::block_hash (0) });
 		store->account.put (transaction, account, nano::account_info ());
 	}
 	auto transaction (store->tx_begin_read ());

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -4667,10 +4667,7 @@ TEST (ledger, dependents_confirmed)
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive1));
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive1));
-	nano::confirmation_height_info height;
-	ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, height));
-	height.height += 1;
-	ledger.store.confirmation_height.put (transaction, nano::dev::genesis_key.pub, height);
+	ledger.confirm (transaction, send1->hash ());
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *receive1));
 	auto receive2 = builder.state ()
 					.account (key1.pub)
@@ -4683,13 +4680,9 @@ TEST (ledger, dependents_confirmed)
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive2));
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive2));
-	ASSERT_TRUE (ledger.store.confirmation_height.get (transaction, key1.pub, height));
-	height.height += 1;
-	ledger.store.confirmation_height.put (transaction, key1.pub, height);
+	ledger.confirm (transaction, receive1->hash ());
 	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive2));
-	ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, height));
-	height.height += 1;
-	ledger.store.confirmation_height.put (transaction, nano::dev::genesis_key.pub, height);
+	ledger.confirm (transaction, send2->hash ());
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *receive2));
 }
 
@@ -4726,10 +4719,7 @@ TEST (ledger, dependents_confirmed_pruning)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
-	nano::confirmation_height_info height;
-	ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, height));
-	height.height = 3;
-	ledger.store.confirmation_height.put (transaction, nano::dev::genesis_key.pub, height);
+	ledger.confirm (transaction, send2->hash ());
 	ASSERT_TRUE (ledger.block_confirmed (transaction, send1->hash ()));
 	ASSERT_EQ (2, ledger.pruning_action (transaction, send2->hash (), 1));
 	auto receive1 = builder.state ()
@@ -4767,10 +4757,7 @@ TEST (ledger, block_confirmed)
 	ASSERT_FALSE (ledger.block_confirmed (transaction, send1->hash ()));
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send1));
 	ASSERT_FALSE (ledger.block_confirmed (transaction, send1->hash ()));
-	nano::confirmation_height_info height;
-	ASSERT_FALSE (ledger.store.confirmation_height.get (transaction, nano::dev::genesis_key.pub, height));
-	++height.height;
-	ledger.store.confirmation_height.put (transaction, nano::dev::genesis_key.pub, height);
+	ledger.confirm (transaction, send1->hash ());
 	ASSERT_TRUE (ledger.block_confirmed (transaction, send1->hash ()));
 }
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -843,7 +843,6 @@ TEST (rpc, frontier)
 			nano::block_hash hash;
 			nano::random_pool::generate_block (hash.bytes.data (), hash.bytes.size ());
 			source[key.pub] = hash;
-			node->store.confirmation_height.put (transaction, key.pub, { 0, nano::block_hash (0) });
 			node->store.account.put (transaction, key.pub, nano::account_info (hash, 0, 0, 0, 0, 0, nano::epoch::epoch_0));
 		}
 	}
@@ -881,7 +880,6 @@ TEST (rpc, frontier_limited)
 			nano::block_hash hash;
 			nano::random_pool::generate_block (hash.bytes.data (), hash.bytes.size ());
 			source[key.pub] = hash;
-			node->store.confirmation_height.put (transaction, key.pub, { 0, nano::block_hash (0) });
 			node->store.account.put (transaction, key.pub, nano::account_info (hash, 0, 0, 0, 0, 0, nano::epoch::epoch_0));
 		}
 	}
@@ -909,7 +907,6 @@ TEST (rpc, frontier_startpoint)
 			nano::block_hash hash;
 			nano::random_pool::generate_block (hash.bytes.data (), hash.bytes.size ());
 			source[key.pub] = hash;
-			node->store.confirmation_height.put (transaction, key.pub, { 0, nano::block_hash (0) });
 			node->store.account.put (transaction, key.pub, nano::account_info (hash, 0, 0, 0, 0, 0, nano::epoch::epoch_0));
 		}
 	}
@@ -3823,10 +3820,6 @@ TEST (rpc, account_info)
 				.build ();
 	ASSERT_EQ (nano::block_status::progress, node1->process (send));
 	auto time = nano::seconds_since_epoch ();
-	{
-		auto transaction = node1->store.tx_begin_write ();
-		node1->store.confirmation_height.put (transaction, nano::dev::genesis_key.pub, { 1, nano::dev::genesis->hash () });
-	}
 
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
 	{

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -234,7 +234,6 @@ TEST (store, load)
 				{
 					nano::account account;
 					nano::random_pool::generate_block (account.bytes.data (), account.bytes.size ());
-					system.nodes[0]->store.confirmation_height.put (transaction, account, { 0, nano::block_hash (0) });
 					system.nodes[0]->store.account.put (transaction, account, nano::account_info ());
 				}
 			}


### PR DESCRIPTION
Fix a number of tests that directly accessed the confirmation_height store and used ledger::confirm or removed the access if unused.