### PR TITLE
Creating nano::secure::transaction type

### DIFF
--- a/nano/core_test/backlog.cpp
+++ b/nano/core_test/backlog.cpp
@@ -21,7 +21,7 @@ TEST (backlog, population)
 	nano::test::system system{};
 	auto & node = *system.add_node ();
 
-	node.backlog.activate_callback.add ([&] (nano::store::transaction const & transaction, nano::account const & account, nano::account_info const & account_info, nano::confirmation_height_info const & conf_info) {
+	node.backlog.activate_callback.add ([&] (nano::secure::transaction const & transaction, nano::account const & account, nano::account_info const & account_info, nano::confirmation_height_info const & conf_info) {
 		nano::lock_guard<nano::mutex> lock{ mutex };
 
 		activated.insert (account);

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1000,7 +1000,7 @@ TEST (mdb_block_store, sideband_height)
 	nano::stats stats;
 	nano::ledger ledger (store, stats, nano::dev::constants);
 	nano::block_builder builder;
-	auto transaction (store.tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store.initialize (transaction, ledger.cache, nano::dev::constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto send = builder

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -651,7 +651,7 @@ TEST (bootstrap_processor, push_diamond_pruning)
 	ASSERT_EQ (nano::block_status::progress, node1->process (receive));
 
 	{
-		auto transaction (node1->store.tx_begin_write ());
+		auto transaction = node1->ledger.tx_begin_write ();
 		node1->ledger.confirm (transaction, open->hash ());
 		ASSERT_EQ (1, node1->ledger.pruning_action (transaction, send1->hash (), 2));
 		ASSERT_EQ (1, node1->ledger.pruning_action (transaction, open->hash (), 1));

--- a/nano/core_test/bootstrap_ascending.cpp
+++ b/nano/core_test/bootstrap_ascending.cpp
@@ -252,7 +252,7 @@ TEST (bootstrap_ascending, trace_base)
 	//	std::cerr << "--------------- Start ---------------\n";
 	ASSERT_EQ (nano::block_status::progress, node0.process (send1));
 	ASSERT_EQ (nano::block_status::progress, node0.process (receive1));
-	ASSERT_EQ (node1.ledger.receivable_end (), node1.ledger.receivable_upper_bound (node1.store.tx_begin_read (), key.pub, 0));
+	ASSERT_EQ (node1.ledger.receivable_end (), node1.ledger.receivable_upper_bound (node1.ledger.tx_begin_read (), key.pub, 0));
 	//	std::cerr << "node0: " << node0.network.endpoint () << std::endl;
 	//	std::cerr << "node1: " << node1.network.endpoint () << std::endl;
 	ASSERT_TIMELY (10s, node1.block (receive1->hash ()) != nullptr);

--- a/nano/core_test/confirming_set.cpp
+++ b/nano/core_test/confirming_set.cpp
@@ -94,7 +94,7 @@ TEST (confirmation_callback, observer_callbacks)
 				 .build ();
 
 	{
-		auto transaction = node->store.tx_begin_write ();
+		auto transaction = node->ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send));
 		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send1));
 	}
@@ -133,7 +133,7 @@ TEST (confirmation_callback, confirmed_history)
 				.work (*system.work.generate (latest))
 				.build ();
 	{
-		auto transaction = node->store.tx_begin_write ();
+		auto transaction = node->ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send));
 	}
 
@@ -159,7 +159,7 @@ TEST (confirmation_callback, confirmed_history)
 		ASSERT_EQ (0, node->active.recently_cemented.list ().size ());
 		ASSERT_TRUE (node->active.empty ());
 
-		auto transaction = node->store.tx_begin_read ();
+		auto transaction = node->ledger.tx_begin_read ();
 		ASSERT_FALSE (node->ledger.block_confirmed (transaction, send->hash ()));
 
 		ASSERT_TIMELY (10s, node->store.write_queue.contains (nano::store::writer::confirmation_height));
@@ -170,7 +170,7 @@ TEST (confirmation_callback, confirmed_history)
 
 	ASSERT_TIMELY (10s, !node->store.write_queue.contains (nano::store::writer::confirmation_height));
 
-	auto transaction = node->store.tx_begin_read ();
+	auto transaction = node->ledger.tx_begin_read ();
 	ASSERT_TRUE (node->ledger.block_confirmed (transaction, send->hash ()));
 
 	ASSERT_TIMELY_EQ (10s, node->active.size (), 0);
@@ -226,7 +226,7 @@ TEST (confirmation_callback, dependent_election)
 				 .work (*system.work.generate (send1->hash ()))
 				 .build ();
 	{
-		auto transaction = node->store.tx_begin_write ();
+		auto transaction = node->ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send));
 		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send1));
 		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send2));

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -31,7 +31,7 @@ TEST (conflicts, start_stop)
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::block_status::progress, node1.process (send1));
 	ASSERT_EQ (0, node1.active.size ());
-	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.ledger.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_EQ (1, node1.active.size ());
@@ -64,7 +64,7 @@ TEST (conflicts, add_existing)
 	ASSERT_TIMELY (5s, node1.block (send1->hash ()));
 
 	// instruct the election scheduler to trigger an election for send1
-	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.ledger.tx_begin_read ());
 
 	// wait for election to be started before processing send2
 	ASSERT_TIMELY (5s, node1.active.active (*send1));

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -151,7 +151,7 @@ TEST (election, quorum_minimum_confirm_success)
 				 .build ();
 	node1.work_generate_blocking (*send1);
 	node1.process_active (send1);
-	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.ledger.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election = node1.active.election (send1->qualified_root ());
 	ASSERT_NE (nullptr, election);

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -31,8 +31,8 @@ TEST (election_scheduler, activate_one_timely)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	system.nodes[0]->ledger.process (system.nodes[0]->store.tx_begin_write (), send1);
-	system.nodes[0]->scheduler.priority.activate (nano::dev::genesis_key.pub, system.nodes[0]->store.tx_begin_read ());
+	system.nodes[0]->ledger.process (system.nodes[0]->ledger.tx_begin_write (), send1);
+	system.nodes[0]->scheduler.priority.activate (nano::dev::genesis_key.pub, system.nodes[0]->ledger.tx_begin_read ());
 	ASSERT_TIMELY (5s, system.nodes[0]->active.election (send1->qualified_root ()));
 }
 
@@ -49,8 +49,8 @@ TEST (election_scheduler, activate_one_flush)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	system.nodes[0]->ledger.process (system.nodes[0]->store.tx_begin_write (), send1);
-	system.nodes[0]->scheduler.priority.activate (nano::dev::genesis_key.pub, system.nodes[0]->store.tx_begin_read ());
+	system.nodes[0]->ledger.process (system.nodes[0]->ledger.tx_begin_write (), send1);
+	system.nodes[0]->scheduler.priority.activate (nano::dev::genesis_key.pub, system.nodes[0]->ledger.tx_begin_read ());
 	ASSERT_TIMELY (5s, system.nodes[0]->active.election (send1->qualified_root ()));
 }
 
@@ -119,7 +119,7 @@ TEST (election_scheduler, no_vacancy)
 	ASSERT_EQ (nano::block_status::progress, node.process (block1));
 
 	// There is vacancy so it should be inserted
-	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.store.tx_begin_read ());
+	node.scheduler.priority.activate (nano::dev::genesis_key.pub, node.ledger.tx_begin_read ());
 	std::shared_ptr<nano::election> election{};
 	ASSERT_TIMELY (5s, (election = node.active.election (block1->qualified_root ())) != nullptr);
 
@@ -135,7 +135,7 @@ TEST (election_scheduler, no_vacancy)
 	ASSERT_EQ (nano::block_status::progress, node.process (block2));
 
 	// There is no vacancy so it should stay queued
-	node.scheduler.priority.activate (key.pub, node.store.tx_begin_read ());
+	node.scheduler.priority.activate (key.pub, node.ledger.tx_begin_read ());
 	ASSERT_TIMELY_EQ (5s, node.scheduler.priority.size (), 1);
 	ASSERT_EQ (node.active.election (block2->qualified_root ()), nullptr);
 

--- a/nano/core_test/frontiers_confirmation.cpp
+++ b/nano/core_test/frontiers_confirmation.cpp
@@ -30,7 +30,7 @@ TEST (frontiers_confirmation, mode)
 					.work (*node->work_generate_blocking (nano::dev::genesis->hash ()))
 					.build ();
 		{
-			auto transaction = node->store.tx_begin_write ();
+			auto transaction = node->ledger.tx_begin_write ();
 			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send));
 		}
 		ASSERT_TIMELY_EQ (5s, node->active.size (), 1);
@@ -52,7 +52,7 @@ TEST (frontiers_confirmation, mode)
 					.work (*node->work_generate_blocking (nano::dev::genesis->hash ()))
 					.build ();
 		{
-			auto transaction = node->store.tx_begin_write ();
+			auto transaction = node->ledger.tx_begin_write ();
 			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send));
 		}
 		ASSERT_TIMELY_EQ (5s, node->active.size (), 1);
@@ -74,7 +74,7 @@ TEST (frontiers_confirmation, mode)
 					.work (*node->work_generate_blocking (nano::dev::genesis->hash ()))
 					.build ();
 		{
-			auto transaction = node->store.tx_begin_write ();
+			auto transaction = node->ledger.tx_begin_write ();
 			ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send));
 		}
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -39,7 +39,7 @@ TEST (ledger, empty)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_read ();
+	auto transaction = ledger.tx_begin_read ();
 	nano::account account;
 	auto balance (ledger.account_balance (transaction, account));
 	ASSERT_TRUE (balance.is_zero ());
@@ -51,7 +51,7 @@ TEST (ledger, genesis_balance)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto balance = ledger.account_balance (transaction, nano::dev::genesis_key.pub);
 	ASSERT_EQ (nano::dev::constants.genesis_amount, balance);
 	auto info = ledger.account_info (transaction, nano::dev::genesis_key.pub);
@@ -84,8 +84,8 @@ TEST (ledger, process_modifies_sideband)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, ledger.process (store.tx_begin_write (), send1));
-	ASSERT_EQ (send1->sideband ().timestamp, ledger.block (store.tx_begin_read (), send1->hash ())->sideband ().timestamp);
+	ASSERT_EQ (nano::block_status::progress, ledger.process (ledger.tx_begin_write (), send1));
+	ASSERT_EQ (send1->sideband ().timestamp, ledger.block (ledger.tx_begin_read (), send1->hash ())->sideband ().timestamp);
 }
 
 // Create a send block and publish it.
@@ -94,7 +94,7 @@ TEST (ledger, process_send)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
@@ -197,7 +197,7 @@ TEST (ledger, process_receive)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
@@ -280,7 +280,7 @@ TEST (ledger, rollback_receiver)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
@@ -329,7 +329,7 @@ TEST (ledger, rollback_representation)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key5;
 	nano::block_builder builder;
@@ -419,7 +419,7 @@ TEST (ledger, receive_rollback)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send = builder
@@ -447,7 +447,7 @@ TEST (ledger, process_duplicate)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
@@ -481,7 +481,7 @@ TEST (ledger, representative_genesis)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto latest = ledger.latest (transaction, nano::dev::genesis_key.pub);
 	ASSERT_FALSE (latest.is_zero ());
 	ASSERT_EQ (nano::dev::genesis->hash (), ledger.representative (transaction, latest));
@@ -499,7 +499,7 @@ TEST (ledger, representative_change)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	nano::keypair key2;
 	auto & pool = ctx.pool ();
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
@@ -538,7 +538,7 @@ TEST (ledger, send_fork)
 	auto & store = ctx.store ();
 	nano::keypair key2;
 	nano::keypair key3;
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
@@ -570,7 +570,7 @@ TEST (ledger, receive_fork)
 	auto & store = ctx.store ();
 	nano::keypair key2;
 	nano::keypair key3;
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
@@ -627,7 +627,7 @@ TEST (ledger, open_fork)
 	auto & store = ctx.store ();
 	nano::keypair key2;
 	nano::keypair key3;
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
@@ -727,7 +727,7 @@ TEST (ledger, representation)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto & rep_weights = ledger.cache.rep_weights;
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	ASSERT_EQ (nano::dev::constants.genesis_amount, rep_weights.representation_get (nano::dev::genesis_key.pub));
 	nano::keypair key2;
@@ -860,7 +860,7 @@ TEST (ledger, double_open)
 	ASSERT_TRUE (!store->init_error ());
 	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key2;
@@ -899,7 +899,7 @@ TEST (ledger, double_receive)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key2;
 	nano::block_builder builder;
@@ -949,10 +949,10 @@ TEST (votes, check_signature)
 				 .build ();
 	node1.work_generate_blocking (*send1);
 	{
-		auto transaction (node1.store.tx_begin_write ());
+		auto transaction = node1.ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, send1));
 	}
-	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.ledger.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_EQ (1, election1->votes ().size ());
@@ -979,7 +979,7 @@ TEST (votes, add_one)
 				 .work (0)
 				 .build ();
 	node1.work_generate_blocking (*send1);
-	auto transaction (node1.store.tx_begin_write ());
+	auto transaction = node1.ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, send1));
 	node1.start_election (send1);
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
@@ -1022,8 +1022,8 @@ TEST (votes, add_existing)
 										 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 										 .build ();
 	node1.work_generate_blocking (*send1);
-	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (node1.store.tx_begin_write (), send1));
-	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (node1.ledger.tx_begin_write (), send1));
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.ledger.tx_begin_read ());
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	auto vote1 = nano::test::make_vote (nano::dev::genesis_key, { send1 }, nano::vote::timestamp_min * 1, 0);
@@ -1080,7 +1080,7 @@ TEST (votes, add_old)
 				 .work (0)
 				 .build ();
 	node1.work_generate_blocking (*send1);
-	auto transaction (node1.store.tx_begin_write ());
+	auto transaction = node1.ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, send1));
 	node1.start_election (send1);
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
@@ -1185,7 +1185,7 @@ TEST (votes, add_cooldown)
 				 .work (0)
 				 .build ();
 	node1.work_generate_blocking (*send1);
-	auto transaction (node1.store.tx_begin_write ());
+	auto transaction = node1.ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, send1));
 	node1.start_election (send1);
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
@@ -1228,7 +1228,7 @@ TEST (ledger, successor)
 				 .work (0)
 				 .build ();
 	node1.work_generate_blocking (*send1);
-	auto transaction (node1.store.tx_begin_write ());
+	auto transaction = node1.ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, send1));
 	ASSERT_EQ (*send1, *node1.ledger.block (transaction, node1.ledger.successor (transaction, nano::qualified_root (nano::root (0), nano::dev::genesis->hash ())).value ()));
 	ASSERT_EQ (*nano::dev::genesis, *node1.ledger.block (transaction, node1.ledger.successor (transaction, nano::dev::genesis->qualified_root ()).value ()));
@@ -1240,7 +1240,7 @@ TEST (ledger, fail_change_old)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1262,7 +1262,7 @@ TEST (ledger, fail_change_gap_previous)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1282,7 +1282,7 @@ TEST (ledger, fail_state_bad_signature)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto block = builder
@@ -1304,7 +1304,7 @@ TEST (ledger, fail_epoch_bad_signature)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto block = builder
@@ -1330,7 +1330,7 @@ TEST (ledger, fail_change_bad_signature)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1350,7 +1350,7 @@ TEST (ledger, fail_change_fork)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1380,7 +1380,7 @@ TEST (ledger, fail_send_old)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1403,7 +1403,7 @@ TEST (ledger, fail_send_gap_previous)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1424,7 +1424,7 @@ TEST (ledger, fail_send_bad_signature)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1445,7 +1445,7 @@ TEST (ledger, fail_send_negative_spend)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1475,7 +1475,7 @@ TEST (ledger, fail_send_fork)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1505,7 +1505,7 @@ TEST (ledger, fail_open_old)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1535,7 +1535,7 @@ TEST (ledger, fail_open_gap_source)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1556,7 +1556,7 @@ TEST (ledger, fail_open_bad_signature)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1586,7 +1586,7 @@ TEST (ledger, fail_open_fork_previous)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1634,7 +1634,7 @@ TEST (ledger, fail_open_account_mismatch)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1665,7 +1665,7 @@ TEST (ledger, fail_receive_old)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1712,7 +1712,7 @@ TEST (ledger, fail_receive_gap_source)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1762,7 +1762,7 @@ TEST (ledger, fail_receive_overreceive)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1802,7 +1802,7 @@ TEST (ledger, fail_receive_bad_signature)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1852,7 +1852,7 @@ TEST (ledger, fail_receive_gap_previous_opened)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1902,7 +1902,7 @@ TEST (ledger, fail_receive_gap_previous_unopened)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -1942,7 +1942,7 @@ TEST (ledger, fail_receive_fork_previous)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -2003,7 +2003,7 @@ TEST (ledger, fail_receive_received_source)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	nano::block_builder builder;
@@ -2084,7 +2084,7 @@ TEST (ledger, latest_empty)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	nano::keypair key;
-	auto transaction = store.tx_begin_read ();
+	auto transaction = ledger.tx_begin_read ();
 	auto latest = ledger.latest (transaction, key.pub);
 	ASSERT_TRUE (latest.is_zero ());
 }
@@ -2094,7 +2094,7 @@ TEST (ledger, latest_root)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key;
 	ASSERT_EQ (key.pub, ledger.latest_root (transaction, key.pub).as_account ());
@@ -2118,7 +2118,7 @@ TEST (ledger, change_representative_move_representation)
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	nano::keypair key1;
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 	nano::block_builder builder;
@@ -2159,7 +2159,7 @@ TEST (ledger, send_open_receive_rollback)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
@@ -2251,7 +2251,7 @@ TEST (ledger, bootstrap_rep_weight)
 	nano::keypair key2;
 	auto & pool = ctx.pool ();
 	{
-		auto transaction = store.tx_begin_write ();
+		auto transaction = ledger.tx_begin_write ();
 		auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 		ASSERT_TRUE (info1);
 		nano::block_builder builder;
@@ -2272,7 +2272,7 @@ TEST (ledger, bootstrap_rep_weight)
 		ASSERT_EQ (1000, ledger.weight (key2.pub));
 	}
 	{
-		auto transaction = store.tx_begin_write ();
+		auto transaction = ledger.tx_begin_write ();
 		auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 		ASSERT_TRUE (info1);
 		nano::block_builder builder;
@@ -2295,7 +2295,7 @@ TEST (ledger, block_destination_source)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair dest;
 	nano::uint128_t balance (nano::dev::constants.genesis_amount);
@@ -2385,7 +2385,7 @@ TEST (ledger, state_account)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2407,7 +2407,7 @@ TEST (ledger, state_send_receive)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2464,7 +2464,7 @@ TEST (ledger, state_receive)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2512,7 +2512,7 @@ TEST (ledger, state_rep_change)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair rep;
 	nano::block_builder builder;
@@ -2546,7 +2546,7 @@ TEST (ledger, state_open)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -2601,7 +2601,7 @@ TEST (ledger, send_after_state_fail)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2632,7 +2632,7 @@ TEST (ledger, receive_after_state_fail)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2662,7 +2662,7 @@ TEST (ledger, change_after_state_fail)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2692,7 +2692,7 @@ TEST (ledger, state_unreceivable_fail)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2729,7 +2729,7 @@ TEST (ledger, state_receive_bad_amount_fail)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2766,7 +2766,7 @@ TEST (ledger, state_no_link_amount_fail)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2799,7 +2799,7 @@ TEST (ledger, state_receive_wrong_account_fail)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -2839,7 +2839,7 @@ TEST (ledger, state_open_state_fork)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -2882,7 +2882,7 @@ TEST (ledger, state_state_open_fork)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -2926,7 +2926,7 @@ TEST (ledger, state_open_previous_fail)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -2959,7 +2959,7 @@ TEST (ledger, state_open_source_fail)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -2992,7 +2992,7 @@ TEST (ledger, state_send_change)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair rep;
 	nano::block_builder builder;
@@ -3026,7 +3026,7 @@ TEST (ledger, state_receive_change)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -3078,7 +3078,7 @@ TEST (ledger, state_open_old)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -3112,7 +3112,7 @@ TEST (ledger, state_receive_old)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -3165,7 +3165,7 @@ TEST (ledger, state_rollback_send)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -3203,7 +3203,7 @@ TEST (ledger, state_rollback_receive)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -3245,7 +3245,7 @@ TEST (ledger, state_rollback_received_send)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair key;
 	nano::block_builder builder;
@@ -3288,7 +3288,7 @@ TEST (ledger, state_rep_change_rollback)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair rep;
 	nano::block_builder builder;
@@ -3315,7 +3315,7 @@ TEST (ledger, state_open_rollback)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -3357,7 +3357,7 @@ TEST (ledger, state_send_change_rollback)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair rep;
 	nano::block_builder builder;
@@ -3385,7 +3385,7 @@ TEST (ledger, state_receive_change_rollback)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::block_builder builder;
 	auto send1 = builder
@@ -3424,7 +3424,7 @@ TEST (ledger, epoch_blocks_v1_general)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -3567,7 +3567,7 @@ TEST (ledger, epoch_blocks_v2_general)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -3732,7 +3732,7 @@ TEST (ledger, epoch_blocks_receive_upgrade)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -3940,7 +3940,7 @@ TEST (ledger, epoch_blocks_fork)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	nano::keypair destination;
 	nano::block_builder builder;
@@ -4055,7 +4055,7 @@ TEST (ledger, successor_epoch)
 					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					  .work (*pool.generate (open->hash ()))
 					  .build ();
-	auto transaction (node1.store.tx_begin_write ());
+	auto transaction = node1.ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, send1));
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, open));
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, change));
@@ -4083,7 +4083,7 @@ TEST (ledger, epoch_open_pending)
 					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					  .work (*pool.generate (key1.pub))
 					  .build ();
-	auto process_result = node1.ledger.process (node1.store.tx_begin_write (), epoch_open);
+	auto process_result = node1.ledger.process (node1.ledger.tx_begin_write (), epoch_open);
 	ASSERT_EQ (nano::block_status::gap_epoch_open_pending, process_result);
 	node1.block_processor.add (epoch_open);
 	// Waits for the block to get saved in the database
@@ -4245,11 +4245,11 @@ TEST (ledger, unchecked_epoch)
 	}
 	node1.block_processor.add (send1);
 	node1.block_processor.add (open1);
-	ASSERT_TIMELY (5s, node1.ledger.block_exists (node1.store.tx_begin_read (), epoch1->hash ()));
+	ASSERT_TIMELY (5s, node1.ledger.block_exists (node1.ledger.tx_begin_read (), epoch1->hash ()));
 	{
 		// Waits for the last blocks to pass through block_processor and unchecked.put queues
 		ASSERT_TIMELY_EQ (10s, 0, node1.unchecked.count ());
-		auto info = node1.ledger.account_info (node1.store.tx_begin_read (), destination.pub);
+		auto info = node1.ledger.account_info (node1.ledger.tx_begin_read (), destination.pub);
 		ASSERT_TRUE (info);
 		ASSERT_EQ (info->epoch (), nano::epoch::epoch_1);
 	}
@@ -4320,9 +4320,9 @@ TEST (ledger, unchecked_epoch_invalid)
 	node1.block_processor.add (send1);
 	node1.block_processor.add (open1);
 	// Waits for the last blocks to pass through block_processor and unchecked.put queues
-	ASSERT_TIMELY (10s, node1.ledger.block_exists (node1.store.tx_begin_read (), epoch2->hash ()));
+	ASSERT_TIMELY (10s, node1.ledger.block_exists (node1.ledger.tx_begin_read (), epoch2->hash ()));
 	{
-		auto transaction = node1.store.tx_begin_read ();
+		auto transaction = node1.ledger.tx_begin_read ();
 		ASSERT_FALSE (node1.ledger.block_exists (transaction, epoch1->hash ()));
 		auto unchecked_count = node1.unchecked.count ();
 		ASSERT_EQ (unchecked_count, 0);
@@ -4387,7 +4387,7 @@ TEST (ledger, unchecked_open)
 	}
 	node1.block_processor.add (send1);
 	// Waits for the send1 block to pass through block_processor and unchecked.put queues
-	ASSERT_TIMELY (5s, node1.ledger.block_exists (node1.store.tx_begin_read (), open1->hash ()));
+	ASSERT_TIMELY (5s, node1.ledger.block_exists (node1.ledger.tx_begin_read (), open1->hash ()));
 	ASSERT_EQ (0, node1.unchecked.count ());
 }
 
@@ -4458,7 +4458,7 @@ TEST (ledger, unchecked_receive)
 		ASSERT_EQ (blocks.size (), 1);
 	}
 	node1.block_processor.add (send2);
-	ASSERT_TIMELY (10s, node1.ledger.block_exists (node1.store.tx_begin_read (), receive1->hash ()));
+	ASSERT_TIMELY (10s, node1.ledger.block_exists (node1.ledger.tx_begin_read (), receive1->hash ()));
 	ASSERT_EQ (0, node1.unchecked.count ());
 }
 
@@ -4467,7 +4467,7 @@ TEST (ledger, confirmation_height_not_updated)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	auto & pool = ctx.pool ();
 	auto account_info = ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (account_info);
@@ -4517,7 +4517,7 @@ TEST (ledger, zero_rep)
 				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				  .work (*system.work.generate (nano::dev::genesis->hash ()))
 				  .build ();
-	auto transaction (node1.store.tx_begin_write ());
+	auto transaction = node1.ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, block1));
 	ASSERT_EQ (0, node1.ledger.cache.rep_weights.representation_get (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, node1.ledger.cache.rep_weights.representation_get (0));
@@ -4553,9 +4553,9 @@ TEST (ledger, work_validation)
 		{
 			block_a->block_work_set (block_a->block_work () + 1);
 		}
-		EXPECT_EQ (nano::block_status::insufficient_work, ledger.process (store.tx_begin_write (), block_a));
+		EXPECT_EQ (nano::block_status::insufficient_work, ledger.process (ledger.tx_begin_write (), block_a));
 		block_a->block_work_set (*pool.generate (block_a->root (), threshold));
-		EXPECT_EQ (nano::block_status::progress, ledger.process (store.tx_begin_write (), block_a));
+		EXPECT_EQ (nano::block_status::progress, ledger.process (ledger.tx_begin_write (), block_a));
 	};
 
 	std::error_code ec;
@@ -4629,7 +4629,7 @@ TEST (ledger, dependents_confirmed)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	nano::block_builder builder;
 	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *nano::dev::genesis));
 	auto & pool = ctx.pool ();
@@ -4694,7 +4694,7 @@ TEST (ledger, dependents_confirmed_pruning)
 	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::block_builder builder;
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -4739,7 +4739,7 @@ TEST (ledger, block_confirmed)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto transaction = store.tx_begin_write ();
+	auto transaction = ledger.tx_begin_write ();
 	nano::block_builder builder;
 	ASSERT_TRUE (ledger.block_confirmed (transaction, nano::dev::genesis->hash ()));
 	auto & pool = ctx.pool ();
@@ -4790,7 +4790,7 @@ TEST (ledger, cache)
 		};
 
 		nano::keypair key;
-		auto const latest = ledger.latest (store.tx_begin_read (), nano::dev::genesis_key.pub);
+		auto const latest = ledger.latest (ledger.tx_begin_read (), nano::dev::genesis_key.pub);
 		auto send = builder.state ()
 					.account (nano::dev::genesis_key.pub)
 					.previous (latest)
@@ -4810,7 +4810,7 @@ TEST (ledger, cache)
 					.work (*pool.generate (key.pub))
 					.build ();
 		{
-			auto transaction (store.tx_begin_write ());
+			auto transaction = ledger.tx_begin_write ();
 			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send));
 		}
 
@@ -4820,7 +4820,7 @@ TEST (ledger, cache)
 		cache_check (nano::ledger (store, stats, nano::dev::constants));
 
 		{
-			auto transaction (store.tx_begin_write ());
+			auto transaction = ledger.tx_begin_write ();
 			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open));
 		}
 
@@ -4830,7 +4830,7 @@ TEST (ledger, cache)
 		cache_check (nano::ledger (store, stats, nano::dev::constants));
 
 		{
-			auto transaction (store.tx_begin_write ());
+			auto transaction = ledger.tx_begin_write ();
 			ledger.confirm (transaction, send->hash ());
 			ASSERT_TRUE (ledger.block_confirmed (transaction, send->hash ()));
 		}
@@ -4840,7 +4840,7 @@ TEST (ledger, cache)
 		cache_check (nano::ledger (store, stats, nano::dev::constants));
 
 		{
-			auto transaction (store.tx_begin_write ());
+			auto transaction = ledger.tx_begin_write ();
 			ledger.confirm (transaction, open->hash ());
 			ASSERT_TRUE (ledger.block_confirmed (transaction, open->hash ()));
 		}
@@ -4850,7 +4850,7 @@ TEST (ledger, cache)
 		cache_check (nano::ledger (store, stats, nano::dev::constants));
 
 		{
-			auto transaction (store.tx_begin_write ());
+			auto transaction = ledger.tx_begin_write ();
 			ledger.pruning_action (transaction, open->hash (), 1);
 		}
 		++pruned_count;
@@ -4867,7 +4867,7 @@ TEST (ledger, pruning_action)
 	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -4953,7 +4953,7 @@ TEST (ledger, pruning_large_chain)
 	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	size_t send_receive_pairs (20);
@@ -5009,7 +5009,7 @@ TEST (ledger, pruning_source_rollback)
 	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5098,7 +5098,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5213,7 +5213,7 @@ TEST (ledger, pruning_legacy_blocks)
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::keypair key1;
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5299,7 +5299,7 @@ TEST (ledger, pruning_safe_functions)
 	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5351,7 +5351,7 @@ TEST (ledger, hash_root_random)
 	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5431,7 +5431,7 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	auto version = nano::store::component::version_current;
 
 	{
-		auto transaction = store.tx_begin_write ();
+		auto transaction = ledger.tx_begin_write ();
 		store.initialize (transaction, ledger.cache, ledger.constants);
 		ASSERT_FALSE (store.init_error ());
 
@@ -5512,7 +5512,7 @@ TEST (ledger, head_block)
 	auto ctx = nano::test::context::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
-	auto tx = store.tx_begin_read ();
+	auto tx = ledger.tx_begin_read ();
 	ASSERT_EQ (*nano::dev::genesis, *ledger.head_block (tx, nano::dev::genesis_key.pub));
 }
 
@@ -5520,7 +5520,7 @@ TEST (ledger, head_block)
 TEST (ledger_receivable, upper_bound_account_none)
 {
 	auto ctx = nano::test::context::ledger_empty ();
-	ASSERT_EQ (ctx.ledger ().receivable_end (), ctx.ledger ().receivable_upper_bound (ctx.store ().tx_begin_read (), 0));
+	ASSERT_EQ (ctx.ledger ().receivable_end (), ctx.ledger ().receivable_upper_bound (ctx.ledger ().tx_begin_read (), 0));
 }
 
 // Test behavior of ledger::receivable_upper_bound when there are receivable entries for multiple accounts
@@ -5539,7 +5539,7 @@ TEST (ledger_receivable, upper_bound_account_key)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*ctx.pool ().generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.store ().tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.ledger ().tx_begin_write (), send1));
 	auto send2 = builder
 				 .state ()
 				 .account (nano::dev::genesis_key.pub)
@@ -5550,8 +5550,8 @@ TEST (ledger_receivable, upper_bound_account_key)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*ctx.pool ().generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.store ().tx_begin_write (), send2));
-	auto tx = ctx.store ().tx_begin_read ();
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.ledger ().tx_begin_write (), send2));
+	auto tx = ctx.ledger ().tx_begin_read ();
 	auto & ledger = ctx.ledger ();
 	auto next1 = ledger.receivable_upper_bound (tx, nano::dev::genesis_key.pub);
 	auto next2 = ledger.receivable_upper_bound (tx, key.pub);
@@ -5587,7 +5587,7 @@ TEST (ledger_receivable, key_two)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*ctx.pool ().generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.store ().tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.ledger ().tx_begin_write (), send1));
 	auto send2 = builder
 				 .state ()
 				 .account (nano::dev::genesis_key.pub)
@@ -5598,8 +5598,8 @@ TEST (ledger_receivable, key_two)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*ctx.pool ().generate (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.store ().tx_begin_write (), send2));
-	auto tx = ctx.store ().tx_begin_read ();
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.ledger ().tx_begin_write (), send2));
+	auto tx = ctx.ledger ().tx_begin_read ();
 	auto & ledger = ctx.ledger ();
 	auto next1 = ledger.receivable_upper_bound (tx, key.pub, 0);
 	ASSERT_TRUE (next1 != ledger.receivable_end () && next1->first.account == key.pub);
@@ -5614,7 +5614,7 @@ TEST (ledger_receivable, key_two)
 TEST (ledger_receivable, any_none)
 {
 	auto ctx = nano::test::context::ledger_empty ();
-	ASSERT_FALSE (ctx.ledger ().receivable_any (ctx.store ().tx_begin_read (), nano::dev::genesis_key.pub));
+	ASSERT_FALSE (ctx.ledger ().receivable_any (ctx.ledger ().tx_begin_read (), nano::dev::genesis_key.pub));
 }
 
 TEST (ledger_receivable, any_one)
@@ -5632,7 +5632,7 @@ TEST (ledger_receivable, any_one)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*ctx.pool ().generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.store ().tx_begin_write (), send1));
-	ASSERT_TRUE (ctx.ledger ().receivable_any (ctx.store ().tx_begin_read (), nano::dev::genesis_key.pub));
-	ASSERT_FALSE (ctx.ledger ().receivable_any (ctx.store ().tx_begin_read (), key.pub));
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.ledger ().tx_begin_write (), send1));
+	ASSERT_TRUE (ctx.ledger ().receivable_any (ctx.ledger ().tx_begin_read (), nano::dev::genesis_key.pub));
+	ASSERT_FALSE (ctx.ledger ().receivable_any (ctx.ledger ().tx_begin_read (), key.pub));
 }

--- a/nano/core_test/ledger_confirm.cpp
+++ b/nano/core_test/ledger_confirm.cpp
@@ -33,7 +33,7 @@ TEST (ledger_confirm, single)
 				 .build ();
 
 	// Check confirmation heights before, should be uninitialized (1 for genesis).
-	auto transaction = node->store.tx_begin_write ();
+	auto transaction = node->ledger.tx_begin_write ();
 	ASSERT_EQ (1, node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub).value ().height);
 	ASSERT_EQ (nano::dev::genesis->hash (), node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub).value ().frontier);
 
@@ -157,7 +157,7 @@ TEST (ledger_confirm, multiple_accounts)
 					.work (*system.work.generate (send6->hash ()))
 					.build ();
 
-	auto transaction = node->store.tx_begin_write ();
+	auto transaction = node->ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send1));
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send2));
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send3));
@@ -323,7 +323,7 @@ TEST (ledger_confirm, send_receive_between_2_accounts)
 				 .build ();
 	// Unpocketed send
 
-	auto transaction = node->store.tx_begin_write ();
+	auto transaction = node->ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send1));
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, open1));
 
@@ -422,7 +422,7 @@ TEST (ledger_confirm, send_receive_self)
 				 .work (*system.work.generate (receive3->hash ()))
 				 .build ();
 
-	auto transaction = node->store.tx_begin_write ();
+	auto transaction = node->ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send1));
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, receive1));
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send2));
@@ -631,7 +631,7 @@ TEST (ledger_confirm, all_block_types)
 						  .work (*system.work.generate (send1->hash ()))
 						  .build ();
 
-	auto transaction (store.tx_begin_write ());
+	auto transaction = node->ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send));
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send1));
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, open));
@@ -700,7 +700,7 @@ TEST (ledger_confirm, conflict_rollback_cemented)
 				  .work (*system.work.generate (genesis_hash))
 				  .build ();
 	{
-		auto transaction = node1->store.tx_begin_write ();
+		auto transaction = node1->ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node1->ledger.process (transaction, fork1a));
 		node1->ledger.confirm (transaction, fork1a->hash ());
 	}
@@ -744,7 +744,7 @@ TEST (ledger_confirm, observers)
 				 .work (*system.work.generate (latest1))
 				 .build ();
 
-	auto transaction = node1->store.tx_begin_write ();
+	auto transaction = node1->ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node1->ledger.process (transaction, send1));
 	node1->ledger.confirm (transaction, send1->hash ());
 	ASSERT_TRUE (node1->ledger.block_confirmed (transaction, send1->hash ()));
@@ -838,7 +838,7 @@ TEST (ledger_confirm, pruned_source)
 				 .sign (key2.prv, key2.pub)
 				 .work (*pool.generate (key2.pub))
 				 .build ();
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, nano::dev::constants);
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send1));
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open1));
@@ -880,7 +880,7 @@ TEST (ledger_confirmDeathTest, rollback_added_block)
 					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					.work (*pool.generate (nano::dev::genesis->hash ()))
 					.build ();
-		auto transaction (store->tx_begin_write ());
+		auto transaction = ledger.tx_begin_write ();
 		store->initialize (transaction, ledger.cache, ledger.constants);
 		ASSERT_DEATH_IF_SUPPORTED (ledger.confirm (transaction, send->hash ()), "");
 	}

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -191,13 +191,13 @@ TEST (network, send_discarded_publish)
 				 .work (*system.work.generate (nano::root (1)))
 				 .build ();
 	{
-		auto transaction (node1.store.tx_begin_read ());
+		auto transaction = node1.ledger.tx_begin_read ();
 		node1.network.flood_block (block);
 		ASSERT_EQ (nano::dev::genesis->hash (), node1.ledger.latest (transaction, nano::dev::genesis_key.pub));
 		ASSERT_EQ (nano::dev::genesis->hash (), node2.latest (nano::dev::genesis_key.pub));
 	}
 	ASSERT_TIMELY (10s, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) != 0);
-	auto transaction (node1.store.tx_begin_read ());
+	auto transaction = node1.ledger.tx_begin_read ();
 	ASSERT_EQ (nano::dev::genesis->hash (), node1.ledger.latest (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::genesis->hash (), node2.latest (nano::dev::genesis_key.pub));
 }
@@ -217,13 +217,13 @@ TEST (network, send_invalid_publish)
 				 .work (*system.work.generate (nano::root (1)))
 				 .build ();
 	{
-		auto transaction (node1.store.tx_begin_read ());
+		auto transaction = node1.ledger.tx_begin_read ();
 		node1.network.flood_block (block);
 		ASSERT_EQ (nano::dev::genesis->hash (), node1.ledger.latest (transaction, nano::dev::genesis_key.pub));
 		ASSERT_EQ (nano::dev::genesis->hash (), node2.latest (nano::dev::genesis_key.pub));
 	}
 	ASSERT_TIMELY (10s, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) != 0);
-	auto transaction (node1.store.tx_begin_read ());
+	auto transaction = node1.ledger.tx_begin_read ();
 	ASSERT_EQ (nano::dev::genesis->hash (), node1.ledger.latest (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::genesis->hash (), node2.latest (nano::dev::genesis_key.pub));
 }
@@ -369,7 +369,7 @@ TEST (receivable_processor, confirm_insufficient_pos)
 				  .build ();
 	node1.work_generate_blocking (*block1);
 	ASSERT_EQ (nano::block_status::progress, node1.process (block1));
-	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.ledger.tx_begin_read ());
 	nano::keypair key1;
 	auto vote = nano::test::make_vote (key1, { block1 }, 0, 0);
 	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
@@ -392,7 +392,7 @@ TEST (receivable_processor, confirm_sufficient_pos)
 				  .build ();
 	node1.work_generate_blocking (*block1);
 	ASSERT_EQ (nano::block_status::progress, node1.process (block1));
-	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.store.tx_begin_read ());
+	node1.scheduler.priority.activate (nano::dev::genesis_key.pub, node1.ledger.tx_begin_read ());
 	auto vote = nano::test::make_vote (nano::dev::genesis_key, { block1 }, 0, 0);
 	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
 	auto channel1 = std::make_shared<nano::transport::inproc::channel> (node1, node1);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -115,7 +115,7 @@ TEST (node, balance)
 {
 	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto transaction (system.nodes[0]->store.tx_begin_write ());
+	auto transaction = system.nodes[0]->ledger.tx_begin_write ();
 	ASSERT_EQ (std::numeric_limits<nano::uint128_t>::max (), system.nodes[0]->ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 }
 
@@ -427,13 +427,13 @@ TEST (node, search_receivable_pruned)
 
 	// Confirmation
 	ASSERT_TIMELY (10s, node1->active.empty () && node2->active.empty ());
-	ASSERT_TIMELY (5s, node1->ledger.block_confirmed (node1->store.tx_begin_read (), send2->hash ()));
+	ASSERT_TIMELY (5s, node1->ledger.block_confirmed (node1->ledger.tx_begin_read (), send2->hash ()));
 	ASSERT_TIMELY_EQ (5s, node2->ledger.cemented_count (), 3);
 	system.wallet (0)->store.erase (node1->wallets.tx_begin_write (), nano::dev::genesis_key.pub);
 
 	// Pruning
 	{
-		auto transaction (node2->store.tx_begin_write ());
+		auto transaction = node2->ledger.tx_begin_write ();
 		ASSERT_EQ (1, node2->ledger.pruning_action (transaction, send1->hash (), 1));
 	}
 	ASSERT_EQ (1, node2->ledger.pruned_count ());
@@ -663,8 +663,8 @@ TEST (node, fork_keep)
 	ASSERT_TRUE (node2.ledger.block_or_pruned_exists (send1->hash ()));
 	// Wait until the genesis rep makes a vote
 	ASSERT_TIMELY (1.5min, election1->votes ().size () != 1);
-	auto transaction0 (node1.store.tx_begin_read ());
-	auto transaction1 (node2.store.tx_begin_read ());
+	auto transaction0 (node1.ledger.tx_begin_read ());
+	auto transaction1 (node2.ledger.tx_begin_read ());
 	// The vote should be in agreement with what we already have.
 	auto winner (*election1->tally ().begin ());
 	ASSERT_EQ (*send1, *winner.second);
@@ -760,10 +760,10 @@ TEST (node, fork_multi_flip)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send2->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (node1.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (node1.ledger.tx_begin_write (), send1));
 	// Node2 has two blocks that will be rolled back by node1's vote
-	ASSERT_EQ (nano::block_status::progress, node2.ledger.process (node2.store.tx_begin_write (), send2));
-	ASSERT_EQ (nano::block_status::progress, node2.ledger.process (node2.store.tx_begin_write (), send3));
+	ASSERT_EQ (nano::block_status::progress, node2.ledger.process (node2.ledger.tx_begin_write (), send2));
+	ASSERT_EQ (nano::block_status::progress, node2.ledger.process (node2.ledger.tx_begin_write (), send3));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv); // Insert voting key in to node1
 
 	auto election = nano::test::start_election (system, node2, send2->hash ());
@@ -810,9 +810,9 @@ TEST (node, fork_bootstrap_flip)
 				 .work (*system0.work.generate (latest))
 				 .build ();
 	// Insert but don't rebroadcast, simulating settled blocks
-	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (node1.store.tx_begin_write (), send1));
-	ASSERT_EQ (nano::block_status::progress, node2.ledger.process (node2.store.tx_begin_write (), send2));
-	ASSERT_TRUE (node2.ledger.block_exists (node2.store.tx_begin_read (), send2->hash ()));
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (node1.ledger.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node2.ledger.process (node2.ledger.tx_begin_write (), send2));
+	ASSERT_TRUE (node2.ledger.block_exists (node2.ledger.tx_begin_read (), send2->hash ()));
 	node2.bootstrap_initiator.bootstrap (node1.network.endpoint ()); // Additionally add new peer to confirm & replace bootstrap block
 	auto again (true);
 	system0.deadline_set (50s);
@@ -821,7 +821,7 @@ TEST (node, fork_bootstrap_flip)
 	{
 		ASSERT_NO_ERROR (system0.poll ());
 		ASSERT_NO_ERROR (system1.poll ());
-		again = !node2.ledger.block_exists (node2.store.tx_begin_read (), send1->hash ());
+		again = !node2.ledger.block_exists (node2.ledger.tx_begin_read (), send1->hash ());
 	}
 }
 
@@ -971,8 +971,8 @@ TEST (node, fork_open_flip)
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 1, winner.first);
 
 	// check the correct blocks are in the ledgers
-	auto transaction1 (node1.store.tx_begin_read ());
-	auto transaction2 (node2.store.tx_begin_read ());
+	auto transaction1 = node1.ledger.tx_begin_read ();
+	auto transaction2 = node2.ledger.tx_begin_read ();
 	ASSERT_TRUE (node1.ledger.block_exists (transaction1, open1->hash ()));
 	ASSERT_TRUE (node2.ledger.block_exists (transaction2, open1->hash ()));
 	ASSERT_FALSE (node2.ledger.block_exists (transaction2, open2->hash ()));
@@ -983,7 +983,7 @@ TEST (node, coherent_observer)
 	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	node1.observers.blocks.add ([&node1] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const &, nano::account const &, nano::uint128_t const &, bool, bool) {
-		auto transaction (node1.store.tx_begin_read ());
+		auto transaction = node1.ledger.tx_begin_read ();
 		ASSERT_TRUE (node1.ledger.block_exists (transaction, status_a.winner->hash ()));
 	});
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
@@ -1169,9 +1169,9 @@ TEST (node, DISABLED_fork_stale)
 				 .build ();
 	node1.work_generate_blocking (*send2);
 	{
-		auto transaction1 (node1.store.tx_begin_write ());
+		auto transaction1 = node1.ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction1, send1));
-		auto transaction2 (node2.store.tx_begin_write ());
+		auto transaction2 = node2.ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node2.ledger.process (transaction2, send2));
 	}
 	node1.process_active (send1);
@@ -1206,9 +1206,9 @@ TEST (node, DISABLED_broadcast_elected)
 	nano::keypair rep_other;
 	nano::block_builder builder;
 	{
-		auto transaction0 (node0->store.tx_begin_write ());
-		auto transaction1 (node1->store.tx_begin_write ());
-		auto transaction2 (node2->store.tx_begin_write ());
+		auto transaction0 = node0->ledger.tx_begin_write ();
+		auto transaction1 = node1->ledger.tx_begin_write ();
+		auto transaction2 = node2->ledger.tx_begin_write ();
 		auto fund_big = builder.send ()
 						.previous (nano::dev::genesis->hash ())
 						.destination (rep_big.pub)
@@ -1361,7 +1361,7 @@ TEST (node, rep_self_vote)
 	ASSERT_EQ (nano::block_status::progress, node0->process (block0));
 	auto & active = node0->active;
 	auto & scheduler = node0->scheduler;
-	scheduler.priority.activate (nano::dev::genesis_key.pub, node0->store.tx_begin_read ());
+	scheduler.priority.activate (nano::dev::genesis_key.pub, node0->ledger.tx_begin_read ());
 	ASSERT_TIMELY (5s, active.election (block0->qualified_root ()));
 	auto election1 = active.election (block0->qualified_root ());
 	ASSERT_NE (nullptr, election1);
@@ -1391,7 +1391,7 @@ TEST (node, DISABLED_bootstrap_no_publish)
 				 .work (0)
 				 .build ();
 	{
-		auto transaction (node0->store.tx_begin_write ());
+		auto transaction = node0->ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node0->ledger.process (transaction, send0));
 	}
 	ASSERT_FALSE (node1->bootstrap_initiator.in_progress ());
@@ -1544,7 +1544,7 @@ TEST (node, bootstrap_confirm_frontiers)
 	// on 2 different systems at once and in sequence and there might be strange timing effects.
 	system0.deadline_set (10s);
 	system1.deadline_set (10s);
-	while (!node1->ledger.block_confirmed (node1->store.tx_begin_read (), send0->hash ()))
+	while (!node1->ledger.block_confirmed (node1->ledger.tx_begin_read (), send0->hash ()))
 	{
 		ASSERT_NO_ERROR (system0.poll (std::chrono::milliseconds (1)));
 		ASSERT_NO_ERROR (system1.poll (std::chrono::milliseconds (1)));
@@ -1572,9 +1572,9 @@ TEST (node, unconfirmed_send)
 	ASSERT_TIMELY (5s, node2.block_confirmed (send1->hash ()));
 
 	// wait until receive1 (auto-receive created by wallet) is cemented
-	ASSERT_TIMELY_EQ (5s, node2.get_confirmation_height (node2.store.tx_begin_read (), key2.pub), 1);
+	ASSERT_TIMELY_EQ (5s, node2.get_confirmation_height (node2.ledger.tx_begin_read (), key2.pub), 1);
 	ASSERT_EQ (node2.balance (key2.pub), 2 * nano::Mxrb_ratio);
-	auto recv1 = node2.ledger.find_receive_block_by_send_hash (node2.store.tx_begin_read (), key2.pub, send1->hash ());
+	auto recv1 = node2.ledger.find_receive_block_by_send_hash (node2.ledger.tx_begin_read (), key2.pub, send1->hash ());
 
 	// create send2 to send from node2 to node1 and save it to node2's ledger without triggering an election (node1 does not hear about it)
 	auto send2 = nano::state_block_builder{}
@@ -1907,7 +1907,7 @@ TEST (node, local_votes_cache)
 				 .work (*node.work_generate_blocking (send2->hash ()))
 				 .build ();
 	{
-		auto transaction (node.store.tx_begin_write ());
+		auto transaction = node.ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node.ledger.process (transaction, send1));
 		ASSERT_EQ (nano::block_status::progress, node.ledger.process (transaction, send2));
 	}
@@ -1938,7 +1938,7 @@ TEST (node, local_votes_cache)
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes), 2);
 	// Max cache
 	{
-		auto transaction (node.store.tx_begin_write ());
+		auto transaction = node.ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node.ledger.process (transaction, send3));
 	}
 	nano::confirm_req message3{ nano::dev::network_params.network, send3->hash (), send3->root () };
@@ -1977,9 +1977,9 @@ TEST (node, DISABLED_local_votes_cache_batch)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
 	node.confirming_set.add (send1->hash ());
-	ASSERT_TIMELY (5s, node.ledger.block_confirmed (node.store.tx_begin_read (), send1->hash ()));
+	ASSERT_TIMELY (5s, node.ledger.block_confirmed (node.ledger.tx_begin_read (), send1->hash ()));
 	auto send2 = nano::state_block_builder ()
 				 .account (nano::dev::genesis_key.pub)
 				 .previous (send1->hash ())
@@ -1989,7 +1989,7 @@ TEST (node, DISABLED_local_votes_cache_batch)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send2));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send2));
 	auto receive1 = nano::state_block_builder ()
 					.account (key1.pub)
 					.previous (0)
@@ -1999,7 +1999,7 @@ TEST (node, DISABLED_local_votes_cache_batch)
 					.sign (key1.prv, key1.pub)
 					.work (*node.work_generate_blocking (key1.pub))
 					.build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), receive1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), receive1));
 	std::vector<std::pair<nano::block_hash, nano::root>> batch{ { send2->hash (), send2->root () }, { receive1->hash (), receive1->root () } };
 	nano::confirm_req message{ nano::dev::network_params.network, batch };
 	auto channel = std::make_shared<nano::transport::fake::channel> (node);
@@ -2202,7 +2202,7 @@ TEST (node, vote_by_hash_bundle)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	blocks.push_back (block);
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), blocks.back ()));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), blocks.back ()));
 	for (auto i = 2; i < 200; ++i)
 	{
 		auto block = builder.make_block ()
@@ -2213,7 +2213,7 @@ TEST (node, vote_by_hash_bundle)
 					 .work (*system.work.generate (blocks.back ()->hash ()))
 					 .build ();
 		blocks.push_back (block);
-		ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), blocks.back ()));
+		ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), blocks.back ()));
 	}
 
 	// Confirming last block will confirm whole chain and allow us to generate votes for those blocks later
@@ -2981,7 +2981,7 @@ TEST (node, bidirectional_tcp)
 	system.deadline_set (10s);
 	while (!confirmed)
 	{
-		auto transaction2 (node2->store.tx_begin_read ());
+		auto transaction2 = node2->ledger.tx_begin_read ();
 		confirmed = node2->ledger.block_confirmed (transaction2, send1->hash ());
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -3014,7 +3014,7 @@ TEST (node, bidirectional_tcp)
 	system.deadline_set (20s);
 	while (!confirmed)
 	{
-		auto transaction1 (node1->store.tx_begin_read ());
+		auto transaction1 = node1->ledger.tx_begin_read ();
 		confirmed = node1->ledger.block_confirmed (transaction1, send2->hash ());
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -3538,7 +3538,7 @@ TEST (node, dependency_graph_frontier)
 
 	for (auto const & node : system.nodes)
 	{
-		auto transaction (node->store.tx_begin_write ());
+		auto transaction = node->ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, gen_send1));
 		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, key1_open));
 		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, key1_send1));
@@ -3669,9 +3669,9 @@ TEST (node, deferred_dependent_elections)
 	ASSERT_FALSE (node.active.active (receive->qualified_root ()));
 	election_open->force_confirm ();
 	ASSERT_TIMELY (5s, node.block_confirmed (open->hash ()));
-	ASSERT_FALSE (node.ledger.dependents_confirmed (node.store.tx_begin_read (), *receive));
+	ASSERT_FALSE (node.ledger.dependents_confirmed (node.ledger.tx_begin_read (), *receive));
 	ASSERT_NEVER (0.5s, node.active.active (receive->qualified_root ()));
-	ASSERT_FALSE (node.ledger.rollback (node.store.tx_begin_write (), receive->hash ()));
+	ASSERT_FALSE (node.ledger.rollback (node.ledger.tx_begin_write (), receive->hash ()));
 	ASSERT_FALSE (node.block (receive->hash ()));
 	node.process_local (receive);
 	ASSERT_TIMELY (5s, node.block (receive->hash ()));

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -17,7 +17,7 @@ TEST (processor_service, bad_send_signature)
 	ASSERT_FALSE (store->init_error ());
 	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);
@@ -43,7 +43,7 @@ TEST (processor_service, bad_receive_signature)
 	ASSERT_FALSE (store->init_error ());
 	nano::stats stats;
 	nano::ledger ledger (*store, stats, nano::dev::constants);
-	auto transaction (store->tx_begin_write ());
+	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto info1 = ledger.account_info (transaction, nano::dev::genesis_key.pub);

--- a/nano/core_test/rep_crawler.cpp
+++ b/nano/core_test/rep_crawler.cpp
@@ -172,7 +172,7 @@ TEST (rep_crawler, rep_remove)
 												.work (*system.work.generate (keys_rep2.pub))
 												.build ();
 	{
-		auto transaction = searching_node.store.tx_begin_write ();
+		auto transaction = searching_node.ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, searching_node.ledger.process (transaction, send_to_rep1));
 		ASSERT_EQ (nano::block_status::progress, searching_node.ledger.process (transaction, receive_rep1));
 		ASSERT_EQ (nano::block_status::progress, searching_node.ledger.process (transaction, send_to_rep2));

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -42,7 +42,7 @@ TEST (request_aggregator, one)
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	// Not yet in the ledger
 	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
 	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	// In the ledger but no vote generated yet
@@ -79,9 +79,9 @@ TEST (request_aggregator, one_update)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
 	node.confirming_set.add (send1->hash ());
-	ASSERT_TIMELY (5s, node.ledger.block_confirmed (node.store.tx_begin_read (), send1->hash ()));
+	ASSERT_TIMELY (5s, node.ledger.block_confirmed (node.ledger.tx_begin_read (), send1->hash ()));
 	auto send2 = nano::state_block_builder ()
 				 .account (nano::dev::genesis_key.pub)
 				 .previous (send1->hash ())
@@ -91,7 +91,7 @@ TEST (request_aggregator, one_update)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (send1->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send2));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send2));
 	auto receive1 = nano::state_block_builder ()
 					.account (key1.pub)
 					.previous (0)
@@ -101,7 +101,7 @@ TEST (request_aggregator, one_update)
 					.sign (key1.prv, key1.pub)
 					.work (*node.work_generate_blocking (key1.pub))
 					.build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), receive1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), receive1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send2->hash (), send2->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
@@ -145,9 +145,9 @@ TEST (request_aggregator, two)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
 	node.confirming_set.add (send1->hash ());
-	ASSERT_TIMELY (5s, node.ledger.block_confirmed (node.store.tx_begin_read (), send1->hash ()));
+	ASSERT_TIMELY (5s, node.ledger.block_confirmed (node.ledger.tx_begin_read (), send1->hash ()));
 	auto send2 = builder.make_block ()
 				 .account (nano::dev::genesis_key.pub)
 				 .previous (send1->hash ())
@@ -166,8 +166,8 @@ TEST (request_aggregator, two)
 					.sign (key1.prv, key1.pub)
 					.work (*node.work_generate_blocking (key1.pub))
 					.build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send2));
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), receive1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send2));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), receive1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send2->hash (), send2->root ());
 	request.emplace_back (receive1->hash (), receive1->root ());
@@ -224,7 +224,7 @@ TEST (request_aggregator, two_endpoints)
 				 .build ();
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
-	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (node1.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (node1.ledger.tx_begin_write (), send1));
 	auto dummy_channel1 = std::make_shared<nano::transport::inproc::channel> (node1, node1);
 	auto dummy_channel2 = std::make_shared<nano::transport::inproc::channel> (node2, node2);
 	ASSERT_NE (nano::transport::map_endpoint_to_v6 (dummy_channel1->get_endpoint ()), nano::transport::map_endpoint_to_v6 (dummy_channel2->get_endpoint ()));
@@ -285,11 +285,11 @@ TEST (request_aggregator, split)
 						  .build ());
 		auto const & block = blocks.back ();
 		previous = block->hash ();
-		ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), block));
+		ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), block));
 		request.emplace_back (block->hash (), block->root ());
 	}
 	// Confirm all blocks
-	node.ledger.confirm (node.store.tx_begin_write (), blocks.back ()->hash ());
+	node.ledger.confirm (node.ledger.tx_begin_write (), blocks.back ()->hash ());
 	ASSERT_TIMELY_EQ (5s, max_vbh + 2, node.ledger.cemented_count ());
 	ASSERT_EQ (max_vbh + 1, request.size ());
 	auto client = std::make_shared<nano::transport::socket> (node);
@@ -328,7 +328,7 @@ TEST (request_aggregator, channel_lifetime)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	{
@@ -359,7 +359,7 @@ TEST (request_aggregator, channel_update)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	std::weak_ptr<nano::transport::channel> channel1_w;
@@ -399,7 +399,7 @@ TEST (request_aggregator, channel_max_queue)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
@@ -427,7 +427,7 @@ TEST (request_aggregator, unique)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
@@ -468,7 +468,7 @@ TEST (request_aggregator, cannot_vote)
 	ASSERT_EQ (nano::block_status::progress, node.process (send1));
 	ASSERT_EQ (nano::block_status::progress, node.process (send2));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	ASSERT_FALSE (node.ledger.dependents_confirmed (node.store.tx_begin_read (), *send2));
+	ASSERT_FALSE (node.ledger.dependents_confirmed (node.ledger.tx_begin_read (), *send2));
 
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	// Correct hash, correct root
@@ -506,7 +506,7 @@ TEST (request_aggregator, cannot_vote)
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node.active.election (send1->qualified_root ()));
 	election->force_confirm ();
-	ASSERT_TIMELY (3s, node.ledger.dependents_confirmed (node.store.tx_begin_read (), *send2));
+	ASSERT_TIMELY (3s, node.ledger.dependents_confirmed (node.ledger.tx_begin_read (), *send2));
 	node.aggregator.add (dummy_channel, request);
 	ASSERT_EQ (1, node.aggregator.size ());
 	ASSERT_TIMELY (3s, node.aggregator.empty ());

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -31,7 +31,7 @@ TEST (system, system_genesis)
 	nano::test::system system (2);
 	for (auto & i : system.nodes)
 	{
-		auto transaction (i->store.tx_begin_read ());
+		auto transaction = i->ledger.tx_begin_read ();
 		ASSERT_EQ (nano::dev::constants.genesis_amount, i->ledger.account_balance (transaction, nano::dev::genesis_key.pub));
 	}
 }
@@ -44,14 +44,14 @@ TEST (system, DISABLED_generate_send_existing)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair stake_preserver;
 	auto send_block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, stake_preserver.pub, nano::dev::constants.genesis_amount / 3 * 2, true));
-	auto info1 = node1.ledger.account_info (node1.store.tx_begin_read (), nano::dev::genesis_key.pub);
+	auto info1 = node1.ledger.account_info (node1.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info1);
 	std::vector<nano::account> accounts;
 	accounts.push_back (nano::dev::genesis_key.pub);
 	system.generate_send_existing (node1, accounts);
 	// Have stake_preserver receive funds after generate_send_existing so it isn't chosen as the destination
 	{
-		auto transaction (node1.store.tx_begin_write ());
+		auto transaction = node1.ledger.tx_begin_write ();
 		nano::block_builder builder;
 		auto open_block = builder
 						  .open ()
@@ -65,21 +65,21 @@ TEST (system, DISABLED_generate_send_existing)
 		ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, open_block));
 	}
 	ASSERT_GT (node1.balance (stake_preserver.pub), node1.balance (nano::dev::genesis_key.pub));
-	auto info2 = node1.ledger.account_info (node1.store.tx_begin_read (), nano::dev::genesis_key.pub);
+	auto info2 = node1.ledger.account_info (node1.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info2);
 	ASSERT_NE (info1->head, info2->head);
 	system.deadline_set (15s);
 	while (info2->block_count < info1->block_count + 2)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		auto transaction (node1.store.tx_begin_read ());
+		auto transaction = node1.ledger.tx_begin_read ();
 		info2 = node1.ledger.account_info (transaction, nano::dev::genesis_key.pub);
 		ASSERT_TRUE (info2);
 	}
 	ASSERT_EQ (info1->block_count + 2, info2->block_count);
 	ASSERT_EQ (info2->balance, nano::dev::constants.genesis_amount / 3);
 	{
-		auto transaction (node1.store.tx_begin_read ());
+		auto transaction = node1.ledger.tx_begin_read ();
 		ASSERT_NE (node1.ledger.amount (transaction, info2->head), 0);
 	}
 	system.stop ();
@@ -102,7 +102,7 @@ TEST (system, DISABLED_generate_send_new)
 	nano::keypair stake_preserver;
 	auto send_block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, stake_preserver.pub, nano::dev::constants.genesis_amount / 3 * 2, true));
 	{
-		auto transaction (node1.store.tx_begin_write ());
+		auto transaction = node1.ledger.tx_begin_write ();
 		nano::block_builder builder;
 		auto open_block = builder
 						  .open ()

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -172,12 +172,12 @@ TEST (vote_spacing, vote_generator)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts));
 	node.generator.add (nano::dev::genesis->hash (), send1->hash ());
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts), 1);
-	ASSERT_FALSE (node.ledger.rollback (node.store.tx_begin_write (), send1->hash ()));
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send2));
+	ASSERT_FALSE (node.ledger.rollback (node.ledger.tx_begin_write (), send1->hash ()));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send2));
 	node.generator.add (nano::dev::genesis->hash (), send2->hash ());
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_spacing), 1);
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts));
@@ -216,11 +216,11 @@ TEST (vote_spacing, rapid)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send1));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
 	node.generator.add (nano::dev::genesis->hash (), send1->hash ());
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts), 1);
-	ASSERT_FALSE (node.ledger.rollback (node.store.tx_begin_write (), send1->hash ()));
-	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.store.tx_begin_write (), send2));
+	ASSERT_FALSE (node.ledger.rollback (node.ledger.tx_begin_write (), send1->hash ()));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send2));
 	node.generator.add (nano::dev::genesis->hash (), send2->hash ());
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_spacing), 1);
 	ASSERT_TIMELY_EQ (3s, 1, node.stats.count (nano::stat::type::vote_generator, nano::stat::detail::generator_broadcasts));

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -182,7 +182,7 @@ TEST (wallet, spend_all_one)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key2;
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max ()));
-	auto transaction (node1.store.tx_begin_read ());
+	auto transaction = node1.ledger.tx_begin_read ();
 	auto info2 = node1.ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_NE (latest1, info2->head);
 	auto block = node1.ledger.block (transaction, info2->head);
@@ -216,7 +216,7 @@ TEST (wallet, spend)
 	// Sending from empty accounts should always be an error.  Accounts need to be opened with an open block, not a send block.
 	ASSERT_EQ (nullptr, system.wallet (0)->send_action (0, key2.pub, 0));
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max ()));
-	auto transaction (node1.store.tx_begin_read ());
+	auto transaction = node1.ledger.tx_begin_read ();
 	auto info2 = node1.ledger.account_info (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info2);
 	ASSERT_NE (latest1, info2->head);
@@ -241,7 +241,7 @@ TEST (wallet, spend_no_previous)
 	nano::test::system system (1);
 	{
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-		auto transaction (system.nodes[0]->store.tx_begin_read ());
+		auto transaction = system.nodes[0]->ledger.tx_begin_read ();
 		auto info1 = system.nodes[0]->ledger.account_info (transaction, nano::dev::genesis_key.pub);
 		ASSERT_TRUE (info1);
 		for (auto i (0); i < 50; ++i)
@@ -645,18 +645,18 @@ TEST (wallet, work_generate)
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::account account1;
 	{
-		auto transaction (node1.wallets.tx_begin_read ());
+		auto transaction = node1.wallets.tx_begin_read ();
 		account1 = system.account (transaction, 0);
 	}
 	nano::keypair key;
 	auto block (wallet->send_action (nano::dev::genesis_key.pub, key.pub, 100));
-	ASSERT_TIMELY (10s, node1.ledger.account_balance (node1.ledger.store.tx_begin_read (), nano::dev::genesis_key.pub) != amount1);
+	ASSERT_TIMELY (10s, node1.ledger.account_balance (node1.ledger.tx_begin_read (), nano::dev::genesis_key.pub) != amount1);
 	system.deadline_set (10s);
 	auto again (true);
 	while (again)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		auto block_transaction (node1.store.tx_begin_read ());
+		auto block_transaction = node1.ledger.tx_begin_read ();
 		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 		again = wallet->store.work_get (transaction, account1, work1) || nano::dev::network_params.work.difficulty (block->work_version (), node1.ledger.latest_root (block_transaction, account1), work1) < node1.default_difficulty (block->work_version ());
 	}
@@ -671,7 +671,7 @@ TEST (wallet, work_cache_delayed)
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::account account1;
 	{
-		auto transaction (node1.wallets.tx_begin_read ());
+		auto transaction = node1.wallets.tx_begin_read ();
 		account1 = system.account (transaction, 0);
 	}
 	nano::keypair key;
@@ -1188,7 +1188,7 @@ TEST (wallet, search_receivable)
 	ASSERT_EQ (2, node.ledger.block_count ());
 	ASSERT_FALSE (wallet.search_receivable (wallet.wallets.tx_begin_read ()));
 	ASSERT_TIMELY_EQ (3s, node.balance (nano::dev::genesis_key.pub), nano::dev::constants.genesis_amount);
-	auto receive_hash = node.ledger.latest (node.store.tx_begin_read (), nano::dev::genesis_key.pub);
+	auto receive_hash = node.ledger.latest (node.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
 	auto receive = node.block (receive_hash);
 	ASSERT_NE (nullptr, receive);
 	ASSERT_EQ (receive->sideband ().height, 3);
@@ -1221,17 +1221,17 @@ TEST (wallet, receive_pruned)
 	// Pruning
 	ASSERT_TIMELY_EQ (5s, node2.ledger.cemented_count (), 3);
 	{
-		auto transaction = node2.store.tx_begin_write ();
+		auto transaction = node2.ledger.tx_begin_write ();
 		ASSERT_EQ (1, node2.ledger.pruning_action (transaction, send1->hash (), 2));
 	}
 	ASSERT_EQ (1, node2.ledger.pruned_count ());
 	ASSERT_TRUE (node2.ledger.block_or_pruned_exists (send1->hash ()));
-	ASSERT_FALSE (node2.ledger.block_exists (node2.store.tx_begin_read (), send1->hash ()));
+	ASSERT_FALSE (node2.ledger.block_exists (node2.ledger.tx_begin_read (), send1->hash ()));
 
 	wallet2.insert_adhoc (key.prv, false);
 
 	auto open1 = wallet2.receive_action (send1->hash (), key.pub, amount, send1->destination (), 1);
 	ASSERT_NE (nullptr, open1);
-	ASSERT_EQ (amount, node2.ledger.balance (node2.store.tx_begin_read (), open1->hash ()));
+	ASSERT_EQ (amount, node2.ledger.balance (node2.ledger.tx_begin_read (), open1->hash ()));
 	ASSERT_TIMELY_EQ (5s, node2.ledger.cemented_count (), 4);
 }

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -254,7 +254,7 @@ TEST (wallets, search_receivable)
 			node.wallets.search_receivable (wallet_id);
 		}
 		ASSERT_TIMELY_EQ (3s, node.balance (nano::dev::genesis_key.pub), nano::dev::constants.genesis_amount);
-		auto receive_hash = node.ledger.latest (node.store.tx_begin_read (), nano::dev::genesis_key.pub);
+		auto receive_hash = node.ledger.latest (node.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
 		auto receive = node.block (receive_hash);
 		ASSERT_NE (nullptr, receive);
 		ASSERT_EQ (receive->sideband ().height, 3);

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1024,7 +1024,7 @@ int main (int argc, char * const * argv)
 			nano::uint128_t balance ((node->config.online_weight_minimum.number () / num_representatives) + 1);
 			for (auto i (0); i != num_representatives; ++i)
 			{
-				auto transaction (node->store.tx_begin_write ());
+				auto transaction = node->ledger.tx_begin_write ();
 				genesis_balance = genesis_balance - balance;
 
 				auto send = builder.state ()
@@ -1379,7 +1379,7 @@ int main (int argc, char * const * argv)
 				for (auto i (0U); i < threads_count; ++i)
 				{
 					threads.emplace_back ([&function_a, node, &mutex, &condition, &finished, &deque_a] () {
-						auto transaction (node->store.tx_begin_read ());
+						auto transaction = node->ledger.tx_begin_read ();
 						nano::unique_lock<nano::mutex> lock{ mutex };
 						while (!deque_a.empty () || !finished)
 						{
@@ -1400,7 +1400,7 @@ int main (int argc, char * const * argv)
 				}
 			};
 
-			auto check_account = [&print_error_message, &silent, &count, &block_count] (std::shared_ptr<nano::node> const & node, nano::store::read_transaction const & transaction, nano::account const & account, nano::account_info const & info) {
+			auto check_account = [&print_error_message, &silent, &count, &block_count] (std::shared_ptr<nano::node> const & node, nano::secure::read_transaction const & transaction, nano::account const & account, nano::account_info const & info) {
 				++count;
 				if (!silent && (count % 20000) == 0)
 				{
@@ -1627,7 +1627,7 @@ int main (int argc, char * const * argv)
 				std::cout << boost::str (boost::format ("Performing %1% threads blocks hash, signature, work validation...\n") % threads_count);
 			}
 			size_t const accounts_deque_overflow (32 * 1024);
-			auto transaction (node->store.tx_begin_read ());
+			auto transaction = node->ledger.tx_begin_read ();
 			for (auto i (node->store.account.begin (transaction)), n (node->store.account.end ()); i != n; ++i)
 			{
 				{
@@ -1673,7 +1673,7 @@ int main (int argc, char * const * argv)
 			finished = false;
 			std::deque<std::pair<nano::pending_key, nano::pending_info>> pending;
 
-			auto check_pending = [&print_error_message, &silent, &count] (std::shared_ptr<nano::node> const & node, nano::store::read_transaction const & transaction, nano::pending_key const & key, nano::pending_info const & info) {
+			auto check_pending = [&print_error_message, &silent, &count] (std::shared_ptr<nano::node> const & node, nano::secure::read_transaction const & transaction, nano::pending_key const & key, nano::pending_info const & info) {
 				++count;
 				if (!silent && (count % 500000) == 0)
 				{
@@ -1793,7 +1793,7 @@ int main (int argc, char * const * argv)
 				node_flags.generate_cache.block_count = true;
 				nano::inactive_node inactive_node (data_path, node_flags);
 				auto source_node = inactive_node.node;
-				auto transaction (source_node->store.tx_begin_read ());
+				auto transaction = source_node->ledger.tx_begin_read ();
 				block_count = source_node->ledger.block_count ();
 				std::cout << boost::str (boost::format ("Performing bootstrap emulation, %1% blocks in ledger...") % block_count) << std::endl;
 				for (auto i (source_node->store.account.begin (transaction)), n (source_node->store.account.end ()); i != n; ++i)

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -109,7 +109,7 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 		status.type = nano::election_status_type::inactive_confirmation_height;
 	}
 	recently_cemented.put (status);
-	auto transaction = node.store.tx_begin_read ();
+	auto transaction = node.ledger.tx_begin_read ();
 	notify_observers (transaction, status, votes);
 	bool cemented_bootstrap_count_reached = node.ledger.cemented_count () >= node.ledger.bootstrap_weight_max_blocks;
 	bool was_active = status.type == nano::election_status_type::active_confirmed_quorum || status.type == nano::election_status_type::active_confirmation_height;
@@ -121,7 +121,7 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 	}
 }
 
-void nano::active_transactions::notify_observers (nano::store::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes)
+void nano::active_transactions::notify_observers (nano::secure::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes)
 {
 	auto block = status.winner;
 	auto account = block->account ();
@@ -140,7 +140,7 @@ void nano::active_transactions::notify_observers (nano::store::read_transaction 
 	}
 }
 
-void nano::active_transactions::activate_successors (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block)
+void nano::active_transactions::activate_successors (nano::secure::read_transaction const & transaction, std::shared_ptr<nano::block> const & block)
 {
 	node.scheduler.priority.activate (block->account (), transaction);
 

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -33,7 +33,7 @@ class election;
 class vote;
 class stats;
 }
-namespace nano::store
+namespace nano::secure
 {
 class read_transaction;
 }
@@ -203,8 +203,8 @@ private:
 	nano::stat::type completion_type (nano::election const & election) const;
 	// Returns a list of elections sorted by difficulty, mutex must be locked
 	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t) const;
-	void activate_successors (nano::store::read_transaction const & transaction, std::shared_ptr<nano::block> const & block);
-	void notify_observers (nano::store::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes);
+	void activate_successors (nano::secure::read_transaction const & transaction, std::shared_ptr<nano::block> const & block);
+	void notify_observers (nano::secure::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes);
 	bool trigger_vote_cache (nano::block_hash);
 
 private: // Dependencies

--- a/nano/node/backlog_population.hpp
+++ b/nano/node/backlog_population.hpp
@@ -8,15 +8,15 @@
 #include <condition_variable>
 #include <thread>
 
-namespace nano::store
+namespace nano::secure
 {
-class component;
 class transaction;
 }
 namespace nano
 {
 class account_info;
 class election_scheduler;
+class ledger;
 class stats;
 
 class backlog_population final
@@ -34,7 +34,7 @@ public:
 		unsigned frequency;
 	};
 
-	backlog_population (const config &, store::component &, nano::stats &);
+	backlog_population (const config &, ledger &, nano::stats &);
 	~backlog_population ();
 
 	void start ();
@@ -50,11 +50,11 @@ public:
 	/**
 	 * Callback called for each backlogged account
 	 */
-	using callback_t = nano::observer_set<store::transaction const &, nano::account const &, nano::account_info const &, nano::confirmation_height_info const &>;
+	using callback_t = nano::observer_set<secure::transaction const &, nano::account const &, nano::account_info const &, nano::confirmation_height_info const &>;
 	callback_t activate_callback;
 
 private: // Dependencies
-	nano::store::component & store;
+	nano::ledger & ledger;
 	nano::stats & stats;
 
 	config config_m;
@@ -64,7 +64,7 @@ private:
 	bool predicate () const;
 
 	void populate_backlog (nano::unique_lock<nano::mutex> & lock);
-	void activate (store::transaction const &, nano::account const &);
+	void activate (secure::transaction const &, nano::account const &);
 
 	/** This is a manual trigger, the ongoing backlog population does not use this.
 	 *  It can be triggered even when backlog population (frontiers confirmation) is disabled. */

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -201,7 +201,7 @@ bool nano::block_processor::add_impl (context ctx, std::shared_ptr<nano::transpo
 	return added;
 }
 
-void nano::block_processor::rollback_competitor (store::write_transaction const & transaction, nano::block const & block)
+void nano::block_processor::rollback_competitor (secure::write_transaction const & transaction, nano::block const & block)
 {
 	auto hash = block.hash ();
 	auto successor_hash = node.ledger.successor (transaction, block.qualified_root ());
@@ -300,7 +300,7 @@ auto nano::block_processor::process_batch (nano::unique_lock<nano::mutex> & lock
 	processed_batch_t processed;
 
 	auto scoped_write_guard = node.store.write_queue.wait (nano::store::writer::process_batch);
-	auto transaction (node.store.tx_begin_write ({ tables::accounts, tables::blocks, tables::pending, tables::rep_weights }));
+	auto transaction = node.ledger.tx_begin_write ({ tables::accounts, tables::blocks, tables::pending, tables::rep_weights });
 	nano::timer<std::chrono::milliseconds> timer_l;
 
 	lock_a.lock ();
@@ -355,7 +355,7 @@ auto nano::block_processor::process_batch (nano::unique_lock<nano::mutex> & lock
 	return processed;
 }
 
-nano::block_status nano::block_processor::process_one (store::write_transaction const & transaction_a, context const & context, bool const forced_a)
+nano::block_status nano::block_processor::process_one (secure::write_transaction const & transaction_a, context const & context, bool const forced_a)
 {
 	auto block = context.block;
 	auto const hash = block->hash ();
@@ -452,7 +452,7 @@ nano::block_status nano::block_processor::process_one (store::write_transaction 
 	return result;
 }
 
-void nano::block_processor::queue_unchecked (store::write_transaction const & transaction_a, nano::hash_or_account const & hash_or_account_a)
+void nano::block_processor::queue_unchecked (secure::write_transaction const & transaction_a, nano::hash_or_account const & hash_or_account_a)
 {
 	node.unchecked.trigger (hash_or_account_a);
 }

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -16,7 +16,7 @@ class block;
 class node;
 }
 
-namespace nano::store
+namespace nano::secure
 {
 class write_transaction;
 }
@@ -116,9 +116,9 @@ public: // Events
 private:
 	void run ();
 	// Roll back block in the ledger that conflicts with 'block'
-	void rollback_competitor (store::write_transaction const &, nano::block const & block);
-	nano::block_status process_one (store::write_transaction const &, context const &, bool forced = false);
-	void queue_unchecked (store::write_transaction const &, nano::hash_or_account const &);
+	void rollback_competitor (secure::write_transaction const &, nano::block const & block);
+	nano::block_status process_one (secure::write_transaction const &, context const &, bool forced = false);
+	void queue_unchecked (secure::write_transaction const &, nano::hash_or_account const &);
 	processed_batch_t process_batch (nano::unique_lock<nano::mutex> &);
 	context next ();
 	bool add_impl (context, std::shared_ptr<nano::transport::channel> const & channel = nullptr);

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -364,7 +364,7 @@ void nano::bulk_pull_server::set_current_end ()
 	}
 	include_start = false;
 	debug_assert (request != nullptr);
-	auto transaction (node->store.tx_begin_read ());
+	auto transaction = node->ledger.tx_begin_read ();
 	if (!node->ledger.block_exists (transaction, request->end))
 	{
 		node->logger.debug (nano::log::type::bulk_pull_server, "Bulk pull end block doesn't exist: {}, sending everything", request->end.to_string ());
@@ -650,7 +650,7 @@ void nano::bulk_pull_account_server::send_frontier ()
 	}
 	if (!invalid_request)
 	{
-		auto stream_transaction (node->store.tx_begin_read ());
+		auto stream_transaction = node->ledger.tx_begin_read ();
 
 		// Get account balance and frontier block hash
 		auto account_frontier_hash (node->ledger.latest (stream_transaction, request->account));
@@ -753,7 +753,7 @@ std::pair<std::unique_ptr<nano::pending_key>, std::unique_ptr<nano::pending_info
 		 * destroy a database transaction, to avoid locking the
 		 * database for a prolonged period.
 		 */
-		auto tx = node->store.tx_begin_read ();
+		auto tx = node->ledger.tx_begin_read ();
 		auto & ledger = node->ledger;
 		auto stream = ledger.receivable_upper_bound (tx, current_key.account, current_key.hash);
 

--- a/nano/node/bootstrap/bootstrap_lazy.cpp
+++ b/nano/node/bootstrap/bootstrap_lazy.cpp
@@ -125,7 +125,7 @@ void nano::bootstrap_attempt_lazy::lazy_pull_flush (nano::unique_lock<nano::mute
 		nano::pull_info::count_t batch_count (lazy_batch_size ());
 		uint64_t read_count (0);
 		std::size_t count (0);
-		auto transaction (node->store.tx_begin_read ());
+		auto transaction = node->ledger.tx_begin_read ();
 		while (!lazy_pulls.empty () && count < max_pulls)
 		{
 			auto pull_start (lazy_pulls.front ());
@@ -165,7 +165,7 @@ bool nano::bootstrap_attempt_lazy::lazy_finished ()
 	}
 	bool result (true);
 	uint64_t read_count (0);
-	auto transaction (node->store.tx_begin_read ());
+	auto transaction = node->ledger.tx_begin_read ();
 	for (auto it (lazy_keys.begin ()), end (lazy_keys.end ()); it != end && !stopped;)
 	{
 		if (node->ledger.block_or_pruned_exists (transaction, *it))
@@ -333,7 +333,7 @@ void nano::bootstrap_attempt_lazy::lazy_block_state (std::shared_ptr<nano::block
 	std::shared_ptr<nano::state_block> block_l (std::static_pointer_cast<nano::state_block> (block_a));
 	if (block_l != nullptr)
 	{
-		auto transaction (node->store.tx_begin_read ());
+		auto transaction = node->ledger.tx_begin_read ();
 		nano::uint128_t balance (block_l->hashables.balance.number ());
 		auto const & link (block_l->hashables.link);
 		// If link is not epoch link or 0. And if block from link is unknown
@@ -418,7 +418,7 @@ void nano::bootstrap_attempt_lazy::lazy_backlog_cleanup ()
 		return;
 	}
 	uint64_t read_count (0);
-	auto transaction (node->store.tx_begin_read ());
+	auto transaction = node->ledger.tx_begin_read ();
 	for (auto it (lazy_state_backlog.begin ()), end (lazy_state_backlog.end ()); it != end && !stopped;)
 	{
 		if (node->ledger.block_or_pruned_exists (transaction, it->first))

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -148,7 +148,7 @@ void nano::bootstrap_server::respond (nano::asc_pull_ack & response, std::shared
 
 void nano::bootstrap_server::process_batch (std::deque<request_t> & batch)
 {
-	auto transaction = store.tx_begin_read ();
+	auto transaction = ledger.tx_begin_read ();
 
 	for (auto & [request, channel] : batch)
 	{
@@ -166,12 +166,12 @@ void nano::bootstrap_server::process_batch (std::deque<request_t> & batch)
 	}
 }
 
-nano::asc_pull_ack nano::bootstrap_server::process (store::transaction const & transaction, const nano::asc_pull_req & message)
+nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::asc_pull_req const & message)
 {
 	return std::visit ([this, &transaction, &message] (auto && request) { return process (transaction, message.id, request); }, message.payload);
 }
 
-nano::asc_pull_ack nano::bootstrap_server::process (const store::transaction &, nano::asc_pull_req::id_t id, const nano::empty_payload & request)
+nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const &, nano::asc_pull_req::id_t id, nano::empty_payload const & request)
 {
 	// Empty payload should never be possible, but return empty response anyway
 	debug_assert (false, "missing payload");
@@ -185,7 +185,7 @@ nano::asc_pull_ack nano::bootstrap_server::process (const store::transaction &, 
  * Blocks request
  */
 
-nano::asc_pull_ack nano::bootstrap_server::process (store::transaction const & transaction, nano::asc_pull_req::id_t id, nano::asc_pull_req::blocks_payload const & request)
+nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::asc_pull_req::id_t id, nano::asc_pull_req::blocks_payload const & request)
 {
 	const std::size_t count = std::min (static_cast<std::size_t> (request.count), max_blocks);
 
@@ -215,7 +215,7 @@ nano::asc_pull_ack nano::bootstrap_server::process (store::transaction const & t
 	return prepare_empty_blocks_response (id);
 }
 
-nano::asc_pull_ack nano::bootstrap_server::prepare_response (store::transaction const & transaction, nano::asc_pull_req::id_t id, nano::block_hash start_block, std::size_t count)
+nano::asc_pull_ack nano::bootstrap_server::prepare_response (secure::transaction const & transaction, nano::asc_pull_req::id_t id, nano::block_hash start_block, std::size_t count)
 {
 	debug_assert (count <= max_blocks); // Should be filtered out earlier
 
@@ -247,7 +247,7 @@ nano::asc_pull_ack nano::bootstrap_server::prepare_empty_blocks_response (nano::
 	return response;
 }
 
-std::vector<std::shared_ptr<nano::block>> nano::bootstrap_server::prepare_blocks (store::transaction const & transaction, nano::block_hash start_block, std::size_t count) const
+std::vector<std::shared_ptr<nano::block>> nano::bootstrap_server::prepare_blocks (secure::transaction const & transaction, nano::block_hash start_block, std::size_t count) const
 {
 	debug_assert (count <= max_blocks); // Should be filtered out earlier
 
@@ -270,7 +270,7 @@ std::vector<std::shared_ptr<nano::block>> nano::bootstrap_server::prepare_blocks
  * Account info request
  */
 
-nano::asc_pull_ack nano::bootstrap_server::process (const store::transaction & transaction, nano::asc_pull_req::id_t id, const nano::asc_pull_req::account_info_payload & request)
+nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::asc_pull_req::id_t id, nano::asc_pull_req::account_info_payload const & request)
 {
 	nano::asc_pull_ack response{ network_constants };
 	response.id = id;
@@ -320,7 +320,7 @@ nano::asc_pull_ack nano::bootstrap_server::process (const store::transaction & t
  * Frontiers request
  */
 
-nano::asc_pull_ack nano::bootstrap_server::process (const store::transaction & transaction, nano::asc_pull_req::id_t id, const nano::asc_pull_req::frontiers_payload & request)
+nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::asc_pull_req::id_t id, nano::asc_pull_req::frontiers_payload const & request)
 {
 	debug_assert (request.count <= max_frontiers); // Should be filtered out earlier
 

--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -7,7 +7,7 @@
 #include <memory>
 #include <utility>
 
-namespace nano::store
+namespace nano::secure
 {
 class transaction;
 }
@@ -51,28 +51,28 @@ public: // Events
 
 private:
 	void process_batch (std::deque<request_t> & batch);
-	nano::asc_pull_ack process (store::transaction const &, nano::asc_pull_req const & message);
+	nano::asc_pull_ack process (secure::transaction const &, nano::asc_pull_req const & message);
 	void respond (nano::asc_pull_ack &, std::shared_ptr<nano::transport::channel> &);
 
-	nano::asc_pull_ack process (store::transaction const &, nano::asc_pull_req::id_t id, nano::empty_payload const & request);
+	nano::asc_pull_ack process (secure::transaction const &, nano::asc_pull_req::id_t id, nano::empty_payload const & request);
 
 	/*
 	 * Blocks request
 	 */
-	nano::asc_pull_ack process (store::transaction const &, nano::asc_pull_req::id_t id, nano::asc_pull_req::blocks_payload const & request);
-	nano::asc_pull_ack prepare_response (store::transaction const &, nano::asc_pull_req::id_t id, nano::block_hash start_block, std::size_t count);
+	nano::asc_pull_ack process (secure::transaction const &, nano::asc_pull_req::id_t id, nano::asc_pull_req::blocks_payload const & request);
+	nano::asc_pull_ack prepare_response (secure::transaction const &, nano::asc_pull_req::id_t id, nano::block_hash start_block, std::size_t count);
 	nano::asc_pull_ack prepare_empty_blocks_response (nano::asc_pull_req::id_t id);
-	std::vector<std::shared_ptr<nano::block>> prepare_blocks (store::transaction const &, nano::block_hash start_block, std::size_t count) const;
+	std::vector<std::shared_ptr<nano::block>> prepare_blocks (secure::transaction const &, nano::block_hash start_block, std::size_t count) const;
 
 	/*
 	 * Account info request
 	 */
-	nano::asc_pull_ack process (store::transaction const &, nano::asc_pull_req::id_t id, nano::asc_pull_req::account_info_payload const & request);
+	nano::asc_pull_ack process (secure::transaction const &, nano::asc_pull_req::id_t id, nano::asc_pull_req::account_info_payload const & request);
 
 	/*
 	 * Frontiers request
 	 */
-	nano::asc_pull_ack process (store::transaction const &, nano::asc_pull_req::id_t id, nano::asc_pull_req::frontiers_payload const & request);
+	nano::asc_pull_ack process (secure::transaction const &, nano::asc_pull_req::id_t id, nano::asc_pull_req::frontiers_payload const & request);
 
 	/*
 	 * Checks if the request should be dropped early on

--- a/nano/node/bootstrap_ascending/iterators.cpp
+++ b/nano/node/bootstrap_ascending/iterators.cpp
@@ -21,7 +21,7 @@ nano::account nano::bootstrap_ascending::database_iterator::operator* () const
 	return current;
 }
 
-void nano::bootstrap_ascending::database_iterator::next (store::transaction & tx)
+void nano::bootstrap_ascending::database_iterator::next (secure::transaction & tx)
 {
 	switch (table)
 	{
@@ -95,7 +95,7 @@ void nano::bootstrap_ascending::buffered_iterator::fill ()
 	debug_assert (buffer.empty ());
 
 	// Fill half from accounts table and half from pending table
-	auto transaction = ledger.store.tx_begin_read ();
+	auto transaction = ledger.tx_begin_read ();
 
 	for (int n = 0; n < size / 2; ++n)
 	{

--- a/nano/node/bootstrap_ascending/iterators.hpp
+++ b/nano/node/bootstrap_ascending/iterators.hpp
@@ -9,9 +9,8 @@ namespace nano
 class ledger;
 }
 
-namespace nano::store
+namespace nano::secure
 {
-class component;
 class transaction;
 }
 
@@ -28,7 +27,7 @@ public:
 
 	explicit database_iterator (nano::ledger & ledger, table_type);
 	nano::account operator* () const;
-	void next (nano::store::transaction & tx);
+	void next (secure::transaction & tx);
 
 private:
 	nano::ledger & ledger;

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -34,7 +34,7 @@ nano::bootstrap_ascending::service::service (nano::node_config & config_a, nano:
 		{
 			nano::lock_guard<nano::mutex> lock{ mutex };
 
-			auto transaction = ledger.store.tx_begin_read ();
+			auto transaction = ledger.tx_begin_read ();
 			for (auto const & [result, context] : batch)
 			{
 				debug_assert (context.block != nullptr);
@@ -125,7 +125,7 @@ std::size_t nano::bootstrap_ascending::service::score_size () const
 - Marks an account as blocked if the result code is gap source as there is no reason request additional blocks for this account until the dependency is resolved
 - Marks an account as forwarded if it has been recently referenced by a block that has been inserted.
  */
-void nano::bootstrap_ascending::service::inspect (store::transaction const & tx, nano::block_status const & result, nano::block const & block)
+void nano::bootstrap_ascending::service::inspect (secure::transaction const & tx, nano::block_status const & result, nano::block const & block)
 {
 	auto const hash = block.hash ();
 

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -21,6 +21,11 @@
 
 namespace mi = boost::multi_index;
 
+namespace nano::secure
+{
+class transaction;
+}
+
 namespace nano
 {
 class block_processor;
@@ -88,7 +93,7 @@ namespace bootstrap_ascending
 
 	private:
 		/* Inspects a block that has been processed by the block processor */
-		void inspect (store::transaction const &, nano::block_status const & result, nano::block const & block);
+		void inspect (secure::transaction const &, nano::block_status const & result, nano::block const & block);
 
 		void throttle_if_needed (nano::unique_lock<nano::mutex> & lock);
 		void run ();

--- a/nano/node/confirming_set.cpp
+++ b/nano/node/confirming_set.cpp
@@ -72,7 +72,7 @@ void nano::confirming_set::run ()
 			{
 				lock.unlock (); // Waiting for db write is potentially slow
 				auto guard = ledger.store.write_queue.wait (nano::store::writer::confirmation_height);
-				auto tx = ledger.store.tx_begin_write ({ nano::tables::confirmation_height });
+				auto tx = ledger.tx_begin_write ({ nano::tables::confirmation_height });
 				lock.lock ();
 				// Process items in the back buffer within a single transaction for a limited amount of time
 				for (auto timeout = std::chrono::steady_clock::now () + batch_time; !stopped && std::chrono::steady_clock::now () < timeout && i != n; ++i)

--- a/nano/node/epoch_upgrader.cpp
+++ b/nano/node/epoch_upgrader.cpp
@@ -135,7 +135,7 @@ void nano::epoch_upgrader::upgrade_impl (nano::raw_key const & prv_a, nano::epoc
 			for (auto i (accounts_list.get<modified_tag> ().begin ()), n (accounts_list.get<modified_tag> ().end ()); i != n && attempts < upgrade_batch_size && attempts < count_limit && !stopped; ++i)
 			{
 				nano::account const & account (i->account);
-				auto info = ledger.account_info (ledger.store.tx_begin_read (), account);
+				auto info = ledger.account_info (ledger.tx_begin_read (), account);
 				if (info && info->epoch () < epoch_a)
 				{
 					++attempts;
@@ -209,10 +209,10 @@ void nano::epoch_upgrader::upgrade_impl (nano::raw_key const & prv_a, nano::epoc
 			std::atomic<uint64_t> upgraded_pending (0);
 			uint64_t workers (0);
 			uint64_t attempts (0);
-			for (auto current = ledger.receivable_upper_bound (ledger.store.tx_begin_read (), 0), end = ledger.receivable_end (); current != end && attempts < upgrade_batch_size && attempts < count_limit && !stopped;)
+			for (auto current = ledger.receivable_upper_bound (ledger.tx_begin_read (), 0), end = ledger.receivable_end (); current != end && attempts < upgrade_batch_size && attempts < count_limit && !stopped;)
 			{
 				auto const & [key, info] = *current;
-				if (!store.account.exists (ledger.store.tx_begin_read (), key.account))
+				if (!store.account.exists (ledger.tx_begin_read (), key.account))
 				{
 					if (info.epoch < epoch_a)
 					{
@@ -255,7 +255,7 @@ void nano::epoch_upgrader::upgrade_impl (nano::raw_key const & prv_a, nano::epoc
 						}
 					}
 					// Move to next pending item
-					current = ledger.receivable_upper_bound (ledger.store.tx_begin_read (), key.account, key.hash);
+					current = ledger.receivable_upper_bound (ledger.tx_begin_read (), key.account, key.hash);
 				}
 				else
 				{
@@ -266,7 +266,7 @@ void nano::epoch_upgrader::upgrade_impl (nano::raw_key const & prv_a, nano::epoc
 					}
 					else
 					{
-						current = ledger.receivable_upper_bound (ledger.store.tx_begin_read (), key.account);
+						current = ledger.receivable_upper_bound (ledger.tx_begin_read (), key.account);
 					}
 				}
 			}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -13,6 +13,7 @@
 #include <nano/node/node_rpc_config.hpp>
 #include <nano/node/telemetry.hpp>
 #include <nano/secure/ledger.hpp>
+#include <nano/secure/transaction.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
@@ -27,7 +28,7 @@ void construct_json (nano::container_info_component * component, boost::property
 using ipc_json_handler_no_arg_func_map = std::unordered_map<std::string, std::function<void (nano::json_handler *)>>;
 ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ();
 auto ipc_json_handler_no_arg_funcs = create_ipc_json_handler_no_arg_func_map ();
-bool block_confirmed (nano::node & node, nano::store::transaction & transaction, nano::block_hash const & hash, bool include_active, bool include_only_confirmed);
+bool block_confirmed (nano::node & node, nano::secure::transaction & transaction, nano::block_hash const & hash, bool include_active, bool include_only_confirmed);
 char const * epoch_as_string (nano::epoch);
 }
 
@@ -261,7 +262,7 @@ nano::account nano::json_handler::account_impl (std::string account_text, std::e
 	return result;
 }
 
-nano::account_info nano::json_handler::account_info_impl (store::transaction const & transaction_a, nano::account const & account_a)
+nano::account_info nano::json_handler::account_info_impl (secure::transaction const & transaction_a, nano::account const & account_a)
 {
 	nano::account_info result;
 	if (!ec)
@@ -395,7 +396,7 @@ uint64_t nano::json_handler::difficulty_ledger (nano::block const & block_a)
 {
 	nano::block_details details (nano::epoch::epoch_0, false, false, false);
 	bool details_found (false);
-	auto transaction (node.store.tx_begin_read ());
+	auto transaction = node.ledger.tx_begin_read ();
 	// Previous block find
 	std::shared_ptr<nano::block> block_previous (nullptr);
 	auto previous (block_a.previous ());
@@ -549,7 +550,7 @@ void nano::json_handler::account_block_count ()
 	auto account (account_impl ());
 	if (!ec)
 	{
-		auto transaction (node.store.tx_begin_read ());
+		auto transaction = node.ledger.tx_begin_read ();
 		auto info (account_info_impl (transaction, account));
 		if (!ec)
 		{
@@ -626,7 +627,7 @@ void nano::json_handler::account_info ()
 		bool const pending = request.get<bool> ("pending", false);
 		bool const receivable = request.get<bool> ("receivable", pending);
 		bool const include_confirmed = request.get<bool> ("include_confirmed", false);
-		auto transaction (node.store.tx_begin_read ());
+		auto transaction = node.ledger.tx_begin_read ();
 		auto info (account_info_impl (transaction, account));
 		nano::confirmation_height_info confirmation_height_info;
 		node.store.confirmation_height.get (transaction, account, confirmation_height_info);
@@ -795,7 +796,7 @@ void nano::json_handler::account_remove ()
 		auto account (rpc_l->account_impl ());
 		if (!rpc_l->ec)
 		{
-			auto transaction (rpc_l->node.wallets.tx_begin_write ());
+			auto transaction = rpc_l->node.wallets.tx_begin_write ();
 			rpc_l->wallet_locked_impl (transaction, wallet);
 			rpc_l->wallet_account_impl (transaction, wallet, account);
 			if (!rpc_l->ec)
@@ -813,7 +814,7 @@ void nano::json_handler::account_representative ()
 	auto account (account_impl ());
 	if (!ec)
 	{
-		auto transaction (node.store.tx_begin_read ());
+		auto transaction = node.ledger.tx_begin_read ();
 		auto info (account_info_impl (transaction, account));
 		if (!ec)
 		{
@@ -835,12 +836,12 @@ void nano::json_handler::account_representative_set ()
 			auto work (rpc_l->work_optional_impl ());
 			if (!rpc_l->ec && work)
 			{
-				auto transaction (rpc_l->node.wallets.tx_begin_write ());
+				auto transaction = rpc_l->node.wallets.tx_begin_write ();
 				rpc_l->wallet_locked_impl (transaction, wallet);
 				rpc_l->wallet_account_impl (transaction, wallet, account);
 				if (!rpc_l->ec)
 				{
-					auto block_transaction (rpc_l->node.store.tx_begin_read ());
+					auto block_transaction = rpc_l->node.ledger.tx_begin_read ();
 					auto info (rpc_l->account_info_impl (block_transaction, account));
 					if (!rpc_l->ec)
 					{
@@ -938,7 +939,7 @@ void nano::json_handler::accounts_representatives ()
 {
 	boost::property_tree::ptree representatives;
 	boost::property_tree::ptree errors;
-	auto transaction = node.store.tx_begin_read ();
+	auto transaction = node.ledger.tx_begin_read ();
 	for (auto & account_from_request : request.get_child ("accounts"))
 	{
 		auto account = account_impl (account_from_request.second.data ());
@@ -995,7 +996,7 @@ void nano::json_handler::accounts_frontiers ()
 {
 	boost::property_tree::ptree frontiers;
 	boost::property_tree::ptree errors;
-	auto transaction = node.store.tx_begin_read ();
+	auto transaction = node.ledger.tx_begin_read ();
 	for (auto & account_from_request : request.get_child ("accounts"))
 	{
 		auto account = account_impl (account_from_request.second.data ());
@@ -1043,7 +1044,7 @@ void nano::json_handler::accounts_receivable ()
 	bool const sorting = request.get<bool> ("sorting", false);
 	auto simple (threshold.is_zero () && !source && !sorting); // if simple, response is a list of hashes for each account
 	boost::property_tree::ptree pending;
-	auto transaction = node.store.tx_begin_read ();
+	auto transaction = node.ledger.tx_begin_read ();
 	for (auto & accounts : request.get_child ("accounts"))
 	{
 		auto account (account_impl (accounts.second.data ()));
@@ -1148,7 +1149,7 @@ void nano::json_handler::block_info ()
 	auto hash (hash_impl ());
 	if (!ec)
 	{
-		auto transaction (node.store.tx_begin_read ());
+		auto transaction = node.ledger.tx_begin_read ();
 		auto block = node.ledger.block (transaction, hash);
 		if (block != nullptr)
 		{
@@ -1199,7 +1200,7 @@ void nano::json_handler::block_confirm ()
 	auto hash (hash_impl ());
 	if (!ec)
 	{
-		auto transaction (node.store.tx_begin_read ());
+		auto transaction = node.ledger.tx_begin_read ();
 		auto block_l = node.ledger.block (transaction, hash);
 		if (block_l != nullptr)
 		{
@@ -1245,7 +1246,7 @@ void nano::json_handler::blocks ()
 {
 	bool const json_block_l = request.get<bool> ("json_block", false);
 	boost::property_tree::ptree blocks;
-	auto transaction (node.store.tx_begin_read ());
+	auto transaction = node.ledger.tx_begin_read ();
 	for (boost::property_tree::ptree::value_type & hashes : request.get_child ("hashes"))
 	{
 		if (!ec)
@@ -1296,7 +1297,7 @@ void nano::json_handler::blocks_info ()
 
 	boost::property_tree::ptree blocks;
 	boost::property_tree::ptree blocks_not_found;
-	auto transaction (node.store.tx_begin_read ());
+	auto transaction = node.ledger.tx_begin_read ();
 	for (boost::property_tree::ptree::value_type & hashes : request.get_child ("hashes"))
 	{
 		if (!ec)
@@ -1430,7 +1431,7 @@ void nano::json_handler::block_account ()
 	auto hash (hash_impl ());
 	if (!ec)
 	{
-		auto transaction (node.store.tx_begin_read ());
+		auto transaction = node.ledger.tx_begin_read ();
 		auto block = node.ledger.block (transaction, hash);
 		if (block)
 		{
@@ -1522,8 +1523,8 @@ void nano::json_handler::block_create ()
 		auto existing (node.wallets.items.find (wallet));
 		if (existing != node.wallets.items.end ())
 		{
-			auto transaction (node.wallets.tx_begin_read ());
-			auto block_transaction (node.store.tx_begin_read ());
+			auto transaction = node.wallets.tx_begin_read ();
+			auto block_transaction = node.ledger.tx_begin_read ();
 			wallet_locked_impl (transaction, existing->second);
 			wallet_account_impl (transaction, existing->second, account);
 			if (!ec)
@@ -1643,14 +1644,14 @@ void nano::json_handler::block_create ()
 			// Fetching account balance & previous for send blocks (if aren't given directly)
 			if (!previous_text.is_initialized () && !balance_text.is_initialized ())
 			{
-				auto transaction (node.store.tx_begin_read ());
+				auto transaction = node.ledger.tx_begin_read ();
 				previous = node.ledger.latest (transaction, pub);
 				balance = node.ledger.account_balance (transaction, pub);
 			}
 			// Double check current balance if previous block is specified
 			else if (previous_text.is_initialized () && balance_text.is_initialized () && type == "send")
 			{
-				auto transaction (node.store.tx_begin_read ());
+				auto transaction = node.ledger.tx_begin_read ();
 				if (node.ledger.block_exists (transaction, previous) && node.ledger.balance (transaction, previous) != balance.number ())
 				{
 					ec = nano::error_rpc::block_create_balance_mismatch;
@@ -1941,7 +1942,7 @@ void nano::json_handler::chain (bool successors)
 	if (!ec)
 	{
 		boost::property_tree::ptree blocks;
-		auto transaction (node.store.tx_begin_read ());
+		auto transaction = node.ledger.tx_begin_read ();
 		while (!hash.is_zero () && blocks.size () < count)
 		{
 			auto block_l = node.ledger.block (transaction, hash);
@@ -2412,7 +2413,7 @@ namespace
 class history_visitor : public nano::block_visitor
 {
 public:
-	history_visitor (nano::json_handler & handler_a, bool raw_a, nano::store::transaction & transaction_a, boost::property_tree::ptree & tree_a, nano::block_hash const & hash_a, std::vector<nano::public_key> const & accounts_filter_a) :
+	history_visitor (nano::json_handler & handler_a, bool raw_a, nano::secure::transaction & transaction_a, boost::property_tree::ptree & tree_a, nano::block_hash const & hash_a, std::vector<nano::public_key> const & accounts_filter_a) :
 		handler (handler_a),
 		raw (raw_a),
 		transaction (transaction_a),
@@ -2601,7 +2602,7 @@ public:
 	}
 	nano::json_handler & handler;
 	bool raw;
-	nano::store::transaction & transaction;
+	nano::secure::transaction & transaction;
 	boost::property_tree::ptree & tree;
 	nano::block_hash const & hash;
 	std::vector<nano::public_key> const & accounts_filter;
@@ -2631,7 +2632,7 @@ void nano::json_handler::account_history ()
 	nano::block_hash hash;
 	bool reverse (request.get_optional<bool> ("reverse") == true);
 	auto head_str (request.get_optional<std::string> ("head"));
-	auto transaction (node.store.tx_begin_read ());
+	auto transaction = node.ledger.tx_begin_read ();
 	auto count (count_impl ());
 	auto offset (offset_optional_impl (0));
 	if (head_str)
@@ -2789,7 +2790,7 @@ void nano::json_handler::ledger ()
 		bool const pending = request.get<bool> ("pending", false);
 		bool const receivable = request.get<bool> ("receivable", pending);
 		boost::property_tree::ptree accounts;
-		auto transaction (node.store.tx_begin_read ());
+		auto transaction = node.ledger.tx_begin_read ();
 		if (!ec && !sorting) // Simple
 		{
 			for (auto i (node.store.account.begin (transaction, start)), n (node.store.account.end ()); i != n && accounts.size () < count; ++i)
@@ -3090,7 +3091,7 @@ void nano::json_handler::receivable ()
 	{
 		auto offset_counter = offset;
 		boost::property_tree::ptree peers_l;
-		auto transaction = node.store.tx_begin_read ();
+		auto transaction = node.ledger.tx_begin_read ();
 		// The ptree container is used if there are any children nodes (e.g source/min_version) otherwise the amount container is used.
 		std::vector<std::pair<std::string, boost::property_tree::ptree>> hash_ptree_pairs;
 		std::vector<std::pair<std::string, nano::uint128_t>> hash_amount_pairs;
@@ -3194,7 +3195,7 @@ void nano::json_handler::receivable_exists ()
 	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
 	if (!ec)
 	{
-		auto transaction (node.store.tx_begin_read ());
+		auto transaction = node.ledger.tx_begin_read ();
 		auto block = node.ledger.block (transaction, hash);
 		if (block != nullptr)
 		{
@@ -3227,7 +3228,7 @@ void nano::json_handler::process ()
 			if (!subtype_text.empty ())
 			{
 				std::shared_ptr<nano::state_block> block_state (std::static_pointer_cast<nano::state_block> (block));
-				auto transaction (rpc_l->node.store.tx_begin_read ());
+				auto transaction = rpc_l->node.ledger.tx_begin_read ();
 				if (!block_state->hashables.previous.is_zero () && !rpc_l->node.ledger.block_exists (transaction, block_state->hashables.previous))
 				{
 					rpc_l->ec = nano::error_process::gap_previous;
@@ -3438,7 +3439,7 @@ void nano::json_handler::receive ()
 		wallet_account_impl (wallet_transaction, wallet, account);
 		if (!ec)
 		{
-			auto block_transaction (node.store.tx_begin_read ());
+			auto block_transaction = node.ledger.tx_begin_read ();
 			if (node.ledger.block_or_pruned_exists (block_transaction, hash))
 			{
 				auto pending_info = node.ledger.pending_info (block_transaction, nano::pending_key (account, hash));
@@ -3667,7 +3668,7 @@ void nano::json_handler::republish ()
 	if (!ec)
 	{
 		boost::property_tree::ptree blocks;
-		auto transaction (node.store.tx_begin_read ());
+		auto transaction = node.ledger.tx_begin_read ();
 		auto block = node.ledger.block (transaction, hash);
 		if (block != nullptr)
 		{
@@ -3806,7 +3807,7 @@ void nano::json_handler::send ()
 		if (!ec)
 		{
 			auto transaction (node.wallets.tx_begin_read ());
-			auto block_transaction (node.store.tx_begin_read ());
+			auto block_transaction = node.ledger.tx_begin_read ();
 			wallet_locked_impl (transaction, wallet);
 			wallet_account_impl (transaction, wallet, source);
 			auto info (account_info_impl (block_transaction, source));
@@ -4285,7 +4286,7 @@ void nano::json_handler::unopened ()
 	}
 	if (!ec)
 	{
-		auto transaction = node.store.tx_begin_read ();
+		auto transaction = node.ledger.tx_begin_read ();
 		auto & ledger = node.ledger;
 		boost::property_tree::ptree accounts;
 		for (auto iterator = ledger.receivable_upper_bound (transaction, start, 0), end = ledger.receivable_end (); iterator != end && accounts.size () < count;)
@@ -4418,7 +4419,7 @@ void nano::json_handler::wallet_info ()
 		uint64_t deterministic_count (0);
 		uint64_t adhoc_count (0);
 		auto transaction (node.wallets.tx_begin_read ());
-		auto block_transaction (node.store.tx_begin_read ());
+		auto block_transaction = node.ledger.tx_begin_read ();
 
 		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end ()); i != n; ++i)
 		{
@@ -4475,7 +4476,7 @@ void nano::json_handler::wallet_balances ()
 	{
 		boost::property_tree::ptree balances;
 		auto transaction (node.wallets.tx_begin_read ());
-		auto block_transaction (node.store.tx_begin_read ());
+		auto block_transaction = node.ledger.tx_begin_read ();
 		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end ()); i != n; ++i)
 		{
 			nano::account const & account (i->first);
@@ -4626,7 +4627,7 @@ void nano::json_handler::wallet_frontiers ()
 	{
 		boost::property_tree::ptree frontiers;
 		auto transaction (node.wallets.tx_begin_read ());
-		auto block_transaction (node.store.tx_begin_read ());
+		auto block_transaction = node.ledger.tx_begin_read ();
 		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end ()); i != n; ++i)
 		{
 			nano::account const & account (i->first);
@@ -4657,7 +4658,7 @@ void nano::json_handler::wallet_history ()
 	{
 		std::multimap<uint64_t, boost::property_tree::ptree, std::greater<uint64_t>> entries;
 		auto transaction (node.wallets.tx_begin_read ());
-		auto block_transaction (node.store.tx_begin_read ());
+		auto block_transaction = node.ledger.tx_begin_read ();
 		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end ()); i != n; ++i)
 		{
 			nano::account const & account (i->first);
@@ -4731,7 +4732,7 @@ void nano::json_handler::wallet_ledger ()
 	{
 		boost::property_tree::ptree accounts;
 		auto transaction (node.wallets.tx_begin_read ());
-		auto block_transaction (node.store.tx_begin_read ());
+		auto block_transaction = node.ledger.tx_begin_read ();
 		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end ()); i != n; ++i)
 		{
 			nano::account const & account (i->first);
@@ -4807,7 +4808,7 @@ void nano::json_handler::wallet_receivable ()
 	{
 		boost::property_tree::ptree pending;
 		auto transaction (node.wallets.tx_begin_read ());
-		auto block_transaction = node.store.tx_begin_read ();
+		auto block_transaction = node.ledger.tx_begin_read ();
 		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end ()); i != n; ++i)
 		{
 			nano::account const & account (i->first);
@@ -4897,7 +4898,7 @@ void nano::json_handler::wallet_representative_set ()
 				std::vector<nano::account> accounts;
 				{
 					auto transaction (rpc_l->node.wallets.tx_begin_read ());
-					auto block_transaction (rpc_l->node.store.tx_begin_read ());
+					auto block_transaction = rpc_l->node.ledger.tx_begin_read ();
 					for (auto i (wallet->store.begin (transaction)), n (wallet->store.end ()); i != n; ++i)
 					{
 						nano::account const & account (i->first);
@@ -4931,7 +4932,7 @@ void nano::json_handler::wallet_republish ()
 		boost::property_tree::ptree blocks;
 		std::deque<std::shared_ptr<nano::block>> republish_bundle;
 		auto transaction (node.wallets.tx_begin_read ());
-		auto block_transaction (node.store.tx_begin_read ());
+		auto block_transaction = node.ledger.tx_begin_read ();
 		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end ()); i != n; ++i)
 		{
 			nano::account const & account (i->first);
@@ -5101,7 +5102,7 @@ void nano::json_handler::work_generate ()
 				if (!account_opt.is_initialized ())
 				{
 					// Fetch account from block if not given
-					auto transaction_l (node.store.tx_begin_read ());
+					auto transaction_l = node.ledger.tx_begin_read ();
 					if (node.ledger.block_exists (transaction_l, hash))
 					{
 						account = node.ledger.account (transaction_l, hash).value ();
@@ -5457,7 +5458,7 @@ ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ()
 }
 
 /** Due to the asynchronous nature of updating confirmation heights, it can also be necessary to check active roots */
-bool block_confirmed (nano::node & node, nano::store::transaction & transaction, nano::block_hash const & hash, bool include_active, bool include_only_confirmed)
+bool block_confirmed (nano::node & node, nano::secure::transaction & transaction, nano::block_hash const & hash, bool include_active, bool include_only_confirmed)
 {
 	bool is_confirmed = false;
 	if (include_active && !include_only_confirmed)

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -10,6 +10,11 @@
 #include <functional>
 #include <string>
 
+namespace nano::secure
+{
+class transaction;
+}
+
 namespace nano
 {
 namespace ipc
@@ -158,7 +163,7 @@ public:
 	bool wallet_locked_impl (store::transaction const &, std::shared_ptr<nano::wallet> const &);
 	bool wallet_account_impl (store::transaction const &, std::shared_ptr<nano::wallet> const &, nano::account const &);
 	nano::account account_impl (std::string = "", std::error_code = nano::error_common::bad_account_number);
-	nano::account_info account_info_impl (store::transaction const &, nano::account const &);
+	nano::account_info account_info_impl (secure::transaction const &, nano::account const &);
 	nano::amount amount_impl ();
 	std::shared_ptr<nano::block> block_impl (bool = true);
 	nano::block_hash hash_impl (std::string = "hash");

--- a/nano/node/local_block_broadcaster.cpp
+++ b/nano/node/local_block_broadcaster.cpp
@@ -5,6 +5,7 @@
 #include <nano/node/local_block_broadcaster.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node.hpp>
+#include <nano/secure/ledger.hpp>
 
 nano::local_block_broadcaster::local_block_broadcaster (nano::node & node_a, nano::block_processor & block_processor_a, nano::network & network_a, nano::stats & stats_a, bool enabled_a) :
 	node{ node_a },
@@ -143,7 +144,7 @@ void nano::local_block_broadcaster::cleanup ()
 	}
 
 	// TODO: Mutex is held during IO, but it should be fine since it's not performance critical
-	auto transaction = node.store.tx_begin_read ();
+	auto transaction = node.ledger.tx_begin_read ();
 	erase_if (local_blocks, [this, &transaction] (auto const & entry) {
 		transaction.refresh_if_needed ();
 

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -118,7 +118,7 @@ public:
 	void add_initial_peers ();
 	void start_election (std::shared_ptr<nano::block> const & block);
 	bool block_confirmed (nano::block_hash const &);
-	bool block_confirmed_or_being_confirmed (nano::store::transaction const &, nano::block_hash const &);
+	bool block_confirmed_or_being_confirmed (nano::secure::transaction const &, nano::block_hash const &);
 	bool block_confirmed_or_being_confirmed (nano::block_hash const &);
 	void do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);
 	void ongoing_online_weight_calculation ();
@@ -219,7 +219,7 @@ public: // Testing convenience functions
 		Transaction is comitted before function return
 	 */
 	[[nodiscard]] nano::block_status process (std::shared_ptr<nano::block> block);
-	[[nodiscard]] nano::block_status process (store::write_transaction const &, std::shared_ptr<nano::block> block);
+	[[nodiscard]] nano::block_status process (secure::write_transaction const &, std::shared_ptr<nano::block> block);
 	nano::block_hash latest (nano::account const &);
 	nano::uint128_t balance (nano::account const &);
 

--- a/nano/node/process_live_dispatcher.cpp
+++ b/nano/node/process_live_dispatcher.cpp
@@ -6,6 +6,7 @@
 #include <nano/node/websocket.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
+#include <nano/secure/transaction.hpp>
 #include <nano/store/component.hpp>
 
 nano::process_live_dispatcher::process_live_dispatcher (nano::ledger & ledger, nano::scheduler::priority & scheduler, nano::vote_cache & vote_cache, nano::websocket_server & websocket) :
@@ -19,7 +20,7 @@ nano::process_live_dispatcher::process_live_dispatcher (nano::ledger & ledger, n
 void nano::process_live_dispatcher::connect (nano::block_processor & block_processor)
 {
 	block_processor.batch_processed.add ([this] (auto const & batch) {
-		auto const transaction = ledger.store.tx_begin_read ();
+		auto const transaction = ledger.tx_begin_read ();
 		for (auto const & [result, context] : batch)
 		{
 			debug_assert (context.block != nullptr);
@@ -28,7 +29,7 @@ void nano::process_live_dispatcher::connect (nano::block_processor & block_proce
 	});
 }
 
-void nano::process_live_dispatcher::inspect (nano::block_status const & result, nano::block const & block, store::transaction const & transaction)
+void nano::process_live_dispatcher::inspect (nano::block_status const & result, nano::block const & block, secure::transaction const & transaction)
 {
 	switch (result)
 	{
@@ -40,7 +41,7 @@ void nano::process_live_dispatcher::inspect (nano::block_status const & result, 
 	}
 }
 
-void nano::process_live_dispatcher::process_live (nano::block const & block, store::transaction const & transaction)
+void nano::process_live_dispatcher::process_live (nano::block const & block, secure::transaction const & transaction)
 {
 	// Start collecting quorum on block
 	if (ledger.dependents_confirmed (transaction, block))

--- a/nano/node/process_live_dispatcher.hpp
+++ b/nano/node/process_live_dispatcher.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace nano::store
+namespace nano::secure
 {
 class transaction;
 }
@@ -28,8 +28,8 @@ public:
 
 private:
 	// Block_processor observer
-	void inspect (nano::block_status const & result, nano::block const & block, store::transaction const & transaction);
-	void process_live (nano::block const & block, store::transaction const & transaction);
+	void inspect (nano::block_status const & result, nano::block const & block, secure::transaction const & transaction);
+	void process_live (nano::block const & block, secure::transaction const & transaction);
 
 	nano::ledger & ledger;
 	nano::scheduler::priority & scheduler;

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -272,7 +272,7 @@ auto nano::rep_crawler::prepare_query_target () -> std::optional<hash_root_t>
 {
 	constexpr int max_attempts = 4;
 
-	auto transaction = node.store.tx_begin_read ();
+	auto transaction = node.ledger.tx_begin_read ();
 
 	std::optional<std::pair<nano::block_hash, nano::block_hash>> hash_root;
 

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -177,7 +177,7 @@ void nano::request_aggregator::erase_duplicates (std::vector<std::pair<nano::blo
 
 std::pair<std::vector<std::shared_ptr<nano::block>>, std::vector<std::shared_ptr<nano::block>>> nano::request_aggregator::aggregate (std::vector<std::pair<nano::block_hash, nano::root>> const & requests_a, std::shared_ptr<nano::transport::channel> & channel_a) const
 {
-	auto transaction (ledger.store.tx_begin_read ());
+	auto transaction = ledger.tx_begin_read ();
 	std::vector<std::shared_ptr<nano::block>> to_generate;
 	std::vector<std::shared_ptr<nano::block>> to_generate_final;
 	std::vector<std::shared_ptr<nano::vote>> cached_votes;

--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -67,7 +67,7 @@ bool nano::scheduler::hinted::predicate () const
 	return active.vacancy (nano::election_behavior::hinted) > 0;
 }
 
-void nano::scheduler::hinted::activate (const nano::store::read_transaction & transaction, const nano::block_hash & hash, bool check_dependents)
+void nano::scheduler::hinted::activate (secure::read_transaction const & transaction, nano::block_hash const & hash, bool check_dependents)
 {
 	const int max_iterations = 64;
 
@@ -133,7 +133,7 @@ void nano::scheduler::hinted::run_iterative ()
 	// Get the list before db transaction starts to avoid unnecessary slowdowns
 	auto tops = vote_cache.top (minimum_tally);
 
-	auto transaction = node.store.tx_begin_read ();
+	auto transaction = node.ledger.tx_begin_read ();
 
 	for (auto const & entry : tops)
 	{

--- a/nano/node/scheduler/hinted.hpp
+++ b/nano/node/scheduler/hinted.hpp
@@ -24,6 +24,11 @@ class active_transactions;
 class vote_cache;
 class online_reps;
 }
+namespace nano::secure
+{
+class transaction;
+class read_transaction;
+}
 
 namespace nano::scheduler
 {
@@ -66,7 +71,7 @@ private:
 	bool predicate () const;
 	void run ();
 	void run_iterative ();
-	void activate (nano::store::read_transaction const &, nano::block_hash const & hash, bool check_dependents);
+	void activate (secure::read_transaction const &, nano::block_hash const & hash, bool check_dependents);
 
 	nano::uint128_t tally_threshold () const;
 	nano::uint128_t final_tally_threshold () const;

--- a/nano/node/scheduler/optimistic.cpp
+++ b/nano/node/scheduler/optimistic.cpp
@@ -127,7 +127,7 @@ void nano::scheduler::optimistic::run ()
 
 		if (predicate ())
 		{
-			auto transaction = ledger.store.tx_begin_read ();
+			auto transaction = ledger.tx_begin_read ();
 
 			while (predicate ())
 			{
@@ -149,7 +149,7 @@ void nano::scheduler::optimistic::run ()
 	}
 }
 
-void nano::scheduler::optimistic::run_one (store::transaction const & transaction, entry const & candidate)
+void nano::scheduler::optimistic::run_one (secure::transaction const & transaction, entry const & candidate)
 {
 	auto block = ledger.head_block (transaction, candidate.account);
 	if (block)

--- a/nano/node/scheduler/optimistic.hpp
+++ b/nano/node/scheduler/optimistic.hpp
@@ -74,7 +74,7 @@ private:
 
 	bool predicate () const;
 	void run ();
-	void run_one (store::transaction const &, entry const & candidate);
+	void run_one (secure::transaction const &, entry const & candidate);
 
 private: // Dependencies
 	optimistic_config const & config;

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -39,7 +39,7 @@ void nano::scheduler::priority::stop ()
 	nano::join_or_pass (thread);
 }
 
-bool nano::scheduler::priority::activate (nano::account const & account_a, store::transaction const & transaction)
+bool nano::scheduler::priority::activate (nano::account const & account_a, secure::transaction const & transaction)
 {
 	debug_assert (!account_a.is_zero ());
 	auto info = node.ledger.account_info (transaction, account_a);

--- a/nano/node/scheduler/priority.hpp
+++ b/nano/node/scheduler/priority.hpp
@@ -17,7 +17,7 @@ class container_info_component;
 class node;
 class stats;
 }
-namespace nano::store
+namespace nano::secure
 {
 class transaction;
 }
@@ -38,7 +38,7 @@ public:
 	 * Activates the first unconfirmed block of \p account_a
 	 * @return true if account was activated
 	 */
-	bool activate (nano::account const &, store::transaction const &);
+	bool activate (nano::account const &, secure::transaction const &);
 	void notify ();
 	std::size_t size () const;
 	bool empty () const;

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -39,7 +39,7 @@ nano::vote_generator::~vote_generator ()
 	stop ();
 }
 
-bool nano::vote_generator::should_vote (store::write_transaction const & transaction, nano::root const & root_a, nano::block_hash const & hash_a)
+bool nano::vote_generator::should_vote (secure::write_transaction const & transaction, nano::root const & root_a, nano::block_hash const & hash_a)
 {
 	auto block = ledger.block (transaction, hash_a);
 	bool should_vote = false;
@@ -95,7 +95,7 @@ void nano::vote_generator::process_batch (std::deque<queue_entry_t> & batch)
 	std::deque<candidate_t> candidates_new;
 	{
 		auto guard = ledger.store.write_queue.wait (is_final ? nano::store::writer::voting_final : nano::store::writer::voting);
-		auto transaction = ledger.store.tx_begin_write ({ tables::final_votes });
+		auto transaction = ledger.tx_begin_write ({ tables::final_votes });
 
 		for (auto & [root, hash] : batch)
 		{
@@ -122,7 +122,7 @@ std::size_t nano::vote_generator::generate (std::vector<std::shared_ptr<nano::bl
 {
 	request_t::first_type req_candidates;
 	{
-		auto transaction (ledger.store.tx_begin_read ());
+		auto transaction = ledger.tx_begin_read ();
 		auto dependents_confirmed = [&transaction, this] (auto const & block_a) {
 			return this->ledger.dependents_confirmed (transaction, *block_a);
 		};

--- a/nano/node/vote_generator.hpp
+++ b/nano/node/vote_generator.hpp
@@ -32,6 +32,11 @@ class vote_processor;
 class vote_spacing;
 class wallets;
 }
+namespace nano::secure
+{
+class transaction;
+class write_transaction;
+}
 namespace nano::transport
 {
 class channel;
@@ -73,7 +78,7 @@ private:
 	 * @param transaction : needs `tables::final_votes` lock
 	 * @return: Should vote
 	 */
-	bool should_vote (store::write_transaction const &, nano::root const &, nano::block_hash const &);
+	bool should_vote (secure::write_transaction const &, nano::root const &, nano::block_hash const &);
 
 private:
 	std::function<void (std::shared_ptr<nano::vote> const &, std::shared_ptr<nano::transport::channel> &)> reply_action; // must be set only during initialization by using set_reply_action

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -767,7 +767,7 @@ nano::public_key nano::wallet::insert_adhoc (nano::raw_key const & key_a, bool g
 	if (store.valid_password (transaction))
 	{
 		key = store.insert_adhoc (transaction, key_a);
-		auto block_transaction (wallets.node.store.tx_begin_read ());
+		auto block_transaction = wallets.node.ledger.tx_begin_read ();
 		if (generate_work_a)
 		{
 			work_ensure (key, wallets.node.ledger.latest_root (block_transaction, key));
@@ -841,7 +841,7 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 	details.is_receive = true;
 	if (wallets.node.config.receive_minimum.number () <= amount_a.number ())
 	{
-		auto block_transaction (wallets.node.ledger.store.tx_begin_read ());
+		auto block_transaction = wallets.node.ledger.tx_begin_read ();
 		auto transaction (wallets.tx_begin_read ());
 		if (wallets.node.ledger.block_or_pruned_exists (block_transaction, send_hash_a))
 		{
@@ -904,7 +904,7 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 	nano::block_details details;
 	{
 		auto transaction (wallets.tx_begin_read ());
-		auto block_transaction (wallets.node.store.tx_begin_read ());
+		auto block_transaction = wallets.node.ledger.tx_begin_read ();
 		if (store.valid_password (transaction))
 		{
 			auto existing (store.find (transaction, source_a));
@@ -945,7 +945,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 	}
 
 	auto prepare_send = [&id_mdb_val, &wallets = this->wallets, &store = this->store, &source_a, &amount_a, &work_a, &account_a] (auto const & transaction) {
-		auto block_transaction (wallets.node.store.tx_begin_read ());
+		auto block_transaction = wallets.node.ledger.tx_begin_read ();
 		auto error (false);
 		auto cached_block (false);
 		std::shared_ptr<nano::block> block;
@@ -1137,7 +1137,7 @@ void nano::wallet::work_update (store::transaction const & transaction_a, nano::
 {
 	debug_assert (!wallets.node.network_params.work.validate_entry (nano::work_version::work_1, root_a, work_a));
 	debug_assert (store.exists (transaction_a, account_a));
-	auto block_transaction (wallets.node.store.tx_begin_read ());
+	auto block_transaction = wallets.node.ledger.tx_begin_read ();
 	auto latest (wallets.node.ledger.latest_root (block_transaction, account_a));
 	if (latest == root_a)
 	{
@@ -1178,7 +1178,7 @@ bool nano::wallet::search_receivable (store::transaction const & wallet_transact
 
 		for (auto i (store.begin (wallet_transaction_a)), n (store.end ()); i != n; ++i)
 		{
-			auto block_transaction (wallets.node.store.tx_begin_read ());
+			auto block_transaction = wallets.node.ledger.tx_begin_read ();
 			nano::account const & account (i->first);
 			// Don't search pending for watch-only accounts
 			if (!nano::wallet_value (i->second).key.is_zero ())
@@ -1232,7 +1232,7 @@ void nano::wallet::init_free_accounts (store::transaction const & transaction_a)
 
 uint32_t nano::wallet::deterministic_check (store::transaction const & transaction_a, uint32_t index)
 {
-	auto block_transaction (wallets.node.store.tx_begin_read ());
+	auto block_transaction = wallets.node.ledger.tx_begin_read ();
 	for (uint32_t i (index + 1), n (index + 64); i < n; ++i)
 	{
 		auto prv = store.deterministic_key (transaction_a, i);
@@ -1538,7 +1538,7 @@ void nano::wallets::foreach_representative (std::function<void (nano::public_key
 		std::vector<std::pair<nano::public_key const, nano::raw_key const>> action_accounts_l;
 		{
 			auto transaction_l (tx_begin_read ());
-			auto ledger_txn{ node.ledger.store.tx_begin_read () };
+			auto ledger_txn = node.ledger.tx_begin_read ();
 			nano::lock_guard<nano::mutex> lock{ mutex };
 			for (auto i (items.begin ()), n (items.end ()); i != n; ++i)
 			{
@@ -1719,7 +1719,7 @@ void nano::wallets::receive_confirmed (nano::block_hash const & hash_a, nano::ac
 		{
 			nano::account representative;
 			representative = wallet->store.representative (wallet_transaction);
-			auto pending = node.ledger.pending_info (node.ledger.store.tx_begin_read (), nano::pending_key (destination_a, hash_a));
+			auto pending = node.ledger.pending_info (node.ledger.tx_begin_read (), nano::pending_key (destination_a, hash_a));
 			if (pending)
 			{
 				auto amount (pending->amount.number ());
@@ -1727,7 +1727,7 @@ void nano::wallets::receive_confirmed (nano::block_hash const & hash_a, nano::ac
 			}
 			else
 			{
-				if (!node.ledger.block_or_pruned_exists (node.ledger.store.tx_begin_read (), hash_a))
+				if (!node.ledger.block_or_pruned_exists (node.ledger.tx_begin_read (), hash_a))
 				{
 					node.logger.warn (nano::log::type::wallet, "Confirmed block is missing: {}", hash_a.to_string ());
 					debug_assert (false, "Confirmed block is missing");

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -263,7 +263,7 @@ nano_qt::accounts::accounts (nano_qt::wallet & wallet_a) :
 void nano_qt::accounts::refresh_wallet_balance ()
 {
 	auto transaction (this->wallet.wallet_m->wallets.tx_begin_read ());
-	auto block_transaction (this->wallet.node.store.tx_begin_read ());
+	auto block_transaction = this->wallet.node.ledger.tx_begin_read ();
 	nano::uint128_t balance (0);
 	nano::uint128_t pending (0);
 	for (auto i (this->wallet.wallet_m->store.begin (transaction)), j (this->wallet.wallet_m->store.end ()); i != j; ++i)
@@ -289,7 +289,7 @@ void nano_qt::accounts::refresh ()
 {
 	model->removeRows (0, model->rowCount ());
 	auto transaction (wallet.wallet_m->wallets.tx_begin_read ());
-	auto block_transaction (this->wallet.node.store.tx_begin_read ());
+	auto block_transaction = this->wallet.node.ledger.tx_begin_read ();
 	QBrush brush;
 	for (auto i (wallet.wallet_m->store.begin (transaction)), j (wallet.wallet_m->store.end ()); i != j; ++i)
 	{
@@ -516,7 +516,7 @@ namespace
 class short_text_visitor : public nano::block_visitor
 {
 public:
-	short_text_visitor (nano::store::transaction const & transaction_a, nano::ledger & ledger_a) :
+	short_text_visitor (nano::secure::transaction const & transaction_a, nano::ledger & ledger_a) :
 		transaction (transaction_a),
 		ledger (ledger_a)
 	{
@@ -623,7 +623,7 @@ public:
 			amount = balance - previous_balance.value ();
 		}
 	}
-	nano::store::transaction const & transaction;
+	nano::secure::transaction const & transaction;
 	nano::ledger & ledger;
 	std::string type;
 	nano::uint128_t amount;
@@ -633,7 +633,7 @@ public:
 
 void nano_qt::history::refresh ()
 {
-	auto transaction (ledger.store.tx_begin_read ());
+	auto transaction = ledger.tx_begin_read ();
 	model->removeRows (0, model->rowCount ());
 	auto hash (ledger.latest (transaction, account));
 	short_text_visitor visitor (transaction, ledger);
@@ -688,7 +688,7 @@ nano_qt::block_viewer::block_viewer (nano_qt::wallet & wallet_a) :
 		nano::block_hash hash_l;
 		if (!hash_l.decode_hex (hash->text ().toStdString ()))
 		{
-			auto transaction (this->wallet.node.store.tx_begin_read ());
+			auto transaction = this->wallet.node.ledger.tx_begin_read ();
 			auto block_l (this->wallet.node.ledger.block (transaction, hash_l));
 			if (block_l != nullptr)
 			{
@@ -713,7 +713,7 @@ nano_qt::block_viewer::block_viewer (nano_qt::wallet & wallet_a) :
 		auto error (block.decode_hex (hash->text ().toStdString ()));
 		if (!error)
 		{
-			auto transaction (this->wallet.node.store.tx_begin_read ());
+			auto transaction = this->wallet.node.ledger.tx_begin_read ();
 			if (this->wallet.node.ledger.block_exists (transaction, block))
 			{
 				rebroadcast->setEnabled (false);
@@ -734,7 +734,7 @@ nano_qt::block_viewer::block_viewer (nano_qt::wallet & wallet_a) :
 void nano_qt::block_viewer::rebroadcast_action (nano::block_hash const & hash_a)
 {
 	auto done (true);
-	auto transaction (wallet.node.ledger.store.tx_begin_read ());
+	auto transaction = wallet.node.ledger.tx_begin_read ();
 	auto block (wallet.node.ledger.block (transaction, hash_a));
 	if (block != nullptr)
 	{
@@ -2240,7 +2240,7 @@ void nano_qt::block_creation::create_send ()
 			if (!error)
 			{
 				auto transaction (wallet.node.wallets.tx_begin_read ());
-				auto block_transaction (wallet.node.store.tx_begin_read ());
+				auto block_transaction = wallet.node.ledger.tx_begin_read ();
 				nano::raw_key key;
 				if (!wallet.wallet_m->store.fetch (transaction, account_l, key))
 				{
@@ -2316,7 +2316,7 @@ void nano_qt::block_creation::create_receive ()
 	if (!error)
 	{
 		auto transaction (wallet.node.wallets.tx_begin_read ());
-		auto block_transaction (wallet.node.store.tx_begin_read ());
+		auto block_transaction = wallet.node.ledger.tx_begin_read ();
 		auto block_l (wallet.node.ledger.block (block_transaction, source_l));
 		if (block_l != nullptr)
 		{
@@ -2480,7 +2480,7 @@ void nano_qt::block_creation::create_open ()
 		if (!error)
 		{
 			auto transaction (wallet.node.wallets.tx_begin_read ());
-			auto block_transaction (wallet.node.store.tx_begin_read ());
+			auto block_transaction = wallet.node.ledger.tx_begin_read ();
 			auto block_l (wallet.node.ledger.block (block_transaction, source_l));
 			if (block_l != nullptr)
 			{

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -194,7 +194,7 @@ TEST (rpc, receivable_offset_and_sorting)
 	auto block6 = system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1.pub, 300);
 
 	// check that all blocks got confirmed
-	ASSERT_TIMELY_EQ (5s, node->ledger.account_receivable (node->store.tx_begin_read (), key1.pub, true), 1600);
+	ASSERT_TIMELY_EQ (5s, node->ledger.account_receivable (node->ledger.tx_begin_read (), key1.pub, true), 1600);
 
 	// check confirmation height is as expected, there is no perfect clarity yet when confirmation height updates after a block get confirmed
 	nano::confirmation_height_info confirmation_height_info;
@@ -371,7 +371,7 @@ TEST (rpc, search_receivable)
 				 .work (*node->work_generate_blocking (latest))
 				 .build ();
 	{
-		auto transaction (node->store.tx_begin_write ());
+		auto transaction = node->ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, block));
 	}
 	auto const rpc_ctx = add_rpc (system, node);

--- a/nano/secure/CMakeLists.txt
+++ b/nano/secure/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(
   pending_info.cpp
   rep_weights.hpp
   rep_weights.cpp
+  transaction.hpp
   utility.hpp
   utility.cpp
   vote.hpp

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -32,7 +32,7 @@ namespace
 class rollback_visitor : public nano::block_visitor
 {
 public:
-	rollback_visitor (nano::store::write_transaction const & transaction_a, nano::ledger & ledger_a, std::vector<std::shared_ptr<nano::block>> & list_a) :
+	rollback_visitor (nano::secure::write_transaction const & transaction_a, nano::ledger & ledger_a, std::vector<std::shared_ptr<nano::block>> & list_a) :
 		transaction (transaction_a),
 		ledger (ledger_a),
 		list (list_a)
@@ -173,7 +173,7 @@ public:
 		}
 		ledger.store.block.del (transaction, hash);
 	}
-	nano::store::write_transaction const & transaction;
+	nano::secure::write_transaction const & transaction;
 	nano::ledger & ledger;
 	std::vector<std::shared_ptr<nano::block>> & list;
 	bool error{ false };
@@ -182,7 +182,7 @@ public:
 class ledger_processor : public nano::mutable_block_visitor
 {
 public:
-	ledger_processor (nano::ledger &, nano::store::write_transaction const &);
+	ledger_processor (nano::ledger &, nano::secure::write_transaction const &);
 	virtual ~ledger_processor () = default;
 	void send_block (nano::send_block &) override;
 	void receive_block (nano::receive_block &) override;
@@ -192,7 +192,7 @@ public:
 	void state_block_impl (nano::state_block &);
 	void epoch_block_impl (nano::state_block &);
 	nano::ledger & ledger;
-	nano::store::write_transaction const & transaction;
+	nano::secure::write_transaction const & transaction;
 	nano::block_status result;
 
 private:
@@ -639,7 +639,7 @@ void ledger_processor::open_block (nano::open_block & block_a)
 	}
 }
 
-ledger_processor::ledger_processor (nano::ledger & ledger_a, nano::store::write_transaction const & transaction_a) :
+ledger_processor::ledger_processor (nano::ledger & ledger_a, nano::secure::write_transaction const & transaction_a) :
 	ledger (ledger_a),
 	transaction (transaction_a)
 {
@@ -651,7 +651,7 @@ ledger_processor::ledger_processor (nano::ledger & ledger_a, nano::store::write_
 class representative_visitor final : public nano::block_visitor
 {
 public:
-	representative_visitor (nano::store::transaction const & transaction_a, nano::ledger & ledger);
+	representative_visitor (nano::secure::transaction const & transaction_a, nano::ledger & ledger);
 	~representative_visitor () = default;
 	void compute (nano::block_hash const & hash_a);
 	void send_block (nano::send_block const & block_a) override;
@@ -659,13 +659,13 @@ public:
 	void open_block (nano::open_block const & block_a) override;
 	void change_block (nano::change_block const & block_a) override;
 	void state_block (nano::state_block const & block_a) override;
-	nano::store::transaction const & transaction;
+	nano::secure::transaction const & transaction;
 	nano::ledger & ledger;
 	nano::block_hash current;
 	nano::block_hash result;
 };
 
-representative_visitor::representative_visitor (nano::store::transaction const & transaction_a, nano::ledger & ledger) :
+representative_visitor::representative_visitor (nano::secure::transaction const & transaction_a, nano::ledger & ledger) :
 	transaction{ transaction_a },
 	ledger{ ledger },
 	result{ 0 }
@@ -722,6 +722,16 @@ nano::ledger::ledger (nano::store::component & store_a, nano::stats & stat_a, na
 	}
 }
 
+auto nano::ledger::tx_begin_write (std::vector<nano::tables> const & tables_to_lock, std::vector<nano::tables> const & tables_no_lock) const -> secure::write_transaction
+{
+	return secure::write_transaction{ store.tx_begin_write (tables_to_lock, tables_no_lock) };
+}
+
+auto nano::ledger::tx_begin_read () const -> secure::read_transaction
+{
+	return secure::read_transaction{ store.tx_begin_read () };
+}
+
 void nano::ledger::initialize (nano::generate_cache_flags const & generate_cache_flags_a)
 {
 	if (generate_cache_flags_a.reps || generate_cache_flags_a.account_count || generate_cache_flags_a.block_count)
@@ -769,7 +779,7 @@ void nano::ledger::initialize (nano::generate_cache_flags const & generate_cache
 }
 
 // Balance for account containing hash
-std::optional<nano::uint128_t> nano::ledger::balance (store::transaction const & transaction, nano::block_hash const & hash) const
+std::optional<nano::uint128_t> nano::ledger::balance (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	if (hash.is_zero ())
 	{
@@ -783,18 +793,18 @@ std::optional<nano::uint128_t> nano::ledger::balance (store::transaction const &
 	return block->balance ().number ();
 }
 
-std::shared_ptr<nano::block> nano::ledger::block (store::transaction const & transaction, nano::block_hash const & hash) const
+std::shared_ptr<nano::block> nano::ledger::block (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	return store.block.get (transaction, hash);
 }
 
-bool nano::ledger::block_exists (store::transaction const & transaction, nano::block_hash const & hash) const
+bool nano::ledger::block_exists (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	return store.block.exists (transaction, hash);
 }
 
 // Balance for an account by account number
-nano::uint128_t nano::ledger::account_balance (store::transaction const & transaction_a, nano::account const & account_a, bool only_confirmed_a) const
+nano::uint128_t nano::ledger::account_balance (secure::transaction const & transaction_a, nano::account const & account_a, bool only_confirmed_a) const
 {
 	nano::uint128_t result (0);
 	if (only_confirmed_a)
@@ -816,7 +826,7 @@ nano::uint128_t nano::ledger::account_balance (store::transaction const & transa
 	return result;
 }
 
-nano::uint128_t nano::ledger::account_receivable (store::transaction const & transaction_a, nano::account const & account_a, bool only_confirmed_a)
+nano::uint128_t nano::ledger::account_receivable (secure::transaction const & transaction_a, nano::account const & account_a, bool only_confirmed_a)
 {
 	nano::uint128_t result{ 0 };
 	for (auto i = receivable_upper_bound (transaction_a, account_a, 0), n = receivable_end (); i != n; ++i)
@@ -830,12 +840,12 @@ nano::uint128_t nano::ledger::account_receivable (store::transaction const & tra
 	return result;
 }
 
-std::optional<nano::pending_info> nano::ledger::pending_info (store::transaction const & transaction, nano::pending_key const & key) const
+std::optional<nano::pending_info> nano::ledger::pending_info (secure::transaction const & transaction, nano::pending_key const & key) const
 {
 	return store.pending.get (transaction, key);
 }
 
-std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (nano::store::write_transaction const & transaction, nano::block_hash const & hash)
+std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_transaction const & transaction, nano::block_hash const & hash)
 {
 	std::deque<std::shared_ptr<nano::block>> result;
 	std::stack<nano::block_hash> stack;
@@ -870,7 +880,7 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (nano::store::wri
 	return result;
 }
 
-void nano::ledger::confirm (nano::store::write_transaction const & transaction, nano::block const & block)
+void nano::ledger::confirm (secure::write_transaction const & transaction, nano::block const & block)
 {
 	debug_assert ((!store.confirmation_height.get (transaction, block.account ()) && block.sideband ().height == 1) || store.confirmation_height.get (transaction, block.account ()).value ().height + 1 == block.sideband ().height);
 	confirmation_height_info info{ block.sideband ().height, block.hash () };
@@ -879,7 +889,7 @@ void nano::ledger::confirm (nano::store::write_transaction const & transaction, 
 	stats.inc (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed);
 }
 
-nano::block_status nano::ledger::process (store::write_transaction const & transaction_a, std::shared_ptr<nano::block> block_a)
+nano::block_status nano::ledger::process (secure::write_transaction const & transaction_a, std::shared_ptr<nano::block> block_a)
 {
 	debug_assert (!constants.work.validate_entry (*block_a) || constants.genesis == nano::dev::genesis);
 	ledger_processor processor (*this, transaction_a);
@@ -891,14 +901,14 @@ nano::block_status nano::ledger::process (store::write_transaction const & trans
 	return processor.result;
 }
 
-nano::block_hash nano::ledger::representative (store::transaction const & transaction_a, nano::block_hash const & hash_a)
+nano::block_hash nano::ledger::representative (secure::transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	auto result (representative_calculated (transaction_a, hash_a));
 	debug_assert (result.is_zero () || block_exists (transaction_a, result));
 	return result;
 }
 
-nano::block_hash nano::ledger::representative_calculated (store::transaction const & transaction_a, nano::block_hash const & hash_a)
+nano::block_hash nano::ledger::representative_calculated (secure::transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	representative_visitor visitor (transaction_a, *this);
 	visitor.compute (hash_a);
@@ -907,10 +917,10 @@ nano::block_hash nano::ledger::representative_calculated (store::transaction con
 
 bool nano::ledger::block_or_pruned_exists (nano::block_hash const & hash_a) const
 {
-	return block_or_pruned_exists (store.tx_begin_read (), hash_a);
+	return block_or_pruned_exists (tx_begin_read (), hash_a);
 }
 
-bool nano::ledger::block_or_pruned_exists (store::transaction const & transaction_a, nano::block_hash const & hash_a) const
+bool nano::ledger::block_or_pruned_exists (secure::transaction const & transaction_a, nano::block_hash const & hash_a) const
 {
 	if (store.pruned.exists (transaction_a, hash_a))
 	{
@@ -927,7 +937,7 @@ std::string nano::ledger::block_text (char const * hash_a)
 std::string nano::ledger::block_text (nano::block_hash const & hash_a)
 {
 	std::string result;
-	auto transaction (store.tx_begin_read ());
+	auto transaction = tx_begin_read ();
 	auto block_l = block (transaction, hash_a);
 	if (block_l != nullptr)
 	{
@@ -936,7 +946,7 @@ std::string nano::ledger::block_text (nano::block_hash const & hash_a)
 	return result;
 }
 
-std::pair<nano::block_hash, nano::block_hash> nano::ledger::hash_root_random (store::transaction const & transaction_a) const
+std::pair<nano::block_hash, nano::block_hash> nano::ledger::hash_root_random (secure::transaction const & transaction_a) const
 {
 	nano::block_hash hash (0);
 	nano::root root (0);
@@ -986,13 +996,13 @@ nano::uint128_t nano::ledger::weight (nano::account const & account_a) const
 	return cache.rep_weights.representation_get (account_a);
 }
 
-nano::uint128_t nano::ledger::weight_exact (store::transaction const & txn_a, nano::account const & representative_a) const
+nano::uint128_t nano::ledger::weight_exact (secure::transaction const & txn_a, nano::account const & representative_a) const
 {
 	return store.rep_weight.get (txn_a, representative_a);
 }
 
 // Rollback blocks until `block_a' doesn't exist or it tries to penetrate the confirmation height
-bool nano::ledger::rollback (store::write_transaction const & transaction_a, nano::block_hash const & block_a, std::vector<std::shared_ptr<nano::block>> & list_a)
+bool nano::ledger::rollback (secure::write_transaction const & transaction_a, nano::block_hash const & block_a, std::vector<std::shared_ptr<nano::block>> & list_a)
 {
 	debug_assert (block_exists (transaction_a, block_a));
 	auto account_l = account (transaction_a, block_a).value ();
@@ -1024,13 +1034,13 @@ bool nano::ledger::rollback (store::write_transaction const & transaction_a, nan
 	return error;
 }
 
-bool nano::ledger::rollback (store::write_transaction const & transaction_a, nano::block_hash const & block_a)
+bool nano::ledger::rollback (secure::write_transaction const & transaction_a, nano::block_hash const & block_a)
 {
 	std::vector<std::shared_ptr<nano::block>> rollback_list;
 	return rollback (transaction_a, block_a, rollback_list);
 }
 
-std::optional<nano::account> nano::ledger::account (store::transaction const & transaction, nano::block_hash const & hash) const
+std::optional<nano::account> nano::ledger::account (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	auto block_l = block (transaction, hash);
 	if (!block_l)
@@ -1040,12 +1050,12 @@ std::optional<nano::account> nano::ledger::account (store::transaction const & t
 	return block_l->account ();
 }
 
-std::optional<nano::account_info> nano::ledger::account_info (store::transaction const & transaction, nano::account const & account) const
+std::optional<nano::account_info> nano::ledger::account_info (secure::transaction const & transaction, nano::account const & account) const
 {
 	return store.account.get (transaction, account);
 }
 
-std::optional<nano::uint128_t> nano::ledger::amount (store::transaction const & transaction_a, nano::block_hash const & hash_a)
+std::optional<nano::uint128_t> nano::ledger::amount (secure::transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	auto block_l = block (transaction_a, hash_a);
 	if (!block_l)
@@ -1066,14 +1076,14 @@ std::optional<nano::uint128_t> nano::ledger::amount (store::transaction const & 
 }
 
 // Return latest block for account
-nano::block_hash nano::ledger::latest (store::transaction const & transaction_a, nano::account const & account_a)
+nano::block_hash nano::ledger::latest (secure::transaction const & transaction_a, nano::account const & account_a)
 {
 	auto info = account_info (transaction_a, account_a);
 	return !info ? 0 : info->head;
 }
 
 // Return latest root for account, account number if there are no blocks for this account.
-nano::root nano::ledger::latest_root (store::transaction const & transaction_a, nano::account const & account_a)
+nano::root nano::ledger::latest_root (secure::transaction const & transaction_a, nano::account const & account_a)
 {
 	auto info = account_info (transaction_a, account_a);
 	if (!info)
@@ -1088,7 +1098,7 @@ nano::root nano::ledger::latest_root (store::transaction const & transaction_a, 
 
 void nano::ledger::dump_account_chain (nano::account const & account_a, std::ostream & stream)
 {
-	auto transaction (store.tx_begin_read ());
+	auto transaction = tx_begin_read ();
 	auto hash (latest (transaction, account_a));
 	while (!hash.is_zero ())
 	{
@@ -1099,7 +1109,7 @@ void nano::ledger::dump_account_chain (nano::account const & account_a, std::ost
 	}
 }
 
-bool nano::ledger::dependents_confirmed (store::transaction const & transaction_a, nano::block const & block_a) const
+bool nano::ledger::dependents_confirmed (secure::transaction const & transaction_a, nano::block const & block_a) const
 {
 	auto dependencies (dependent_blocks (transaction_a, block_a));
 	return std::all_of (dependencies.begin (), dependencies.end (), [this, &transaction_a] (nano::block_hash const & hash_a) {
@@ -1120,7 +1130,7 @@ bool nano::ledger::is_epoch_link (nano::link const & link_a) const
 class dependent_block_visitor : public nano::block_visitor
 {
 public:
-	dependent_block_visitor (nano::ledger const & ledger_a, nano::store::transaction const & transaction_a) :
+	dependent_block_visitor (nano::ledger const & ledger_a, nano::secure::transaction const & transaction_a) :
 		ledger (ledger_a),
 		transaction (transaction_a),
 		result ({ 0, 0 })
@@ -1151,14 +1161,14 @@ public:
 		result[0] = block_a.hashables.previous;
 		result[1] = block_a.hashables.link.as_block_hash ();
 		// ledger.is_send will check the sideband first, if block_a has a loaded sideband the check that previous block exists can be skipped
-		if (ledger.is_epoch_link (block_a.hashables.link) || is_send (transaction, block_a))
+		if (ledger.is_epoch_link (block_a.hashables.link) || is_send (block_a))
 		{
 			result[1].clear ();
 		}
 	}
 	// This function is used in place of block->is_send () as it is tolerant to the block not having the sideband information loaded
 	// This is needed for instance in vote generation on forks which have not yet had sideband information attached
-	bool is_send (nano::store::transaction const & transaction, nano::state_block const & block) const
+	bool is_send (nano::state_block const & block) const
 	{
 		if (block.previous ().is_zero ())
 		{
@@ -1171,11 +1181,11 @@ public:
 		return block.balance_field ().value () < ledger.balance (transaction, block.previous ());
 	}
 	nano::ledger const & ledger;
-	nano::store::transaction const & transaction;
+	nano::secure::transaction const & transaction;
 	std::array<nano::block_hash, 2> result;
 };
 
-std::array<nano::block_hash, 2> nano::ledger::dependent_blocks (store::transaction const & transaction_a, nano::block const & block_a) const
+std::array<nano::block_hash, 2> nano::ledger::dependent_blocks (secure::transaction const & transaction_a, nano::block const & block_a) const
 {
 	dependent_block_visitor visitor (*this, transaction_a);
 	block_a.visit (visitor);
@@ -1186,7 +1196,7 @@ std::array<nano::block_hash, 2> nano::ledger::dependent_blocks (store::transacti
  *  The send block hash is not checked in any way, it is assumed to be correct.
  * @return Return the receive block on success and null on failure
  */
-std::shared_ptr<nano::block> nano::ledger::find_receive_block_by_send_hash (store::transaction const & transaction, nano::account const & destination, nano::block_hash const & send_block_hash)
+std::shared_ptr<nano::block> nano::ledger::find_receive_block_by_send_hash (secure::transaction const & transaction, nano::account const & destination, nano::block_hash const & send_block_hash)
 {
 	std::shared_ptr<nano::block> result;
 	debug_assert (send_block_hash != 0);
@@ -1225,7 +1235,7 @@ nano::link const & nano::ledger::epoch_link (nano::epoch epoch_a) const
 	return constants.epochs.link (epoch_a);
 }
 
-void nano::ledger::update_account (store::write_transaction const & transaction_a, nano::account const & account_a, nano::account_info const & old_a, nano::account_info const & new_a)
+void nano::ledger::update_account (secure::write_transaction const & transaction_a, nano::account const & account_a, nano::account_info const & old_a, nano::account_info const & new_a)
 {
 	if (!new_a.head.is_zero ())
 	{
@@ -1249,7 +1259,7 @@ void nano::ledger::update_account (store::write_transaction const & transaction_
 	}
 }
 
-std::optional<nano::block_hash> nano::ledger::successor (store::transaction const & transaction_a, nano::qualified_root const & root_a) const noexcept
+std::optional<nano::block_hash> nano::ledger::successor (secure::transaction const & transaction_a, nano::qualified_root const & root_a) const noexcept
 {
 	if (!root_a.previous ().is_zero ())
 	{
@@ -1269,12 +1279,12 @@ std::optional<nano::block_hash> nano::ledger::successor (store::transaction cons
 	}
 }
 
-std::optional<nano::block_hash> nano::ledger::successor (store::transaction const & transaction, nano::block_hash const & hash) const noexcept
+std::optional<nano::block_hash> nano::ledger::successor (secure::transaction const & transaction, nano::block_hash const & hash) const noexcept
 {
 	return successor (transaction, { hash, hash });
 }
 
-std::shared_ptr<nano::block> nano::ledger::forked_block (store::transaction const & transaction_a, nano::block const & block_a)
+std::shared_ptr<nano::block> nano::ledger::forked_block (secure::transaction const & transaction_a, nano::block const & block_a)
 {
 	debug_assert (!block_exists (transaction_a, block_a.hash ()));
 	auto root (block_a.root ());
@@ -1295,7 +1305,7 @@ std::shared_ptr<nano::block> nano::ledger::forked_block (store::transaction cons
 	return result;
 }
 
-std::shared_ptr<nano::block> nano::ledger::head_block (store::transaction const & transaction, nano::account const & account)
+std::shared_ptr<nano::block> nano::ledger::head_block (secure::transaction const & transaction, nano::account const & account)
 {
 	auto info = store.account.get (transaction, account);
 	if (info)
@@ -1305,7 +1315,7 @@ std::shared_ptr<nano::block> nano::ledger::head_block (store::transaction const 
 	return nullptr;
 }
 
-bool nano::ledger::block_confirmed (store::transaction const & transaction_a, nano::block_hash const & hash_a) const
+bool nano::ledger::block_confirmed (secure::transaction const & transaction_a, nano::block_hash const & hash_a) const
 {
 	if (store.pruned.exists (transaction_a, hash_a))
 	{
@@ -1322,7 +1332,7 @@ bool nano::ledger::block_confirmed (store::transaction const & transaction_a, na
 	return false;
 }
 
-uint64_t nano::ledger::pruning_action (store::write_transaction & transaction_a, nano::block_hash const & hash_a, uint64_t const batch_size_a)
+uint64_t nano::ledger::pruning_action (secure::write_transaction & transaction_a, nano::block_hash const & hash_a, uint64_t const batch_size_a)
 {
 	uint64_t pruned_count (0);
 	nano::block_hash hash (hash_a);
@@ -1503,7 +1513,7 @@ nano::epoch nano::ledger::version (nano::block const & block)
 	return nano::epoch::epoch_0;
 }
 
-nano::epoch nano::ledger::version (store::transaction const & transaction, nano::block_hash const & hash) const
+nano::epoch nano::ledger::version (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	auto block_l = block (transaction, hash);
 	if (block_l == nullptr)
@@ -1513,19 +1523,19 @@ nano::epoch nano::ledger::version (store::transaction const & transaction, nano:
 	return version (*block_l);
 }
 
-uint64_t nano::ledger::height (store::transaction const & transaction, nano::block_hash const & hash) const
+uint64_t nano::ledger::height (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	auto block_l = block (transaction, hash);
 	return block_l->sideband ().height;
 }
 
-bool nano::ledger::receivable_any (store::transaction const & tx, nano::account const & account) const
+bool nano::ledger::receivable_any (secure::transaction const & tx, nano::account const & account) const
 {
 	auto next = receivable_upper_bound (tx, account, 0);
 	return next != receivable_end ();
 }
 
-std::optional<std::pair<nano::pending_key, nano::pending_info>> nano::ledger::receivable_lower_bound (store::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const
+std::optional<std::pair<nano::pending_key, nano::pending_info>> nano::ledger::receivable_lower_bound (secure::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const
 {
 	auto result = store.pending.begin (tx, { account, hash });
 	if (result == store.pending.end ())
@@ -1540,12 +1550,12 @@ nano::receivable_iterator nano::ledger::receivable_end () const
 	return nano::receivable_iterator{};
 }
 
-nano::receivable_iterator nano::ledger::receivable_upper_bound (store::transaction const & tx, nano::account const & account) const
+nano::receivable_iterator nano::ledger::receivable_upper_bound (secure::transaction const & tx, nano::account const & account) const
 {
 	return receivable_iterator{ *this, tx, receivable_lower_bound (tx, account.number () + 1, 0) };
 }
 
-nano::receivable_iterator nano::ledger::receivable_upper_bound (store::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const
+nano::receivable_iterator nano::ledger::receivable_upper_bound (secure::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const
 {
 	auto result = receivable_lower_bound (tx, account, hash.number () + 1);
 	if (!result || result.value ().first.account != account)

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -6,6 +6,7 @@
 #include <nano/secure/generate_cache_flags.hpp>
 #include <nano/secure/ledger_cache.hpp>
 #include <nano/secure/pending_info.hpp>
+#include <nano/secure/transaction.hpp>
 
 #include <deque>
 #include <map>
@@ -13,8 +14,6 @@
 namespace nano::store
 {
 class component;
-class transaction;
-class write_transaction;
 }
 
 namespace nano
@@ -33,66 +32,71 @@ class ledger final
 
 public:
 	ledger (nano::store::component &, nano::stats &, nano::ledger_constants & constants, nano::generate_cache_flags const & = nano::generate_cache_flags{}, nano::uint128_t min_rep_weight_a = 0);
+
+	/** Start read-write transaction */
+	secure::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_to_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) const;
+	/** Start read-only transaction */
+	secure::read_transaction tx_begin_read () const;
 	/**
 	 * Returns the account for a given hash
 	 * Returns std::nullopt if the block doesn't exist or has been pruned
 	 */
-	std::optional<nano::account> account (store::transaction const &, nano::block_hash const &) const;
-	std::optional<nano::account_info> account_info (store::transaction const & transaction, nano::account const & account) const;
-	std::optional<nano::uint128_t> amount (store::transaction const &, nano::block_hash const &);
-	std::optional<nano::uint128_t> balance (store::transaction const &, nano::block_hash const &) const;
-	std::shared_ptr<nano::block> block (store::transaction const & transaction, nano::block_hash const & hash) const;
-	bool block_exists (store::transaction const & transaction, nano::block_hash const & hash) const;
-	nano::uint128_t account_balance (store::transaction const &, nano::account const &, bool = false) const;
-	nano::uint128_t account_receivable (store::transaction const &, nano::account const &, bool = false);
+	std::optional<nano::account> account (secure::transaction const &, nano::block_hash const &) const;
+	std::optional<nano::account_info> account_info (secure::transaction const & transaction, nano::account const & account) const;
+	std::optional<nano::uint128_t> amount (secure::transaction const &, nano::block_hash const &);
+	std::optional<nano::uint128_t> balance (secure::transaction const &, nano::block_hash const &) const;
+	std::shared_ptr<nano::block> block (secure::transaction const & transaction, nano::block_hash const & hash) const;
+	bool block_exists (secure::transaction const & transaction, nano::block_hash const & hash) const;
+	nano::uint128_t account_balance (secure::transaction const &, nano::account const &, bool = false) const;
+	nano::uint128_t account_receivable (secure::transaction const &, nano::account const &, bool = false);
 	/**
 	 * Returns the cached vote weight for the given representative.
 	 * If the weight is below the cache limit it returns 0.
 	 * During bootstrap it returns the preconfigured bootstrap weights.
 	 */
 	nano::uint128_t weight (nano::account const &) const;
-	std::optional<nano::block_hash> successor (store::transaction const &, nano::qualified_root const &) const noexcept;
-	std::optional<nano::block_hash> successor (store::transaction const & transaction, nano::block_hash const & hash) const noexcept;
+	std::optional<nano::block_hash> successor (secure::transaction const &, nano::qualified_root const &) const noexcept;
+	std::optional<nano::block_hash> successor (secure::transaction const & transaction, nano::block_hash const & hash) const noexcept;
 	/* Returns the exact vote weight for the given representative by doing a database lookup */
-	nano::uint128_t weight_exact (store::transaction const &, nano::account const &) const;
-	std::shared_ptr<nano::block> forked_block (store::transaction const &, nano::block const &);
-	std::shared_ptr<nano::block> head_block (store::transaction const &, nano::account const &);
-	bool block_confirmed (store::transaction const &, nano::block_hash const &) const;
-	nano::block_hash latest (store::transaction const &, nano::account const &);
-	nano::root latest_root (store::transaction const &, nano::account const &);
-	nano::block_hash representative (store::transaction const &, nano::block_hash const &);
-	nano::block_hash representative_calculated (store::transaction const &, nano::block_hash const &);
+	nano::uint128_t weight_exact (secure::transaction const &, nano::account const &) const;
+	std::shared_ptr<nano::block> forked_block (secure::transaction const &, nano::block const &);
+	std::shared_ptr<nano::block> head_block (secure::transaction const &, nano::account const &);
+	bool block_confirmed (secure::transaction const &, nano::block_hash const &) const;
+	nano::block_hash latest (secure::transaction const &, nano::account const &);
+	nano::root latest_root (secure::transaction const &, nano::account const &);
+	nano::block_hash representative (secure::transaction const &, nano::block_hash const &);
+	nano::block_hash representative_calculated (secure::transaction const &, nano::block_hash const &);
 	bool block_or_pruned_exists (nano::block_hash const &) const;
-	bool block_or_pruned_exists (store::transaction const &, nano::block_hash const &) const;
+	bool block_or_pruned_exists (secure::transaction const &, nano::block_hash const &) const;
 	std::string block_text (char const *);
 	std::string block_text (nano::block_hash const &);
-	std::pair<nano::block_hash, nano::block_hash> hash_root_random (store::transaction const &) const;
-	std::optional<nano::pending_info> pending_info (store::transaction const & transaction, nano::pending_key const & key) const;
-	std::deque<std::shared_ptr<nano::block>> confirm (nano::store::write_transaction const & transaction, nano::block_hash const & hash);
-	nano::block_status process (store::write_transaction const & transaction, std::shared_ptr<nano::block> block);
-	bool rollback (store::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
-	bool rollback (store::write_transaction const &, nano::block_hash const &);
-	void update_account (store::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);
-	uint64_t pruning_action (store::write_transaction &, nano::block_hash const &, uint64_t const);
+	std::pair<nano::block_hash, nano::block_hash> hash_root_random (secure::transaction const &) const;
+	std::optional<nano::pending_info> pending_info (secure::transaction const & transaction, nano::pending_key const & key) const;
+	std::deque<std::shared_ptr<nano::block>> confirm (secure::write_transaction const & transaction, nano::block_hash const & hash);
+	nano::block_status process (secure::write_transaction const & transaction, std::shared_ptr<nano::block> block);
+	bool rollback (secure::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
+	bool rollback (secure::write_transaction const &, nano::block_hash const &);
+	void update_account (secure::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);
+	uint64_t pruning_action (secure::write_transaction &, nano::block_hash const &, uint64_t const);
 	void dump_account_chain (nano::account const &, std::ostream & = std::cout);
-	bool dependents_confirmed (store::transaction const &, nano::block const &) const;
+	bool dependents_confirmed (secure::transaction const &, nano::block const &) const;
 	bool is_epoch_link (nano::link const &) const;
-	std::array<nano::block_hash, 2> dependent_blocks (store::transaction const &, nano::block const &) const;
-	std::shared_ptr<nano::block> find_receive_block_by_send_hash (store::transaction const & transaction, nano::account const & destination, nano::block_hash const & send_block_hash);
+	std::array<nano::block_hash, 2> dependent_blocks (secure::transaction const &, nano::block const &) const;
+	std::shared_ptr<nano::block> find_receive_block_by_send_hash (secure::transaction const & transaction, nano::account const & destination, nano::block_hash const & send_block_hash);
 	nano::account const & epoch_signer (nano::link const &) const;
 	nano::link const & epoch_link (nano::epoch) const;
 	bool migrate_lmdb_to_rocksdb (std::filesystem::path const &) const;
 	bool bootstrap_weight_reached () const;
 	static nano::epoch version (nano::block const & block);
-	nano::epoch version (store::transaction const & transaction, nano::block_hash const & hash) const;
-	uint64_t height (store::transaction const & transaction, nano::block_hash const & hash) const;
+	nano::epoch version (secure::transaction const & transaction, nano::block_hash const & hash) const;
+	uint64_t height (secure::transaction const & transaction, nano::block_hash const & hash) const;
 	// Returns whether there are any receivable entries for 'account'
-	bool receivable_any (store::transaction const & tx, nano::account const & account) const;
+	bool receivable_any (secure::transaction const & tx, nano::account const & account) const;
 	nano::receivable_iterator receivable_end () const;
 	// Returns the next receivable entry for an account greater than 'account'
-	nano::receivable_iterator receivable_upper_bound (store::transaction const & tx, nano::account const & account) const;
+	nano::receivable_iterator receivable_upper_bound (secure::transaction const & tx, nano::account const & account) const;
 	// Returns the next receivable entry for the account 'account' with hash greater than 'hash'
-	nano::receivable_iterator receivable_upper_bound (store::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const;
+	nano::receivable_iterator receivable_upper_bound (secure::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const;
 	std::unique_ptr<container_info_component> collect_container_info (std::string const & name) const;
 	uint64_t cemented_count () const;
 	uint64_t block_count () const;
@@ -110,8 +114,8 @@ public:
 
 private:
 	// Returns the next receivable entry equal or greater than 'key'
-	std::optional<std::pair<nano::pending_key, nano::pending_info>> receivable_lower_bound (store::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const;
+	std::optional<std::pair<nano::pending_key, nano::pending_info>> receivable_lower_bound (secure::transaction const & tx, nano::account const & account, nano::block_hash const & hash) const;
 	void initialize (nano::generate_cache_flags const &);
-	void confirm (nano::store::write_transaction const & transaction, nano::block const & block);
+	void confirm (secure::write_transaction const & transaction, nano::block const & block);
 };
 }

--- a/nano/secure/pending_info.cpp
+++ b/nano/secure/pending_info.cpp
@@ -72,7 +72,7 @@ bool nano::pending_key::operator< (nano::pending_key const & other_a) const
 	return account == other_a.account ? hash < other_a.hash : account < other_a.account;
 }
 
-nano::receivable_iterator::receivable_iterator (nano::ledger const & ledger, nano::store::transaction const & tx, std::optional<std::pair<nano::pending_key, nano::pending_info>> item) :
+nano::receivable_iterator::receivable_iterator (nano::ledger const & ledger, nano::secure::transaction const & tx, std::optional<std::pair<nano::pending_key, nano::pending_info>> item) :
 	ledger{ &ledger },
 	tx{ &tx },
 	item{ item }

--- a/nano/secure/pending_info.hpp
+++ b/nano/secure/pending_info.hpp
@@ -9,7 +9,7 @@ namespace nano
 class ledger;
 }
 
-namespace nano::store
+namespace nano::secure
 {
 class transaction;
 }
@@ -66,7 +66,7 @@ class receivable_iterator
 {
 public:
 	receivable_iterator () = default;
-	receivable_iterator (nano::ledger const & ledger, nano::store::transaction const & tx, std::optional<std::pair<nano::pending_key, nano::pending_info>> item);
+	receivable_iterator (nano::ledger const & ledger, nano::secure::transaction const & tx, std::optional<std::pair<nano::pending_key, nano::pending_info>> item);
 	bool operator== (receivable_iterator const & other) const;
 	bool operator!= (receivable_iterator const & other) const;
 	// Advances to the next receivable entry for the same account
@@ -76,7 +76,7 @@ public:
 
 private:
 	nano::ledger const * ledger{ nullptr };
-	nano::store::transaction const * tx{ nullptr };
+	nano::secure::transaction const * tx{ nullptr };
 	nano::account account{ 0 };
 	std::optional<std::pair<nano::pending_key, nano::pending_info>> item;
 };

--- a/nano/secure/transaction.hpp
+++ b/nano/secure/transaction.hpp
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <nano/store/transaction.hpp> // Correct include for nano::store transaction classes
+
+#include <utility> // For std::move
+
+namespace nano::secure
+{
+
+class transaction
+{
+public:
+	transaction () = default;
+	virtual ~transaction () = default;
+
+	// Deleting copy and assignment operations
+	transaction (const transaction &) = delete;
+	transaction & operator= (const transaction &) = delete;
+
+	// Default move operations
+	transaction (transaction &&) noexcept = default;
+	transaction & operator= (transaction &&) noexcept = default;
+
+	// Pure virtual function to get a const reference to the base store transaction
+	virtual const nano::store::transaction & base_txn () const = 0;
+
+	// Conversion operator to const nano::store::transaction&
+	virtual operator const nano::store::transaction & () const = 0;
+};
+
+class write_transaction : public transaction
+{
+	nano::store::write_transaction txn;
+
+public:
+	explicit write_transaction (nano::store::write_transaction && t) noexcept :
+		txn (std::move (t))
+	{
+	}
+
+	// Override to return a reference to the encapsulated write_transaction
+	const nano::store::transaction & base_txn () const override
+	{
+		return txn;
+	}
+
+	void commit ()
+	{
+		txn.commit ();
+	}
+
+	void renew ()
+	{
+		txn.renew ();
+	}
+
+	void refresh ()
+	{
+		txn.refresh ();
+	}
+
+	// Conversion operator to const nano::store::transaction&
+	operator const nano::store::transaction & () const override
+	{
+		return txn;
+	}
+
+	// Additional conversion operator specific to nano::store::write_transaction
+	operator const nano::store::write_transaction & () const
+	{
+		return txn;
+	}
+};
+
+class read_transaction : public transaction
+{
+	nano::store::read_transaction txn;
+
+public:
+	explicit read_transaction (nano::store::read_transaction && t) noexcept :
+		txn (std::move (t))
+	{
+	}
+
+	// Override to return a reference to the encapsulated read_transaction
+	const nano::store::transaction & base_txn () const override
+	{
+		return txn;
+	}
+
+	void refresh () const
+	{
+		txn.refresh ();
+	}
+
+	void refresh_if_needed (std::chrono::milliseconds max_age = std::chrono::milliseconds{ 500 }) const
+	{
+		txn.refresh_if_needed (max_age);
+	}
+
+	// Conversion operator to const nano::store::transaction&
+	operator const nano::store::transaction & () const override
+	{
+		return txn;
+	}
+
+	// Additional conversion operator specific to nano::store::read_transaction
+	operator const nano::store::read_transaction & () const
+	{
+		return txn;
+	}
+};
+} // namespace nano::secure

--- a/nano/test_common/ledger.cpp
+++ b/nano/test_common/ledger.cpp
@@ -10,7 +10,7 @@ nano::test::context::ledger_context::ledger_context (std::deque<std::shared_ptr<
 	pool_m{ nano::dev::network_params.network, 1 }
 {
 	debug_assert (!store_m->init_error ());
-	auto tx = store_m->tx_begin_write ();
+	auto tx = ledger_m.tx_begin_write ();
 	store_m->initialize (tx, ledger_m.cache, ledger_m.constants);
 	for (auto const & i : blocks_m)
 	{

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -33,7 +33,7 @@ namespace test
 		void generate_usage_traffic (uint32_t, uint32_t, size_t);
 		void generate_usage_traffic (uint32_t, uint32_t);
 		nano::account get_random_account (std::vector<nano::account> &);
-		nano::uint128_t get_random_amount (store::transaction const &, nano::node &, nano::account const &);
+		nano::uint128_t get_random_amount (secure::transaction const &, nano::node &, nano::account const &);
 		void generate_rollback (nano::node &, std::vector<nano::account> &);
 		void generate_change_known (nano::node &, std::vector<nano::account> &);
 		void generate_change_unknown (nano::node &, std::vector<nano::account> &);

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -66,7 +66,7 @@ nano::account nano::test::random_account ()
 
 bool nano::test::process (nano::node & node, std::vector<std::shared_ptr<nano::block>> blocks)
 {
-	auto const transaction = node.store.tx_begin_write ({ tables::accounts, tables::blocks, tables::pending, tables::rep_weights });
+	auto const transaction = node.ledger.tx_begin_write ({ tables::accounts, tables::blocks, tables::pending, tables::rep_weights });
 	for (auto & block : blocks)
 	{
 		auto result = node.process (transaction, block);
@@ -123,7 +123,7 @@ bool nano::test::exists (nano::node & node, std::vector<std::shared_ptr<nano::bl
 
 bool nano::test::block_or_pruned_all_exists (nano::node & node, std::vector<nano::block_hash> hashes)
 {
-	auto transaction = node.store.tx_begin_read ();
+	auto transaction = node.ledger.tx_begin_read ();
 	return std::all_of (hashes.begin (), hashes.end (),
 	[&] (const auto & hash) {
 		return node.ledger.block_or_pruned_exists (transaction, hash);
@@ -137,7 +137,7 @@ bool nano::test::block_or_pruned_all_exists (nano::node & node, std::vector<std:
 
 bool nano::test::block_or_pruned_none_exists (nano::node & node, std::vector<nano::block_hash> hashes)
 {
-	auto transaction = node.store.tx_begin_read ();
+	auto transaction = node.ledger.tx_begin_read ();
 	return std::none_of (hashes.begin (), hashes.end (),
 	[&] (const auto & hash) {
 		return node.ledger.block_or_pruned_exists (transaction, hash);
@@ -281,7 +281,7 @@ bool nano::test::start_elections (nano::test::system & system_a, nano::node & no
 
 nano::account_info nano::test::account_info (nano::node const & node, nano::account const & acc)
 {
-	auto const tx = node.ledger.store.tx_begin_read ();
+	auto const tx = node.ledger.tx_begin_read ();
 	auto opt = node.ledger.account_info (tx, acc);
 	if (opt.has_value ())
 	{
@@ -292,7 +292,7 @@ nano::account_info nano::test::account_info (nano::node const & node, nano::acco
 
 uint64_t nano::test::account_height (nano::node const & node, nano::account const & acc)
 {
-	auto const tx = node.ledger.store.tx_begin_read ();
+	auto const tx = node.ledger.tx_begin_read ();
 	nano::confirmation_height_info height_info;
 	if (node.ledger.store.confirmation_height.get (tx, acc, height_info))
 	{
@@ -316,7 +316,7 @@ void nano::test::print_all_receivable_entries (const nano::store::component & st
 void nano::test::print_all_account_info (const nano::ledger & ledger)
 {
 	std::cout << "Printing all account info:\n";
-	auto const tx = ledger.store.tx_begin_read ();
+	auto const tx = ledger.tx_begin_read ();
 	auto const end = ledger.store.account.end ();
 	for (auto i = ledger.store.account.begin (tx); i != end; ++i)
 	{


### PR DESCRIPTION
Creating nano::secure::transaction type which is used by nano::ledger and can be expanded to include memory locking.