### PR TITLE
Bugfix add_outer_node(), it should be added to disconnected set of nodes

### DIFF
--- a/nano/test_common/network.cpp
+++ b/nano/test_common/network.cpp
@@ -24,19 +24,21 @@ std::shared_ptr<nano::transport::channel_tcp> nano::test::establish_tcp (nano::t
 	return result;
 }
 
+// TODO: merge with make_disconnected_node
 std::shared_ptr<nano::node> nano::test::add_outer_node (nano::test::system & system_a, nano::node_config const & config_a, nano::node_flags flags_a)
 {
 	auto outer_node = std::make_shared<nano::node> (system_a.io_ctx, nano::unique_path (), config_a, system_a.work, flags_a);
 	outer_node->start ();
-	system_a.nodes.push_back (outer_node);
+	system_a.disconnected_nodes.push_back (outer_node);
 	return outer_node;
 }
 
+// TODO: merge with make_disconnected_node
 std::shared_ptr<nano::node> nano::test::add_outer_node (nano::test::system & system_a, nano::node_flags flags_a)
 {
 	auto outer_node = std::make_shared<nano::node> (system_a.io_ctx, system_a.get_available_port (), nano::unique_path (), system_a.work, flags_a);
 	outer_node->start ();
-	system_a.nodes.push_back (outer_node);
+	system_a.disconnected_nodes.push_back (outer_node);
 	return outer_node;
 }
 


### PR DESCRIPTION
By adding it to the standard set of nodes, any sebsequent node additions will connect to it and it is will remain unconnected.

add_outer_node should be merged with make_disconnected_node.