### PR TITLE
Vote generator write queue

### DIFF
--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -94,6 +94,7 @@ void nano::vote_generator::process_batch (std::deque<queue_entry_t> & batch)
 {
 	std::deque<candidate_t> candidates_new;
 	{
+		auto guard = ledger.store.write_queue.wait (is_final ? nano::store::writer::voting_final : nano::store::writer::voting);
 		auto transaction = ledger.store.tx_begin_write ({ tables::final_votes });
 
 		for (auto & [root, hash] : batch)

--- a/nano/store/write_queue.hpp
+++ b/nano/store/write_queue.hpp
@@ -14,6 +14,8 @@ enum class writer
 	confirmation_height,
 	process_batch,
 	pruning,
+	voting,
+	voting_final,
 	testing // Used in tests to emulate a write lock
 };
 


### PR DESCRIPTION
Changes the vote_generators to respect the database write queue.

Add consistency check to ensure the writer token is not already queued since they're waited for by value.
Change wait-loop to use the predicated overload of wait.