### PR TITLE
Shorten transaction lifetimes by using temporary expressions in some trivial cases.

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3014,8 +3014,7 @@ TEST (node, bidirectional_tcp)
 	system.deadline_set (20s);
 	while (!confirmed)
 	{
-		auto transaction1 (node1->store.tx_begin_read ());
-		confirmed = node1->ledger.block_confirmed (transaction1, send2->hash ());
+		confirmed = node1->ledger.block_confirmed (node1->store.tx_begin_read (), send2->hash ());
 		ASSERT_NO_ERROR (system.poll ());
 	}
 }

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -241,8 +241,7 @@ TEST (wallet, spend_no_previous)
 	nano::test::system system (1);
 	{
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-		auto transaction (system.nodes[0]->store.tx_begin_read ());
-		auto info1 = system.nodes[0]->ledger.account_info (transaction, nano::dev::genesis_key.pub);
+		auto info1 = system.nodes[0]->ledger.account_info (system.nodes[0]->store.tx_begin_read (), nano::dev::genesis_key.pub);
 		ASSERT_TRUE (info1);
 		for (auto i (0); i < 50; ++i)
 		{

--- a/nano/node/scheduler/optimistic.cpp
+++ b/nano/node/scheduler/optimistic.cpp
@@ -127,8 +127,6 @@ void nano::scheduler::optimistic::run ()
 
 		if (predicate ())
 		{
-			auto transaction = ledger.store.tx_begin_read ();
-
 			while (predicate ())
 			{
 				debug_assert (!candidates.empty ());
@@ -137,7 +135,7 @@ void nano::scheduler::optimistic::run ()
 
 				lock.unlock ();
 
-				run_one (transaction, candidate);
+				run_one (ledger.store.tx_begin_read (), candidate);
 
 				lock.lock ();
 			}


### PR DESCRIPTION
Eliminate holding ledger transactions while making or servicing callbacks. This is to facilitate using a shared_mutex to synchronize memory objects with the ledger https://github.com/nanocurrency/nano-node/pull/4567