### PR TITLE
Fix windows tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -144,4 +144,3 @@ jobs:
         run: ../ci/tests/run-system-tests.sh
         working-directory: build
         shell: bash
-        continue-on-error: true # FIXME: Investigate why this fails on Windows

--- a/ci/tests/run-system-tests.sh
+++ b/ci/tests/run-system-tests.sh
@@ -27,8 +27,9 @@ for script in ${NANO_SYSTEST_DIR}/*.sh; do
     # Redirecting output to a file to prevent it from being mixed with the output of the action
     # Using timeout command to enforce time limits
     if [[ "$OSTYPE" == "msys" ]]; then
-        # Windows minimal system (msys) detected. Launch a command prompt for better compatibility and timeout function
-        cmd.exe /C "timeout /T $((TEST_TIMEOUT * 1000)) /NOBREAK & ./$script > ${name}.log 2>&1"
+        # Windows minimal system (msys) detected. Launch a command prompt for better compatibility
+		# Todo: Add timeout logic to limit execution time. This will probably require a powershell script
+        cmd.exe /C "./$script > ${name}.log 2>&1"
     else
         # Other systems like Mac or Linux
         timeout $TEST_TIMEOUT ./$script > "${name}.log" 2>&1

--- a/ci/tests/run-system-tests.sh
+++ b/ci/tests/run-system-tests.sh
@@ -26,7 +26,14 @@ for script in ${NANO_SYSTEST_DIR}/*.sh; do
 
     # Redirecting output to a file to prevent it from being mixed with the output of the action
     # Using timeout command to enforce time limits
-    timeout $TEST_TIMEOUT ./$script > "${name}.log" 2>&1
+    if [[ "$OSTYPE" == "msys" ]]; then
+        # Windows minimal system (msys) detected. Launch a command prompt for better compatibility and timeout function
+        cmd.exe /C "timeout /T $((TEST_TIMEOUT * 1000)) /NOBREAK & ./$script > ${name}.log 2>&1"
+    else
+        # Other systems like Mac or Linux
+        timeout $TEST_TIMEOUT ./$script > "${name}.log" 2>&1
+    fi
+    
     status=$?
     cat "${name}.log"
 


### PR DESCRIPTION
The timeout command behaves differently in windows than linux and mac. In windows it will pause for the specified value before continuing the script.
This PR enables windows system tests to be launched from a native Windows command prompt instead of the bash and use the build in timeout function (in milliseconds)