### PR TITLE
Introduce `active_transactions_config`

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(
   entry.cpp
   fakes/websocket_client.hpp
   fakes/work_peer.hpp
-  active_transactions.cpp
+  active_elections.cpp
   async.cpp
   backlog.cpp
   block.cpp

--- a/nano/core_test/active_transactions.cpp
+++ b/nano/core_test/active_transactions.cpp
@@ -163,7 +163,7 @@ TEST (active_transactions, keep_local)
 	nano::node_config node_config = system.default_config ();
 	node_config.enable_voting = false;
 	// Bound to 2, won't drop wallet created transactions, but good to test dropping remote
-	node_config.active_elections_size = 2;
+	node_config.active_transactions.size = 2;
 	// Disable frontier confirmation to allow the test to finish before
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
@@ -234,7 +234,7 @@ TEST (active_transactions, keep_local)
 	node.process_active (receive3);
 
 	/// bound elections, should drop after one loop
-	ASSERT_TIMELY_EQ (5s, node.active.size (), node_config.active_elections_size);
+	ASSERT_TIMELY_EQ (5s, node.active.size (), node_config.active_transactions.size);
 	// ASSERT_EQ (1, node.scheduler.size ());
 }
 
@@ -1318,7 +1318,7 @@ TEST (active_transactions, vacancy)
 	{
 		nano::test::system system;
 		nano::node_config config = system.default_config ();
-		config.active_elections_size = 1;
+		config.active_transactions.size = 1;
 		auto & node = *system.add_node (config);
 		nano::state_block_builder builder;
 		auto send = builder.make_block ()
@@ -1354,7 +1354,7 @@ TEST (active_transactions, fifo)
 	nano::test::system system{};
 
 	nano::node_config config = system.default_config ();
-	config.active_elections_size = 1;
+	config.active_transactions.size = 1;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
 	auto & node = *system.add_node (config);
@@ -1441,8 +1441,8 @@ TEST (active_transactions, limit_vote_hinted_elections)
 	const int aec_limit = 10;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	config.optimistic_scheduler.enabled = false;
-	config.active_elections_size = aec_limit;
-	config.active_elections_hinted_limit_percentage = 10; // Should give us a limit of 1 hinted election
+	config.active_transactions.size = aec_limit;
+	config.active_transactions.hinted_limit_percentage = 10; // Should give us a limit of 1 hinted election
 	auto & node = *system.add_node (config);
 
 	// Setup representatives
@@ -1506,8 +1506,8 @@ TEST (active_transactions, allow_limited_overflow)
 	nano::node_config config = system.default_config ();
 	const int aec_limit = 20;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config.active_elections_size = aec_limit;
-	config.active_elections_hinted_limit_percentage = 20; // Should give us a limit of 4 hinted elections
+	config.active_transactions.size = aec_limit;
+	config.active_transactions.hinted_limit_percentage = 20; // Should give us a limit of 4 hinted elections
 	auto & node = *system.add_node (config);
 
 	auto blocks = nano::test::setup_independent_blocks (system, node, aec_limit * 4);
@@ -1555,8 +1555,8 @@ TEST (active_transactions, allow_limited_overflow_adapt)
 	nano::node_config config = system.default_config ();
 	const int aec_limit = 20;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config.active_elections_size = aec_limit;
-	config.active_elections_hinted_limit_percentage = 20; // Should give us a limit of 4 hinted elections
+	config.active_transactions.size = aec_limit;
+	config.active_transactions.hinted_limit_percentage = 20; // Should give us a limit of 4 hinted elections
 	auto & node = *system.add_node (config);
 
 	auto blocks = nano::test::setup_independent_blocks (system, node, aec_limit * 4);

--- a/nano/core_test/backlog.cpp
+++ b/nano/core_test/backlog.cpp
@@ -1,5 +1,5 @@
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/blockprocessor.cpp
+++ b/nano/core_test/blockprocessor.cpp
@@ -16,9 +16,9 @@ TEST (block_processor, broadcast_block_on_arrival)
 	nano::test::system system;
 	nano::node_config config1 = system.default_config ();
 	// Deactivates elections on both nodes.
-	config1.active_elections_size = 0;
+	config1.active_transactions.size = 0;
 	nano::node_config config2 = system.default_config ();
-	config2.active_elections_size = 0;
+	config2.active_transactions.size = 0;
 	nano::node_flags flags;
 	// Disables bootstrap listener to make sure the block won't be shared by this channel.
 	flags.disable_bootstrap_listener = true;

--- a/nano/core_test/blockprocessor.cpp
+++ b/nano/core_test/blockprocessor.cpp
@@ -16,9 +16,9 @@ TEST (block_processor, broadcast_block_on_arrival)
 	nano::test::system system;
 	nano::node_config config1 = system.default_config ();
 	// Deactivates elections on both nodes.
-	config1.active_transactions.size = 0;
+	config1.active_elections.size = 0;
 	nano::node_config config2 = system.default_config ();
-	config2.active_transactions.size = 0;
+	config2.active_elections.size = 0;
 	nano::node_flags flags;
 	// Disables bootstrap listener to make sure the block won't be shared by this channel.
 	flags.disable_bootstrap_listener = true;

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1,5 +1,5 @@
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/bootstrap/block_deserializer.hpp>
 #include <nano/node/bootstrap/bootstrap_frontier.hpp>
 #include <nano/node/bootstrap/bootstrap_lazy.hpp>

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/transport/inproc.hpp>

--- a/nano/core_test/confirming_set.cpp
+++ b/nano/core_test/confirming_set.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/confirming_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/make_store.hpp>

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -1,5 +1,5 @@
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -1,5 +1,5 @@
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -56,7 +56,7 @@ TEST (election_scheduler, activate_one_flush)
 
 /**
  * Tests that the election scheduler and the active transactions container (AEC)
- * work in sync with regards to the node configuration value "active_elections_size".
+ * work in sync with regards to the node configuration value "active_transactions.size".
  *
  * The test sets up two forcefully cemented blocks -- a send on the genesis account and a receive on a second account.
  * It then creates two other blocks, each a successor to one of the previous two,
@@ -74,7 +74,7 @@ TEST (election_scheduler, no_vacancy)
 	nano::test::system system{};
 
 	nano::node_config config = system.default_config ();
-	config.active_elections_size = 1;
+	config.active_transactions.size = 1;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
 	auto & node = *system.add_node (config);

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -1,5 +1,5 @@
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>
@@ -56,7 +56,7 @@ TEST (election_scheduler, activate_one_flush)
 
 /**
  * Tests that the election scheduler and the active transactions container (AEC)
- * work in sync with regards to the node configuration value "active_transactions.size".
+ * work in sync with regards to the node configuration value "active_elections.size".
  *
  * The test sets up two forcefully cemented blocks -- a send on the genesis account and a receive on a second account.
  * It then creates two other blocks, each a successor to one of the previous two,
@@ -74,7 +74,7 @@ TEST (election_scheduler, no_vacancy)
 	nano::test::system system{};
 
 	nano::node_config config = system.default_config ();
-	config.active_transactions.size = 1;
+	config.active_elections.size = 1;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 
 	auto & node = *system.add_node (config);

--- a/nano/core_test/frontiers_confirmation.cpp
+++ b/nano/core_test/frontiers_confirmation.cpp
@@ -1,5 +1,5 @@
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -128,7 +128,7 @@ TEST (ledger, process_send)
 	ASSERT_EQ (2, send->sideband ().height);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.any.block_amount (transaction, hash1));
 	ASSERT_EQ (nano::dev::genesis_key.pub, send->account ());
-	ASSERT_EQ (50, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub).value ().number ());
+	ASSERT_EQ (50, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.account_receivable (transaction, key2.pub));
 	auto info2 = ledger.any.account_get (transaction, nano::dev::genesis_key.pub);
 	ASSERT_TRUE (info2);
@@ -264,19 +264,19 @@ TEST (ledger, process_receive)
 	ASSERT_EQ (key2.pub, receive->sideband ().account);
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, receive->sideband ().balance.number ());
 	ASSERT_EQ (2, receive->sideband ().height);
-	ASSERT_EQ (25, ledger.any.block_amount (transaction, hash4).value ().number ());
+	ASSERT_EQ (25, ledger.any.block_amount (transaction, hash4));
 	ASSERT_EQ (nano::block_status::progress, return2);
 	ASSERT_EQ (key2.pub, receive->account ());
 	ASSERT_EQ (hash4, ledger.any.account_head (transaction, key2.pub));
-	ASSERT_EQ (25, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub).value ().number ());
+	ASSERT_EQ (25, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.account_receivable (transaction, key2.pub));
-	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, ledger.any.account_balance (transaction, key2.pub).value ().number ());
+	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, ledger.any.account_balance (transaction, key2.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 25, ledger.weight (key3.pub));
 	ASSERT_FALSE (ledger.rollback (transaction, hash4));
 	ASSERT_FALSE (ledger.any.block_successor (transaction, hash2));
-	ASSERT_EQ (25, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub).value ().number ());
+	ASSERT_EQ (25, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (25, ledger.account_receivable (transaction, key2.pub));
-	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.any.account_balance (transaction, key2.pub).value ().number ());
+	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.any.account_balance (transaction, key2.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.weight (key3.pub));
 	ASSERT_EQ (hash2, ledger.any.account_head (transaction, key2.pub));
 	auto pending1 = ledger.any.pending_get (transaction, nano::pending_key (key2.pub, hash3));
@@ -319,7 +319,7 @@ TEST (ledger, rollback_receiver)
 	nano::block_hash hash2 (open->hash ());
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open));
 	ASSERT_EQ (hash2, ledger.any.account_head (transaction, key2.pub));
-	ASSERT_EQ (50, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub).value ().number ());
+	ASSERT_EQ (50, ledger.any.account_balance (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 50, ledger.any.account_balance (transaction, key2.pub));
 	ASSERT_EQ (50, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (0, ledger.weight (key2.pub));
@@ -527,7 +527,7 @@ TEST (ledger, representative_change)
 				 .build ();
 	auto return1 (ledger.process (transaction, block));
 	ASSERT_EQ (nano::block_status::progress, return1);
-	ASSERT_EQ (0, ledger.any.block_amount (transaction, block->hash ()).value ().number ());
+	ASSERT_EQ (0, ledger.any.block_amount (transaction, block->hash ()));
 	ASSERT_EQ (nano::dev::genesis_key.pub, block->account ());
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (key2.pub));
@@ -2543,7 +2543,7 @@ TEST (ledger, state_rep_change)
 	ASSERT_NE (nullptr, change2);
 	ASSERT_EQ (*change1, *change2);
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.any.block_balance (transaction, change1->hash ()));
-	ASSERT_EQ (0, ledger.any.block_amount (transaction, change1->hash ()).value ().number ());
+	ASSERT_EQ (0, ledger.any.block_amount (transaction, change1->hash ()));
 	ASSERT_EQ (0, ledger.weight (nano::dev::genesis_key.pub));
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (rep.pub));
 	ASSERT_EQ (2, change2->sideband ().height);
@@ -3563,7 +3563,7 @@ TEST (ledger, epoch_blocks_v1_general)
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive2));
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
-	ASSERT_EQ (0, ledger.any.block_balance (transaction, epoch4->hash ()).value ().number ());
+	ASSERT_EQ (0, ledger.any.block_balance (transaction, epoch4->hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.any.block_balance (transaction, receive2->hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.any.block_amount (transaction, receive2->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis_key.pub));
@@ -3731,7 +3731,7 @@ TEST (ledger, epoch_blocks_v2_general)
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive2));
 	ASSERT_EQ (nano::epoch::epoch_2, receive2->sideband ().details.epoch);
 	ASSERT_EQ (nano::epoch::epoch_1, receive2->sideband ().source_epoch);
-	ASSERT_EQ (0, ledger.any.block_balance (transaction, epoch6->hash ()).value ().number ());
+	ASSERT_EQ (0, ledger.any.block_balance (transaction, epoch6->hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.any.block_balance (transaction, receive2->hash ()));
 	ASSERT_EQ (nano::Gxrb_ratio, ledger.any.block_amount (transaction, receive2->hash ()));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Gxrb_ratio, ledger.weight (nano::dev::genesis_key.pub));

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -4,7 +4,7 @@
 #include <nano/lib/logging.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/threading.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/make_store.hpp>
 #include <nano/node/scheduler/component.hpp>

--- a/nano/core_test/ledger_confirm.cpp
+++ b/nano/core_test/ledger_confirm.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/make_store.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/core_test/memory_pool.cpp
+++ b/nano/core_test/memory_pool.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/memory.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/secure/common.hpp>
 
 #include <gtest/gtest.h>

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/logging.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/confirming_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/inactive_node.hpp>

--- a/nano/core_test/optimistic_scheduler.cpp
+++ b/nano/core_test/optimistic_scheduler.cpp
@@ -1,5 +1,5 @@
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/core_test/rep_crawler.cpp
+++ b/nano/core_test/rep_crawler.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/logging.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/repcrawler.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/node/transport/inproc.hpp>

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/confirming_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/local_vote_history.hpp>

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -152,7 +152,7 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.rpc.child_process.enable, defaults.rpc.child_process.enable);
 	ASSERT_EQ (conf.rpc.child_process.rpc_path, defaults.rpc.child_process.rpc_path);
 
-	ASSERT_EQ (conf.node.active_transactions.size, defaults.node.active_transactions.size);
+	ASSERT_EQ (conf.node.active_elections.size, defaults.node.active_elections.size);
 	ASSERT_EQ (conf.node.allow_local_peers, defaults.node.allow_local_peers);
 	ASSERT_EQ (conf.node.backup_before_upgrade, defaults.node.backup_before_upgrade);
 	ASSERT_EQ (conf.node.bandwidth_limit, defaults.node.bandwidth_limit);
@@ -451,7 +451,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	priority_bootstrap = 999
 	priority_local = 999
 
-	[node.active_transactions]
+	[node.active_elections]
 	size = 999
 	hinted_limit_percentage = 90
 	optimistic_limit_percentage = 90
@@ -607,7 +607,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.rpc.child_process.enable, defaults.rpc.child_process.enable);
 	ASSERT_NE (conf.rpc.child_process.rpc_path, defaults.rpc.child_process.rpc_path);
 
-	ASSERT_NE (conf.node.active_transactions.size, defaults.node.active_transactions.size);
+	ASSERT_NE (conf.node.active_elections.size, defaults.node.active_elections.size);
 	ASSERT_NE (conf.node.allow_local_peers, defaults.node.allow_local_peers);
 	ASSERT_NE (conf.node.backup_before_upgrade, defaults.node.backup_before_upgrade);
 	ASSERT_NE (conf.node.bandwidth_limit, defaults.node.bandwidth_limit);
@@ -1024,7 +1024,7 @@ TEST (toml, log_config_no_defaults)
 	rotation_count = 999
 
 	[log.levels]
-	active_transactions = "trace"
+	active_elections = "trace"
 	blockprocessor = "trace"
 	)toml";
 
@@ -1081,7 +1081,7 @@ TEST (toml, merge_config_files)
 
 	ss << R"toml(
 	[node]
-	 active_transactions.size = 999
+	 active_elections.size = 999
 	 # backlog_scan_batch_size = 7777
 	[node.bootstrap_ascending]
 	 block_wait_count = 33333
@@ -1104,8 +1104,8 @@ TEST (toml, merge_config_files)
 	merged_toml.read (ss2);
 	merged_config.deserialize_toml (merged_toml);
 
-	ASSERT_NE (merged_config.node.active_transactions.size, default_config.node.active_transactions.size);
-	ASSERT_EQ (merged_config.node.active_transactions.size, 999);
+	ASSERT_NE (merged_config.node.active_elections.size, default_config.node.active_elections.size);
+	ASSERT_EQ (merged_config.node.active_elections.size, 999);
 	ASSERT_NE (merged_config.node.backlog_scan_batch_size, 7777);
 	ASSERT_EQ (merged_config.node.bootstrap_ascending.block_wait_count, 33333);
 	ASSERT_TRUE (merged_config_string.find ("old_entry") == std::string::npos);

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -152,7 +152,7 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.rpc.child_process.enable, defaults.rpc.child_process.enable);
 	ASSERT_EQ (conf.rpc.child_process.rpc_path, defaults.rpc.child_process.rpc_path);
 
-	ASSERT_EQ (conf.node.active_elections_size, defaults.node.active_elections_size);
+	ASSERT_EQ (conf.node.active_transactions.size, defaults.node.active_transactions.size);
 	ASSERT_EQ (conf.node.allow_local_peers, defaults.node.allow_local_peers);
 	ASSERT_EQ (conf.node.backup_before_upgrade, defaults.node.backup_before_upgrade);
 	ASSERT_EQ (conf.node.bandwidth_limit, defaults.node.bandwidth_limit);
@@ -167,7 +167,6 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.bootstrap_frontier_request_count, defaults.node.bootstrap_frontier_request_count);
 	ASSERT_EQ (conf.node.bootstrap_fraction_numerator, defaults.node.bootstrap_fraction_numerator);
 	ASSERT_EQ (conf.node.confirming_set_batch_time, defaults.node.confirming_set_batch_time);
-	ASSERT_EQ (conf.node.confirmation_history_size, defaults.node.confirmation_history_size);
 	ASSERT_EQ (conf.node.enable_voting, defaults.node.enable_voting);
 	ASSERT_EQ (conf.node.external_address, defaults.node.external_address);
 	ASSERT_EQ (conf.node.external_port, defaults.node.external_port);
@@ -397,7 +396,6 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 
 	ss << R"toml(
 	[node]
-	active_elections_size = 999
 	allow_local_peers = false
 	backup_before_upgrade = true
 	bandwidth_limit = 999
@@ -412,7 +410,6 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	bootstrap_frontier_request_count = 9999
 	bootstrap_fraction_numerator = 999
 	confirming_set_batch_time = 999
-	confirmation_history_size = 999
 	enable_voting = false
 	external_address = "0:0:0:0:0:ffff:7f01:101"
 	external_port = 999
@@ -453,6 +450,13 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	priority_live = 999
 	priority_bootstrap = 999
 	priority_local = 999
+
+	[node.active_transactions]
+	size = 999
+	hinted_limit_percentage = 90
+	optimistic_limit_percentage = 90
+	confirmation_history_size = 999
+	confirmation_cache = 999
 
 	[node.diagnostics.txn_tracking]
 	enable = true
@@ -603,7 +607,7 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.rpc.child_process.enable, defaults.rpc.child_process.enable);
 	ASSERT_NE (conf.rpc.child_process.rpc_path, defaults.rpc.child_process.rpc_path);
 
-	ASSERT_NE (conf.node.active_elections_size, defaults.node.active_elections_size);
+	ASSERT_NE (conf.node.active_transactions.size, defaults.node.active_transactions.size);
 	ASSERT_NE (conf.node.allow_local_peers, defaults.node.allow_local_peers);
 	ASSERT_NE (conf.node.backup_before_upgrade, defaults.node.backup_before_upgrade);
 	ASSERT_NE (conf.node.bandwidth_limit, defaults.node.bandwidth_limit);
@@ -618,7 +622,6 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.bootstrap_frontier_request_count, defaults.node.bootstrap_frontier_request_count);
 	ASSERT_NE (conf.node.bootstrap_fraction_numerator, defaults.node.bootstrap_fraction_numerator);
 	ASSERT_NE (conf.node.confirming_set_batch_time, defaults.node.confirming_set_batch_time);
-	ASSERT_NE (conf.node.confirmation_history_size, defaults.node.confirmation_history_size);
 	ASSERT_NE (conf.node.enable_voting, defaults.node.enable_voting);
 	ASSERT_NE (conf.node.external_address, defaults.node.external_address);
 	ASSERT_NE (conf.node.external_port, defaults.node.external_port);
@@ -1078,7 +1081,7 @@ TEST (toml, merge_config_files)
 
 	ss << R"toml(
 	[node]
-	 active_elections_size = 999
+	 active_transactions.size = 999
 	 # backlog_scan_batch_size = 7777
 	[node.bootstrap_ascending]
 	 block_wait_count = 33333
@@ -1101,8 +1104,8 @@ TEST (toml, merge_config_files)
 	merged_toml.read (ss2);
 	merged_config.deserialize_toml (merged_toml);
 
-	ASSERT_NE (merged_config.node.active_elections_size, default_config.node.active_elections_size);
-	ASSERT_EQ (merged_config.node.active_elections_size, 999);
+	ASSERT_NE (merged_config.node.active_transactions.size, default_config.node.active_transactions.size);
+	ASSERT_EQ (merged_config.node.active_transactions.size, 999);
 	ASSERT_NE (merged_config.node.backlog_scan_batch_size, 7777);
 	ASSERT_EQ (merged_config.node.bootstrap_ascending.block_wait_count, 33333);
 	ASSERT_TRUE (merged_config_string.find ("old_entry") == std::string::npos);

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/vote_processor.hpp>

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -146,7 +146,7 @@ TEST (vote_spacing, vote_generator)
 {
 	nano::node_config config;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config.active_elections_hinted_limit_percentage = 0; // Disable election hinting
+	config.active_transactions.hinted_limit_percentage = 0; // Disable election hinting
 	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_search_pending = true;
@@ -190,7 +190,7 @@ TEST (vote_spacing, rapid)
 {
 	nano::node_config config;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config.active_elections_hinted_limit_percentage = 0; // Disable election hinting
+	config.active_transactions.hinted_limit_percentage = 0; // Disable election hinting
 	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_search_pending = true;

--- a/nano/core_test/voting.cpp
+++ b/nano/core_test/voting.cpp
@@ -146,7 +146,7 @@ TEST (vote_spacing, vote_generator)
 {
 	nano::node_config config;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config.active_transactions.hinted_limit_percentage = 0; // Disable election hinting
+	config.active_elections.hinted_limit_percentage = 0; // Disable election hinting
 	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_search_pending = true;
@@ -190,7 +190,7 @@ TEST (vote_spacing, rapid)
 {
 	nano::node_config config;
 	config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	config.active_transactions.hinted_limit_percentage = 0; // Disable election hinting
+	config.active_elections.hinted_limit_percentage = 0; // Disable election hinting
 	nano::test::system system;
 	nano::node_flags node_flags;
 	node_flags.disable_search_pending = true;

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1,7 +1,7 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/thread_runner.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -1,5 +1,5 @@
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/inactive_node.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -1,6 +1,6 @@
 #include <nano/core_test/fakes/websocket_client.hpp>
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/test_common/network.hpp>

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -45,7 +45,7 @@ enum class type
 	ipc_server,
 	websocket,
 	tls,
-	active_transactions,
+	active_elections,
 	election,
 	blockprocessor,
 	network,
@@ -104,7 +104,7 @@ enum class detail
 	// node
 	process_confirmed,
 
-	// active_transactions
+	// active_elections
 	active_started,
 	active_stopped,
 

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -55,7 +55,7 @@ enum class type
 	bootstrap_server_overfill,
 	bootstrap_server_response,
 	active,
-	active_transactions,
+	active_elections,
 	active_started,
 	active_confirmed,
 	active_dropped,

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1238,7 +1238,7 @@ int main (int argc, char * const * argv)
 			else
 			{
 				config2.frontiers_confirmation = daemon_config.node.frontiers_confirmation;
-				config2.active_elections_size = daemon_config.node.active_elections_size;
+				config2.active_transactions.size = daemon_config.node.active_transactions.size;
 			}
 
 			auto node2 (std::make_shared<nano::node> (io_ctx2, path2, config2, work, flags, 1));

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -4,7 +4,7 @@
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/nano_node/daemon.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/cli.hpp>
 #include <nano/node/confirming_set.hpp>
 #include <nano/node/daemonconfig.hpp>
@@ -1238,7 +1238,7 @@ int main (int argc, char * const * argv)
 			else
 			{
 				config2.frontiers_confirmation = daemon_config.node.frontiers_confirmation;
-				config2.active_transactions.size = daemon_config.node.active_transactions.size;
+				config2.active_elections.size = daemon_config.node.active_elections.size;
 			}
 
 			auto node2 (std::make_shared<nano::node> (io_ctx2, path2, config2, work, flags, 1));

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -14,8 +14,8 @@ endif()
 add_library(
   node
   ${platform_sources}
-  active_transactions.hpp
-  active_transactions.cpp
+  active_elections.hpp
+  active_elections.cpp
   backlog_population.hpp
   backlog_population.cpp
   bandwidth_limiter.hpp

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/threading.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/confirming_set.hpp>
 #include <nano/node/election.hpp>
@@ -17,8 +17,8 @@
 
 using namespace std::chrono;
 
-nano::active_transactions::active_transactions (nano::node & node_a, nano::confirming_set & confirming_set, nano::block_processor & block_processor_a) :
-	config{ node_a.config.active_transactions },
+nano::active_elections::active_elections (nano::node & node_a, nano::confirming_set & confirming_set, nano::block_processor & block_processor_a) :
+	config{ node_a.config.active_elections },
 	node{ node_a },
 	confirming_set{ confirming_set },
 	block_processor{ block_processor_a },
@@ -51,13 +51,13 @@ nano::active_transactions::active_transactions (nano::node & node_a, nano::confi
 	});
 }
 
-nano::active_transactions::~active_transactions ()
+nano::active_elections::~active_elections ()
 {
 	// Thread must be stopped before destruction
 	debug_assert (!thread.joinable ());
 }
 
-void nano::active_transactions::start ()
+void nano::active_elections::start ()
 {
 	if (node.flags.disable_request_loop)
 	{
@@ -72,7 +72,7 @@ void nano::active_transactions::start ()
 	});
 }
 
-void nano::active_transactions::stop ()
+void nano::active_elections::stop ()
 {
 	{
 		nano::lock_guard<nano::mutex> guard{ mutex };
@@ -83,7 +83,7 @@ void nano::active_transactions::stop ()
 	clear ();
 }
 
-void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::block> const & block)
+void nano::active_elections::block_cemented_callback (std::shared_ptr<nano::block> const & block)
 {
 	debug_assert (node.block_confirmed (block->hash ()));
 	if (auto election_l = election (block->qualified_root ()))
@@ -124,7 +124,7 @@ void nano::active_transactions::block_cemented_callback (std::shared_ptr<nano::b
 	}
 }
 
-void nano::active_transactions::notify_observers (nano::secure::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes)
+void nano::active_elections::notify_observers (nano::secure::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes)
 {
 	auto block = status.winner;
 	auto account = block->account ();
@@ -143,7 +143,7 @@ void nano::active_transactions::notify_observers (nano::secure::read_transaction
 	}
 }
 
-void nano::active_transactions::activate_successors (nano::secure::read_transaction const & transaction, std::shared_ptr<nano::block> const & block)
+void nano::active_elections::activate_successors (nano::secure::read_transaction const & transaction, std::shared_ptr<nano::block> const & block)
 {
 	node.scheduler.priority.activate (transaction, block->account ());
 
@@ -154,13 +154,13 @@ void nano::active_transactions::activate_successors (nano::secure::read_transact
 	}
 }
 
-void nano::active_transactions::add_election_winner_details (nano::block_hash const & hash_a, std::shared_ptr<nano::election> const & election_a)
+void nano::active_elections::add_election_winner_details (nano::block_hash const & hash_a, std::shared_ptr<nano::election> const & election_a)
 {
 	nano::lock_guard<nano::mutex> guard{ election_winner_details_mutex };
 	election_winner_details.emplace (hash_a, election_a);
 }
 
-std::shared_ptr<nano::election> nano::active_transactions::remove_election_winner_details (nano::block_hash const & hash_a)
+std::shared_ptr<nano::election> nano::active_elections::remove_election_winner_details (nano::block_hash const & hash_a)
 {
 	nano::lock_guard<nano::mutex> guard{ election_winner_details_mutex };
 	std::shared_ptr<nano::election> result;
@@ -173,7 +173,7 @@ std::shared_ptr<nano::election> nano::active_transactions::remove_election_winne
 	return result;
 }
 
-void nano::active_transactions::block_already_cemented_callback (nano::block_hash const & hash_a)
+void nano::active_elections::block_already_cemented_callback (nano::block_hash const & hash_a)
 {
 	// Depending on timing there is a situation where the election_winner_details is not reset.
 	// This can happen when a block wins an election, and the block is confirmed + observer
@@ -182,7 +182,7 @@ void nano::active_transactions::block_already_cemented_callback (nano::block_has
 	remove_election_winner_details (hash_a);
 }
 
-int64_t nano::active_transactions::limit (nano::election_behavior behavior) const
+int64_t nano::active_elections::limit (nano::election_behavior behavior) const
 {
 	switch (behavior)
 	{
@@ -206,7 +206,7 @@ int64_t nano::active_transactions::limit (nano::election_behavior behavior) cons
 	return 0;
 }
 
-int64_t nano::active_transactions::vacancy (nano::election_behavior behavior) const
+int64_t nano::active_elections::vacancy (nano::election_behavior behavior) const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	switch (behavior)
@@ -221,7 +221,7 @@ int64_t nano::active_transactions::vacancy (nano::election_behavior behavior) co
 	return 0;
 }
 
-void nano::active_transactions::request_confirm (nano::unique_lock<nano::mutex> & lock_a)
+void nano::active_elections::request_confirm (nano::unique_lock<nano::mutex> & lock_a)
 {
 	debug_assert (lock_a.owns_lock ());
 
@@ -258,7 +258,7 @@ void nano::active_transactions::request_confirm (nano::unique_lock<nano::mutex> 
 	lock_a.lock ();
 }
 
-void nano::active_transactions::cleanup_election (nano::unique_lock<nano::mutex> & lock_a, std::shared_ptr<nano::election> election)
+void nano::active_elections::cleanup_election (nano::unique_lock<nano::mutex> & lock_a, std::shared_ptr<nano::election> election)
 {
 	debug_assert (!mutex.try_lock ());
 	debug_assert (lock_a.owns_lock ());
@@ -279,9 +279,9 @@ void nano::active_transactions::cleanup_election (nano::unique_lock<nano::mutex>
 	roots.get<tag_root> ().erase (roots.get<tag_root> ().find (election->qualified_root));
 
 	node.stats.inc (completion_type (*election), to_stat_detail (election->behavior ()));
-	node.logger.trace (nano::log::type::active_transactions, nano::log::detail::active_stopped, nano::log::arg{ "election", election });
+	node.logger.trace (nano::log::type::active_elections, nano::log::detail::active_stopped, nano::log::arg{ "election", election });
 
-	node.logger.debug (nano::log::type::active_transactions, "Erased election for blocks: {} (behavior: {}, state: {})",
+	node.logger.debug (nano::log::type::active_elections, "Erased election for blocks: {} (behavior: {}, state: {})",
 	fmt::join (std::views::keys (blocks_l), ", "),
 	to_string (election->behavior ()),
 	to_string (election->state ()));
@@ -308,7 +308,7 @@ void nano::active_transactions::cleanup_election (nano::unique_lock<nano::mutex>
 	}
 }
 
-nano::stat::type nano::active_transactions::completion_type (nano::election const & election) const
+nano::stat::type nano::active_elections::completion_type (nano::election const & election) const
 {
 	if (election.confirmed ())
 	{
@@ -321,13 +321,13 @@ nano::stat::type nano::active_transactions::completion_type (nano::election cons
 	return nano::stat::type::active_dropped;
 }
 
-std::vector<std::shared_ptr<nano::election>> nano::active_transactions::list_active (std::size_t max_a)
+std::vector<std::shared_ptr<nano::election>> nano::active_elections::list_active (std::size_t max_a)
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	return list_active_impl (max_a);
 }
 
-std::vector<std::shared_ptr<nano::election>> nano::active_transactions::list_active_impl (std::size_t max_a) const
+std::vector<std::shared_ptr<nano::election>> nano::active_elections::list_active_impl (std::size_t max_a) const
 {
 	std::vector<std::shared_ptr<nano::election>> result_l;
 	result_l.reserve (std::min (max_a, roots.size ()));
@@ -342,7 +342,7 @@ std::vector<std::shared_ptr<nano::election>> nano::active_transactions::list_act
 	return result_l;
 }
 
-void nano::active_transactions::request_loop ()
+void nano::active_elections::request_loop ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped)
@@ -363,7 +363,7 @@ void nano::active_transactions::request_loop ()
 	}
 }
 
-void nano::active_transactions::trim ()
+void nano::active_elections::trim ()
 {
 	/*
 	 * Both normal and hinted election schedulers are well-behaved, meaning they first check for AEC vacancy before inserting new elections.
@@ -377,7 +377,7 @@ void nano::active_transactions::trim ()
 	}
 }
 
-nano::election_insertion_result nano::active_transactions::insert (std::shared_ptr<nano::block> const & block_a, nano::election_behavior election_behavior_a)
+nano::election_insertion_result nano::active_elections::insert (std::shared_ptr<nano::block> const & block_a, nano::election_behavior election_behavior_a)
 {
 	debug_assert (block_a);
 	debug_assert (block_a->has_sideband ());
@@ -404,7 +404,7 @@ nano::election_insertion_result nano::active_transactions::insert (std::shared_p
 				node.online_reps.observe (rep_a);
 			};
 			result.election = nano::make_shared<nano::election> (node, block_a, nullptr, observe_rep_cb, election_behavior_a);
-			roots.get<tag_root> ().emplace (nano::active_transactions::conflict_info{ root, result.election });
+			roots.get<tag_root> ().emplace (nano::active_elections::conflict_info{ root, result.election });
 			blocks.emplace (hash, result.election);
 
 			// Keep track of election count by election type
@@ -412,11 +412,11 @@ nano::election_insertion_result nano::active_transactions::insert (std::shared_p
 			count_by_behavior[result.election->behavior ()]++;
 
 			node.stats.inc (nano::stat::type::active_started, to_stat_detail (election_behavior_a));
-			node.logger.trace (nano::log::type::active_transactions, nano::log::detail::active_started,
+			node.logger.trace (nano::log::type::active_elections, nano::log::detail::active_started,
 			nano::log::arg{ "behavior", election_behavior_a },
 			nano::log::arg{ "election", result.election });
 
-			node.logger.debug (nano::log::type::active_transactions, "Started new election for block: {} (behavior: {})",
+			node.logger.debug (nano::log::type::active_elections, "Started new election for block: {} (behavior: {})",
 			hash.to_string (),
 			to_string (election_behavior_a));
 		}
@@ -453,7 +453,7 @@ nano::election_insertion_result nano::active_transactions::insert (std::shared_p
 	return result;
 }
 
-bool nano::active_transactions::trigger_vote_cache (nano::block_hash hash)
+bool nano::active_elections::trigger_vote_cache (nano::block_hash hash)
 {
 	auto cached = node.vote_cache.find (hash);
 	for (auto const & cached_vote : cached)
@@ -464,7 +464,7 @@ bool nano::active_transactions::trigger_vote_cache (nano::block_hash hash)
 }
 
 // Validate a vote and apply it to the current election if one exists
-std::unordered_map<nano::block_hash, nano::vote_code> nano::active_transactions::vote (std::shared_ptr<nano::vote> const & vote, nano::vote_source source)
+std::unordered_map<nano::block_hash, nano::vote_code> nano::active_elections::vote (std::shared_ptr<nano::vote> const & vote, nano::vote_source source)
 {
 	debug_assert (!vote->validate ()); // false => valid vote
 
@@ -513,25 +513,25 @@ std::unordered_map<nano::block_hash, nano::vote_code> nano::active_transactions:
 	return results;
 }
 
-bool nano::active_transactions::active (nano::qualified_root const & root_a) const
+bool nano::active_elections::active (nano::qualified_root const & root_a) const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	return roots.get<tag_root> ().find (root_a) != roots.get<tag_root> ().end ();
 }
 
-bool nano::active_transactions::active (nano::block const & block_a) const
+bool nano::active_elections::active (nano::block const & block_a) const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	return roots.get<tag_root> ().find (block_a.qualified_root ()) != roots.get<tag_root> ().end () && blocks.find (block_a.hash ()) != blocks.end ();
 }
 
-bool nano::active_transactions::active (const nano::block_hash & hash) const
+bool nano::active_elections::active (const nano::block_hash & hash) const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	return blocks.find (hash) != blocks.end ();
 }
 
-std::shared_ptr<nano::election> nano::active_transactions::election (nano::qualified_root const & root_a) const
+std::shared_ptr<nano::election> nano::active_elections::election (nano::qualified_root const & root_a) const
 {
 	std::shared_ptr<nano::election> result;
 	nano::lock_guard<nano::mutex> lock{ mutex };
@@ -543,7 +543,7 @@ std::shared_ptr<nano::election> nano::active_transactions::election (nano::quali
 	return result;
 }
 
-std::shared_ptr<nano::block> nano::active_transactions::winner (nano::block_hash const & hash_a) const
+std::shared_ptr<nano::block> nano::active_elections::winner (nano::block_hash const & hash_a) const
 {
 	std::shared_ptr<nano::block> result;
 	nano::unique_lock<nano::mutex> lock{ mutex };
@@ -557,12 +557,12 @@ std::shared_ptr<nano::block> nano::active_transactions::winner (nano::block_hash
 	return result;
 }
 
-bool nano::active_transactions::erase (nano::block const & block_a)
+bool nano::active_elections::erase (nano::block const & block_a)
 {
 	return erase (block_a.qualified_root ());
 }
 
-bool nano::active_transactions::erase (nano::qualified_root const & root_a)
+bool nano::active_elections::erase (nano::qualified_root const & root_a)
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	auto root_it (roots.get<tag_root> ().find (root_a));
@@ -574,7 +574,7 @@ bool nano::active_transactions::erase (nano::qualified_root const & root_a)
 	return false;
 }
 
-bool nano::active_transactions::erase_hash (nano::block_hash const & hash_a)
+bool nano::active_elections::erase_hash (nano::block_hash const & hash_a)
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	[[maybe_unused]] auto erased (blocks.erase (hash_a));
@@ -582,7 +582,7 @@ bool nano::active_transactions::erase_hash (nano::block_hash const & hash_a)
 	return erased == 1;
 }
 
-void nano::active_transactions::erase_oldest ()
+void nano::active_elections::erase_oldest ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	if (!roots.empty ())
@@ -592,19 +592,19 @@ void nano::active_transactions::erase_oldest ()
 	}
 }
 
-bool nano::active_transactions::empty () const
+bool nano::active_elections::empty () const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	return roots.empty ();
 }
 
-std::size_t nano::active_transactions::size () const
+std::size_t nano::active_elections::size () const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	return roots.size ();
 }
 
-bool nano::active_transactions::publish (std::shared_ptr<nano::block> const & block_a)
+bool nano::active_elections::publish (std::shared_ptr<nano::block> const & block_a)
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	auto existing (roots.get<tag_root> ().find (block_a->qualified_root ()));
@@ -628,13 +628,13 @@ bool nano::active_transactions::publish (std::shared_ptr<nano::block> const & bl
 	return result;
 }
 
-std::size_t nano::active_transactions::election_winner_details_size ()
+std::size_t nano::active_elections::election_winner_details_size ()
 {
 	nano::lock_guard<nano::mutex> guard{ election_winner_details_mutex };
 	return election_winner_details.size ();
 }
 
-void nano::active_transactions::clear ()
+void nano::active_elections::clear ()
 {
 	{
 		nano::lock_guard<nano::mutex> guard{ mutex };
@@ -644,20 +644,20 @@ void nano::active_transactions::clear ()
 	vacancy_update ();
 }
 
-std::unique_ptr<nano::container_info_component> nano::collect_container_info (active_transactions & active_transactions, std::string const & name)
+std::unique_ptr<nano::container_info_component> nano::collect_container_info (active_elections & active_elections, std::string const & name)
 {
-	nano::lock_guard<nano::mutex> guard{ active_transactions.mutex };
+	nano::lock_guard<nano::mutex> guard{ active_elections.mutex };
 
 	auto composite = std::make_unique<container_info_composite> (name);
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "roots", active_transactions.roots.size (), sizeof (decltype (active_transactions.roots)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "blocks", active_transactions.blocks.size (), sizeof (decltype (active_transactions.blocks)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "election_winner_details", active_transactions.election_winner_details_size (), sizeof (decltype (active_transactions.election_winner_details)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "normal", static_cast<std::size_t> (active_transactions.count_by_behavior[nano::election_behavior::normal]), 0 }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "hinted", static_cast<std::size_t> (active_transactions.count_by_behavior[nano::election_behavior::hinted]), 0 }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "optimistic", static_cast<std::size_t> (active_transactions.count_by_behavior[nano::election_behavior::optimistic]), 0 }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "roots", active_elections.roots.size (), sizeof (decltype (active_elections.roots)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "blocks", active_elections.blocks.size (), sizeof (decltype (active_elections.blocks)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "election_winner_details", active_elections.election_winner_details_size (), sizeof (decltype (active_elections.election_winner_details)::value_type) }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "normal", static_cast<std::size_t> (active_elections.count_by_behavior[nano::election_behavior::normal]), 0 }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "hinted", static_cast<std::size_t> (active_elections.count_by_behavior[nano::election_behavior::hinted]), 0 }));
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "optimistic", static_cast<std::size_t> (active_elections.count_by_behavior[nano::election_behavior::optimistic]), 0 }));
 
-	composite->add_component (active_transactions.recently_confirmed.collect_container_info ("recently_confirmed"));
-	composite->add_component (active_transactions.recently_cemented.collect_container_info ("recently_cemented"));
+	composite->add_component (active_elections.recently_confirmed.collect_container_info ("recently_confirmed"));
+	composite->add_component (active_elections.recently_cemented.collect_container_info ("recently_cemented"));
 
 	return composite;
 }
@@ -767,14 +767,14 @@ std::unique_ptr<nano::container_info_component> nano::recently_cemented_cache::c
 }
 
 /*
- * active_transactions_config
+ * active_elections_config
  */
 
-nano::active_transactions_config::active_transactions_config (const nano::network_constants & network_constants)
+nano::active_elections_config::active_elections_config (const nano::network_constants & network_constants)
 {
 }
 
-nano::error nano::active_transactions_config::serialize (nano::tomlconfig & toml) const
+nano::error nano::active_elections_config::serialize (nano::tomlconfig & toml) const
 {
 	toml.put ("size", size, "Number of active elections. Elections beyond this limit have limited survival time.\nWarning: modifying this value may result in a lower confirmation rate. \ntype:uint64,[250..]");
 	toml.put ("hinted_limit_percentage", hinted_limit_percentage, "Limit of hinted elections as percentage of `active_elections_size` \ntype:uint64");
@@ -785,7 +785,7 @@ nano::error nano::active_transactions_config::serialize (nano::tomlconfig & toml
 	return toml.get_error ();
 }
 
-nano::error nano::active_transactions_config::deserialize (nano::tomlconfig & toml)
+nano::error nano::active_elections_config::deserialize (nano::tomlconfig & toml)
 {
 	toml.get ("size", size);
 	toml.get ("hinted_limit_percentage", hinted_limit_percentage);

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -25,7 +25,7 @@ namespace mi = boost::multi_index;
 namespace nano
 {
 class node;
-class active_transactions;
+class active_elections;
 class block;
 class block_sideband;
 class block_processor;
@@ -41,10 +41,10 @@ class read_transaction;
 
 namespace nano
 {
-class active_transactions_config final
+class active_elections_config final
 {
 public:
-	explicit active_transactions_config (nano::network_constants const &);
+	explicit active_elections_config (nano::network_constants const &);
 
 	nano::error deserialize (nano::tomlconfig & toml);
 	nano::error serialize (nano::tomlconfig & toml) const;
@@ -132,7 +132,7 @@ public: // Container info
  * Core class for determining consensus
  * Holds all active blocks i.e. recently added blocks that need confirmation
  */
-class active_transactions final
+class active_elections final
 {
 private: // Elections
 	class conflict_info final
@@ -163,8 +163,8 @@ private: // Elections
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> blocks;
 
 public:
-	active_transactions (nano::node &, nano::confirming_set &, nano::block_processor &);
-	~active_transactions ();
+	active_elections (nano::node &, nano::confirming_set &, nano::block_processor &);
+	~active_elections ();
 
 	void start ();
 	void stop ();
@@ -230,7 +230,7 @@ private:
 	bool trigger_vote_cache (nano::block_hash);
 
 private: // Dependencies
-	active_transactions_config const & config;
+	active_elections_config const & config;
 	nano::node & node;
 	nano::confirming_set & confirming_set;
 	nano::block_processor & block_processor;
@@ -258,7 +258,7 @@ private:
 	std::thread thread;
 
 	friend class election;
-	friend std::unique_ptr<container_info_component> collect_container_info (active_transactions &, std::string const &);
+	friend std::unique_ptr<container_info_component> collect_container_info (active_elections &, std::string const &);
 
 public: // Tests
 	void clear ();
@@ -266,15 +266,15 @@ public: // Tests
 	friend class node_fork_storm_Test;
 	friend class system_block_sequence_Test;
 	friend class node_mass_block_new_Test;
-	friend class active_transactions_vote_replays_Test;
+	friend class active_elections_vote_replays_Test;
 	friend class frontiers_confirmation_prioritize_frontiers_Test;
 	friend class frontiers_confirmation_prioritize_frontiers_max_optimistic_elections_Test;
 	friend class confirmation_height_prioritize_frontiers_overwrite_Test;
-	friend class active_transactions_confirmation_consistency_Test;
+	friend class active_elections_confirmation_consistency_Test;
 	friend class node_deferred_dependent_elections_Test;
-	friend class active_transactions_pessimistic_elections_Test;
+	friend class active_elections_pessimistic_elections_Test;
 	friend class frontiers_confirmation_expired_optimistic_elections_removal_Test;
 };
 
-std::unique_ptr<container_info_component> collect_container_info (active_transactions & active_transactions, std::string const & name);
+std::unique_ptr<container_info_component> collect_container_info (active_elections & active_elections, std::string const & name);
 }

--- a/nano/node/active_transactions.cpp
+++ b/nano/node/active_transactions.cpp
@@ -766,7 +766,6 @@ std::unique_ptr<nano::container_info_component> nano::recently_cemented_cache::c
 	return composite;
 }
 
-
 /*
  * active_transactions_config
  */

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -44,26 +44,23 @@ namespace nano
 class active_transactions_config final
 {
 public:
-    explicit active_transactions_config (nano::network_constants const &);
+	explicit active_transactions_config (nano::network_constants const &);
 
-    nano::error deserialize (nano::tomlconfig & toml);
-    nano::error serialize (nano::tomlconfig & toml) const;
+	nano::error deserialize (nano::tomlconfig & toml);
+	nano::error serialize (nano::tomlconfig & toml) const;
 
 public:
-    // Maximum number of simultaneous active elections (AEC size)
-    std::size_t size{ 5000 };
-    // Limit of hinted elections as percentage of `active_elections_size` 
-    std::size_t hinted_limit_percentage{ 20 };
-    // Limit of optimistic elections as percentage of `active_elections_size`
-    std::size_t optimistic_limit_percentage{ 10 };
+	// Maximum number of simultaneous active elections (AEC size)
+	std::size_t size{ 5000 };
+	// Limit of hinted elections as percentage of `active_elections_size`
+	std::size_t hinted_limit_percentage{ 20 };
+	// Limit of optimistic elections as percentage of `active_elections_size`
+	std::size_t optimistic_limit_percentage{ 10 };
 	// Maximum confirmation history size
 	std::size_t confirmation_history_size{ 2048 };
 	// Maximum cache size for recently_confirmed
 	std::size_t confirmation_cache{ 65536 };
-
-	
-	
-};	
+};
 
 class recently_confirmed_cache final
 {
@@ -234,7 +231,7 @@ private:
 
 private: // Dependencies
 	active_transactions_config const & config;
-	nano::node & node;	
+	nano::node & node;
 	nano::confirming_set & confirming_set;
 	nano::block_processor & block_processor;
 

--- a/nano/node/active_transactions.hpp
+++ b/nano/node/active_transactions.hpp
@@ -41,6 +41,30 @@ class read_transaction;
 
 namespace nano
 {
+class active_transactions_config final
+{
+public:
+    explicit active_transactions_config (nano::network_constants const &);
+
+    nano::error deserialize (nano::tomlconfig & toml);
+    nano::error serialize (nano::tomlconfig & toml) const;
+
+public:
+    // Maximum number of simultaneous active elections (AEC size)
+    std::size_t size{ 5000 };
+    // Limit of hinted elections as percentage of `active_elections_size` 
+    std::size_t hinted_limit_percentage{ 20 };
+    // Limit of optimistic elections as percentage of `active_elections_size`
+    std::size_t optimistic_limit_percentage{ 10 };
+	// Maximum confirmation history size
+	std::size_t confirmation_history_size{ 2048 };
+	// Maximum cache size for recently_confirmed
+	std::size_t confirmation_cache{ 65536 };
+
+	
+	
+};	
+
 class recently_confirmed_cache final
 {
 public:
@@ -209,7 +233,8 @@ private:
 	bool trigger_vote_cache (nano::block_hash);
 
 private: // Dependencies
-	nano::node & node;
+	active_transactions_config const & config;
+	nano::node & node;	
 	nano::confirming_set & confirming_set;
 	nano::block_processor & block_processor;
 

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -2,7 +2,7 @@
 #include <nano/lib/enum_util.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/timer.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/blockprocessor.hpp>
 #include <nano/node/local_vote_history.hpp>
 #include <nano/node/node.hpp>

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -93,7 +93,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 	// clang-format off
 	description_a.add_options()
 		("disable_add_initial_peers", "Disable contacting the peer in the peers table at startup")
-		("disable_activate_successors", "Disables activate_successors in active_transactions")
+		("disable_activate_successors", "Disables activate_successors in active_elections")
 		("disable_backup", "Disable wallet automatic backups")
 		("disable_lazy_bootstrap", "Disables lazy bootstrap")
 		("disable_legacy_bootstrap", "Disables legacy bootstrap")

--- a/nano/node/common.cpp
+++ b/nano/node/common.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/memory.hpp>
 #include <nano/lib/stream.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/network.hpp>

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/enum_util.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/local_vote_history.hpp>

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -181,7 +181,7 @@ public: // Logging
 private: // Constants
 	static std::size_t constexpr max_blocks{ 10 };
 
-	friend class active_transactions;
+	friend class active_elections;
 	friend class confirmation_solicitor;
 
 public: // Only used in tests

--- a/nano/node/inactive_node.cpp
+++ b/nano/node/inactive_node.cpp
@@ -1,4 +1,4 @@
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/inactive_node.hpp>
 #include <nano/node/node.hpp>
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3,7 +3,7 @@
 #include <nano/lib/json_error_response.hpp>
 #include <nano/lib/stats_sinks.hpp>
 #include <nano/lib/timer.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/bootstrap/bootstrap_lazy.hpp>
 #include <nano/node/bootstrap_ascending/service.hpp>
 #include <nano/node/common.hpp>
@@ -2039,7 +2039,7 @@ void nano::json_handler::election_statistics ()
 		}
 	}
 
-	auto utilization_percentage = (static_cast<double> (total_count * 100) / node.config.active_transactions.size);
+	auto utilization_percentage = (static_cast<double> (total_count * 100) / node.config.active_elections.size);
 	auto max_election_age = std::chrono::duration_cast<std::chrono::milliseconds> (now - oldest_election_start).count ();
 	auto average_election_age = total_count ? std::chrono::duration_cast<std::chrono::milliseconds> (total_age).count () / total_count : 0;
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2039,7 +2039,7 @@ void nano::json_handler::election_statistics ()
 		}
 	}
 
-	auto utilization_percentage = (static_cast<double> (total_count * 100) / node.config.active_elections_size);
+	auto utilization_percentage = (static_cast<double> (total_count * 100) / node.config.active_transactions.size);
 	auto max_election_age = std::chrono::duration_cast<std::chrono::milliseconds> (now - oldest_election_start).count ();
 	auto average_election_age = total_count ? std::chrono::duration_cast<std::chrono::milliseconds> (total_age).count () / total_count : 0;
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -2,7 +2,7 @@
 #include <nano/lib/stream.hpp>
 #include <nano/lib/tomlconfig.hpp>
 #include <nano/lib/utility.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/confirming_set.hpp>
 #include <nano/node/daemonconfig.hpp>
@@ -178,7 +178,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	block_processor (*this),
 	confirming_set_impl{ std::make_unique<nano::confirming_set> (ledger, config.confirming_set_batch_time) },
 	confirming_set{ *confirming_set_impl },
-	active_impl{ std::make_unique<nano::active_transactions> (*this, confirming_set, block_processor) },
+	active_impl{ std::make_unique<nano::active_elections> (*this, confirming_set, block_processor) },
 	active{ *active_impl },
 	rep_crawler (config.rep_crawler, *this),
 	rep_tiers{ ledger, network_params, online_reps, stats, logger },

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -43,7 +43,7 @@
 
 namespace nano
 {
-class active_transactions;
+class active_elections;
 class confirming_set;
 class node;
 class vote_processor;
@@ -172,8 +172,8 @@ public:
 	nano::block_processor block_processor;
 	std::unique_ptr<nano::confirming_set> confirming_set_impl;
 	nano::confirming_set & confirming_set;
-	std::unique_ptr<nano::active_transactions> active_impl;
-	nano::active_transactions & active;
+	std::unique_ptr<nano::active_elections> active_impl;
+	nano::active_elections & active;
 	nano::online_reps online_reps;
 	nano::rep_crawler rep_crawler;
 	nano::rep_tiers rep_tiers;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -120,7 +120,7 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("external_port", external_port, "The external port number of this node (NAT). Only used if external_address is set.\ntype:uint16");
 	toml.put ("tcp_incoming_connections_max", tcp_incoming_connections_max, "Maximum number of incoming TCP connections.\ntype:uint64");
 	toml.put ("use_memory_pools", use_memory_pools, "If true, allocate memory from memory pools. Enabling this may improve performance. Memory is never released to the OS.\ntype:bool");
-	
+
 	toml.put ("bandwidth_limit", bandwidth_limit, "Outbound traffic limit in bytes/sec after which messages will be dropped.\nNote: changing to unlimited bandwidth (0) is not recommended for limited connections.\ntype:uint64");
 	toml.put ("bandwidth_limit_burst_ratio", bandwidth_limit_burst_ratio, "Burst ratio for outbound traffic shaping.\ntype:double");
 
@@ -468,7 +468,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		toml.get (pow_sleep_interval_key, pow_sleep_interval_l);
 		pow_sleep_interval = std::chrono::nanoseconds (pow_sleep_interval_l);
 		toml.get<bool> ("use_memory_pools", use_memory_pools);
-	
+
 		toml.get<std::size_t> ("bandwidth_limit", bandwidth_limit);
 		toml.get<double> ("bandwidth_limit_burst_ratio", bandwidth_limit_burst_ratio);
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -34,6 +34,7 @@ nano::node_config::node_config (const std::optional<uint16_t> & peering_port_a, 
 	ipc_config{ network_params.network },
 	external_address{ boost::asio::ip::address_v6{}.to_string () },
 	rep_crawler{ network_params.network },
+	active_transactions{ network_params.network },
 	block_processor{ network_params.network },
 	peer_history{ network_params.network },
 	tcp{ network_params.network }
@@ -119,9 +120,7 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("external_port", external_port, "The external port number of this node (NAT). Only used if external_address is set.\ntype:uint16");
 	toml.put ("tcp_incoming_connections_max", tcp_incoming_connections_max, "Maximum number of incoming TCP connections.\ntype:uint64");
 	toml.put ("use_memory_pools", use_memory_pools, "If true, allocate memory from memory pools. Enabling this may improve performance. Memory is never released to the OS.\ntype:bool");
-	toml.put ("confirmation_history_size", confirmation_history_size, "Maximum confirmation history size. If tracking the rate of block confirmations, the websocket feature is recommended instead.\ntype:uint64");
-	toml.put ("active_elections_size", active_elections_size, "Number of active elections. Elections beyond this limit have limited survival time.\nWarning: modifying this value may result in a lower confirmation rate.\ntype:uint64,[250..]");
-
+	
 	toml.put ("bandwidth_limit", bandwidth_limit, "Outbound traffic limit in bytes/sec after which messages will be dropped.\nNote: changing to unlimited bandwidth (0) is not recommended for limited connections.\ntype:uint64");
 	toml.put ("bandwidth_limit_burst_ratio", bandwidth_limit_burst_ratio, "Burst ratio for outbound traffic shaping.\ntype:double");
 
@@ -218,6 +217,10 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	rep_crawler.serialize (rep_crawler_l);
 	toml.put_child ("rep_crawler", rep_crawler_l);
 
+	nano::tomlconfig active_transactions_l;
+	active_transactions.serialize (active_transactions_l);
+	toml.put_child ("active_transactions", active_transactions_l);
+
 	nano::tomlconfig block_processor_l;
 	block_processor.serialize (block_processor_l);
 	toml.put_child ("block_processor", block_processor_l);
@@ -309,6 +312,12 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			auto config_l = toml.get_required_child ("rep_crawler");
 			rep_crawler.deserialize (config_l);
+		}
+
+		if (toml.has_key ("active_transactions"))
+		{
+			auto config_l = toml.get_required_child ("active_transactions");
+			active_transactions.deserialize (config_l);
 		}
 
 		if (toml.has_key ("block_processor"))
@@ -459,9 +468,7 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		toml.get (pow_sleep_interval_key, pow_sleep_interval_l);
 		pow_sleep_interval = std::chrono::nanoseconds (pow_sleep_interval_l);
 		toml.get<bool> ("use_memory_pools", use_memory_pools);
-		toml.get<std::size_t> ("confirmation_history_size", confirmation_history_size);
-		toml.get<std::size_t> ("active_elections_size", active_elections_size);
-
+	
 		toml.get<std::size_t> ("bandwidth_limit", bandwidth_limit);
 		toml.get<double> ("bandwidth_limit_burst_ratio", bandwidth_limit_burst_ratio);
 
@@ -524,9 +531,9 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			toml.get_error ().set ("io_threads must be non-zero");
 		}
-		if (active_elections_size <= 250 && !network_params.network.is_dev_network ())
+		if (active_transactions.size <= 250 && !network_params.network.is_dev_network ())
 		{
-			toml.get_error ().set ("active_elections_size must be greater than 250");
+			toml.get_error ().set ("active_transactions.size must be greater than 250");
 		}
 		if (bandwidth_limit > std::numeric_limits<std::size_t>::max ())
 		{

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -34,7 +34,7 @@ nano::node_config::node_config (const std::optional<uint16_t> & peering_port_a, 
 	ipc_config{ network_params.network },
 	external_address{ boost::asio::ip::address_v6{}.to_string () },
 	rep_crawler{ network_params.network },
-	active_transactions{ network_params.network },
+	active_elections{ network_params.network },
 	block_processor{ network_params.network },
 	peer_history{ network_params.network },
 	tcp{ network_params.network }
@@ -217,9 +217,9 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	rep_crawler.serialize (rep_crawler_l);
 	toml.put_child ("rep_crawler", rep_crawler_l);
 
-	nano::tomlconfig active_transactions_l;
-	active_transactions.serialize (active_transactions_l);
-	toml.put_child ("active_transactions", active_transactions_l);
+	nano::tomlconfig active_elections_l;
+	active_elections.serialize (active_elections_l);
+	toml.put_child ("active_elections", active_elections_l);
 
 	nano::tomlconfig block_processor_l;
 	block_processor.serialize (block_processor_l);
@@ -314,10 +314,10 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 			rep_crawler.deserialize (config_l);
 		}
 
-		if (toml.has_key ("active_transactions"))
+		if (toml.has_key ("active_elections"))
 		{
-			auto config_l = toml.get_required_child ("active_transactions");
-			active_transactions.deserialize (config_l);
+			auto config_l = toml.get_required_child ("active_elections");
+			active_elections.deserialize (config_l);
 		}
 
 		if (toml.has_key ("block_processor"))
@@ -531,9 +531,9 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			toml.get_error ().set ("io_threads must be non-zero");
 		}
-		if (active_transactions.size <= 250 && !network_params.network.is_dev_network ())
+		if (active_elections.size <= 250 && !network_params.network.is_dev_network ())
 		{
-			toml.get_error ().set ("active_transactions.size must be greater than 250");
+			toml.get_error ().set ("active_elections.size must be greater than 250");
 		}
 		if (bandwidth_limit > std::numeric_limits<std::size_t>::max ())
 		{

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -8,6 +8,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/rocksdbconfig.hpp>
 #include <nano/lib/stats.hpp>
+#include <nano/node/active_transactions.hpp>
 #include <nano/node/blockprocessor.hpp>
 #include <nano/node/bootstrap/bootstrap_config.hpp>
 #include <nano/node/bootstrap/bootstrap_server.hpp>
@@ -90,7 +91,6 @@ public:
 	uint32_t bootstrap_frontier_request_count{ 1024 * 1024 };
 	nano::websocket::config websocket_config;
 	nano::diagnostics_config diagnostics_config;
-	std::size_t confirmation_history_size{ 2048 };
 	std::string callback_address;
 	uint16_t callback_port{ 0 };
 	std::string callback_target;
@@ -104,12 +104,7 @@ public:
 	/** Timeout for initiated async operations */
 	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_dev_network () && !is_sanitizer_build ()) ? std::chrono::seconds (5) : std::chrono::seconds (15) };
 	std::chrono::nanoseconds pow_sleep_interval{ 0 };
-	// TODO: Move related settings to `active_transactions_config` class
-	std::size_t active_elections_size{ 5000 };
-	/** Limit of hinted elections as percentage of `active_elections_size` */
-	std::size_t active_elections_hinted_limit_percentage{ 20 };
-	/** Limit of optimistic elections as percentage of `active_elections_size` */
-	std::size_t active_elections_optimistic_limit_percentage{ 10 };
+
 	/** Default maximum incoming TCP connections, including realtime network & bootstrap */
 	unsigned tcp_incoming_connections_max{ 2048 };
 	bool use_memory_pools{ true };
@@ -142,6 +137,7 @@ public:
 	nano::vote_cache_config vote_cache;
 	nano::rep_crawler_config rep_crawler;
 	nano::block_processor_config block_processor;
+	nano::active_transactions_config active_transactions;
 	nano::vote_processor_config vote_processor;
 	nano::peer_history_config peer_history;
 	nano::transport::tcp_config tcp;

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -8,7 +8,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/rocksdbconfig.hpp>
 #include <nano/lib/stats.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/blockprocessor.hpp>
 #include <nano/node/bootstrap/bootstrap_config.hpp>
 #include <nano/node/bootstrap/bootstrap_server.hpp>
@@ -137,7 +137,7 @@ public:
 	nano::vote_cache_config vote_cache;
 	nano::rep_crawler_config rep_crawler;
 	nano::block_processor_config block_processor;
-	nano::active_transactions_config active_transactions;
+	nano::active_elections_config active_elections;
 	nano::vote_processor_config vote_processor;
 	nano::peer_history_config peer_history;
 	nano::transport::tcp_config tcp;

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -1,4 +1,4 @@
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/repcrawler.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -23,7 +23,7 @@ namespace mi = boost::multi_index;
 namespace nano
 {
 class node;
-class active_transactions;
+class active_elections;
 
 struct representative
 {
@@ -93,7 +93,7 @@ private: // Dependencies
 	nano::stats & stats;
 	nano::logger & logger;
 	nano::network_constants & network_constants;
-	nano::active_transactions & active;
+	nano::active_elections & active;
 
 private:
 	void run ();

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/stats.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/local_vote_history.hpp>
 #include <nano/node/network.hpp>
@@ -12,7 +12,7 @@
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/store/component.hpp>
 
-nano::request_aggregator::request_aggregator (nano::node_config const & config_a, nano::stats & stats_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::active_transactions & active_a) :
+nano::request_aggregator::request_aggregator (nano::node_config const & config_a, nano::stats & stats_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::active_elections & active_a) :
 	config{ config_a },
 	max_delay (config_a.network_params.network.is_dev_network () ? 50 : 300),
 	small_delay (config_a.network_params.network.is_dev_network () ? 10 : 50),

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -19,7 +19,7 @@ namespace mi = boost::multi_index;
 
 namespace nano
 {
-class active_transactions;
+class active_elections;
 class ledger;
 class local_vote_history;
 class node_config;
@@ -62,7 +62,7 @@ class request_aggregator final
 	// clang-format on
 
 public:
-	request_aggregator (nano::node_config const & config, nano::stats & stats_a, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::active_transactions &);
+	request_aggregator (nano::node_config const & config, nano::stats & stats_a, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::active_elections &);
 
 	/** Add a new request by \p channel_a for hashes \p hashes_roots_a */
 	void add (std::shared_ptr<nano::transport::channel> const & channel_a, std::vector<std::pair<nano::block_hash, nano::root>> const & hashes_roots_a);
@@ -89,7 +89,7 @@ private:
 	nano::local_vote_history & local_votes;
 	nano::ledger & ledger;
 	nano::wallets & wallets;
-	nano::active_transactions & active;
+	nano::active_elections & active;
 	nano::vote_generator & generator;
 	nano::vote_generator & final_generator;
 

--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/stats.hpp>
 #include <nano/lib/tomlconfig.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election_behavior.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/hinted.hpp>
@@ -11,7 +11,7 @@
  * hinted
  */
 
-nano::scheduler::hinted::hinted (hinted_config const & config_a, nano::node & node_a, nano::vote_cache & vote_cache_a, nano::active_transactions & active_a, nano::online_reps & online_reps_a, nano::stats & stats_a) :
+nano::scheduler::hinted::hinted (hinted_config const & config_a, nano::node & node_a, nano::vote_cache & vote_cache_a, nano::active_elections & active_a, nano::online_reps & online_reps_a, nano::stats & stats_a) :
 	config{ config_a },
 	node{ node_a },
 	vote_cache{ vote_cache_a },

--- a/nano/node/scheduler/hinted.hpp
+++ b/nano/node/scheduler/hinted.hpp
@@ -20,7 +20,7 @@ namespace nano
 {
 class node;
 class node_config;
-class active_transactions;
+class active_elections;
 class vote_cache;
 class online_reps;
 }
@@ -54,7 +54,7 @@ public:
 class hinted final
 {
 public:
-	hinted (hinted_config const &, nano::node &, nano::vote_cache &, nano::active_transactions &, nano::online_reps &, nano::stats &);
+	hinted (hinted_config const &, nano::node &, nano::vote_cache &, nano::active_elections &, nano::online_reps &, nano::stats &);
 	~hinted ();
 
 	void start ();
@@ -79,7 +79,7 @@ private:
 private: // Dependencies
 	nano::node & node;
 	nano::vote_cache & vote_cache;
-	nano::active_transactions & active;
+	nano::active_elections & active;
 	nano::online_reps & online_reps;
 	nano::stats & stats;
 

--- a/nano/node/scheduler/manual.cpp
+++ b/nano/node/scheduler/manual.cpp
@@ -1,4 +1,4 @@
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/manual.hpp>

--- a/nano/node/scheduler/optimistic.cpp
+++ b/nano/node/scheduler/optimistic.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/tomlconfig.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election_behavior.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/optimistic.hpp>
@@ -9,7 +9,7 @@
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_confirmed.hpp>
 
-nano::scheduler::optimistic::optimistic (optimistic_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::active_transactions & active_a, nano::network_constants const & network_constants_a, nano::stats & stats_a) :
+nano::scheduler::optimistic::optimistic (optimistic_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::active_elections & active_a, nano::network_constants const & network_constants_a, nano::stats & stats_a) :
 	config{ config_a },
 	node{ node_a },
 	ledger{ ledger_a },

--- a/nano/node/scheduler/optimistic.hpp
+++ b/nano/node/scheduler/optimistic.hpp
@@ -23,7 +23,7 @@ namespace mi = boost::multi_index;
 namespace nano
 {
 class account_info;
-class active_transactions;
+class active_elections;
 class ledger;
 class node;
 }
@@ -51,7 +51,7 @@ class optimistic final
 	struct entry;
 
 public:
-	optimistic (optimistic_config const &, nano::node &, nano::ledger &, nano::active_transactions &, nano::network_constants const & network_constants, nano::stats &);
+	optimistic (optimistic_config const &, nano::node &, nano::ledger &, nano::active_elections &, nano::network_constants const & network_constants, nano::stats &);
 	~optimistic ();
 
 	void start ();
@@ -80,7 +80,7 @@ private: // Dependencies
 	optimistic_config const & config;
 	nano::node & node;
 	nano::ledger & ledger;
-	nano::active_transactions & active;
+	nano::active_elections & active;
 	nano::network_constants const & network_constants;
 	nano::stats & stats;
 

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -1,5 +1,5 @@
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/buckets.hpp>

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -24,7 +24,7 @@ namespace mi = boost::multi_index;
 namespace nano
 {
 class node;
-class active_transactions;
+class active_elections;
 class election;
 class vote;
 }

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/stats.hpp>
 #include <nano/lib/thread_roles.hpp>
 #include <nano/lib/timer.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/node_observers.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/online_reps.hpp>
@@ -15,7 +15,7 @@
 
 using namespace std::chrono_literals;
 
-nano::vote_processor::vote_processor (vote_processor_config const & config_a, nano::active_transactions & active_a, nano::node_observers & observers_a, nano::stats & stats_a, nano::node_flags & flags_a, nano::logger & logger_a, nano::online_reps & online_reps_a, nano::rep_crawler & rep_crawler_a, nano::ledger & ledger_a, nano::network_params & network_params_a, nano::rep_tiers & rep_tiers_a) :
+nano::vote_processor::vote_processor (vote_processor_config const & config_a, nano::active_elections & active_a, nano::node_observers & observers_a, nano::stats & stats_a, nano::node_flags & flags_a, nano::logger & logger_a, nano::online_reps & online_reps_a, nano::rep_crawler & rep_crawler_a, nano::ledger & ledger_a, nano::network_params & network_params_a, nano::rep_tiers & rep_tiers_a) :
 	config{ config_a },
 	active{ active_a },
 	observers{ observers_a },

--- a/nano/node/vote_processor.hpp
+++ b/nano/node/vote_processor.hpp
@@ -14,7 +14,7 @@
 
 namespace nano
 {
-class active_transactions;
+class active_elections;
 namespace store
 {
 	class component;
@@ -56,7 +56,7 @@ public:
 class vote_processor final
 {
 public:
-	vote_processor (vote_processor_config const &, nano::active_transactions &, nano::node_observers &, nano::stats &, nano::node_flags &, nano::logger &, nano::online_reps &, nano::rep_crawler &, nano::ledger &, nano::network_params &, nano::rep_tiers &);
+	vote_processor (vote_processor_config const &, nano::active_elections &, nano::node_observers &, nano::stats &, nano::node_flags &, nano::logger &, nano::online_reps &, nano::rep_crawler &, nano::ledger &, nano::network_params &, nano::rep_tiers &);
 	~vote_processor ();
 
 	void start ();
@@ -75,7 +75,7 @@ public:
 
 private: // Dependencies
 	vote_processor_config const & config;
-	nano::active_transactions & active;
+	nano::active_elections & active;
 	nano::node_observers & observers;
 	nano::stats & stats;
 	nano::logger & logger;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -4,7 +4,7 @@
 #include <nano/lib/rpcconfig.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/threading.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/confirming_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/ipc/ipc_server.hpp>

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -995,7 +995,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 	nano::node_config node_config = system.default_config ();
 	node_config.online_weight_minimum = 100;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	node_config.active_elections_size = 400000;
+	node_config.active_transactions.size = 400000;
 	nano::node_flags node_flags;
 	auto node = system.add_node (node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -2,7 +2,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/thread_runner.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/confirming_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/make_store.hpp>
@@ -995,7 +995,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 	nano::node_config node_config = system.default_config ();
 	node_config.online_weight_minimum = 100;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
-	node_config.active_transactions.size = 400000;
+	node_config.active_elections.size = 400000;
 	nano::node_flags node_flags;
 	auto node = system.add_node (node_config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);

--- a/nano/slow_test/vote_cache.cpp
+++ b/nano/slow_test/vote_cache.cpp
@@ -1,5 +1,5 @@
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/test_common/rate_observer.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -1,7 +1,7 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/thread_runner.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/common.hpp>
 #include <nano/node/transport/tcp_listener.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -1,6 +1,6 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
-#include <nano/node/active_transactions.hpp>
+#include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/manual.hpp>


### PR DESCRIPTION
Introduce `active_transactions_config` :


| Old config                                | New config                                   |
|-------------------------------------------|----------------------------------------------|
| active_elections_size                     | active_transactions.size                     |
| active_elections_hinted_limit_percentage | active_transactions.hinted_limit_percentage |
| active_elections_optimistic_limit_percentage | active_transactions.optimistic_limit_percentage |
| confirmation_history_size                 | active_transactions.confirmation_history_size|
|  /                 | active_transactions.confirmation_cache|



Newly introduced `confirmation_cache` is used in `recently_confirmed{ config.confirmation_cache },`  instead of the hardcoded value `65536`
