### PR TITLE
RPC endpoint for election statistics

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2002,6 +2002,44 @@ void nano::json_handler::confirmation_active ()
 	response_errors ();
 }
 
+void nano::json_handler::election_statistics ()
+{
+	auto active_elections = node.active.list_active ();
+	unsigned normal_count = 0;
+	unsigned hinted_count = 0;
+	unsigned optimistic_count = 0;
+	unsigned total_count = 0;
+
+	for (auto const & election : active_elections)
+	{
+		total_count++;
+		switch (election->behavior ())
+		{
+			case election_behavior::normal:
+				normal_count++;
+				break;
+			case election_behavior::hinted:
+				hinted_count++;
+				break;
+			case election_behavior::optimistic:
+				optimistic_count++;
+				break;
+		}
+	}
+
+	auto utilization_percentage = (static_cast<double> (total_count * 100) / node.config.active_elections_size);
+	std::stringstream stream;
+	stream << std::fixed << std::setprecision (2) << utilization_percentage;
+
+	response_l.put ("normal", normal_count);
+	response_l.put ("hinted", hinted_count);
+	response_l.put ("optimistic", optimistic_count);
+	response_l.put ("total", total_count);
+	response_l.put ("aec_utilization_percentage", stream.str ());
+
+	response_errors ();
+}
+
 void nano::json_handler::confirmation_history ()
 {
 	boost::property_tree::ptree elections;
@@ -5327,6 +5365,7 @@ ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ()
 	no_arg_funcs.emplace ("delegators", &nano::json_handler::delegators);
 	no_arg_funcs.emplace ("delegators_count", &nano::json_handler::delegators_count);
 	no_arg_funcs.emplace ("deterministic_key", &nano::json_handler::deterministic_key);
+	no_arg_funcs.emplace ("election_statistics", &nano::json_handler::election_statistics);
 	no_arg_funcs.emplace ("epoch_upgrade", &nano::json_handler::epoch_upgrade);
 	no_arg_funcs.emplace ("frontiers", &nano::json_handler::frontiers);
 	no_arg_funcs.emplace ("frontier_count", &nano::json_handler::account_count);

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -46,6 +46,7 @@ public:
 	void accounts_pending ();
 	void accounts_receivable ();
 	void active_difficulty ();
+	void election_statistics ();
 	void available_supply ();
 	void block_info ();
 	void block_confirm ();

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6866,3 +6866,18 @@ TEST (rpc, confirmation_info)
 		ASSERT_EQ (0, response.get<unsigned> ("total_tally"));
 	}
 }
+
+TEST (rpc, election_statistics)
+{
+	nano::test::system system;
+	auto node1 = add_ipc_enabled_node (system);
+	auto const rpc_ctx = add_rpc (system, node1);
+	boost::property_tree::ptree request1;
+	request1.put ("action", "election_statistics");
+	auto response1 (wait_response (system, rpc_ctx, request1));
+	ASSERT_EQ ("0", response1.get<std::string> ("normal"));
+	ASSERT_EQ ("0", response1.get<std::string> ("hinted"));
+	ASSERT_EQ ("0", response1.get<std::string> ("optimistic"));
+	ASSERT_EQ ("0", response1.get<std::string> ("total"));
+	ASSERT_EQ ("0.00", response1.get<std::string> ("aec_utilization_percentage"));
+}


### PR DESCRIPTION
This pull request adds a new election_statistics RPC endpoint to help identify bottlenecks within the AEC.
The endpoint will respond with the number of active elections for each electiontype. It will also return the percentage of AEC slots in use.
If this is merged, I intend to expand the dataset with the average and max election age.

Request:
```
{
    "action": "election_statistics" 
}
```

Response example:
```
{
    "normal": "1595",
    "hinted": "70",
    "optimistic": "222",
    "total": "1887",
    "aec_utilization_percentage": "37.74"
}
```