### PR TITLE
Generate indented toml config files for improved legibility

### DIFF
--- a/nano/lib/tomlconfig.cpp
+++ b/nano/lib/tomlconfig.cpp
@@ -186,15 +186,7 @@ void nano::tomlconfig::erase_default_values (tomlconfig & defaults_a)
 	erase_defaults (defaults_l.get_tree (), self.get_tree (), get_tree ());
 }
 
-std::string nano::tomlconfig::to_string ()
-{
-	std::stringstream ss;
-	cpptoml::toml_writer writer{ ss, "" };
-	tree->accept (writer);
-	return ss.str ();
-}
-
-std::string nano::tomlconfig::to_string_commented_entries ()
+std::string nano::tomlconfig::to_string (bool comment_values)
 {
 	std::stringstream ss, ss_processed;
 	cpptoml::toml_writer writer{ ss, "" };
@@ -202,9 +194,16 @@ std::string nano::tomlconfig::to_string_commented_entries ()
 	std::string line;
 	while (std::getline (ss, line, '\n'))
 	{
-		if (!line.empty () && line[0] != '#' && line[0] != '[')
+		if (!line.empty () && line[0] != '[')
 		{
-			line = "#" + line;
+			if (line[0] == '#') // Already commented
+			{
+				line = "\t" + line;
+			}
+			else
+			{
+				line = comment_values ? "\t# " + line : "\t" + line;
+			}
 		}
 		ss_processed << line << std::endl;
 	}

--- a/nano/lib/tomlconfig.hpp
+++ b/nano/lib/tomlconfig.hpp
@@ -47,8 +47,7 @@ public:
 	tomlconfig & erase (std::string const & key_a);
 	std::shared_ptr<cpptoml::array> create_array (std::string const & key, boost::optional<char const *> documentation_a);
 	void erase_default_values (tomlconfig & defaults_a);
-	std::string to_string ();
-	std::string to_string_commented_entries ();
+	std::string to_string (bool comment_values);
 
 	/** Set value for the given key. Any existing value will be overwritten. */
 	template <typename T>

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -703,11 +703,11 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 
 			if (vm.count ("use_defaults"))
 			{
-				std::cout << toml.to_string () << std::endl;
+				std::cout << toml.to_string (false) << std::endl;
 			}
 			else
 			{
-				std::cout << toml.to_string_commented_entries () << std::endl;
+				std::cout << toml.to_string (true) << std::endl;
 			}
 		}
 	}


### PR DESCRIPTION
The current config layout is quite hard to navigate.
This PR adds indentation to clearly show what is a child object of a node. Indentations are allowed for the TOML format according to the official documentation.
`--generate_config` cli command has been tested with both node, rpc and log configs. It also supports the `--use_defaults` command with correct output.
Here is a small sample of the new config file for illustration:
```
[node.httpcallback]

        # Callback address.
        # type:string,ip
        # address = ""

        # Callback port number.
        # type:uint16
        # port = 0

        # Callback target path.
        # type:string,uri
        # target = ""

[node.ipc.flatbuffers]

        # Allow client to send unknown fields in json messages. These will be ignored.
        # type:bool
        # skip_unexpected_fields_in_json = true

        # Verify that the buffer is valid before parsing. This is recommended when receiving data from untrusted sources.
        # type:bool
        # verify_buffers = true

[node.ipc.local]

        # If enabled, certain unsafe RPCs can be used. Not recommended for production systems.
        # type:bool
        # allow_unsafe = false

        # Enable or disable IPC via local domain socket.
        # type:bool
        # enable = false

        # Timeout for requests.
        # type:seconds
        # io_timeout = 15

        # Path to the local domain socket.
        # type:string
        # path = "/tmp/nano"

[node.ipc.tcp]

        # Enable or disable IPC via TCP server.
        # type:bool
        # enable = false

        # Timeout for requests.
        # type:seconds
        # io_timeout = 15

        # Server listening port.
        # type:uint16
        # port = 7077
```
