### PR TITLE
Wait until fair queue source drains before removal

### DIFF
--- a/nano/node/fair_queue.hpp
+++ b/nano/node/fair_queue.hpp
@@ -330,7 +330,7 @@ private:
 		iterator = queues.end ();
 
 		erase_if (queues, [] (auto const & entry) {
-			return !entry.first.alive ();
+			return entry.second.empty () && !entry.first.alive ();
 		});
 	}
 


### PR DESCRIPTION
The previous behavior o closing queues with pending entries was causing too much confusion during performance testing.