### PR TITLE
Add ability for channels to pause/resume processing of incoming messages

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -607,7 +607,7 @@ TEST (tcp_listener, tcp_listener_timeout_node_id_handshake)
 	ASSERT_TRUE (cookie);
 	nano::node_id_handshake::query_payload query{ *cookie };
 	nano::node_id_handshake node_id_handshake{ nano::dev::network_params.network, query };
-	auto channel = std::make_shared<nano::transport::channel_tcp> (*node0, socket);
+	auto channel = std::make_shared<nano::transport::channel_tcp> (*node0, socket, std::weak_ptr<nano::transport::tcp_server>{});
 	socket->async_connect (node0->tcp_listener.endpoint (), [&node_id_handshake, channel] (boost::system::error_code const & ec) {
 		ASSERT_FALSE (ec);
 		channel->send (node_id_handshake, [] (boost::system::error_code const & ec, size_t size_a) {

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -37,7 +37,7 @@ TEST (request_aggregator, one)
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client, std::weak_ptr<nano::transport::tcp_server>{});
 	node.aggregator.request (request, dummy_channel);
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	// Not yet in the ledger
@@ -103,7 +103,7 @@ TEST (request_aggregator, one_update)
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send2->hash (), send2->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client, std::weak_ptr<nano::transport::tcp_server>{});
 	node.aggregator.request (request, dummy_channel);
 	request.clear ();
 	request.emplace_back (receive1->hash (), receive1->root ());
@@ -169,7 +169,7 @@ TEST (request_aggregator, two)
 	request.emplace_back (send2->hash (), send2->root ());
 	request.emplace_back (receive1->hash (), receive1->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client, std::weak_ptr<nano::transport::tcp_server>{});
 	// Process both blocks
 	node.aggregator.request (request, dummy_channel);
 	// One vote should be generated for both blocks
@@ -288,7 +288,7 @@ TEST (request_aggregator, split)
 	ASSERT_TIMELY_EQ (5s, max_vbh + 2, node.ledger.cemented_count ());
 	ASSERT_EQ (max_vbh + 1, request.size ());
 	auto client = std::make_shared<nano::transport::socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client, std::weak_ptr<nano::transport::tcp_server>{});
 	node.aggregator.request (request, dummy_channel);
 	// In the ledger but no vote generated yet
 	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
@@ -327,7 +327,7 @@ TEST (request_aggregator, channel_max_queue)
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client, std::weak_ptr<nano::transport::tcp_server>{});
 	node.aggregator.request (request, dummy_channel);
 	node.aggregator.request (request, dummy_channel);
 	ASSERT_LT (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
@@ -356,7 +356,7 @@ TEST (request_aggregator, DISABLED_unique)
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client, std::weak_ptr<nano::transport::tcp_server>{});
 	node.aggregator.request (request, dummy_channel);
 	node.aggregator.request (request, dummy_channel);
 	node.aggregator.request (request, dummy_channel);
@@ -401,7 +401,7 @@ TEST (request_aggregator, cannot_vote)
 	// Incorrect hash, correct root
 	request.emplace_back (1, send2->root ());
 	auto client = std::make_shared<nano::transport::socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::channel_tcp> (node, client, std::weak_ptr<nano::transport::tcp_server>{});
 	node.aggregator.request (request, dummy_channel);
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -422,7 +422,7 @@ TEST (socket, drop_policy)
 		});
 
 		auto client = std::make_shared<nano::transport::socket> (*node);
-		auto channel = std::make_shared<nano::transport::channel_tcp> (*node, client);
+		auto channel = std::make_shared<nano::transport::channel_tcp> (*node, client, std::weak_ptr<nano::transport::tcp_server>{});
 
 		std::atomic completed_writes{ 0 };
 

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -158,6 +158,10 @@ enum class detail
 	frontier_req,
 	bulk_pull_account,
 
+	// message_processor
+	channel_pause,
+	channel_resume,
+
 	_last // Must be the last enum
 };
 

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -22,6 +22,7 @@ enum class type
 	bootstrap,
 	network,
 	tcp_server,
+	tcp_server_message,
 	vote,
 	vote_processor,
 	vote_processor_tier,

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -160,7 +160,7 @@ void nano::bootstrap_connections::connect_client (nano::tcp_endpoint const & end
 		{
 			this_l->node.logger.debug (nano::log::type::bootstrap, "Connection established to: {}", nano::util::to_str (endpoint_a));
 
-			auto client (std::make_shared<nano::bootstrap_client> (this_l->node.shared (), std::make_shared<nano::transport::channel_tcp> (*this_l->node.shared (), socket), socket));
+			auto client (std::make_shared<nano::bootstrap_client> (this_l->node.shared (), std::make_shared<nano::transport::channel_tcp> (*this_l->node.shared (), socket, std::weak_ptr<nano::transport::tcp_server>{}), socket));
 			this_l->pool_connection (client, true, push_front);
 		}
 		else

--- a/nano/node/fair_queue.hpp
+++ b/nano/node/fair_queue.hpp
@@ -161,6 +161,11 @@ private:
 		{
 			return requests.size ();
 		}
+
+		bool full () const
+		{
+			return requests.size () == max_size;
+		}
 	};
 
 public:
@@ -191,6 +196,12 @@ public:
 		debug_assert (total_size == calculate_total_size ());
 		return total_size;
 	};
+
+	bool full (origin_type source) const
+	{
+		auto it = queues.find (source);
+		return it == queues.end () ? false : it->second.full ();
+	}
 
 	bool empty () const
 	{

--- a/nano/node/message_processor.hpp
+++ b/nano/node/message_processor.hpp
@@ -33,7 +33,7 @@ public:
 	void start ();
 	void stop ();
 
-	bool put (std::unique_ptr<nano::message>, std::shared_ptr<nano::transport::channel> const &);
+	void put (std::unique_ptr<nano::message>, std::shared_ptr<nano::transport::channel> const &);
 	void process (nano::message const &, std::shared_ptr<nano::transport::channel> const &);
 
 	std::unique_ptr<container_info_component> collect_container_info (std::string const & name);

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -127,6 +127,16 @@ public:
 		network_version = network_version_a;
 	}
 
+	void pause ()
+	{
+		paused = true;
+	}
+
+	virtual bool resume_maybe ()
+	{
+		return paused.exchange (false);
+	}
+
 	nano::endpoint get_peering_endpoint () const;
 	void set_peering_endpoint (nano::endpoint endpoint);
 
@@ -139,6 +149,7 @@ private:
 	boost::optional<nano::account> node_id{ boost::none };
 	std::atomic<uint8_t> network_version{ 0 };
 	std::optional<nano::endpoint> peering_endpoint{};
+	std::atomic<bool> paused{ false };
 
 protected:
 	nano::node & node;

--- a/nano/node/transport/tcp.hpp
+++ b/nano/node/transport/tcp.hpp
@@ -31,7 +31,7 @@ namespace transport
 		friend class nano::transport::tcp_channels;
 
 	public:
-		channel_tcp (nano::node &, std::weak_ptr<nano::transport::socket>);
+		channel_tcp (nano::node &, std::weak_ptr<nano::transport::socket>, std::weak_ptr<nano::transport::tcp_server> server);
 		~channel_tcp () override;
 
 		void update_endpoints ();
@@ -90,8 +90,11 @@ namespace transport
 			}
 		}
 
+		bool resume_maybe () override;
+
 	public:
 		std::weak_ptr<nano::transport::socket> socket;
+		std::weak_ptr<nano::transport::tcp_server> server;
 
 	private:
 		nano::endpoint endpoint;

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -161,7 +161,7 @@ auto nano::transport::tcp_server::process_message (std::unique_ptr<nano::message
 		return process_result::abort;
 	}
 
-	node->stats.inc (nano::stat::type::tcp_server, to_stat_detail (message->type ()), nano::stat::dir::in);
+	node->stats.inc (nano::stat::type::tcp_server_message, to_stat_detail (message->type ()), nano::stat::dir::in);
 
 	debug_assert (is_undefined_connection () || is_realtime_connection () || is_bootstrap_connection ());
 

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -254,8 +254,7 @@ void nano::transport::tcp_server::queue_realtime (std::unique_ptr<nano::message>
 
 	channel->set_last_packet_received (std::chrono::steady_clock::now ());
 
-	bool added = node->message_processor.put (std::move (message), channel);
-	// TODO: Throttle if not added
+	node->message_processor.put (std::move (message), channel);
 }
 
 auto nano::transport::tcp_server::process_handshake (nano::node_id_handshake const & message) -> handshake_status

--- a/nano/node/transport/tcp_server.hpp
+++ b/nano/node/transport/tcp_server.hpp
@@ -134,6 +134,7 @@ private: // Visitors
 		std::shared_ptr<tcp_server> server;
 	};
 
+	friend class channel_tcp;
 	friend class handshake_message_visitor;
 };
 }

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -135,12 +135,6 @@ std::shared_ptr<nano::node> nano::test::system::add_node (nano::node_config cons
 			auto starting_size_1 = node1->network.size ();
 			auto starting_size_2 = node2->network.size ();
 
-			auto starting_realtime_1 = node1->tcp_listener.realtime_count ();
-			auto starting_realtime_2 = node2->tcp_listener.realtime_count ();
-
-			auto starting_keepalives_1 = node1->stats.count (stat::type::message, stat::detail::keepalive, stat::dir::in);
-			auto starting_keepalives_2 = node2->stats.count (stat::type::message, stat::detail::keepalive, stat::dir::in);
-
 			logger.debug (nano::log::type::system, "Connecting nodes: {} and {}", node1->identifier (), node2->identifier ());
 
 			// TCP is the only transport layer available.
@@ -155,27 +149,13 @@ std::shared_ptr<nano::node> nano::test::system::add_node (nano::node_config cons
 				});
 				debug_assert (!ec);
 			}
-
-			if (type_a == nano::transport::transport_type::tcp && node_config_a.tcp_incoming_connections_max != 0 && !node_flags_a.disable_tcp_realtime)
 			{
-				{
-					// Wait for initial connection finish
-					auto ec = poll_until_true (5s, [&node1, &node2, starting_realtime_1, starting_realtime_2] () {
-						auto realtime_1 = node1->tcp_listener.realtime_count ();
-						auto realtime_2 = node2->tcp_listener.realtime_count ();
-						return realtime_1 > starting_realtime_1 && realtime_2 > starting_realtime_2;
-					});
-					debug_assert (!ec);
-				}
-				{
-					// Wait for keepalive message exchange
-					auto ec = poll_until_true (5s, [&node1, &node2, starting_keepalives_1, starting_keepalives_2] () {
-						auto keepalives_1 = node1->stats.count (stat::type::message, stat::detail::keepalive, stat::dir::in);
-						auto keepalives_2 = node2->stats.count (stat::type::message, stat::detail::keepalive, stat::dir::in);
-						return keepalives_1 > starting_keepalives_1 && keepalives_2 > starting_keepalives_2;
-					});
-					debug_assert (!ec);
-				}
+				auto ec = poll_until_true (5s, [&node1, &node2] () {
+					bool result_1 = node1->network.find_node_id (node2->node_id.pub) != nullptr;
+					bool result_2 = node2->network.find_node_id (node1->node_id.pub) != nullptr;
+					return result_1 && result_2;
+				});
+				debug_assert (!ec);
 			}
 		}
 


### PR DESCRIPTION
This is a follow on to PR https://github.com/nanocurrency/nano-node/pull/4609 and responds to the fair queue for a channel being full by pausing incoming message processing for the channel.

Pausing incoming message handling will cause TCP flow control to back up to the sender and limit incoming data.