### PR TITLE
Use multithreaded io runner in socket tests

### DIFF
--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -418,7 +418,7 @@ TEST (socket, drop_policy)
 	nano::inactive_node inactivenode (nano::unique_path (), node_flags);
 	auto node = inactivenode.node;
 
-	nano::thread_runner runner (node->io_ctx_shared, 1);
+	nano::thread_runner runner (node->io_ctx_shared);
 
 	std::vector<std::shared_ptr<nano::transport::socket>> connections;
 
@@ -485,7 +485,7 @@ TEST (socket, concurrent_writes)
 
 	// This gives more realistic execution than using system#poll, allowing writes to
 	// queue up and drain concurrently.
-	nano::thread_runner runner (node->io_ctx_shared, 1);
+	nano::thread_runner runner (node->io_ctx_shared);
 
 	constexpr size_t max_connections = 4;
 	constexpr size_t client_count = max_connections;


### PR DESCRIPTION
Enabling multithreaded io context in socket tests was one of the changes in https://github.com/nanocurrency/nano-node/pull/4523 that helped uncover additional TSAN problems.