### PR TITLE
Fix pruning tests that did not confirm blocks before pruning.

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -652,6 +652,7 @@ TEST (bootstrap_processor, push_diamond_pruning)
 
 	{
 		auto transaction (node1->store.tx_begin_write ());
+		node1->ledger.confirm (transaction, open->hash ());
 		ASSERT_EQ (1, node1->ledger.pruning_action (transaction, send1->hash (), 2));
 		ASSERT_EQ (1, node1->ledger.pruning_action (transaction, open->hash (), 1));
 		ASSERT_TRUE (node1->ledger.block_exists (transaction, nano::dev::genesis->hash ()));

--- a/nano/core_test/ledger_confirm.cpp
+++ b/nano/core_test/ledger_confirm.cpp
@@ -845,6 +845,7 @@ TEST (ledger_confirm, pruned_source)
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send3));
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open2));
+	ledger.confirm (transaction, send2->hash ());
 	ASSERT_EQ (2, ledger.pruning_action (transaction, send2->hash (), 2));
 	ASSERT_FALSE (ledger.block_exists (transaction, send2->hash ()));
 	ASSERT_FALSE (ledger.block_confirmed (transaction, open2->hash ()));

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -581,6 +581,7 @@ TEST (history, pruned_source)
 		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive));
 		auto open = std::make_shared<nano::open_block> (send2->hash (), key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
 		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open));
+		ledger.confirm (transaction, send1->hash ());
 		ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 2));
 		next_pruning = send2->hash ();
 	}
@@ -593,6 +594,7 @@ TEST (history, pruned_source)
 	// Additional legacy test
 	{
 		auto transaction (store->tx_begin_write ());
+		ledger.confirm (transaction, next_pruning);
 		ASSERT_EQ (1, ledger.pruning_action (transaction, next_pruning, 2));
 	}
 	history1.refresh ();
@@ -608,7 +610,9 @@ TEST (history, pruned_source)
 		auto latest_key (ledger.latest (transaction, key.pub));
 		auto receive = std::make_shared<nano::state_block> (key.pub, latest_key, key.pub, 200, send->hash (), key.prv, key.pub, *system.work.generate (latest_key));
 		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive));
+		ledger.confirm (transaction, latest);
 		ASSERT_EQ (1, ledger.pruning_action (transaction, latest, 2));
+		ledger.confirm (transaction, latest_key);
 		ASSERT_EQ (1, ledger.pruning_action (transaction, latest_key, 2));
 	}
 	history1.refresh ();

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1346,6 +1346,7 @@ uint64_t nano::ledger::pruning_action (store::write_transaction & transaction_a,
 		auto block_l = block (transaction_a, hash);
 		if (block_l != nullptr)
 		{
+			release_assert (block_confirmed (transaction_a, hash));
 			store.block.del (transaction_a, hash);
 			store.pruned.put (transaction_a, hash);
 			hash = block_l->previous ();


### PR DESCRIPTION
Strongly ensure blocks are confirmed while pruning.

node::collect_ledger_pruning_targets already ensures blocks are confirmed before pruning however this was not the case in tests. Removed one test that only tested erroneous behavior.