### PR TITLE
Replace `tcp_message_manager`

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -878,68 +878,6 @@ TEST (network, tcp_no_accept_excluded_peers)
 	ASSERT_TIMELY_EQ (5s, node0->network.size (), 1);
 }
 
-/*
-namespace nano
-{
-TEST (network, tcp_message_manager)
-{
-	nano::transport::tcp_message_manager manager (1);
-	item.node_id = nano::account (100);
-	ASSERT_EQ (0, manager.entries.size ());
-	manager.put_message (item);
-	ASSERT_EQ (1, manager.entries.size ());
-	ASSERT_EQ (manager.get_message ().node_id, item.node_id);
-	ASSERT_EQ (0, manager.entries.size ());
-
-	// Fill the queue
-	manager.entries = decltype (manager.entries) (manager.max_entries, item);
-	ASSERT_EQ (manager.entries.size (), manager.max_entries);
-
-	// This task will wait until a message is consumed
-	auto future = std::async (std::launch::async, [&] {
-		manager.put_message (item);
-	});
-
-	// This should give sufficient time to execute put_message
-	// and prove that it waits on condition variable
-	std::this_thread::sleep_for (200ms);
-
-	ASSERT_EQ (manager.entries.size (), manager.max_entries);
-	ASSERT_EQ (manager.get_message ().node_id, item.node_id);
-	ASSERT_NE (std::future_status::timeout, future.wait_for (1s));
-	ASSERT_EQ (manager.entries.size (), manager.max_entries);
-
-	nano::tcp_message_manager manager2 (2);
-	size_t message_count = 10'000;
-	std::vector<std::thread> consumers;
-	for (auto i = 0; i < 4; ++i)
-	{
-		consumers.emplace_back ([&] {
-			for (auto i = 0; i < message_count; ++i)
-			{
-				ASSERT_EQ (manager.get_message ().node_id, item.node_id);
-			}
-		});
-	}
-	std::vector<std::thread> producers;
-	for (auto i = 0; i < 4; ++i)
-	{
-		producers.emplace_back ([&] {
-			for (auto i = 0; i < message_count; ++i)
-			{
-				manager.put_message (item);
-			}
-		});
-	}
-
-	for (auto & t : boost::range::join (producers, consumers))
-	{
-		t.join ();
-	}
-}
-}
-*/
-
 TEST (network, cleanup_purge)
 {
 	auto test_start = std::chrono::steady_clock::now ();

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -273,6 +273,9 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.request_aggregator.max_queue, defaults.node.request_aggregator.max_queue);
 	ASSERT_EQ (conf.node.request_aggregator.threads, defaults.node.request_aggregator.threads);
 	ASSERT_EQ (conf.node.request_aggregator.batch_size, defaults.node.request_aggregator.batch_size);
+
+	ASSERT_EQ (conf.node.message_processor.threads, defaults.node.message_processor.threads);
+	ASSERT_EQ (conf.node.message_processor.max_queue, defaults.node.message_processor.max_queue);
 }
 
 TEST (toml, optional_child)
@@ -584,6 +587,10 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	threads = 999
 	batch_size = 999
 
+	[node.message_processor]
+	threads = 999
+	max_queue = 999
+
 	[opencl]
 	device = 999
 	enable = true
@@ -741,6 +748,9 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.request_aggregator.max_queue, defaults.node.request_aggregator.max_queue);
 	ASSERT_NE (conf.node.request_aggregator.threads, defaults.node.request_aggregator.threads);
 	ASSERT_NE (conf.node.request_aggregator.batch_size, defaults.node.request_aggregator.batch_size);
+
+	ASSERT_NE (conf.node.message_processor.threads, defaults.node.message_processor.threads);
+	ASSERT_NE (conf.node.message_processor.max_queue, defaults.node.message_processor.max_queue);
 }
 
 /** There should be no required values **/

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -49,7 +49,7 @@ enum class type
 	election,
 	blockprocessor,
 	network,
-	network_processed,
+	message,
 	channel,
 	channel_sent,
 	socket,
@@ -78,6 +78,7 @@ enum class type
 	thread_runner,
 	signal_manager,
 	peer_history,
+	message_processor,
 
 	// bootstrap
 	bulk_pull_client,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -72,6 +72,9 @@ enum class type
 	syn_cookies,
 	peer_history,
 	port_mapping,
+	message_processor,
+	message_processor_overfill,
+	message_processor_type,
 
 	bootstrap_ascending,
 	bootstrap_ascending_accounts,

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -22,8 +22,8 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::work:
 			thread_role_name_string = "Work pool";
 			break;
-		case nano::thread_role::name::packet_processing:
-			thread_role_name_string = "Pkt processing";
+		case nano::thread_role::name::message_processing:
+			thread_role_name_string = "Msg processing";
 			break;
 		case nano::thread_role::name::vote_processing:
 			thread_role_name_string = "Vote processing";

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -12,7 +12,7 @@ enum class name
 	unknown,
 	io,
 	work,
-	packet_processing,
+	message_processing,
 	vote_processing,
 	block_processing,
 	request_loop,

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -99,6 +99,8 @@ add_library(
   local_vote_history.hpp
   make_store.hpp
   make_store.cpp
+  message_processor.hpp
+  message_processor.cpp
   network.hpp
   network.cpp
   nodeconfig.hpp

--- a/nano/node/message_processor.cpp
+++ b/nano/node/message_processor.cpp
@@ -1,0 +1,316 @@
+#include <nano/lib/thread_roles.hpp>
+#include <nano/node/message_processor.hpp>
+#include <nano/node/node.hpp>
+
+nano::message_processor::message_processor (message_processor_config const & config_a, nano::node & node_a) :
+	config{ config_a },
+	node{ node_a },
+	stats{ node.stats },
+	logger{ node.logger }
+{
+	queue.max_size_query = [this] (auto const & origin) {
+		return config.max_queue;
+	};
+
+	queue.priority_query = [this] (auto const & origin) {
+		return 1;
+	};
+}
+
+nano::message_processor::~message_processor ()
+{
+	debug_assert (threads.empty ());
+}
+
+void nano::message_processor::start ()
+{
+	debug_assert (threads.empty ());
+
+	for (int n = 0; n < config.threads; ++n)
+	{
+		threads.emplace_back ([this] () {
+			nano::thread_role::set (nano::thread_role::name::message_processing);
+			try
+			{
+				run ();
+			}
+			catch (boost::system::error_code & ec)
+			{
+				node.logger.critical (nano::log::type::network, "Error: {}", ec.message ());
+				release_assert (false);
+			}
+			catch (std::error_code & ec)
+			{
+				node.logger.critical (nano::log::type::network, "Error: {}", ec.message ());
+				release_assert (false);
+			}
+			catch (std::runtime_error & err)
+			{
+				node.logger.critical (nano::log::type::network, "Error: {}", err.what ());
+				release_assert (false);
+			}
+			catch (...)
+			{
+				node.logger.critical (nano::log::type::network, "Unknown error");
+				release_assert (false);
+			}
+		});
+	}
+}
+
+void nano::message_processor::stop ()
+{
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		stopped = true;
+	}
+	condition.notify_all ();
+
+	for (auto & thread : threads)
+	{
+		if (thread.joinable ())
+		{
+			thread.join ();
+		}
+	}
+	threads.clear ();
+}
+
+bool nano::message_processor::put (std::unique_ptr<nano::message> message, std::shared_ptr<nano::transport::channel> const & channel)
+{
+	release_assert (message != nullptr);
+	release_assert (channel != nullptr);
+
+	auto const type = message->type ();
+
+	bool added = false;
+	{
+		nano::lock_guard<nano::mutex> guard{ mutex };
+		added = queue.push ({ std::move (message), channel }, { nano::no_value{}, channel });
+	}
+	if (added)
+	{
+		stats.inc (nano::stat::type::message_processor, nano::stat::detail::process);
+		stats.inc (nano::stat::type::message_processor_type, to_stat_detail (type));
+
+		condition.notify_all ();
+	}
+	else
+	{
+		stats.inc (nano::stat::type::message_processor, nano::stat::detail::overfill);
+		stats.inc (nano::stat::type::message_processor_overfill, to_stat_detail (type));
+	}
+	return added;
+}
+
+void nano::message_processor::run ()
+{
+	nano::unique_lock<nano::mutex> lock{ mutex };
+	while (!stopped)
+	{
+		stats.inc (nano::stat::type::message_processor, nano::stat::detail::loop);
+
+		if (!queue.empty ())
+		{
+			run_batch (lock);
+			debug_assert (!lock.owns_lock ());
+			lock.lock ();
+		}
+		else
+		{
+			condition.wait (lock, [&] {
+				return stopped || !queue.empty ();
+			});
+		}
+	}
+}
+
+void nano::message_processor::run_batch (nano::unique_lock<nano::mutex> & lock)
+{
+	debug_assert (lock.owns_lock ());
+	debug_assert (!mutex.try_lock ());
+	debug_assert (!queue.empty ());
+
+	nano::timer<std::chrono::milliseconds> timer;
+	timer.start ();
+
+	size_t const max_batch_size = 1024 * 4;
+	auto batch = queue.next_batch (max_batch_size);
+
+	lock.unlock ();
+
+	for (auto const & [entry, origin] : batch)
+	{
+		auto const & [message, channel] = entry;
+		release_assert (message != nullptr);
+		process (*message, channel);
+	}
+
+	if (timer.since_start () > std::chrono::milliseconds (100))
+	{
+		logger.debug (nano::log::type::message_processor, "Processed {} messages in {} milliseconds (rate of {} messages per second)",
+		batch.size (),
+		timer.since_start ().count (),
+		((batch.size () * 1000ULL) / timer.value ().count ()));
+	}
+}
+
+namespace
+{
+// TODO: This was moved, so compare with latest develop before merging to avoid merge bugs
+class process_visitor : public nano::message_visitor
+{
+public:
+	process_visitor (nano::node & node_a, std::shared_ptr<nano::transport::channel> const & channel_a) :
+		node{ node_a },
+		channel{ channel_a }
+	{
+	}
+
+	void keepalive (nano::keepalive const & message) override
+	{
+		// Check for special node port data
+		auto peer0 (message.peers[0]);
+		if (peer0.address () == boost::asio::ip::address_v6{} && peer0.port () != 0)
+		{
+			// TODO: Remove this as we do not need to establish a second connection to the same peer
+			nano::endpoint new_endpoint (channel->get_tcp_endpoint ().address (), peer0.port ());
+			node.network.merge_peer (new_endpoint);
+
+			// Remember this for future forwarding to other peers
+			channel->set_peering_endpoint (new_endpoint);
+		}
+	}
+
+	void publish (nano::publish const & message) override
+	{
+		bool added = node.block_processor.add (message.block, nano::block_source::live, channel);
+		if (!added)
+		{
+			node.network.publish_filter.clear (message.digest);
+			node.stats.inc (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::in);
+		}
+	}
+
+	void confirm_req (nano::confirm_req const & message) override
+	{
+		// Don't load nodes with disabled voting
+		// TODO: This check should be cached somewhere
+		if (node.config.enable_voting && node.wallets.reps ().voting > 0)
+		{
+			if (!message.roots_hashes.empty ())
+			{
+				node.aggregator.request (message.roots_hashes, channel);
+			}
+		}
+	}
+
+	void confirm_ack (nano::confirm_ack const & message) override
+	{
+		if (!message.vote->account.is_zero ())
+		{
+			node.vote_processor.vote (message.vote, channel);
+		}
+	}
+
+	void bulk_pull (nano::bulk_pull const &) override
+	{
+		debug_assert (false);
+	}
+
+	void bulk_pull_account (nano::bulk_pull_account const &) override
+	{
+		debug_assert (false);
+	}
+
+	void bulk_push (nano::bulk_push const &) override
+	{
+		debug_assert (false);
+	}
+
+	void frontier_req (nano::frontier_req const &) override
+	{
+		debug_assert (false);
+	}
+
+	void node_id_handshake (nano::node_id_handshake const & message) override
+	{
+		node.stats.inc (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in);
+	}
+
+	void telemetry_req (nano::telemetry_req const & message) override
+	{
+		// Send an empty telemetry_ack if we do not want, just to acknowledge that we have received the message to
+		// remove any timeouts on the server side waiting for a message.
+		nano::telemetry_ack telemetry_ack{ node.network_params.network };
+		if (!node.flags.disable_providing_telemetry_metrics)
+		{
+			auto telemetry_data = node.local_telemetry ();
+			telemetry_ack = nano::telemetry_ack{ node.network_params.network, telemetry_data };
+		}
+		channel->send (telemetry_ack, nullptr, nano::transport::buffer_drop_policy::no_socket_drop);
+	}
+
+	void telemetry_ack (nano::telemetry_ack const & message) override
+	{
+		node.telemetry.process (message, channel);
+	}
+
+	void asc_pull_req (nano::asc_pull_req const & message) override
+	{
+		node.bootstrap_server.request (message, channel);
+	}
+
+	void asc_pull_ack (nano::asc_pull_ack const & message) override
+	{
+		node.ascendboot.process (message, channel);
+	}
+
+private:
+	nano::node & node;
+	std::shared_ptr<nano::transport::channel> channel;
+};
+}
+
+void nano::message_processor::process (nano::message const & message, std::shared_ptr<nano::transport::channel> const & channel)
+{
+	release_assert (channel != nullptr);
+
+	debug_assert (message.header.network == node.network_params.network.current_network);
+	debug_assert (message.header.version_using >= node.network_params.network.protocol_version_min);
+
+	stats.inc (nano::stat::type::message, to_stat_detail (message.type ()), nano::stat::dir::in);
+	logger.trace (nano::log::type::message, to_log_detail (message.type ()), nano::log::arg{ "message", message });
+
+	process_visitor visitor{ node, channel };
+	message.visit (visitor);
+}
+
+std::unique_ptr<nano::container_info_component> nano::message_processor::collect_container_info (std::string const & name)
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+
+	auto composite = std::make_unique<container_info_composite> (name);
+	composite->add_component (queue.collect_container_info ("queue"));
+	return composite;
+}
+
+/*
+ * message_processor_config
+ */
+
+nano::error nano::message_processor_config::serialize (nano::tomlconfig & toml) const
+{
+	toml.put ("threads", threads, "Number of threads to use for message processing. \ntype:uint64");
+	toml.put ("max_queue", max_queue, "Maximum number of messages per peer to queue for processing. \ntype:uint64");
+
+	return toml.get_error ();
+}
+
+nano::error nano::message_processor_config::deserialize (nano::tomlconfig & toml)
+{
+	toml.get ("threads", threads);
+	toml.get ("max_queue", max_queue);
+
+	return toml.get_error ();
+}

--- a/nano/node/message_processor.hpp
+++ b/nano/node/message_processor.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <nano/lib/locks.hpp>
+#include <nano/lib/threading.hpp>
+#include <nano/node/fair_queue.hpp>
+#include <nano/node/fwd.hpp>
+
+#include <thread>
+#include <vector>
+
+namespace nano
+{
+class message_processor_config final
+{
+public:
+	nano::error deserialize (nano::tomlconfig & toml);
+	nano::error serialize (nano::tomlconfig & toml) const;
+
+public:
+	size_t threads{ std::min (nano::hardware_concurrency () / 4, 2u) };
+	size_t max_queue{ 64 };
+};
+
+/*
+ * If mutex locking is ever a performance bottleneck, using a lock-free queue in front of the priority queue should be considered.
+ */
+class message_processor final
+{
+public:
+	explicit message_processor (message_processor_config const &, nano::node &);
+	~message_processor ();
+
+	void start ();
+	void stop ();
+
+	bool put (std::unique_ptr<nano::message>, std::shared_ptr<nano::transport::channel> const &);
+	void process (nano::message const &, std::shared_ptr<nano::transport::channel> const &);
+
+	std::unique_ptr<container_info_component> collect_container_info (std::string const & name);
+
+private:
+	void run ();
+	void run_batch (nano::unique_lock<nano::mutex> &);
+
+private: // Dependencies
+	message_processor_config const & config;
+	nano::node & node;
+	nano::stats & stats;
+	nano::logger & logger;
+
+private:
+	using entry_t = std::pair<std::unique_ptr<nano::message>, std::shared_ptr<nano::transport::channel>>;
+	nano::fair_queue<entry_t, nano::no_value> queue;
+
+	std::atomic<bool> stopped{ false };
+	nano::mutex mutex;
+	nano::condition_variable condition;
+	std::vector<std::thread> threads;
+};
+}

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -1,3 +1,5 @@
+#include "message_processor.hpp"
+
 #include <nano/crypto_lib/random_pool_shuffle.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/threading.hpp>
@@ -63,14 +65,6 @@ void nano::network::start ()
 	if (!node.flags.disable_tcp_realtime)
 	{
 		tcp_channels.start ();
-
-		for (std::size_t i = 0; i < node.config.network_threads; ++i)
-		{
-			processing_threads.emplace_back (nano::thread_attributes::get_default (), [this] () {
-				nano::thread_role::set (nano::thread_role::name::packet_processing);
-				run_processing ();
-			});
-		}
 	}
 }
 
@@ -97,35 +91,6 @@ void nano::network::stop ()
 	join_or_pass (reachout_cached_thread);
 
 	port = 0;
-}
-
-void nano::network::run_processing ()
-{
-	try
-	{
-		// TODO: Move responsibility of packet queuing and processing to the message_processor class
-		tcp_channels.process_messages ();
-	}
-	catch (boost::system::error_code & ec)
-	{
-		node.logger.critical (nano::log::type::network, "Error: {}", ec.message ());
-		release_assert (false);
-	}
-	catch (std::error_code & ec)
-	{
-		node.logger.critical (nano::log::type::network, "Error: {}", ec.message ());
-		release_assert (false);
-	}
-	catch (std::runtime_error & err)
-	{
-		node.logger.critical (nano::log::type::network, "Error: {}", err.what ());
-		release_assert (false);
-	}
-	catch (...)
-	{
-		node.logger.critical (nano::log::type::network, "Unknown error");
-		release_assert (false);
-	}
 }
 
 void nano::network::run_cleanup ()
@@ -346,136 +311,12 @@ void nano::network::flood_block_many (std::deque<std::shared_ptr<nano::block>> b
 	}
 }
 
-namespace
-{
-class network_message_visitor : public nano::message_visitor
-{
-public:
-	network_message_visitor (nano::node & node_a, std::shared_ptr<nano::transport::channel> const & channel_a) :
-		node{ node_a },
-		channel{ channel_a }
-	{
-	}
-
-	void keepalive (nano::keepalive const & message_a) override
-	{
-		// Check for special node port data
-		auto peer0 (message_a.peers[0]);
-		if (peer0.address () == boost::asio::ip::address_v6{} && peer0.port () != 0)
-		{
-			// TODO: Remove this as we do not need to establish a second connection to the same peer
-			nano::endpoint new_endpoint (channel->get_tcp_endpoint ().address (), peer0.port ());
-			node.network.merge_peer (new_endpoint);
-
-			// Remember this for future forwarding to other peers
-			channel->set_peering_endpoint (new_endpoint);
-		}
-	}
-
-	void publish (nano::publish const & message) override
-	{
-		bool added = node.block_processor.add (message.block, nano::block_source::live, channel);
-		if (!added)
-		{
-			node.network.publish_filter.clear (message.digest);
-			node.stats.inc (nano::stat::type::drop, nano::stat::detail::publish, nano::stat::dir::in);
-		}
-	}
-
-	void confirm_req (nano::confirm_req const & message) override
-	{
-		// Don't load nodes with disabled voting
-		// TODO: This check should be cached somewhere
-		if (node.config.enable_voting && node.wallets.reps ().voting > 0)
-		{
-			if (!message.roots_hashes.empty ())
-			{
-				node.aggregator.request (message.roots_hashes, channel);
-			}
-		}
-	}
-
-	void confirm_ack (nano::confirm_ack const & message_a) override
-	{
-		if (!message_a.vote->account.is_zero ())
-		{
-			node.vote_processor.vote (message_a.vote, channel);
-		}
-	}
-
-	void bulk_pull (nano::bulk_pull const &) override
-	{
-		debug_assert (false);
-	}
-
-	void bulk_pull_account (nano::bulk_pull_account const &) override
-	{
-		debug_assert (false);
-	}
-
-	void bulk_push (nano::bulk_push const &) override
-	{
-		debug_assert (false);
-	}
-
-	void frontier_req (nano::frontier_req const &) override
-	{
-		debug_assert (false);
-	}
-
-	void node_id_handshake (nano::node_id_handshake const & message_a) override
-	{
-		node.stats.inc (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in);
-	}
-
-	void telemetry_req (nano::telemetry_req const & message_a) override
-	{
-		// Send an empty telemetry_ack if we do not want, just to acknowledge that we have received the message to
-		// remove any timeouts on the server side waiting for a message.
-		nano::telemetry_ack telemetry_ack{ node.network_params.network };
-		if (!node.flags.disable_providing_telemetry_metrics)
-		{
-			auto telemetry_data = node.local_telemetry ();
-			telemetry_ack = nano::telemetry_ack{ node.network_params.network, telemetry_data };
-		}
-		channel->send (telemetry_ack, nullptr, nano::transport::buffer_drop_policy::no_socket_drop);
-	}
-
-	void telemetry_ack (nano::telemetry_ack const & message_a) override
-	{
-		node.telemetry.process (message_a, channel);
-	}
-
-	void asc_pull_req (nano::asc_pull_req const & message) override
-	{
-		node.bootstrap_server.request (message, channel);
-	}
-
-	void asc_pull_ack (nano::asc_pull_ack const & message) override
-	{
-		node.ascendboot.process (message, channel);
-	}
-
-private:
-	nano::node & node;
-	std::shared_ptr<nano::transport::channel> channel;
-};
-}
-
-void nano::network::process_message (nano::message const & message, std::shared_ptr<nano::transport::channel> const & channel)
-{
-	node.stats.inc (nano::stat::type::message, to_stat_detail (message.type ()), nano::stat::dir::in);
-	node.logger.trace (nano::log::type::network_processed, to_log_detail (message.type ()), nano::log::arg{ "message", message });
-
-	network_message_visitor visitor{ node, channel };
-	message.visit (visitor);
-}
-
 void nano::network::inbound (const nano::message & message, const std::shared_ptr<nano::transport::channel> & channel)
 {
 	debug_assert (message.header.network == node.network_params.network.current_network);
 	debug_assert (message.header.version_using >= node.network_params.network.protocol_version_min);
-	process_message (message, channel);
+
+	node.message_processor.process (message, channel);
 }
 
 // Send keepalives to all the peers we've been notified of

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -108,12 +108,10 @@ public: // Handshake
 	nano::node_id_handshake::response_payload prepare_handshake_response (nano::node_id_handshake::query_payload const & query, bool v2) const;
 
 private:
-	void run_processing ();
 	void run_cleanup ();
 	void run_keepalive ();
 	void run_reachout ();
 	void run_reachout_cached ();
-	void process_message (nano::message const &, std::shared_ptr<nano::transport::channel> const &);
 
 private: // Dependencies
 	nano::node & node;

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -6,8 +6,6 @@
 #include <nano/node/transport/tcp.hpp>
 #include <nano/secure/network_filter.hpp>
 
-#include <boost/thread/thread.hpp>
-
 #include <deque>
 #include <memory>
 #include <unordered_set>
@@ -134,7 +132,6 @@ private:
 	std::atomic<bool> stopped{ false };
 	mutable nano::mutex mutex;
 	nano::condition_variable condition;
-	std::vector<boost::thread> processing_threads; // Using boost::thread to enable increased stack size
 	std::thread cleanup_thread;
 	std::thread keepalive_thread;
 	std::thread reachout_thread;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -45,6 +45,7 @@ namespace nano
 {
 class active_elections;
 class confirming_set;
+class message_processor;
 class node;
 class vote_processor;
 class vote_router;
@@ -161,6 +162,8 @@ public:
 	std::unique_ptr<nano::ledger> ledger_impl;
 	nano::ledger & ledger;
 	nano::outbound_bandwidth_limiter outbound_limiter;
+	std::unique_ptr<nano::message_processor> message_processor_impl;
+	nano::message_processor & message_processor;
 	nano::network network;
 	nano::telemetry telemetry;
 	nano::bootstrap_initiator bootstrap_initiator;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -85,6 +85,11 @@ nano::node_config::node_config (const std::optional<uint16_t> & peering_port_a, 
 	}
 }
 
+nano::node_config::~node_config ()
+{
+	// Keep the node_config destructor definition here to avoid incomplete type issues
+}
+
 nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 {
 	if (peering_port.has_value ())
@@ -237,6 +242,10 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	request_aggregator.serialize (request_aggregator_l);
 	toml.put_child ("request_aggregator", request_aggregator_l);
 
+	nano::tomlconfig message_processor_l;
+	message_processor.serialize (message_processor_l);
+	toml.put_child ("message_processor", message_processor_l);
+
 	return toml.get_error ();
 }
 
@@ -346,6 +355,12 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			auto config_l = toml.get_required_child ("request_aggregator");
 			request_aggregator.deserialize (config_l);
+		}
+
+		if (toml.has_key ("message_processor"))
+		{
+			auto config_l = toml.get_required_child ("message_processor");
+			message_processor.deserialize (config_l);
 		}
 
 		if (toml.has_key ("work_peers"))

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -13,6 +13,7 @@
 #include <nano/node/bootstrap/bootstrap_config.hpp>
 #include <nano/node/bootstrap/bootstrap_server.hpp>
 #include <nano/node/ipc/ipc_config.hpp>
+#include <nano/node/message_processor.hpp>
 #include <nano/node/peer_history.hpp>
 #include <nano/node/repcrawler.hpp>
 #include <nano/node/request_aggregator.hpp>
@@ -41,6 +42,8 @@ enum class frontiers_confirmation_mode : uint8_t
 	invalid
 };
 
+class message_processor_config;
+
 /**
  * Node configuration
  */
@@ -50,6 +53,7 @@ public:
 	// TODO: Users of this class rely on the default copy consturctor. This prevents using unique_ptrs with forward declared types.
 	node_config (nano::network_params & network_params = nano::dev::network_params);
 	node_config (const std::optional<uint16_t> &, nano::network_params & network_params = nano::dev::network_params);
+	~node_config ();
 
 	nano::error serialize_toml (nano::tomlconfig &) const;
 	nano::error deserialize_toml (nano::tomlconfig &);
@@ -143,6 +147,7 @@ public:
 	nano::peer_history_config peer_history;
 	nano::transport::tcp_config tcp;
 	nano::request_aggregator_config request_aggregator;
+	nano::message_processor_config message_processor;
 
 public:
 	std::string serialize_frontiers_confirmation (nano::frontiers_confirmation_mode) const;

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -253,7 +253,9 @@ void nano::transport::tcp_server::queue_realtime (std::unique_ptr<nano::message>
 	release_assert (channel != nullptr);
 
 	channel->set_last_packet_received (std::chrono::steady_clock::now ());
-	node->network.tcp_channels.queue_message (std::move (message), channel);
+
+	bool added = node->message_processor.put (std::move (message), channel);
+	// TODO: Throttle if not added
 }
 
 auto nano::transport::tcp_server::process_handshake (nano::node_id_handshake const & message) -> handshake_status


### PR DESCRIPTION
This replaces `tcp_message_manager` with a new `message_processor` component based around fair queue. There are two major differences:
- Instead of a single, large shared message queue each peer gets its own smaller, dedicated queue. 
- The producer/consumer condition behavior is changed, so that when overfilled it no longer blocks, instead dropping new messages. (With channels ideally throttling receiving new messages, but that's a todo for future network refactorings)

In the future it should be explored if message dispatch can be done directly from IO threads, thus saving one intermediate queue. This requires simulating real live network contention conditions, ie. 200+ peers.