### PR TITLE
Run UPNP port mapping on a dedicated thread

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -540,20 +540,6 @@ TEST (network, endpoint_bad_fd)
 	ASSERT_TIMELY_EQ (10s, system.nodes[0]->network.endpoint ().port (), 0);
 }
 
-TEST (node, port_mapping)
-{
-	nano::test::system system (1);
-	auto node0 (system.nodes[0]);
-	node0->port_mapping.refresh_devices ();
-	node0->port_mapping.start ();
-	auto end (std::chrono::steady_clock::now () + std::chrono::seconds (500));
-	(void)end;
-	// while (std::chrono::steady_clock::now () < end)
-	{
-		ASSERT_NO_ERROR (system.poll ());
-	}
-}
-
 TEST (tcp_listener, tcp_node_id_handshake)
 {
 	nano::test::system system (1);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3890,3 +3890,10 @@ TEST (node_config, node_id_private_key_persistence)
 	nano::keypair kp4 = nano::load_or_create_node_id (path);
 	ASSERT_EQ (kp4.prv, nano::keypair ("3F28D035B8AA75EA53DF753BFD065CF6138E742971B2C99B84FD8FE328FED2D9").prv);
 }
+
+TEST (node, port_mapping)
+{
+	nano::test::system system;
+	auto node = system.add_node ();
+	node->port_mapping.refresh_devices ();
+}

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -64,6 +64,7 @@ enum class type : uint8_t
 	rep_tiers,
 	syn_cookies,
 	peer_history,
+	port_mapping,
 
 	bootstrap_ascending,
 	bootstrap_ascending_accounts,

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -134,6 +134,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::peer_history:
 			thread_role_name_string = "Peer history";
 			break;
+		case nano::thread_role::name::port_mapping:
+			thread_role_name_string = "Port mapping";
+			break;
 		default:
 			debug_assert (false && "nano::thread_role::get_string unhandled thread role");
 	}

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -51,6 +51,7 @@ enum class name
 	signal_manager,
 	tcp_listener,
 	peer_history,
+	port_mapping,
 };
 
 std::string_view to_string (name);

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -5,7 +5,6 @@
 #include <miniupnp/miniupnpc/include/upnpcommands.h>
 #include <miniupnp/miniupnpc/include/upnperrors.h>
 
-#include <boost/format.hpp>
 #include <boost/range/adaptor/filtered.hpp>
 
 std::string nano::mapping_protocol::to_string ()
@@ -37,6 +36,13 @@ void nano::port_mapping::start ()
 {
 	debug_assert (!thread.joinable ());
 
+	// Long discovery time and fast setup/teardown make this impractical for testing
+	// TODO: Find a way to test this
+	if (node.network_params.network.is_dev_network ())
+	{
+		return;
+	}
+
 	thread = std::thread ([this] {
 		nano::thread_role::set (nano::thread_role::name::port_mapping);
 		run ();
@@ -51,7 +57,10 @@ void nano::port_mapping::stop ()
 	}
 	condition.notify_all ();
 
-	thread.join ();
+	if (thread.joinable ())
+	{
+		thread.join ();
+	}
 
 	nano::lock_guard<nano::mutex> guard_l (mutex);
 	for (auto & protocol : protocols | boost::adaptors::filtered ([] (auto const & p) { return p.enabled; }))
@@ -99,35 +108,32 @@ std::string nano::port_mapping::to_string ()
 
 void nano::port_mapping::refresh_devices ()
 {
-	if (!node.network_params.network.is_dev_network ())
+	upnp_state upnp_l;
+	int discover_error_l = 0;
+	upnp_l.devices = upnpDiscover (2000, nullptr, nullptr, UPNP_LOCAL_PORT_ANY, false, 2, &discover_error_l);
+	std::array<char, 64> local_address_l;
+	local_address_l.fill (0);
+	auto igd_error_l (UPNP_GetValidIGD (upnp_l.devices, &upnp_l.urls, &upnp_l.data, local_address_l.data (), sizeof (local_address_l)));
+
+	// Bump logging level periodically
+	node.logger.log ((check_count % 15 == 0) ? nano::log::level::info : nano::log::level::debug,
+	nano::log::type::upnp, "UPnP local address {}, discovery: {}, IGD search: {}",
+	local_address_l.data (),
+	discover_error_l,
+	igd_error_l);
+
+	for (auto i (upnp_l.devices); i != nullptr; i = i->pNext)
 	{
-		upnp_state upnp_l;
-		int discover_error_l = 0;
-		upnp_l.devices = upnpDiscover (2000, nullptr, nullptr, UPNP_LOCAL_PORT_ANY, false, 2, &discover_error_l);
-		std::array<char, 64> local_address_l;
-		local_address_l.fill (0);
-		auto igd_error_l (UPNP_GetValidIGD (upnp_l.devices, &upnp_l.urls, &upnp_l.data, local_address_l.data (), sizeof (local_address_l)));
+		node.logger.debug (nano::log::type::upnp, "UPnP device url: {}, st: {}, usn: {}", i->descURL, i->st, i->usn);
+	}
 
-		// Bump logging level periodically
-		node.logger.log ((check_count % 15 == 0) ? nano::log::level::info : nano::log::level::debug,
-		nano::log::type::upnp, "UPnP local address {}, discovery: {}, IGD search: {}",
-		local_address_l.data (),
-		discover_error_l,
-		igd_error_l);
-
-		for (auto i (upnp_l.devices); i != nullptr; i = i->pNext)
-		{
-			node.logger.debug (nano::log::type::upnp, "UPnP device url: {}, st: {}, usn: {}", i->descURL, i->st, i->usn);
-		}
-
-		// Update port mapping
-		nano::lock_guard<nano::mutex> guard_l (mutex);
-		upnp = std::move (upnp_l);
-		if (igd_error_l == 1 || igd_error_l == 2)
-		{
-			boost::system::error_code ec;
-			address = boost::asio::ip::address_v4::from_string (local_address_l.data (), ec);
-		}
+	// Update port mapping
+	nano::lock_guard<nano::mutex> guard_l (mutex);
+	upnp = std::move (upnp_l);
+	if (igd_error_l == 1 || igd_error_l == 2)
+	{
+		boost::system::error_code ec;
+		address = boost::asio::ip::address_v4::from_string (local_address_l.data (), ec);
 	}
 }
 
@@ -147,48 +153,48 @@ nano::endpoint nano::port_mapping::external_address ()
 
 void nano::port_mapping::refresh_mapping ()
 {
-	debug_assert (!node.network_params.network.is_dev_network ());
-	if (!stopped)
+	nano::lock_guard<nano::mutex> guard_l (mutex);
+
+	if (stopped)
 	{
-		nano::lock_guard<nano::mutex> guard_l (mutex);
-		auto node_port_l (std::to_string (node.network.endpoint ().port ()));
-		auto config_port_l (get_config_port (node_port_l));
+		return;
+	}
 
-		// We don't map the RPC port because, unless RPC authentication was added, this would almost always be a security risk
-		for (auto & protocol : protocols | boost::adaptors::filtered ([] (auto const & p) { return p.enabled; }))
+	auto node_port_l (std::to_string (node.network.endpoint ().port ()));
+	auto config_port_l (get_config_port (node_port_l));
+
+	// We don't map the RPC port because, unless RPC authentication was added, this would almost always be a security risk
+	for (auto & protocol : protocols | boost::adaptors::filtered ([] (auto const & p) { return p.enabled; }))
+	{
+		auto upnp_description = std::string ("Nano Node (") + node.network_params.network.get_current_network_as_string () + ")";
+		auto add_port_mapping_error_l (UPNP_AddPortMapping (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), node_port_l.c_str (), address.to_string ().c_str (), upnp_description.c_str (), protocol.name, nullptr, std::to_string (node.network_params.portmapping.lease_duration.count ()).c_str ()));
+
+		if (add_port_mapping_error_l == UPNPCOMMAND_SUCCESS)
 		{
-			auto upnp_description = std::string ("Nano Node (") + node.network_params.network.get_current_network_as_string () + ")";
-			auto add_port_mapping_error_l (UPNP_AddPortMapping (upnp.urls.controlURL, upnp.data.first.servicetype, config_port_l.c_str (), node_port_l.c_str (), address.to_string ().c_str (), upnp_description.c_str (), protocol.name, nullptr, std::to_string (node.network_params.portmapping.lease_duration.count ()).c_str ()));
+			protocol.external_port = static_cast<uint16_t> (std::atoi (config_port_l.data ()));
 
-			if (add_port_mapping_error_l == UPNPCOMMAND_SUCCESS)
-			{
-				protocol.external_port = static_cast<uint16_t> (std::atoi (config_port_l.data ()));
+			node.logger.info (nano::log::type::upnp, "UPnP {} {}:{} mapped to: {}",
+			protocol.name,
+			protocol.external_address.to_string (),
+			config_port_l,
+			node_port_l);
+		}
+		else
+		{
+			protocol.external_port = 0;
 
-				node.logger.info (nano::log::type::upnp, "UPnP {} {}:{} mapped to: {}",
-				protocol.name,
-				protocol.external_address.to_string (),
-				config_port_l,
-				node_port_l);
-			}
-			else
-			{
-				protocol.external_port = 0;
-
-				node.logger.warn (nano::log::type::upnp, "UPnP {} {}:{} failed: {} ({})",
-				protocol.name,
-				protocol.external_address.to_string (),
-				config_port_l,
-				add_port_mapping_error_l,
-				strupnperror (add_port_mapping_error_l));
-			}
+			node.logger.warn (nano::log::type::upnp, "UPnP {} {}:{} failed: {} ({})",
+			protocol.name,
+			protocol.external_address.to_string (),
+			config_port_l,
+			add_port_mapping_error_l,
+			strupnperror (add_port_mapping_error_l));
 		}
 	}
 }
 
 bool nano::port_mapping::check_lost_or_old_mapping ()
 {
-	// Long discovery time and fast setup/teardown make this impractical for testing
-	debug_assert (!node.network_params.network.is_dev_network ());
 	bool result_l (false);
 	nano::lock_guard<nano::mutex> guard_l (mutex);
 	auto node_port_l (std::to_string (node.network.endpoint ().port ()));
@@ -252,6 +258,8 @@ bool nano::port_mapping::check_lost_or_old_mapping ()
 
 void nano::port_mapping::check_mapping ()
 {
+	debug_assert (!node.network_params.network.is_dev_network ());
+
 	refresh_devices ();
 
 	if (upnp.devices != nullptr)


### PR DESCRIPTION
This reworks the `port_mapping` component responsible for port redirection configuration to run on a dedicated thread. This should help with node resiliency. 

However, the problem I noticed is that testing `port_mapping` component doesn't seem to be part of our CI. There is a comment indicating that maybe this was attempted in the past:
> // Long discovery time and fast setup/teardown make this impractical for testing

I'd recommend that we look into it. Perhaps it can be done as part of our system test suite.