### PR TITLE
Use memory weight instead of exact weight when computing wallet reps.

### DIFF
--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1644,12 +1644,7 @@ nano::wallet_representatives nano::wallets::reps () const
 
 bool nano::wallets::check_rep (nano::account const & account_a, nano::uint128_t const & half_principal_weight_a, bool const acquire_lock_a)
 {
-	nano::uint128_t weight;
-	{
-		auto ledger_txn{ node.ledger.store.tx_begin_read () };
-		weight = node.ledger.weight_exact (ledger_txn, account_a);
-	}
-
+	auto weight = node.ledger.weight (account_a);
 	if (weight < node.config.vote_minimum.number ())
 	{
 		return false; // account not a representative


### PR DESCRIPTION
This function is used to check if an account has enough weight to be a rep. If this account isn't in memory because of its high weight, by definition it doesn't have enough weight.

This also eliminates a database transaction while holding the reps_cache_mutex in nano::wallets::compute_reps. This mutex is in several hot paths of code such as nano::wallets::reps being called from message_visitor::confirm_req