### PR TITLE
Clean up and remove recursive transaction usage

### DIFF
--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -650,8 +650,7 @@ TEST (wallet, work_generate)
 	}
 	nano::keypair key;
 	auto block (wallet->send_action (nano::dev::genesis_key.pub, key.pub, 100));
-	auto transaction (node1.store.tx_begin_read ());
-	ASSERT_TIMELY (10s, node1.ledger.account_balance (transaction, nano::dev::genesis_key.pub) != amount1);
+	ASSERT_TIMELY (10s, node1.ledger.account_balance (node1.ledger.store.tx_begin_read (), nano::dev::genesis_key.pub) != amount1);
 	system.deadline_set (10s);
 	auto again (true);
 	while (again)

--- a/nano/node/epoch_upgrader.cpp
+++ b/nano/node/epoch_upgrader.cpp
@@ -134,9 +134,8 @@ void nano::epoch_upgrader::upgrade_impl (nano::raw_key const & prv_a, nano::epoc
 			uint64_t attempts (0);
 			for (auto i (accounts_list.get<modified_tag> ().begin ()), n (accounts_list.get<modified_tag> ().end ()); i != n && attempts < upgrade_batch_size && attempts < count_limit && !stopped; ++i)
 			{
-				auto transaction (store.tx_begin_read ());
 				nano::account const & account (i->account);
-				auto info = ledger.account_info (transaction, account);
+				auto info = ledger.account_info (ledger.store.tx_begin_read (), account);
 				if (info && info->epoch () < epoch_a)
 				{
 					++attempts;
@@ -210,11 +209,10 @@ void nano::epoch_upgrader::upgrade_impl (nano::raw_key const & prv_a, nano::epoc
 			std::atomic<uint64_t> upgraded_pending (0);
 			uint64_t workers (0);
 			uint64_t attempts (0);
-			auto transaction = store.tx_begin_read ();
-			for (auto current = ledger.receivable_upper_bound (transaction, 0), end = ledger.receivable_end (); current != end && attempts < upgrade_batch_size && attempts < count_limit && !stopped;)
+			for (auto current = ledger.receivable_upper_bound (ledger.store.tx_begin_read (), 0), end = ledger.receivable_end (); current != end && attempts < upgrade_batch_size && attempts < count_limit && !stopped;)
 			{
 				auto const & [key, info] = *current;
-				if (!store.account.exists (transaction, key.account))
+				if (!store.account.exists (ledger.store.tx_begin_read (), key.account))
 				{
 					if (info.epoch < epoch_a)
 					{
@@ -257,7 +255,7 @@ void nano::epoch_upgrader::upgrade_impl (nano::raw_key const & prv_a, nano::epoc
 						}
 					}
 					// Move to next pending item
-					current = ledger.receivable_upper_bound (transaction, key.account, key.hash);
+					current = ledger.receivable_upper_bound (ledger.store.tx_begin_read (), key.account, key.hash);
 				}
 				else
 				{
@@ -268,7 +266,7 @@ void nano::epoch_upgrader::upgrade_impl (nano::raw_key const & prv_a, nano::epoc
 					}
 					else
 					{
-						current = ledger.receivable_upper_bound (transaction, key.account);
+						current = ledger.receivable_upper_bound (ledger.store.tx_begin_read (), key.account);
 					}
 				}
 			}

--- a/nano/node/scheduler/optimistic.cpp
+++ b/nano/node/scheduler/optimistic.cpp
@@ -155,7 +155,7 @@ void nano::scheduler::optimistic::run_one (store::transaction const & transactio
 	if (block)
 	{
 		// Ensure block is not already confirmed
-		if (!node.block_confirmed_or_being_confirmed (block->hash ()))
+		if (!node.block_confirmed_or_being_confirmed (transaction, block->hash ()))
 		{
 			// Try to insert it into AEC
 			// We check for AEC vacancy inside our predicate

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5770,8 +5770,8 @@ TEST (rpc, block_confirmed)
 
 	// Open an account directly in the ledger
 	{
-		auto transaction = node->store.tx_begin_write ();
-		nano::block_hash latest (node->latest (nano::dev::genesis_key.pub));
+		auto transaction = node->ledger.store.tx_begin_write ();
+		nano::block_hash latest (node->ledger.latest (transaction, nano::dev::genesis_key.pub));
 		auto send1 = builder
 					 .send ()
 					 .previous (latest)


### PR DESCRIPTION
Recursive transactions are generally unnecessary and will deadlock when mutually exclusive memory protection is needed/added to ledger transactions.

Use enclosing transaction within scheduler::optimistic::run_one rather than opening a new one. This seems like a typo since the existing transaction is readily available.

In the epoch upgrade algorithm, the receivable_iterator was not incremented so the transaction stored in the iterator was not used. The outer loop already re-opens the transaction to get an up-to-date view of the ledger so I didn't identify any necessity for the algorithm to have a consistent ledger view as it's running.