### PR TITLE
Feature: disable_activate_successors flag

### DIFF
--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -116,7 +116,7 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 	bool was_active = status.type == nano::election_status_type::active_confirmed_quorum || status.type == nano::election_status_type::active_confirmation_height;
 
 	// Next-block activations are only done for blocks with previously active elections
-	if (cemented_bootstrap_count_reached && was_active)
+	if (cemented_bootstrap_count_reached && was_active && !node.flags.disable_activate_successors)
 	{
 		activate_successors (transaction, block);
 	}

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -92,6 +92,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 	// clang-format off
 	description_a.add_options()
 		("disable_add_initial_peers", "Disable contacting the peer in the peers table at startup")
+		("disable_activate_successors", "Disables activate_successors in active_transactions")
 		("disable_backup", "Disable wallet automatic backups")
 		("disable_lazy_bootstrap", "Disables lazy bootstrap")
 		("disable_legacy_bootstrap", "Disables legacy bootstrap")
@@ -121,6 +122,7 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 {
 	std::error_code ec;
 	flags_a.disable_add_initial_peers = (vm.count ("disable_add_initial_peers") > 0);
+	flags_a.disable_activate_successors = (vm.count ("disable_activate_successors") > 0);
 	flags_a.disable_backup = (vm.count ("disable_backup") > 0);
 	flags_a.disable_lazy_bootstrap = (vm.count ("disable_lazy_bootstrap") > 0);
 	flags_a.disable_legacy_bootstrap = (vm.count ("disable_legacy_bootstrap") > 0);

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -157,6 +157,7 @@ public:
 	std::vector<std::string> config_overrides;
 	std::vector<std::string> rpc_config_overrides;
 	bool disable_add_initial_peers{ false }; // For testing only
+	bool disable_activate_successors{ false }; // For testing only
 	bool disable_backup{ false };
 	bool disable_lazy_bootstrap{ false };
 	bool disable_legacy_bootstrap{ false };


### PR DESCRIPTION
This flag stops active_transactions from calling `activate_successors()`, which is useful for testing.