### PR TITLE
Max election age precision

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2036,19 +2036,20 @@ void nano::json_handler::election_statistics ()
 	}
 
 	auto utilization_percentage = (static_cast<double> (total_count * 100) / node.config.active_elections_size);
-	auto max_election_age = std::chrono::duration_cast<std::chrono::seconds> (now - oldest_election_start).count ();
+	auto max_election_age = std::chrono::duration<double> (now - oldest_election_start).count ();
 	double average_election_age = total_count ? std::chrono::duration<double> (total_age).count () / total_count : 0;
 
-	std::stringstream stream_utilization, stream_average_age;
+	std::stringstream stream_utilization, stream_average_age, stream_max_election_age;
 	stream_utilization << std::fixed << std::setprecision (2) << utilization_percentage;
 	stream_average_age << std::fixed << std::setprecision (2) << average_election_age;
+	stream_max_election_age << std::fixed << std::setprecision (2) << max_election_age;
 
 	response_l.put ("normal", normal_count);
 	response_l.put ("hinted", hinted_count);
 	response_l.put ("optimistic", optimistic_count);
 	response_l.put ("total", total_count);
 	response_l.put ("aec_utilization_percentage", stream_utilization.str ());
-	response_l.put ("max_election_age", max_election_age);
+	response_l.put ("max_election_age", stream_max_election_age.str ());
 	response_l.put ("average_election_age", stream_average_age.str ());
 
 	response_errors ();

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2036,21 +2036,19 @@ void nano::json_handler::election_statistics ()
 	}
 
 	auto utilization_percentage = (static_cast<double> (total_count * 100) / node.config.active_elections_size);
-	auto max_election_age = std::chrono::duration<double> (now - oldest_election_start).count ();
-	double average_election_age = total_count ? std::chrono::duration<double> (total_age).count () / total_count : 0;
+	auto max_election_age = std::chrono::duration_cast<std::chrono::milliseconds> (now - oldest_election_start).count ();
+	auto average_election_age = total_count ? std::chrono::duration_cast<std::chrono::milliseconds> (total_age).count () / total_count : 0;
 
-	std::stringstream stream_utilization, stream_average_age, stream_max_election_age;
+	std::stringstream stream_utilization;
 	stream_utilization << std::fixed << std::setprecision (2) << utilization_percentage;
-	stream_average_age << std::fixed << std::setprecision (2) << average_election_age;
-	stream_max_election_age << std::fixed << std::setprecision (2) << max_election_age;
 
 	response_l.put ("normal", normal_count);
 	response_l.put ("hinted", hinted_count);
 	response_l.put ("optimistic", optimistic_count);
 	response_l.put ("total", total_count);
 	response_l.put ("aec_utilization_percentage", stream_utilization.str ());
-	response_l.put ("max_election_age", stream_max_election_age.str ());
-	response_l.put ("average_election_age", stream_average_age.str ());
+	response_l.put ("max_election_age", max_election_age);
+	response_l.put ("average_election_age", average_election_age);
 
 	response_errors ();
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2019,10 +2019,7 @@ void nano::json_handler::election_statistics ()
 		auto election_start = election->get_election_start ();
 		auto age = now - election_start;
 		total_age += age;
-		if (election_start < oldest_election_start)
-		{
-			oldest_election_start = election_start;
-		}
+		oldest_election_start = std::min (oldest_election_start, election->get_election_start ());
 
 		switch (election->behavior ())
 		{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6898,8 +6898,8 @@ TEST (rpc, election_statistics)
 	ASSERT_EQ ("0", response.get<std::string> ("optimistic"));
 	ASSERT_EQ ("1", response.get<std::string> ("total"));
 	ASSERT_NE ("0.00", response.get<std::string> ("aec_utilization_percentage"));
-	ASSERT_GT (response.get<double> ("max_election_age"), 0);
-	ASSERT_GT (response.get<double> ("average_election_age"), 0);
-	ASSERT_LT (response.get<double> ("max_election_age"), 5);
-	ASSERT_LT (response.get<double> ("average_election_age"), 5);
+	ASSERT_GT (response.get<int> ("max_election_age"), 0);
+	ASSERT_GT (response.get<int> ("average_election_age"), 0);
+	ASSERT_LT (response.get<int> ("max_election_age"), 5000);
+	ASSERT_LT (response.get<int> ("average_election_age"), 5000);
 }

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6870,14 +6870,10 @@ TEST (rpc, confirmation_info)
 TEST (rpc, election_statistics)
 {
 	nano::test::system system;
-	nano::node_config node_config;
-	node_config.ipc_config.transport_tcp.enabled = true;
-	node_config.ipc_config.transport_tcp.port = system.get_available_port ();
-	nano::node_flags node_flags;
-	node_flags.disable_request_loop = true;
-	auto node1 (system.add_node (node_config, node_flags));
+	auto node1 = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node1);
 
+	// process block and wait for election to start, the election will not be completed because there are no voters on the network
 	nano::block_builder builder;
 	auto send1 = builder
 				 .send ()
@@ -6888,20 +6884,22 @@ TEST (rpc, election_statistics)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	node1->process_active (send1);
-	ASSERT_TIMELY (5s, !node1->active.empty ());
-	ASSERT_TRUE (nano::test::start_elections (system, *node1, { send1 }));
-	ASSERT_EQ (1, node1->active.size ());
+	ASSERT_TIMELY_EQ (5s, node1->active.size (), 1);
+
+	// delay to ensure returned age is not rounded down to zero
+	system.delay_ms (20ms);
 
 	boost::property_tree::ptree request;
 	request.put ("action", "election_statistics");
-	{
-		auto response (wait_response (system, rpc_ctx, request));
-		ASSERT_EQ ("1", response.get<std::string> ("normal"));
-		ASSERT_EQ ("0", response.get<std::string> ("hinted"));
-		ASSERT_EQ ("0", response.get<std::string> ("optimistic"));
-		ASSERT_EQ ("1", response.get<std::string> ("total"));
-		ASSERT_NE ("0.00", response.get<std::string> ("aec_utilization_percentage"));
-		ASSERT_NO_THROW (response.get<std::string> ("max_election_age"));
-		ASSERT_NO_THROW (response.get<std::string> ("average_election_age"));
-	}
+
+	auto response = wait_response (system, rpc_ctx, request);
+	ASSERT_EQ ("1", response.get<std::string> ("normal"));
+	ASSERT_EQ ("0", response.get<std::string> ("hinted"));
+	ASSERT_EQ ("0", response.get<std::string> ("optimistic"));
+	ASSERT_EQ ("1", response.get<std::string> ("total"));
+	ASSERT_NE ("0.00", response.get<std::string> ("aec_utilization_percentage"));
+	ASSERT_GT (response.get<double> ("max_election_age"), 0);
+	ASSERT_GT (response.get<double> ("average_election_age"), 0);
+	ASSERT_LT (response.get<double> ("max_election_age"), 5);
+	ASSERT_LT (response.get<double> ("average_election_age"), 5);
 }


### PR DESCRIPTION
`max_election_age` is currently being casted as `std::chrono::seconds` which causes the value to be rounded to nearest second. This pr changes it to use `double` and returns the value with 2 decimals.
It's unfortunate that I did not notice this issue in the original PR.
The unit test is also updated to test that both election age values are greater than zero. On my machine they are 0.09 seconds during unit test.
I also implemented the syntax Colin suggested for `oldest_election_start` to avoid the if statement