### PR TITLE
Fix race condition between election creation and vote_cache triggering

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -436,7 +436,7 @@ TEST (inactive_votes_cache, multiple_votes)
 	node.scheduler.priority.activate (node.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node.active.election (send1->qualified_root ()));
-	ASSERT_EQ (3, election->votes ().size ()); // 2 votes and 1 default not_an_acount
+	ASSERT_TIMELY_EQ (5s, 3, election->votes ().size ()); // 2 votes and 1 default not_an_acount
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
 }
 


### PR DESCRIPTION
The vote_cache is triggered after an election is created, and specifically after the active_elections mutex is released, which causes a race condition when checking the votes in an election.