### PR TITLE
Election age statistics

### DIFF
--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -118,6 +118,10 @@ public: // Interface
 	nano::vote_info get_last_vote (nano::account const & account);
 	void set_last_vote (nano::account const & account, nano::vote_info vote_info);
 	nano::election_status get_status () const;
+	std::chrono::steady_clock::time_point get_election_start () const
+	{
+		return election_start;
+	}
 
 private: // Dependencies
 	nano::node & node;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6888,6 +6888,7 @@ TEST (rpc, election_statistics)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	node1->process_active (send1);
+	ASSERT_TIMELY (5s, !node1->active.empty ());
 	ASSERT_TRUE (nano::test::start_elections (system, *node1, { send1 }));
 	ASSERT_EQ (1, node1->active.size ());
 


### PR DESCRIPTION
This PR adds information to the `election_statistics` RPC call about the maximum and average age of elections in AEC .
This will help identify long running elections.
I have also updated the unit test to create an election

Request:
```
{
  "action": "election_statistics"
}
```
Response example:
```
{
    "normal": "200",
    "hinted": "22",
    "optimistic": "425",
    "total": "647",
    "aec_utilization_percentage": "8.09",
    "max_election_age": "6",
    "average_election_age": "2.46"
}
```