### PR TITLE
Directly confirm blocks within unit tests rather than starting/forcing elections

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -128,8 +128,7 @@ TEST (active_elections, confirm_frontier)
 		// we cannot use the same block instance on 2 different nodes, so make a copy
 		auto send_copy = builder.make_block ().from (*send).build ();
 		ASSERT_TRUE (nano::test::process (node1, { send_copy }));
-		ASSERT_TRUE (nano::test::start_elections (system, node1, { send_copy }));
-		ASSERT_TIMELY (5s, nano::test::confirmed (node1, { send_copy }));
+		nano::test::confirm (node1.ledger, send_copy);
 	}
 
 	// The rep crawler would otherwise request confirmations in order to find representatives
@@ -193,14 +192,7 @@ TEST (active_elections, keep_local)
 	ASSERT_NE (nullptr, send6);
 
 	// force-confirm blocks
-	for (auto const & block : { send1, send2, send3, send4, send5, send6 })
-	{
-		std::shared_ptr<nano::election> election{};
-		ASSERT_TIMELY (5s, (election = node.active.election (block->qualified_root ())) != nullptr);
-		node.process_confirmed (nano::election_status{ block });
-		election->force_confirm ();
-		ASSERT_TIMELY (5s, node.block_confirmed (block->hash ()));
-	}
+	nano::test::confirm (node.ledger, send6);
 
 	nano::state_block_builder builder{};
 	const auto receive1 = builder.make_block ()

--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -1368,7 +1368,7 @@ TEST (bootstrap_processor, lazy_pruning_missing_block)
 	std::vector<std::shared_ptr<nano::block>> const blocks{ send1, send2, open, state_open };
 	ASSERT_TRUE (nano::test::process (*node1, blocks));
 	ASSERT_TIMELY (5s, nano::test::exists (*node1, blocks));
-	nano::test::force_confirm (node1->ledger, blocks);
+	nano::test::confirm (node1->ledger, blocks);
 	ASSERT_TIMELY (5s, nano::test::confirmed (*node1, blocks));
 	ASSERT_EQ (5, node1->ledger.block_count ());
 	ASSERT_EQ (5, node1->ledger.cemented_count ());

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -290,8 +290,7 @@ TEST (election, continuous_voting)
 				 .build ();
 
 	ASSERT_TRUE (nano::test::process (node1, { send1 }));
-	ASSERT_TRUE (nano::test::start_elections (system, node1, { send1 }, true));
-	ASSERT_TIMELY (5s, nano::test::confirmed (node1, { send1 }));
+	nano::test::confirm (node1.ledger, send1);
 
 	node1.stats.clear ();
 

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2164,8 +2164,7 @@ TEST (node, vote_by_hash_bundle)
 	}
 
 	// Confirming last block will confirm whole chain and allow us to generate votes for those blocks later
-	ASSERT_TRUE (nano::test::start_elections (system, node, { blocks.back () }, true));
-	ASSERT_TIMELY (5s, nano::test::confirmed (node, { blocks.back () }));
+	nano::test::confirm (node.ledger, blocks.back ());
 
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key1;
@@ -2343,8 +2342,7 @@ TEST (node, epoch_conflict_confirm)
 	ASSERT_TRUE (nano::test::process (node1, { send, send2, open }));
 
 	// Confirm open block in node1 to allow generating votes
-	ASSERT_TRUE (nano::test::start_elections (system, node1, { open }, true));
-	ASSERT_TIMELY (5s, nano::test::confirmed (node1, { open }));
+	nano::test::confirm (node1.ledger, open);
 
 	// Process initial blocks on node0
 	ASSERT_TRUE (nano::test::process (node0, { send, send2, open }));
@@ -3029,8 +3027,7 @@ TEST (node, rollback_vote_self)
 
 	// Process and mark the first 2 blocks as confirmed to allow voting
 	ASSERT_TRUE (nano::test::process (node, { send1, open }));
-	ASSERT_TRUE (nano::test::start_elections (system, node, { send1, open }, true));
-	ASSERT_TIMELY_EQ (5s, node.ledger.cemented_count (), 3);
+	nano::test::confirm (node.ledger, open);
 
 	// wait until the rep weights have caught up with the weight transfer
 	ASSERT_TIMELY_EQ (5s, nano::dev::constants.genesis_amount / 2, node.weight (key.pub));

--- a/nano/core_test/optimistic_scheduler.cpp
+++ b/nano/core_test/optimistic_scheduler.cpp
@@ -27,8 +27,7 @@ TEST (optimistic_scheduler, activate_one)
 	auto & [account, blocks] = chains.front ();
 
 	// Confirm block towards at the beginning the chain, so gap between confirmation and account frontier is larger than `gap_threshold`
-	ASSERT_TRUE (nano::test::start_elections (system, node, { blocks.at (11) }, true));
-	ASSERT_TIMELY (5s, nano::test::confirmed (node, { blocks.at (11) }));
+	nano::test::confirm (node.ledger, blocks.at (11));
 
 	// Ensure unconfirmed account head block gets activated
 	auto const & block = blocks.back ();
@@ -96,8 +95,7 @@ TEST (optimistic_scheduler, under_gap_threshold)
 	auto & [account, blocks] = chains.front ();
 
 	// Confirm block towards the end of the chain, so gap between confirmation and account frontier is less than `gap_threshold`
-	ASSERT_TRUE (nano::test::start_elections (system, node, { blocks.at (55) }, true));
-	ASSERT_TIMELY (5s, nano::test::confirmed (node, { blocks.at (55) }));
+	nano::test::confirm (node.ledger, blocks.at (55));
 
 	// Manually trigger backlog scan
 	node.backlog.trigger ();

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -147,8 +147,7 @@ TEST (rpc, receivable_unconfirmed)
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
-	ASSERT_TRUE (nano::test::start_elections (system, *node, { block1->hash () }, true));
-	ASSERT_TIMELY (5s, nano::test::confirmed (*node, { block1 }));
+	nano::test::confirm (node->ledger, block1);
 	request.put ("include_only_confirmed", "true");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 }
@@ -550,8 +549,7 @@ TEST (rpc, accounts_receivable_confirmed)
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
-	ASSERT_TRUE (nano::test::start_elections (system, *node, { block1->hash () }, true));
-	ASSERT_TIMELY (5s, nano::test::confirmed (*node, { block1 }));
+	nano::test::confirm (node->ledger, block1);
 	request.put ("include_only_confirmed", "true");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 }

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1401,9 +1401,3 @@ std::unique_ptr<nano::container_info_component> nano::ledger::collect_container_
 	composite->add_component (cache.rep_weights.collect_container_info ("rep_weights"));
 	return composite;
 }
-
-void nano::ledger::force_confirm (secure::write_transaction const & transaction, nano::block const & block)
-{
-	release_assert (*constants.genesis == *constants.nano_dev_genesis);
-	confirm (transaction, block);
-}

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -102,8 +102,5 @@ private:
 public:
 	ledger_set_any & any;
 	ledger_set_confirmed & confirmed;
-
-public: // Only used in tests
-	void force_confirm (secure::write_transaction const & transaction, nano::block const & block);
 };
 }

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1957,9 +1957,9 @@ TEST (node, aggressive_flooding)
 		ASSERT_EQ (node1.latest (nano::dev::genesis_key.pub), node_wallet.first->latest (nano::dev::genesis_key.pub));
 		ASSERT_EQ (genesis_blocks.back ()->hash (), node_wallet.first->latest (nano::dev::genesis_key.pub));
 		// Confirm blocks for rep crawler & receiving
-		ASSERT_TRUE (nano::test::start_elections (system, *node_wallet.first, { genesis_blocks.back () }, true));
+		nano::test::confirm (node_wallet.first->ledger, genesis_blocks.back ());
 	}
-	ASSERT_TRUE (nano::test::start_elections (system, node1, { genesis_blocks.back () }, true));
+	nano::test::confirm (node1.ledger, genesis_blocks.back ());
 
 	// Wait until all genesis blocks are received
 	auto all_received = [&nodes_wallets] () {

--- a/nano/slow_test/vote_cache.cpp
+++ b/nano/slow_test/vote_cache.cpp
@@ -41,8 +41,7 @@ nano::keypair setup_rep (nano::test::system & system, nano::node & node, nano::u
 				.build ();
 
 	EXPECT_TRUE (nano::test::process (node, { send, open }));
-	EXPECT_TRUE (nano::test::start_elections (system, node, { send, open }, true));
-	EXPECT_TIMELY (5s, nano::test::confirmed (node, { send, open }));
+	nano::test::confirm (node.ledger, open->hash ());
 
 	return key;
 }
@@ -107,8 +106,7 @@ std::vector<std::shared_ptr<nano::block>> setup_blocks (nano::test::system & sys
 	EXPECT_TRUE (nano::test::process (node, receives));
 
 	// Confirm whole genesis chain at once
-	EXPECT_TRUE (nano::test::start_elections (system, node, { sends.back () }, true));
-	EXPECT_TIMELY (5s, nano::test::confirmed (node, { sends }));
+	nano::test::confirm (node.ledger, sends.back ()->hash ());
 
 	std::cout << "setup_blocks done" << std::endl;
 

--- a/nano/test_common/chains.cpp
+++ b/nano/test_common/chains.cpp
@@ -36,8 +36,7 @@ nano::block_list_t nano::test::setup_chain (nano::test::system & system, nano::n
 	if (confirm)
 	{
 		// Confirm whole chain at once
-		EXPECT_TRUE (nano::test::start_elections (system, node, { blocks.back () }, true));
-		EXPECT_TIMELY (5s, nano::test::confirmed (node, blocks));
+		nano::test::confirm (node.ledger, blocks);
 	}
 
 	return blocks;
@@ -84,8 +83,7 @@ std::vector<std::pair<nano::account, nano::block_list_t>> nano::test::setup_chai
 		if (confirm)
 		{
 			// Ensure blocks are in the ledger and confirmed
-			EXPECT_TRUE (nano::test::start_elections (system, node, { send, open }, true));
-			EXPECT_TIMELY (5s, nano::test::confirmed (node, { send, open }));
+			nano::test::confirm (node.ledger, open);
 		}
 
 		auto added_blocks = nano::test::setup_chain (system, node, block_count, key, confirm);
@@ -143,8 +141,7 @@ nano::block_list_t nano::test::setup_independent_blocks (nano::test::system & sy
 	}
 
 	// Confirm whole genesis chain at once
-	EXPECT_TRUE (nano::test::start_elections (system, node, { latest }, true));
-	EXPECT_TIMELY (5s, nano::test::confirmed (node, { latest }));
+	nano::test::confirm (node.ledger, latest);
 
 	return blocks;
 }
@@ -177,8 +174,10 @@ std::pair<std::shared_ptr<nano::block>, std::shared_ptr<nano::block>> nano::test
 				.build ();
 
 	EXPECT_TRUE (nano::test::process (node, { send, open }));
-	EXPECT_TRUE (nano::test::start_elections (system, node, { send, open }, force_confirm));
-	EXPECT_TIMELY (5s, nano::test::confirmed (node, { send, open }));
+	if (force_confirm)
+	{
+		nano::test::confirm (node.ledger, open);
+	}
 	return std::make_pair (send, open);
 }
 

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -123,12 +123,22 @@ bool nano::test::exists (nano::node & node, std::vector<std::shared_ptr<nano::bl
 	return exists (node, blocks_to_hashes (blocks));
 }
 
-void nano::test::force_confirm (nano::ledger & ledger, std::vector<std::shared_ptr<nano::block>> const blocks)
+void nano::test::confirm (nano::ledger & ledger, std::vector<std::shared_ptr<nano::block>> const blocks)
 {
 	for (auto const block : blocks)
 	{
-		ledger.force_confirm (ledger.tx_begin_write (), *block);
+		confirm (ledger, block);
 	}
+}
+
+void nano::test::confirm (nano::ledger & ledger, std::shared_ptr<nano::block> const block)
+{
+	confirm (ledger, block->hash ());
+}
+
+void nano::test::confirm (nano::ledger & ledger, nano::block_hash const & hash)
+{
+	ledger.confirm (ledger.tx_begin_write (), hash);
 }
 
 bool nano::test::block_or_pruned_all_exists (nano::node & node, std::vector<nano::block_hash> hashes)

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -326,7 +326,9 @@ namespace test
 	 * height of the account to be the height of the block.
 	 * The blocks are confirmed in the order that they are given.
 	 */
-	void force_confirm (nano::ledger & ledger, std::vector<std::shared_ptr<nano::block>> const blocks);
+	void confirm (nano::ledger & ledger, std::vector<std::shared_ptr<nano::block>> const blocks);
+	void confirm (nano::ledger & ledger, std::shared_ptr<nano::block> const block);
+	void confirm (nano::ledger & ledger, nano::block_hash const & hash);
 	/*
 	 * Convenience function to check whether *all* of the hashes exists in node ledger or in the pruned table.
 	 * @return true if all blocks are fully processed and inserted in the ledger, false otherwise


### PR DESCRIPTION
Replaces nano::test::force_confirm with nano::test::confirm and overrides. The action was renamed to test::confirm because the action is to confirm.  election::force_confirm is an action specific to an election where the normal path causes confirmation after the vote tally has quorum and force_confirm simulates this.

This removes ledger::force_confirm as it was inappropriately calling the private ledger::confirm(block) rather than the public ledger::confirm(hash).

While this doesn't fix any test specifically it should help with general unit test reliability by not running election functionality when setting up tests.