### PR TITLE
Move node::receive_confirmed to wallets::receive_confirmed

### DIFF
--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -87,7 +87,6 @@ public:
 	void stop ();
 	std::shared_ptr<nano::node> shared ();
 	int store_version ();
-	void receive_confirmed (store::transaction const & block_transaction_a, nano::block_hash const & hash_a, nano::account const & destination_a);
 	void process_confirmed (nano::election_status const &, uint64_t = 0);
 	void process_active (std::shared_ptr<nano::block> const &);
 	std::optional<nano::block_status> process_local (std::shared_ptr<nano::block> const &);

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -220,6 +220,7 @@ public:
 	bool check_rep (nano::account const &, nano::uint128_t const &, bool const = true);
 	void compute_reps ();
 	void ongoing_compute_reps ();
+	void receive_confirmed (nano::block_hash const & hash_a, nano::account const & destination_a);
 	std::unordered_map<nano::wallet_id, std::shared_ptr<nano::wallet>> get_wallets ();
 	nano::network_params & network_params;
 	std::function<void (bool)> observer;


### PR DESCRIPTION
This is inherently a wallet operation so it's more appropriate to be on the wallets class.

This also breaks a direct dependency/cycle from block processing to the wallet operations.

This also breaks a lock order inversion where a ledger transaction mutex is held while acquiring the wallet mutexes while most operations do it in the reverse order.