### PR TITLE
Separate vote_router from active_transactions

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -7,6 +7,7 @@
 #include <nano/node/scheduler/manual.hpp>
 #include <nano/node/scheduler/priority.hpp>
 #include <nano/node/transport/inproc.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_confirmed.hpp>

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -3,6 +3,7 @@
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
@@ -72,7 +73,7 @@ TEST (election, quorum_minimum_flip_success)
 	ASSERT_TIMELY_EQ (5s, election->blocks ().size (), 2);
 
 	auto vote = nano::test::make_final_vote (nano::dev::genesis_key, { send2->hash () });
-	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote).at (send2->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node1.vote_router.vote (vote).at (send2->hash ()));
 
 	ASSERT_TIMELY (5s, election->confirmed ());
 	auto const winner = election->winner ();
@@ -121,7 +122,7 @@ TEST (election, quorum_minimum_flip_fail)
 
 	// genesis generates a final vote for send2 but it should not be enough to reach quorum due to the online_weight_minimum being so high
 	auto vote = nano::test::make_final_vote (nano::dev::genesis_key, { send2->hash () });
-	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote).at (send2->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node.vote_router.vote (vote).at (send2->hash ()));
 
 	// give the election some time before asserting it is not confirmed so that in case
 	// it would be wrongfully confirmed, have that immediately fail instead of race
@@ -157,7 +158,7 @@ TEST (election, quorum_minimum_confirm_success)
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (1, election->blocks ().size ());
 	auto vote = nano::test::make_final_vote (nano::dev::genesis_key, { send1->hash () });
-	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote).at (send1->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node1.vote_router.vote (vote).at (send1->hash ()));
 	ASSERT_NE (nullptr, node1.block (send1->hash ()));
 	ASSERT_TIMELY (5s, election->confirmed ());
 }
@@ -188,7 +189,7 @@ TEST (election, quorum_minimum_confirm_fail)
 	ASSERT_EQ (1, election->blocks ().size ());
 
 	auto vote = nano::test::make_final_vote (nano::dev::genesis_key, { send1->hash () });
-	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote).at (send1->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node1.vote_router.vote (vote).at (send1->hash ()));
 
 	// give the election a chance to confirm
 	WAIT (1s);
@@ -251,7 +252,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 	ASSERT_EQ (1, election->blocks ().size ());
 
 	auto vote1 = nano::test::make_final_vote (nano::dev::genesis_key, { send1->hash () });
-	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1).at (send1->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node1.vote_router.vote (vote1).at (send1->hash ()));
 
 	auto channel = node1.network.find_node_id (node2.get_node_id ());
 	ASSERT_NE (channel, nullptr);
@@ -265,7 +266,7 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 		// Modify online_m for online_reps to more than is available, this checks that voting below updates it to current online reps.
 		node1.online_reps.online_m = node_config.online_weight_minimum.number () + 20;
 	}
-	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote2).at (send1->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node1.vote_router.vote (vote2).at (send1->hash ()));
 	ASSERT_TIMELY (5s, election->confirmed ());
 	ASSERT_NE (nullptr, node1.block (send1->hash ()));
 }

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -10,6 +10,7 @@
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/priority.hpp>
 #include <nano/node/transport/inproc.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_confirmed.hpp>
 #include <nano/store/rocksdb/rocksdb.hpp>
@@ -997,9 +998,9 @@ TEST (votes, add_one)
 	auto election1 = node1.active.election (send1->qualified_root ());
 	ASSERT_EQ (1, election1->votes ().size ());
 	auto vote1 = nano::test::make_vote (nano::dev::genesis_key, { send1 }, nano::vote::timestamp_min * 1, 0);
-	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1).at (send1->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node1.vote_router.vote (vote1).at (send1->hash ()));
 	auto vote2 = nano::test::make_vote (nano::dev::genesis_key, { send1 }, nano::vote::timestamp_min * 2, 0);
-	ASSERT_EQ (nano::vote_code::ignored, node1.active.vote (vote2).at (send1->hash ())); // Ignored due to vote cooldown
+	ASSERT_EQ (nano::vote_code::ignored, node1.vote_router.vote (vote2).at (send1->hash ())); // Ignored due to vote cooldown
 	ASSERT_EQ (2, election1->votes ().size ());
 	auto votes1 (election1->votes ());
 	auto existing1 (votes1.find (nano::dev::genesis_key.pub));
@@ -1038,7 +1039,7 @@ TEST (votes, add_existing)
 	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
 	auto election1 = node1.active.election (send1->qualified_root ());
 	auto vote1 = nano::test::make_vote (nano::dev::genesis_key, { send1 }, nano::vote::timestamp_min * 1, 0);
-	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote1).at (send1->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node1.vote_router.vote (vote1).at (send1->hash ()));
 	// Block is already processed from vote
 	ASSERT_TRUE (node1.active.publish (send1));
 	ASSERT_EQ (nano::vote::timestamp_min * 1, election1->last_votes[nano::dev::genesis_key.pub].timestamp);
@@ -1060,13 +1061,13 @@ TEST (votes, add_existing)
 	auto vote_info1 = election1->get_last_vote (nano::dev::genesis_key.pub);
 	vote_info1.time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
 	election1->set_last_vote (nano::dev::genesis_key.pub, vote_info1);
-	ASSERT_EQ (nano::vote_code::vote, node1.active.vote (vote2).at (send2->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node1.vote_router.vote (vote2).at (send2->hash ()));
 	ASSERT_EQ (nano::vote::timestamp_min * 2, election1->last_votes[nano::dev::genesis_key.pub].timestamp);
 	// Also resend the old vote, and see if we respect the timestamp
 	auto vote_info2 = election1->get_last_vote (nano::dev::genesis_key.pub);
 	vote_info2.time = std::chrono::steady_clock::now () - std::chrono::seconds (20);
 	election1->set_last_vote (nano::dev::genesis_key.pub, vote_info2);
-	ASSERT_EQ (nano::vote_code::replay, node1.active.vote (vote1).at (send1->hash ()));
+	ASSERT_EQ (nano::vote_code::replay, node1.vote_router.vote (vote1).at (send1->hash ()));
 	ASSERT_EQ (nano::vote::timestamp_min * 2, election1->votes ()[nano::dev::genesis_key.pub].timestamp);
 	auto votes (election1->votes ());
 	ASSERT_EQ (2, votes.size ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -14,6 +14,7 @@
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/transport/tcp_listener.hpp>
 #include <nano/node/vote_generator.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_confirmed.hpp>
@@ -3053,7 +3054,7 @@ TEST (node, rollback_vote_self)
 
 		ASSERT_EQ (0, election->votes_with_weight ().size ());
 		// Vote with key to switch the winner
-		election->vote (key.pub, 0, fork->hash ());
+		election->vote (key.pub, 0, fork->hash (), nano::vote_source::live);
 		ASSERT_EQ (1, election->votes_with_weight ().size ());
 		// The winner changed
 		ASSERT_EQ (election->winner ()->hash (), fork->hash ());

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -405,8 +405,8 @@ TEST (node, search_receivable_confirmed)
 
 	system.wallet (0)->insert_adhoc (key2.prv);
 	ASSERT_FALSE (system.wallet (0)->search_receivable (system.wallet (0)->wallets.tx_begin_read ()));
-	ASSERT_TIMELY (5s, !node->active.active (send1->hash ()));
-	ASSERT_TIMELY (5s, !node->active.active (send2->hash ()));
+	ASSERT_TIMELY (5s, !node->vote_router.active (send1->hash ()));
+	ASSERT_TIMELY (5s, !node->vote_router.active (send2->hash ()));
 	ASSERT_TIMELY_EQ (5s, node->balance (key2.pub), 2 * node->config.receive_minimum.number ());
 }
 
@@ -3329,7 +3329,7 @@ TEST (node, dependency_graph)
 
 		// Ensure that active blocks have their ancestors confirmed
 		auto error = std::any_of (dependency_graph.cbegin (), dependency_graph.cend (), [&] (auto entry) {
-			if (node.active.active (entry.first))
+			if (node.vote_router.active (entry.first))
 			{
 				for (auto ancestor : entry.second)
 				{

--- a/nano/core_test/optimistic_scheduler.cpp
+++ b/nano/core_test/optimistic_scheduler.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -31,7 +32,7 @@ TEST (optimistic_scheduler, activate_one)
 
 	// Ensure unconfirmed account head block gets activated
 	auto const & block = blocks.back ();
-	ASSERT_TIMELY (5s, node.active.active (block->hash ()));
+	ASSERT_TIMELY (5s, node.vote_router.active (block->hash ()));
 	ASSERT_EQ (node.active.election (block->qualified_root ())->behavior (), nano::election_behavior::optimistic);
 }
 
@@ -52,7 +53,7 @@ TEST (optimistic_scheduler, activate_one_zero_conf)
 
 	// Ensure unconfirmed account head block gets activated
 	auto const & block = blocks.back ();
-	ASSERT_TIMELY (5s, node.active.active (block->hash ()));
+	ASSERT_TIMELY (5s, node.vote_router.active (block->hash ()));
 	ASSERT_EQ (node.active.election (block->qualified_root ())->behavior (), nano::election_behavior::optimistic);
 }
 
@@ -74,7 +75,7 @@ TEST (optimistic_scheduler, activate_many)
 	ASSERT_TIMELY (5s, std::all_of (chains.begin (), chains.end (), [&] (auto const & entry) {
 		auto const & [account, blocks] = entry;
 		auto const & block = blocks.back ();
-		return node.active.active (block->hash ()) && node.active.election (block->qualified_root ())->behavior () == nano::election_behavior::optimistic;
+		return node.vote_router.active (block->hash ()) && node.active.election (block->qualified_root ())->behavior () == nano::election_behavior::optimistic;
 	}));
 }
 
@@ -103,5 +104,5 @@ TEST (optimistic_scheduler, under_gap_threshold)
 
 	// Ensure unconfirmed account head block gets activated
 	auto const & block = blocks.back ();
-	ASSERT_NEVER (3s, node.active.active (block->hash ()));
+	ASSERT_NEVER (3s, node.vote_router.active (block->hash ()));
 }

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -4,6 +4,7 @@
 #include <nano/node/election.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/vote_processor.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
@@ -187,7 +188,7 @@ TEST (vote_processor, no_broadcast_local)
 	ASSERT_FALSE (node.wallets.reps ().have_half_rep ()); // Genesis balance remaining after `send' is less than the half_rep threshold
 	// Process a vote with a key that is in the local wallet.
 	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::milliseconds_since_epoch (), nano::vote::duration_max, std::vector<nano::block_hash>{ send->hash () });
-	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote).at (send->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node.vote_router.vote (vote).at (send->hash ()));
 	// Make sure the vote was processed.
 	auto election (node.active.election (send->qualified_root ()));
 	ASSERT_NE (nullptr, election);
@@ -237,7 +238,7 @@ TEST (vote_processor, local_broadcast_without_a_representative)
 	node.start_election (send);
 	// Process a vote without a representative
 	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::milliseconds_since_epoch (), nano::vote::duration_max, std::vector<nano::block_hash>{ send->hash () });
-	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote).at (send->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node.vote_router.vote (vote).at (send->hash ()));
 	// Make sure the vote was processed.
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node.active.election (send->qualified_root ()));
@@ -290,7 +291,7 @@ TEST (vote_processor, no_broadcast_local_with_a_principal_representative)
 	ASSERT_TRUE (node.wallets.reps ().have_half_rep ()); // Genesis balance after `send' is over both half_rep and PR threshold.
 	// Process a vote with a key that is in the local wallet.
 	auto vote = std::make_shared<nano::vote> (nano::dev::genesis_key.pub, nano::dev::genesis_key.prv, nano::milliseconds_since_epoch (), nano::vote::duration_max, std::vector<nano::block_hash>{ send->hash () });
-	ASSERT_EQ (nano::vote_code::vote, node.active.vote (vote).at (send->hash ()));
+	ASSERT_EQ (nano::vote_code::vote, node.vote_router.vote (vote).at (send->hash ()));
 	// Make sure the vote was processed.
 	auto election (node.active.election (send->qualified_root ()));
 	ASSERT_NE (nullptr, election);

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -2,6 +2,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/active_elections.hpp>
 #include <nano/node/transport/fake.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -139,6 +139,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::port_mapping:
 			thread_role_name_string = "Port mapping";
 			break;
+		case nano::thread_role::name::vote_router:
+			thread_role_name_string = "Vote router";
+			break;
 		default:
 			debug_assert (false && "nano::thread_role::get_string unhandled thread role");
 	}

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -53,6 +53,7 @@ enum class name
 	peer_history,
 	port_mapping,
 	stats,
+	vote_router,
 };
 
 std::string_view to_string (name);

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -179,6 +179,8 @@ add_library(
   vote_generator.cpp
   vote_processor.hpp
   vote_processor.cpp
+  vote_router.hpp
+  vote_router.cpp
   vote_spacing.hpp
   vote_spacing.cpp
   vote_with_weight_info.hpp

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -97,7 +97,6 @@ private: // Elections
 	>>;
 	// clang-format on
 	ordered_roots roots;
-	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> blocks;
 
 public:
 	active_elections (nano::node &, nano::confirming_set &, nano::block_processor &);
@@ -110,22 +109,14 @@ public:
 	 * Starts new election with a specified behavior type
 	 */
 	nano::election_insertion_result insert (std::shared_ptr<nano::block> const &, nano::election_behavior = nano::election_behavior::normal);
-	// Distinguishes replay votes, cannot be determined if the block is not in any election
-	std::unordered_map<nano::block_hash, nano::vote_code> vote (std::shared_ptr<nano::vote> const &, nano::vote_source = nano::vote_source::live);
 	// Is the root of this block in the roots container
 	bool active (nano::block const &) const;
 	bool active (nano::qualified_root const &) const;
-	/**
-	 * Is the block hash present in any active election
-	 */
-	bool active (nano::block_hash const &) const;
 	std::shared_ptr<nano::election> election (nano::qualified_root const &) const;
-	std::shared_ptr<nano::block> winner (nano::block_hash const &) const;
 	// Returns a list of elections sorted by difficulty
 	std::vector<std::shared_ptr<nano::election>> list_active (std::size_t = std::numeric_limits<std::size_t>::max ());
 	bool erase (nano::block const &);
 	bool erase (nano::qualified_root const &);
-	bool erase_hash (nano::block_hash const &);
 	void erase_oldest ();
 	bool empty () const;
 	std::size_t size () const;
@@ -148,10 +139,6 @@ public:
 	void add_election_winner_details (nano::block_hash const &, std::shared_ptr<nano::election> const &);
 	std::shared_ptr<nano::election> remove_election_winner_details (nano::block_hash const &);
 
-public: // Events
-	using vote_processed_event_t = nano::observer_set<std::shared_ptr<nano::vote> const &, nano::vote_source, std::unordered_map<nano::block_hash, nano::vote_code> const &>;
-	vote_processed_event_t vote_processed;
-
 private:
 	// Erase elections if we're over capacity
 	void trim ();
@@ -164,7 +151,6 @@ private:
 	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t) const;
 	void activate_successors (nano::secure::read_transaction const & transaction, std::shared_ptr<nano::block> const & block);
 	void notify_observers (nano::secure::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes);
-	bool trigger_vote_cache (nano::block_hash);
 
 private: // Dependencies
 	active_elections_config const & config;

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -7,6 +7,7 @@
 #include <nano/node/election_status.hpp>
 #include <nano/node/recently_cemented_cache.hpp>
 #include <nano/node/recently_confirmed_cache.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/node/vote_with_weight_info.hpp>
 #include <nano/secure/common.hpp>
 

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -7,6 +7,7 @@
 #include <nano/node/network.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/vote_generator.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger.hpp>
 
 using namespace std::chrono;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -691,7 +691,7 @@ bool nano::election::replace_by_weight (nano::unique_lock<nano::mutex> & lock_a,
 	bool replaced (false);
 	if (!replaced_block.is_zero ())
 	{
-		node.active.erase_hash (replaced_block);
+		node.vote_router.disconnect (replaced_block);
 		lock_a.lock ();
 		remove_block (replaced_block);
 		replaced = true;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -19,6 +19,8 @@ class channel;
 class confirmation_solicitor;
 class inactive_cache_information;
 class node;
+enum class vote_code;
+enum class vote_source;
 
 class vote_info final
 {
@@ -105,7 +107,7 @@ public: // Interface
 	 * Process vote. Internally uses cooldown to throttle non-final votes
 	 * If the election reaches consensus, it will be confirmed
 	 */
-	nano::vote_code vote (nano::account const & representative, uint64_t timestamp, nano::block_hash const & block_hash, nano::vote_source = nano::vote_source::live);
+	nano::vote_code vote (nano::account const & representative, uint64_t timestamp, nano::block_hash const & block_hash, nano::vote_source);
 	bool publish (std::shared_ptr<nano::block> const & block_a);
 	// Confirm this block if quorum is met
 	void confirm_if_quorum (nano::unique_lock<nano::mutex> &);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -20,6 +20,7 @@
 #include <nano/node/transport/tcp_listener.hpp>
 #include <nano/node/vote_generator.hpp>
 #include <nano/node/vote_processor.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -47,6 +47,7 @@ class active_elections;
 class confirming_set;
 class node;
 class vote_processor;
+class vote_router;
 class work_pool;
 class peer_history;
 
@@ -177,14 +178,16 @@ public:
 	nano::online_reps online_reps;
 	nano::rep_crawler rep_crawler;
 	nano::rep_tiers rep_tiers;
-	std::unique_ptr<nano::vote_processor> vote_processor_impl;
-	nano::vote_processor & vote_processor;
 	unsigned warmed_up;
 	std::unique_ptr<nano::local_vote_history> history_impl;
 	nano::local_vote_history & history;
 	nano::block_uniquer block_uniquer;
 	nano::vote_uniquer vote_uniquer;
 	nano::vote_cache vote_cache;
+	std::unique_ptr<nano::vote_router> vote_router_impl;
+	nano::vote_router & vote_router;
+	std::unique_ptr<nano::vote_processor> vote_processor_impl;
+	nano::vote_processor & vote_processor;
 	std::unique_ptr<nano::vote_generator> generator_impl;
 	nano::vote_generator & generator;
 	std::unique_ptr<nano::vote_generator> final_generator_impl;

--- a/nano/node/node_observers.hpp
+++ b/nano/node/node_observers.hpp
@@ -9,6 +9,7 @@ namespace nano
 {
 class election_status;
 class telemetry;
+enum class vote_code;
 }
 namespace nano::transport
 {

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -19,12 +19,12 @@ namespace mi = boost::multi_index;
 
 namespace nano
 {
-class active_elections;
 class ledger;
 class local_vote_history;
 class node_config;
 class stats;
 class vote_generator;
+class vote_router;
 class wallets;
 
 /**
@@ -62,7 +62,7 @@ class request_aggregator final
 	// clang-format on
 
 public:
-	request_aggregator (nano::node_config const & config, nano::stats & stats_a, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::active_elections &);
+	request_aggregator (nano::node_config const & config, nano::stats & stats_a, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::vote_router & vote_router);
 
 	/** Add a new request by \p channel_a for hashes \p hashes_roots_a */
 	void add (std::shared_ptr<nano::transport::channel> const & channel_a, std::vector<std::pair<nano::block_hash, nano::root>> const & hashes_roots_a);
@@ -89,7 +89,7 @@ private:
 	nano::local_vote_history & local_votes;
 	nano::ledger & ledger;
 	nano::wallets & wallets;
-	nano::active_elections & active;
+	nano::vote_router & vote_router;
 	nano::vote_generator & generator;
 	nano::vote_generator & final_generator;
 

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -2,6 +2,7 @@
 #include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/vote_cache.hpp>
+#include <nano/node/vote_router.hpp>
 
 #include <ranges>
 

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -27,6 +27,8 @@ class node;
 class active_elections;
 class election;
 class vote;
+enum class vote_code;
+enum class vote_source;
 }
 
 namespace nano

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -1,7 +1,6 @@
 #include <nano/lib/stats.hpp>
 #include <nano/lib/thread_roles.hpp>
 #include <nano/lib/timer.hpp>
-#include <nano/node/active_elections.hpp>
 #include <nano/node/node_observers.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/online_reps.hpp>
@@ -16,9 +15,9 @@
 
 using namespace std::chrono_literals;
 
-nano::vote_processor::vote_processor (vote_processor_config const & config_a, nano::active_elections & active_a, nano::node_observers & observers_a, nano::stats & stats_a, nano::node_flags & flags_a, nano::logger & logger_a, nano::online_reps & online_reps_a, nano::rep_crawler & rep_crawler_a, nano::ledger & ledger_a, nano::network_params & network_params_a, nano::rep_tiers & rep_tiers_a) :
+nano::vote_processor::vote_processor (vote_processor_config const & config_a, nano::vote_router & vote_router, nano::node_observers & observers_a, nano::stats & stats_a, nano::node_flags & flags_a, nano::logger & logger_a, nano::online_reps & online_reps_a, nano::rep_crawler & rep_crawler_a, nano::ledger & ledger_a, nano::network_params & network_params_a, nano::rep_tiers & rep_tiers_a) :
 	config{ config_a },
-	active{ active_a },
+	vote_router{ vote_router },
 	observers{ observers_a },
 	stats{ stats_a },
 	logger{ logger_a },
@@ -172,7 +171,7 @@ nano::vote_code nano::vote_processor::vote_blocking (std::shared_ptr<nano::vote>
 	auto result = nano::vote_code::invalid;
 	if (!vote->validate ()) // false => valid vote
 	{
-		auto vote_results = active.vote (vote);
+		auto vote_results = vote_router.vote (vote);
 
 		// Aggregate results for individual hashes
 		bool replay = false;

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -8,6 +8,7 @@
 #include <nano/node/rep_tiers.hpp>
 #include <nano/node/repcrawler.hpp>
 #include <nano/node/vote_processor.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
 

--- a/nano/node/vote_processor.hpp
+++ b/nano/node/vote_processor.hpp
@@ -14,7 +14,6 @@
 
 namespace nano
 {
-class active_elections;
 namespace store
 {
 	class component;
@@ -31,6 +30,7 @@ class node_flags;
 class stats;
 class rep_tiers;
 enum class vote_code;
+class vote_router;
 
 namespace transport
 {
@@ -57,7 +57,7 @@ public:
 class vote_processor final
 {
 public:
-	vote_processor (vote_processor_config const &, nano::active_elections &, nano::node_observers &, nano::stats &, nano::node_flags &, nano::logger &, nano::online_reps &, nano::rep_crawler &, nano::ledger &, nano::network_params &, nano::rep_tiers &);
+	vote_processor (vote_processor_config const &, nano::vote_router & vote_router, nano::node_observers &, nano::stats &, nano::node_flags &, nano::logger &, nano::online_reps &, nano::rep_crawler &, nano::ledger &, nano::network_params &, nano::rep_tiers &);
 	~vote_processor ();
 
 	void start ();
@@ -76,7 +76,7 @@ public:
 
 private: // Dependencies
 	vote_processor_config const & config;
-	nano::active_elections & active;
+	nano::vote_router & vote_router;
 	nano::node_observers & observers;
 	nano::stats & stats;
 	nano::logger & logger;

--- a/nano/node/vote_processor.hpp
+++ b/nano/node/vote_processor.hpp
@@ -30,6 +30,7 @@ class network_params;
 class node_flags;
 class stats;
 class rep_tiers;
+enum class vote_code;
 
 namespace transport
 {

--- a/nano/node/vote_router.cpp
+++ b/nano/node/vote_router.cpp
@@ -1,0 +1,187 @@
+#include <nano/lib/enum_util.hpp>
+#include <nano/lib/thread_roles.hpp>
+#include <nano/lib/utility.hpp>
+#include <nano/node/active_elections.hpp>
+#include <nano/node/election.hpp>
+#include <nano/node/vote_cache.hpp>
+#include <nano/node/vote_router.hpp>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+nano::stat::detail nano::to_stat_detail (nano::vote_code code)
+{
+	return nano::enum_util::cast<nano::stat::detail> (code);
+}
+
+nano::stat::detail nano::to_stat_detail (nano::vote_source source)
+{
+	return nano::enum_util::cast<nano::stat::detail> (source);
+}
+
+nano::vote_router::vote_router (nano::vote_cache & cache, nano::recently_confirmed_cache & recently_confirmed) :
+	cache{ cache },
+	recently_confirmed{ recently_confirmed }
+{
+}
+
+nano::vote_router::~vote_router ()
+{
+	// Thread must be stopped before destruction
+	debug_assert (!thread.joinable ());
+}
+
+void nano::vote_router::connect (nano::block_hash const & hash, std::weak_ptr<nano::election> election)
+{
+	std::unique_lock lock{ mutex };
+	elections.insert_or_assign (hash, election);
+}
+
+void nano::vote_router::disconnect (nano::election const & election)
+{
+	std::unique_lock lock{ mutex };
+	for (auto const & [hash, _] : election.blocks ())
+	{
+		elections.erase (hash);
+	}
+}
+
+void nano::vote_router::disconnect (nano::block_hash const & hash)
+{
+	std::unique_lock lock{ mutex };
+	[[maybe_unused]] auto erased = elections.erase (hash);
+	debug_assert (erased == 1);
+}
+
+// Validate a vote and apply it to the current election if one exists
+std::unordered_map<nano::block_hash, nano::vote_code> nano::vote_router::vote (std::shared_ptr<nano::vote> const & vote, nano::vote_source source)
+{
+	debug_assert (!vote->validate ()); // false => valid vote
+
+	std::unordered_map<nano::block_hash, nano::vote_code> results;
+	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> process;
+	std::vector<nano::block_hash> inactive; // Hashes that should be added to inactive vote cache
+	{
+		std::shared_lock lock{ mutex };
+		for (auto const & hash : vote->hashes)
+		{
+			// Ignore duplicate hashes (should not happen with a well-behaved voting node)
+			if (results.find (hash) != results.end ())
+			{
+				continue;
+			}
+
+			if (auto existing = elections.find (hash); existing != elections.end ())
+			{
+				if (auto election = existing->second.lock (); election != nullptr)
+				{
+					process[hash] = election;
+				}
+			}
+			if (process.count (hash) != 0)
+			{
+				// There was an active election for hash
+			}
+			else if (!recently_confirmed.exists (hash))
+			{
+				inactive.emplace_back (hash);
+				results[hash] = nano::vote_code::indeterminate;
+			}
+			else
+			{
+				results[hash] = nano::vote_code::replay;
+			}
+		}
+	}
+
+	for (auto const & [block_hash, election] : process)
+	{
+		auto const vote_result = election->vote (vote->account, vote->timestamp (), block_hash, source);
+		results[block_hash] = vote_result;
+	}
+
+	// All hashes should have their result set
+	debug_assert (std::all_of (vote->hashes.begin (), vote->hashes.end (), [&results] (auto const & hash) {
+		return results.find (hash) != results.end ();
+	}));
+
+	vote_processed.notify (vote, source, results);
+
+	return results;
+}
+
+bool nano::vote_router::trigger_vote_cache (nano::block_hash const & hash)
+{
+	auto cached = cache.find (hash);
+	for (auto const & cached_vote : cached)
+	{
+		vote (cached_vote, nano::vote_source::cache);
+	}
+	return !cached.empty ();
+}
+
+bool nano::vote_router::active (nano::block_hash const & hash) const
+{
+	std::shared_lock lock{ mutex };
+	if (auto existing = elections.find (hash); existing != elections.end ())
+	{
+		if (auto election = existing->second.lock (); election != nullptr)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+std::shared_ptr<nano::election> nano::vote_router::election (nano::block_hash const & hash) const
+{
+	std::shared_lock lock{ mutex };
+	if (auto existing = elections.find (hash); existing != elections.end ())
+	{
+		if (auto election = existing->second.lock (); election != nullptr)
+		{
+			return election;
+		}
+	}
+	return nullptr;
+}
+
+void nano::vote_router::start ()
+{
+	thread = std::thread{ [this] () {
+		nano::thread_role::set (nano::thread_role::name::vote_router);
+		run ();
+	} };
+}
+
+void nano::vote_router::stop ()
+{
+	std::unique_lock lock{ mutex };
+	stopped = true;
+	lock.unlock ();
+	condition.notify_all ();
+	if (thread.joinable ())
+	{
+		thread.join ();
+	}
+}
+
+std::unique_ptr<nano::container_info_component> nano::vote_router::collect_container_info (std::string const & name) const
+{
+	std::shared_lock lock{ mutex };
+
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "elections", elections.size (), sizeof (decltype (elections)::value_type) }));
+	return composite;
+}
+
+void nano::vote_router::run ()
+{
+	std::unique_lock lock{ mutex };
+	while (!stopped)
+	{
+		std::erase_if (elections, [] (auto const & pair) { return pair.second.lock () == nullptr; });
+		condition.wait_for (lock, 15s, [&] () { return stopped; });
+	}
+}

--- a/nano/node/vote_router.hpp
+++ b/nano/node/vote_router.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+
+#include <memory>
+#include <shared_mutex>
+#include <thread>
+#include <unordered_map>
+
+namespace nano
+{
+class container_info_component;
+class election;
+class recently_confirmed_cache;
+class vote;
+class vote_cache;
+}
+
+namespace nano
+{
+enum class vote_code
+{
+	invalid, // Vote is not signed correctly
+	replay, // Vote does not have the highest timestamp, it's a replay
+	vote, // Vote has the highest timestamp
+	indeterminate, // Unknown if replay or vote
+	ignored, // Vote is valid, but got ingored (e.g. due to cooldown)
+};
+
+nano::stat::detail to_stat_detail (vote_code);
+
+enum class vote_source
+{
+	live,
+	cache,
+};
+
+nano::stat::detail to_stat_detail (vote_source);
+
+// This class routes votes to their associated election
+// This class holds a weak_ptr as this container does not own the elections
+// Routing entries are removed perodically if the weak_ptr has expired
+class vote_router final
+{
+public:
+	vote_router (nano::vote_cache & cache, nano::recently_confirmed_cache & recently_confirmed);
+	~vote_router ();
+	// Add a route for 'hash' to 'election'
+	// Existing routes will be replaced
+	// Election must hold the block for the hash being passed in
+	void connect (nano::block_hash const & hash, std::weak_ptr<nano::election> election);
+	// Remove all routes to this election
+	void disconnect (nano::election const & election);
+	void disconnect (nano::block_hash const & hash);
+	// Route vote to associated elections
+	// Distinguishes replay votes, cannot be determined if the block is not in any election
+	std::unordered_map<nano::block_hash, nano::vote_code> vote (std::shared_ptr<nano::vote> const &, nano::vote_source = nano::vote_source::live);
+	bool trigger_vote_cache (nano::block_hash const & hash);
+	bool active (nano::block_hash const & hash) const;
+	std::shared_ptr<nano::election> election (nano::block_hash const & hash) const;
+
+	void start ();
+	void stop ();
+
+	using vote_processed_event_t = nano::observer_set<std::shared_ptr<nano::vote> const &, nano::vote_source, std::unordered_map<nano::block_hash, nano::vote_code> const &>;
+	vote_processed_event_t vote_processed;
+
+	std::unique_ptr<container_info_component> collect_container_info (std::string const & name) const;
+
+private:
+	void run ();
+
+	nano::vote_cache & cache;
+	nano::recently_confirmed_cache & recently_confirmed;
+	// Mapping of block hashes to elections.
+	// Election already contains the associated block
+	std::unordered_map<nano::block_hash, std::weak_ptr<nano::election>> elections;
+	bool stopped{ false };
+	std::condition_variable_any condition;
+	mutable std::shared_mutex mutex;
+	std::thread thread;
+};
+}

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -8,6 +8,7 @@
 #include <nano/node/election_status.hpp>
 #include <nano/node/node_observers.hpp>
 #include <nano/node/transport/channel.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/secure/ledger.hpp>

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -28,6 +28,7 @@ class node_observers;
 class telemetry_data;
 class tls_config;
 class vote;
+enum class vote_code;
 class wallets;
 }
 

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -360,20 +360,6 @@ nano::block_hash const & nano::unchecked_key::key () const
 	return previous;
 }
 
-/*
- *
- */
-
-nano::stat::detail nano::to_stat_detail (nano::vote_code code)
-{
-	return nano::enum_util::cast<nano::stat::detail> (code);
-}
-
-nano::stat::detail nano::to_stat_detail (nano::vote_source source)
-{
-	return nano::enum_util::cast<nano::stat::detail> (source);
-}
-
 std::string_view nano::to_string (nano::block_status code)
 {
 	return nano::enum_util::name (code);

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -191,25 +191,6 @@ namespace confirmation_height
 	uint64_t const unbounded_cutoff{ 16384 };
 }
 
-enum class vote_code
-{
-	invalid, // Vote is not signed correctly
-	replay, // Vote does not have the highest timestamp, it's a replay
-	vote, // Vote has the highest timestamp
-	indeterminate, // Unknown if replay or vote
-	ignored, // Vote is valid, but got ingored (e.g. due to cooldown)
-};
-
-nano::stat::detail to_stat_detail (vote_code);
-
-enum class vote_source
-{
-	live,
-	cache,
-};
-
-nano::stat::detail to_stat_detail (vote_source);
-
 enum class block_status
 {
 	progress, // Hasn't been seen before, signed correctly

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1805,7 +1805,6 @@ TEST (node, mass_block_new)
 		{
 			nano::lock_guard<nano::mutex> guard{ node.active.mutex };
 			node.active.roots.clear ();
-			node.active.blocks.clear ();
 		}
 	};
 

--- a/nano/slow_test/vote_cache.cpp
+++ b/nano/slow_test/vote_cache.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/active_elections.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/test_common/rate_observer.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
@@ -176,7 +177,7 @@ TEST (vote_cache, perf_singlethreaded)
 			auto vote = nano::test::make_vote (reps[rep_idx], hashes);
 
 			// Process the vote
-			node.active.vote (vote);
+			node.vote_router.vote (vote);
 		}
 	}
 
@@ -241,7 +242,7 @@ TEST (vote_cache, perf_multithreaded)
 				auto vote = nano::test::make_vote (reps[rep_idx], hashes);
 
 				// Process the vote
-				node.active.vote (vote);
+				node.vote_router.vote (vote);
 			}
 		}
 	});

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -6,6 +6,7 @@
 #include <nano/node/scheduler/manual.hpp>
 #include <nano/node/scheduler/priority.hpp>
 #include <nano/node/transport/fake.hpp>
+#include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_confirmed.hpp>
@@ -182,7 +183,7 @@ bool nano::test::active (nano::node & node, std::vector<nano::block_hash> hashes
 {
 	for (auto & hash : hashes)
 	{
-		if (!node.active.active (hash))
+		if (!node.vote_router.active (hash))
 		{
 			return false;
 		}


### PR DESCRIPTION
This change is to simplify the active_transactions class which has many responsibilities around election management. This change separates the responsibility of routing votes to their respective elections from other responsibilities inside active_transactions.

The mapping hash -> election in nano::active_transactions::blocks is moved into a new class nano::vote_router. Vote processing logic is moved from nano::active_transactions::vote to nano::vote_router::vote.

nano::vote_router changes the behavior from active_transactions::blocks in that it does not own the lifetime of elections. Only a weak_ptr to election is held and a background thread cleans up orphaned routes periodically.

nano::vote_code and nano::vote_source are moved into the vote_router.hpp file and forward declared when possible.