### PR TITLE
Build fixes.

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -128,7 +128,7 @@ TEST (ledger, process_send)
 	ASSERT_EQ (2, send->sideband ().height);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.any.block_amount (transaction, hash1));
 	ASSERT_EQ (nano::dev::genesis_key.pub, send->account ());
-	ASSERT_EQ (50, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (50, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub).value ().number ());
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_receivable (transaction, key2.pub));
 	auto info2 = ledger.any.account_get (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info2);
@@ -264,19 +264,19 @@ TEST (ledger, process_receive)
 	ASSERT_EQ (key2.pub, receive->sideband ().account);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, receive->sideband ().balance.number ());
 	ASSERT_EQ (2, receive->sideband ().height);
-	ASSERT_EQ (25, ledger.any.block_amount (transaction, hash4));
+	ASSERT_EQ (25, ledger.any.block_amount (transaction, hash4).value ().number ());
 	ASSERT_EQ (nano::block_status::progress, return2);
 	ASSERT_EQ (key2.pub, receive->account ());
 	ASSERT_EQ (hash4, ledger.any.account_head (transaction, key2.pub));
-	ASSERT_EQ (25, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (25, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub).value ().number ());
 	ASSERT_EQ (0, ledger.account_receivable (transaction, key2.pub));
-	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, ledger.any.account_balance (transaction, key2.pub));
+	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, ledger.any.account_balance (transaction, key2.pub).value ().number ());
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, ledger.weight (key3.pub));
 	ASSERT_FALSE (ledger.rollback (transaction, hash4));
 	ASSERT_FALSE (ledger.any.block_successor (transaction, hash2));
-	ASSERT_EQ (25, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (25, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub).value ().number ());
 	ASSERT_EQ (25, ledger.account_receivable (transaction, key2.pub));
-	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.any.account_balance (transaction, key2.pub));
+	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.any.account_balance (transaction, key2.pub).value ().number ());
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.weight (key3.pub));
 	ASSERT_EQ (hash2, ledger.any.account_head (transaction, key2.pub));
 	auto pending1 = ledger.any.pending_get (transaction, nano::pending_key (key2.pub, hash3));
@@ -319,7 +319,7 @@ TEST (ledger, rollback_receiver)
 	nano::block_hash hash2 (open->hash ());
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open));
 	ASSERT_EQ (hash2, ledger.any.account_head (transaction, key2.pub));
-	ASSERT_EQ (50, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (50, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub).value ().number ());
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.any.account_balance (transaction, key2.pub));
 	ASSERT_EQ (50, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
@@ -527,7 +527,7 @@ TEST (ledger, representative_change)
 				 .build ();
 	auto return1 (ledger.process (transaction, block));
 	ASSERT_EQ (nano::block_status::progress, return1);
-	ASSERT_EQ (0, ledger.any.block_amount (transaction, block->hash ()));
+	ASSERT_EQ (0, ledger.any.block_amount (transaction, block->hash ()).value ().number ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, block->account ());
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key2.pub));
@@ -2543,7 +2543,7 @@ TEST (ledger, state_rep_change)
 	ASSERT_NE (nullptr, change2);
 	ASSERT_EQ (*change1, *change2);
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.any.block_balance (transaction, change1->hash ()));
-	ASSERT_EQ (0, ledger.any.block_amount (transaction, change1->hash ()));
+	ASSERT_EQ (0, ledger.any.block_amount (transaction, change1->hash ()).value ().number ());
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (rep.pub));
 	ASSERT_EQ (2, change2->sideband ().height);
@@ -3563,7 +3563,7 @@ TEST (ledger, epoch_blocks_v1_general)
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive2));
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
-	ASSERT_EQ (0, ledger.any.block_balance (transaction, epoch4->hash ()));
+	ASSERT_EQ (0, ledger.any.block_balance (transaction, epoch4->hash ()).value ().number ());
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.any.block_balance (transaction, receive2->hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.any.block_amount (transaction, receive2->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis_key.pub));
@@ -3731,7 +3731,7 @@ TEST (ledger, epoch_blocks_v2_general)
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive2));
 	ASSERT_EQ (nano::epoch::epoch_2, receive2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
-	ASSERT_EQ (0, ledger.any.block_balance (transaction, epoch6->hash ()));
+	ASSERT_EQ (0, ledger.any.block_balance (transaction, epoch6->hash ()).value ().number ());
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.any.block_balance (transaction, receive2->hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.any.block_amount (transaction, receive2->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis_key.pub));


### PR DESCRIPTION
Fixes build errors on GCC 13.2

nano-node.src/submodules/gtest/googletest/include/gtest/gtest.h:1379:11: error: no match for ‘operator==’ (operand types are ‘const int’ and ‘const std::optional<nano::amount>’)
