### PR TITLE
Stats logging

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -335,10 +335,10 @@ TEST (block_store, pending_iterator)
  */
 TEST (block_store, pending_iterator_comparison)
 {
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	nano::test::system system;
+
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stats stats;
 	auto transaction (store->tx_begin_write ());
 	// Populate pending
 	store->pending.put (transaction, nano::pending_key (nano::account (3), nano::block_hash (1)), nano::pending_info (nano::account (10), nano::amount (1), nano::epoch::epoch_0));
@@ -624,12 +624,13 @@ TEST (mdb_block_store, supported_version_upgrades)
 		// Don't test this in rocksdb mode
 		GTEST_SKIP ();
 	}
+
 	// Check that upgrading from an unsupported version is not supported
 	auto path (nano::unique_path () / "data.ldb");
 	nano::logger logger;
 	{
 		nano::store::lmdb::component store (logger, path, nano::dev::constants);
-		nano::stats stats;
+		nano::stats stats{ logger };
 		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, ledger.cache, nano::dev::constants);
@@ -647,7 +648,7 @@ TEST (mdb_block_store, supported_version_upgrades)
 	// Now try with the minimum version
 	{
 		nano::store::lmdb::component store (logger, path1, nano::dev::constants);
-		nano::stats stats;
+		nano::stats stats{ logger };
 		nano::ledger ledger (store, stats, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
 		store.initialize (transaction, ledger.cache, nano::dev::constants);
@@ -895,7 +896,7 @@ TEST (block_store, cemented_count_cache)
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
 	auto transaction (store->tx_begin_write ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	store->initialize (transaction, ledger.cache, nano::dev::constants);
 	ASSERT_EQ (1, ledger.cemented_count ());
@@ -998,7 +999,7 @@ TEST (mdb_block_store, sideband_height)
 	nano::keypair key3;
 	nano::store::lmdb::component store (logger, nano::unique_path () / "data.ldb", nano::dev::constants);
 	ASSERT_FALSE (store.init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (store, stats, nano::dev::constants);
 	nano::block_builder builder;
 	auto transaction = ledger.tx_begin_write ();
@@ -1369,7 +1370,7 @@ TEST (mdb_block_store, upgrade_v21_v22)
 
 	auto path (nano::unique_path () / "data.ldb");
 	nano::logger logger;
-	nano::stats stats;
+	nano::stats stats{ logger };
 	auto const check_correct_state = [&] () {
 		nano::store::lmdb::component store (logger, path, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
@@ -1405,7 +1406,7 @@ TEST (mdb_block_store, upgrade_v23_v24)
 
 	auto path (nano::unique_path () / "data.ldb");
 	nano::logger logger;
-	nano::stats stats;
+	nano::stats stats{ logger };
 	auto const check_correct_state = [&] () {
 		nano::store::lmdb::component store (logger, path, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());
@@ -1444,7 +1445,7 @@ TEST (rocksdb_block_store, upgrade_v21_v22)
 
 	auto const path = nano::unique_path () / "rocksdb";
 	nano::logger logger;
-	nano::stats stats;
+	nano::stats stats{ logger };
 	auto const check_correct_state = [&] () {
 		nano::store::rocksdb::component store (logger, path, nano::dev::constants);
 		auto transaction (store.tx_begin_write ());

--- a/nano/core_test/bootstrap_ascending.cpp
+++ b/nano/core_test/bootstrap_ascending.cpp
@@ -27,44 +27,43 @@ nano::block_hash random_hash ()
 
 TEST (account_sets, construction)
 {
-	nano::stats stats;
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	nano::test::system system;
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ stats };
+	nano::bootstrap_ascending::account_sets sets{ system.stats };
 }
 
 TEST (account_sets, empty_blocked)
 {
+	nano::test::system system;
+
 	nano::account account{ 1 };
-	nano::stats stats;
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ stats };
+	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	ASSERT_FALSE (sets.blocked (account));
 }
 
 TEST (account_sets, block)
 {
+	nano::test::system system;
+
 	nano::account account{ 1 };
-	nano::stats stats;
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ stats };
+	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	sets.block (account, random_hash ());
 	ASSERT_TRUE (sets.blocked (account));
 }
 
 TEST (account_sets, unblock)
 {
+	nano::test::system system;
+
 	nano::account account{ 1 };
-	nano::stats stats;
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ stats };
+	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	auto hash = random_hash ();
 	sets.block (account, hash);
 	sets.unblock (account, hash);
@@ -73,23 +72,23 @@ TEST (account_sets, unblock)
 
 TEST (account_sets, priority_base)
 {
+	nano::test::system system;
+
 	nano::account account{ 1 };
-	nano::stats stats;
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ stats };
+	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	ASSERT_EQ (1.0f, sets.priority (account));
 }
 
 TEST (account_sets, priority_blocked)
 {
+	nano::test::system system;
+
 	nano::account account{ 1 };
-	nano::stats stats;
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ stats };
+	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	sets.block (account, random_hash ());
 	ASSERT_EQ (0.0f, sets.priority (account));
 }
@@ -97,12 +96,12 @@ TEST (account_sets, priority_blocked)
 // When account is unblocked, check that it retains it former priority
 TEST (account_sets, priority_unblock_keep)
 {
+	nano::test::system system;
+
 	nano::account account{ 1 };
-	nano::stats stats;
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ stats };
+	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	sets.priority_up (account);
 	sets.priority_up (account);
 	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial * nano::bootstrap_ascending::account_sets::priority_increase);
@@ -115,12 +114,12 @@ TEST (account_sets, priority_unblock_keep)
 
 TEST (account_sets, priority_up_down)
 {
+	nano::test::system system;
+
 	nano::account account{ 1 };
-	nano::stats stats;
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ stats };
+	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	sets.priority_up (account);
 	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial);
 	sets.priority_down (account);
@@ -130,12 +129,12 @@ TEST (account_sets, priority_up_down)
 // Check that priority downward saturates to 1.0f
 TEST (account_sets, priority_down_sat)
 {
+	nano::test::system system;
+
 	nano::account account{ 1 };
-	nano::stats stats;
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ stats };
+	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	sets.priority_down (account);
 	ASSERT_EQ (1.0f, sets.priority (account));
 }
@@ -143,12 +142,12 @@ TEST (account_sets, priority_down_sat)
 // Ensure priority value is bounded
 TEST (account_sets, saturate_priority)
 {
+	nano::test::system system;
+
 	nano::account account{ 1 };
-	nano::stats stats;
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ stats };
+	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	for (int n = 0; n < 1000; ++n)
 	{
 		sets.priority_up (account);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -869,7 +869,7 @@ TEST (ledger, double_open)
 	nano::logger logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
@@ -4702,7 +4702,7 @@ TEST (ledger, dependents_confirmed_pruning)
 	nano::logger logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction = ledger.tx_begin_write ();
@@ -4875,7 +4875,7 @@ TEST (ledger, pruning_action)
 	nano::logger logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction = ledger.tx_begin_write ();
@@ -4961,7 +4961,7 @@ TEST (ledger, pruning_large_chain)
 	nano::logger logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction = ledger.tx_begin_write ();
@@ -5017,7 +5017,7 @@ TEST (ledger, pruning_source_rollback)
 	nano::logger logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction = ledger.tx_begin_write ();
@@ -5106,7 +5106,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	nano::logger logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction = ledger.tx_begin_write ();
@@ -5220,7 +5220,7 @@ TEST (ledger, pruning_legacy_blocks)
 	nano::logger logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::keypair key1;
@@ -5307,7 +5307,7 @@ TEST (ledger, pruning_safe_functions)
 	nano::logger logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction = ledger.tx_begin_write ();
@@ -5359,7 +5359,7 @@ TEST (ledger, hash_root_random)
 	nano::logger logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	ledger.pruning = true;
 	auto transaction = ledger.tx_begin_write ();

--- a/nano/core_test/ledger_confirm.cpp
+++ b/nano/core_test/ledger_confirm.cpp
@@ -777,12 +777,12 @@ TEST (ledger_confirm, election_winner_details_clearing_node_process_confirmed)
 
 TEST (ledger_confirm, pruned_source)
 {
-	nano::logger logger;
+	nano::test::system system;
+
 	auto path (nano::unique_path ());
-	auto store = nano::make_store (logger, path, nano::dev::constants);
+	auto store = nano::make_store (system.logger, path, nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stats stats;
-	nano::ledger ledger (*store, stats, nano::dev::constants);
+	nano::ledger ledger (*store, system.stats, nano::dev::constants);
 	ledger.pruning = true;
 	nano::store::write_queue write_queue (false);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -862,12 +862,12 @@ TEST (ledger_confirmDeathTest, rollback_added_block)
 	// valgrind can be noisy with death tests
 	if (!nano::running_within_valgrind ())
 	{
-		nano::logger logger;
+		nano::test::system system;
+
 		auto path (nano::unique_path ());
-		auto store = nano::make_store (logger, path, nano::dev::constants);
+		auto store = nano::make_store (system.logger, path, nano::dev::constants);
 		ASSERT_TRUE (!store->init_error ());
-		nano::stats stats;
-		nano::ledger ledger (*store, stats, nano::dev::constants);
+		nano::ledger ledger (*store, system.stats, nano::dev::constants);
 		nano::store::write_queue write_queue (false);
 		nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 		nano::keypair key1;

--- a/nano/core_test/processor_service.cpp
+++ b/nano/core_test/processor_service.cpp
@@ -7,17 +7,18 @@
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/utility.hpp>
 #include <nano/store/component.hpp>
+#include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
 
 TEST (processor_service, bad_send_signature)
 {
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	nano::test::system system;
+
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::stats stats;
-	nano::ledger ledger (*store, stats, nano::dev::constants);
+	nano::ledger ledger (*store, system.stats, nano::dev::constants);
 	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -39,11 +40,11 @@ TEST (processor_service, bad_send_signature)
 
 TEST (processor_service, bad_receive_signature)
 {
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
+	nano::test::system system;
+
+	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::stats stats;
-	nano::ledger ledger (*store, stats, nano::dev::constants);
+	nano::ledger ledger (*store, system.stats, nano::dev::constants);
 	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };

--- a/nano/core_test/unchecked_map.cpp
+++ b/nano/core_test/unchecked_map.cpp
@@ -21,12 +21,15 @@ class context
 {
 public:
 	context () :
+		stats{ logger },
 		unchecked{ max_unchecked_blocks, stats, false }
 	{
 	}
+	nano::logger logger;
 	nano::stats stats;
 	nano::unchecked_map unchecked;
 };
+
 std::shared_ptr<nano::block> block ()
 {
 	nano::block_builder builder;

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(
   configbase.hpp
   diagnosticsconfig.hpp
   diagnosticsconfig.cpp
+  env.hpp
+  env.cpp
   epoch.hpp
   epoch.cpp
   errors.hpp

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -1,6 +1,7 @@
 #include <nano/crypto/blake2/blake2.h>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
+#include <nano/lib/env.hpp>
 #include <nano/lib/logging.hpp>
 
 #include <boost/format.hpp>
@@ -316,16 +317,6 @@ std::string get_tls_toml_config_path (std::filesystem::path const & data_path)
 	return (data_path / "config-tls.toml").string ();
 }
 } // namespace nano
-
-std::optional<std::string> nano::get_env (const char * variable_name)
-{
-	auto value = std::getenv (variable_name);
-	if (value)
-	{
-		return value;
-	}
-	return {};
-}
 
 std::string nano::get_env_or_default (char const * variable_name, std::string default_value)
 {

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -90,10 +90,6 @@ uint8_t get_pre_release_node_version ();
  */
 
 /*
- * Get environment variable as string or none if variable is not present
- */
-std::optional<std::string> get_env (char const * variable_name);
-/*
  * Get environment variable as string or `default_value` if variable is not present
  */
 std::string get_env_or_default (char const * variable_name, std::string const default_value);

--- a/nano/lib/env.cpp
+++ b/nano/lib/env.cpp
@@ -1,0 +1,37 @@
+#include <nano/lib/env.hpp>
+
+#include <boost/algorithm/string.hpp>
+
+#include <string>
+
+std::optional<std::string> nano::get_env (std::string_view name)
+{
+	std::string name_str{ name };
+	if (auto value = std::getenv (name_str.c_str ()))
+	{
+		return std::string{ value };
+	}
+	return std::nullopt;
+}
+
+std::optional<bool> nano::get_env_bool (std::string_view name)
+{
+	std::vector<std::string> const on_values{ "1", "true", "on" };
+	std::vector<std::string> const off_values{ "0", "false", "off" };
+
+	if (auto value = get_env (name))
+	{
+		// Using case-insensitive comparison
+		if (std::any_of (on_values.begin (), on_values.end (), [&value] (auto const & on) { return boost::iequals (*value, on); }))
+		{
+			return true;
+		}
+		if (std::any_of (off_values.begin (), off_values.end (), [&value] (auto const & off) { return boost::iequals (*value, off); }))
+		{
+			return false;
+		}
+
+		throw std::invalid_argument ("Invalid environment boolean value: " + *value);
+	}
+	return std::nullopt;
+}

--- a/nano/lib/env.hpp
+++ b/nano/lib/env.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+namespace nano
+{
+/*
+ * Get environment variable as a specific type or none if variable is not present.
+ */
+std::optional<std::string> get_env (std::string_view name);
+
+// @throws std::invalid_argument if the value is not a valid boolean
+std::optional<bool> get_env_bool (std::string_view name);
+}

--- a/nano/lib/logging.cpp
+++ b/nano/lib/logging.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/config.hpp>
+#include <nano/lib/env.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/logging_enums.hpp>
 #include <nano/lib/utility.hpp>

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -28,6 +28,7 @@ enum class type
 	system,
 	init,
 	config,
+	stats,
 	logging,
 	node,
 	node_wrapper,

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -21,6 +21,7 @@ namespace nano
 class node;
 class tomlconfig;
 class jsonconfig;
+class logger;
 
 /**
  * Serialize and deserialize the 'statistics' node from config.json
@@ -71,7 +72,7 @@ public:
 	using sampler_value_t = int64_t;
 
 public:
-	explicit stats (nano::stats_config = {});
+	explicit stats (nano::logger &, nano::stats_config = {});
 	~stats ();
 
 	void start ();
@@ -200,6 +201,9 @@ private:
 
 private:
 	nano::stats_config const config;
+	nano::logger & logger;
+
+	bool const enable_logging;
 
 	/** Time of last clear() call */
 	std::chrono::steady_clock::time_point timestamp{ std::chrono::steady_clock::now () };

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -143,7 +143,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	config (config_a),
 	network_params{ config.network_params },
 	logger{ make_logger_identifier (node_id) },
-	stats (config.stats_config),
+	stats{ logger, config.stats_config },
 	workers{ config.background_threads, nano::thread_role::name::worker },
 	bootstrap_workers{ config.bootstrap_serving_threads, nano::thread_role::name::bootstrap_worker },
 	flags (flags_a),

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/config.hpp>
+#include <nano/lib/env.hpp>
 #include <nano/secure/utility.hpp>
 #include <nano/secure/working.hpp>
 

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -126,7 +126,7 @@ TEST (ledger, deep_account_compute)
 	nano::logger logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	auto transaction = ledger.tx_begin_write ();
 	store->initialize (transaction, ledger.cache, ledger.constants);
@@ -1136,7 +1136,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 	auto path (nano::unique_path ());
 	auto store = nano::make_store (logger, path, nano::dev::constants);
 	ASSERT_TRUE (!store->init_error ());
-	nano::stats stats;
+	nano::stats stats{ logger };
 	nano::ledger ledger (*store, stats, nano::dev::constants);
 	nano::store::write_queue write_database_queue (false);
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };

--- a/nano/test_common/ledger.cpp
+++ b/nano/test_common/ledger.cpp
@@ -5,6 +5,7 @@
 
 nano::test::context::ledger_context::ledger_context (std::deque<std::shared_ptr<nano::block>> && blocks) :
 	store_m{ nano::make_store (logger, nano::unique_path (), nano::dev::constants) },
+	stats_m{ logger },
 	ledger_m{ *store_m, stats_m, nano::dev::constants },
 	blocks_m{ blocks },
 	pool_m{ nano::dev::network_params.network, 1 }

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -35,7 +35,8 @@ std::string nano::error_system_messages::message (int ev) const
 
 nano::test::system::system () :
 	io_ctx{ std::make_shared<boost::asio::io_context> () },
-	io_guard{ boost::asio::make_work_guard (*io_ctx) }
+	io_guard{ boost::asio::make_work_guard (*io_ctx) },
+	stats{ logger }
 {
 	auto scale_str = std::getenv ("DEADLINE_SCALE_FACTOR");
 	if (scale_str)

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -81,8 +81,8 @@ namespace test
 		boost::asio::executor_work_guard<boost::asio::io_context::executor_type> io_guard;
 		std::vector<std::shared_ptr<nano::node>> nodes;
 		std::vector<std::shared_ptr<nano::node>> disconnected_nodes;
-		nano::stats stats;
 		nano::logger logger{ "tests" };
+		nano::stats stats;
 		nano::work_pool work{ nano::dev::network_params.network, std::max (nano::hardware_concurrency (), 1u) };
 		std::chrono::time_point<std::chrono::steady_clock, std::chrono::duration<double>> deadline{ std::chrono::steady_clock::time_point::max () };
 		double deadline_scaling_factor{ 1.0 };


### PR DESCRIPTION
This allows logging individual stat counter increments. This is useful for debugging tests. This functionality can be enabled by setting `NANO_LOG_STATS=[1,true,on]` environment variable.

Example output:
```
[2024-05-02 18:43:27.939] [node_16gzg] [stats] [debug] Stat: bootstrap_server::request::in += 1
[2024-05-02 18:43:27.939] [node_16gzg] [stats] [debug] Stat: bootstrap_server_request::blocks::in += 1
[2024-05-02 18:43:27.939] [node_3e5x4] [stats] [debug] Stat: traffic_tcp::all::out += 51
[2024-05-02 18:43:27.939] [node_3e5x4] [stats] [debug] Stat: bootstrap_ascending::track::in += 1
[2024-05-02 18:43:27.939] [node_3e5x4] [stats] [debug] Sample: bootstrap_tag_duration -> 1
```