### PR TITLE
Enable reporting TSAN errors

### DIFF
--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -15,8 +15,12 @@ jobs:
           - { name: UBSAN, ignore_errors: false }
           - { name: ASAN, ignore_errors: false, leak_check: false }
           - { name: ASAN_INT, ignore_errors: true, leak_check: false }
-          - { name: TSAN, ignore_errors: true }
+          - { name: TSAN, ignore_errors: false }
           - { name: LEAK, ignore_errors: true, leak_check: true }
+        exclude:
+          # Bug when running with TSAN: "ThreadSanitizer: CHECK failed: sanitizer_deadlock_detector"
+          - BACKEND: rocksdb
+            SANITIZER: { name: TSAN }
     runs-on: ubuntu-22.04
     env:
       COMPILER: ${{ matrix.COMPILER }}
@@ -72,7 +76,7 @@ jobs:
         SANITIZER:
           - { name: UBSAN, ignore_errors: false }
           - { name: ASAN, ignore_errors: false }
-          - { name: TSAN, ignore_errors: true }
+          - { name: TSAN, ignore_errors: false }
     runs-on: macos-14
     env:
       COMPILER: ${{ matrix.COMPILER }}


### PR DESCRIPTION
This is the last important sanitizer in our ci pipeline that is currently silently ignoring errors.