### PR TITLE
Configuration and environment variable improvements

### DIFF
--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -238,35 +238,6 @@ uint64_t get_env_threshold_or_default (char const * variable_name, uint64_t cons
 	return value ? boost::lexical_cast<HexTo<uint64_t>> (value) : default_value;
 }
 
-uint16_t test_node_port ()
-{
-	auto test_env = nano::get_env_or_default ("NANO_TEST_NODE_PORT", "17075");
-	return boost::lexical_cast<uint16_t> (test_env);
-}
-uint16_t test_rpc_port ()
-{
-	auto test_env = nano::get_env_or_default ("NANO_TEST_RPC_PORT", "17076");
-	return boost::lexical_cast<uint16_t> (test_env);
-}
-uint16_t test_ipc_port ()
-{
-	auto test_env = nano::get_env_or_default ("NANO_TEST_IPC_PORT", "17077");
-	return boost::lexical_cast<uint16_t> (test_env);
-}
-uint16_t test_websocket_port ()
-{
-	auto test_env = nano::get_env_or_default ("NANO_TEST_WEBSOCKET_PORT", "17078");
-	return boost::lexical_cast<uint16_t> (test_env);
-}
-
-std::array<uint8_t, 2> test_magic_number ()
-{
-	auto test_env = get_env_or_default ("NANO_TEST_MAGIC_NUMBER", "RX");
-	std::array<uint8_t, 2> ret;
-	std::copy (test_env.begin (), test_env.end (), ret.data ());
-	return ret;
-}
-
 void force_nano_dev_network ()
 {
 	nano::network_constants::set_active_network (nano::networks::nano_dev_network);
@@ -316,36 +287,44 @@ std::string get_tls_toml_config_path (std::filesystem::path const & data_path)
 {
 	return (data_path / "config-tls.toml").string ();
 }
-} // namespace nano
-
-std::string nano::get_env_or_default (char const * variable_name, std::string default_value)
-{
-	auto value = nano::env::get (variable_name);
-	return value.value_or (default_value);
 }
 
-int nano::get_env_int_or_default (const char * variable_name, const int default_value)
+uint16_t nano::test_node_port ()
 {
-	auto value = nano::env::get (variable_name);
-	if (value)
-	{
-		try
-		{
-			return boost::lexical_cast<int> (*value);
-		}
-		catch (...)
-		{
-			// It is unexpected that this exception will be caught, log to cerr the reason.
-			std::cerr << boost::str (boost::format ("Error parsing environment variable: %1% value: %2%") % variable_name % *value);
-			throw;
-		}
-	}
-	return default_value;
+	auto test_env = nano::env::get ("NANO_TEST_NODE_PORT").value_or ("17075");
+	return boost::lexical_cast<uint16_t> (test_env);
+}
+
+uint16_t nano::test_rpc_port ()
+{
+	auto test_env = nano::env::get ("NANO_TEST_RPC_PORT").value_or ("17076");
+	return boost::lexical_cast<uint16_t> (test_env);
+}
+
+uint16_t nano::test_ipc_port ()
+{
+	auto test_env = nano::env::get ("NANO_TEST_IPC_PORT").value_or ("17077");
+	return boost::lexical_cast<uint16_t> (test_env);
+}
+
+uint16_t nano::test_websocket_port ()
+{
+	auto test_env = nano::env::get ("NANO_TEST_WEBSOCKET_PORT").value_or ("17078");
+	return boost::lexical_cast<uint16_t> (test_env);
+}
+
+std::array<uint8_t, 2> nano::test_magic_number ()
+{
+	auto test_env = nano::env::get ("NANO_TEST_MAGIC_NUMBER").value_or ("RX");
+	release_assert (test_env.size () == 2);
+	std::array<uint8_t, 2> ret{};
+	std::copy (test_env.begin (), test_env.end (), ret.data ());
+	return ret;
 }
 
 uint32_t nano::test_scan_wallet_reps_delay ()
 {
-	auto test_env = nano::get_env_or_default ("NANO_TEST_WALLET_SCAN_REPS_DELAY", "900000"); // 15 minutes by default
+	auto test_env = nano::env::get ("NANO_TEST_WALLET_SCAN_REPS_DELAY").value_or ("900000"); // 15 minutes default
 	return boost::lexical_cast<uint32_t> (test_env);
 }
 

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -258,11 +258,6 @@ bool slow_instrumentation ()
 	return is_tsan_build () || nano::running_within_valgrind ();
 }
 
-bool is_sanitizer_build ()
-{
-	return is_asan_build () || is_tsan_build ();
-}
-
 std::string get_node_toml_config_path (std::filesystem::path const & data_path)
 {
 	return (data_path / "config-node.toml").string ();

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -16,10 +16,19 @@ template <typename ElemT>
 struct HexTo
 {
 	ElemT value;
+
+	HexTo () = default;
+
+	HexTo (ElemT val) :
+		value{ val }
+	{
+	}
+
 	operator ElemT () const
 	{
 		return value;
 	}
+
 	friend std::istream & operator>> (std::istream & in, HexTo & out)
 	{
 		in >> std::hex >> out.value;
@@ -47,9 +56,9 @@ nano::work_thresholds const nano::work_thresholds::publish_dev (
 );
 
 nano::work_thresholds const nano::work_thresholds::publish_test ( // defaults to live network levels
-get_env_threshold_or_default ("NANO_TEST_EPOCH_1", 0xffffffc000000000),
-get_env_threshold_or_default ("NANO_TEST_EPOCH_2", 0xfffffff800000000), // 8x higher than epoch_1
-get_env_threshold_or_default ("NANO_TEST_EPOCH_2_RECV", 0xfffffe0000000000) // 8x lower than epoch_1
+nano::env::get<HexTo<uint64_t>> ("NANO_TEST_EPOCH_1").value_or (0xffffffc000000000),
+nano::env::get<HexTo<uint64_t>> ("NANO_TEST_EPOCH_2").value_or (0xfffffff800000000), // 8x higher than epoch_1
+nano::env::get<HexTo<uint64_t>> ("NANO_TEST_EPOCH_2_RECV").value_or (0xfffffe0000000000) // 8x lower than epoch_1
 );
 
 uint64_t nano::work_thresholds::threshold_entry (nano::work_version const version_a, nano::block_type const type_a) const
@@ -230,12 +239,6 @@ uint8_t get_patch_node_version ()
 uint8_t get_pre_release_node_version ()
 {
 	return boost::numeric_cast<uint8_t> (boost::lexical_cast<int> (NANO_PRE_RELEASE_VERSION_STRING));
-}
-
-uint64_t get_env_threshold_or_default (char const * variable_name, uint64_t const default_value)
-{
-	auto * value = getenv (variable_name);
-	return value ? boost::lexical_cast<HexTo<uint64_t>> (value) : default_value;
 }
 
 void force_nano_dev_network ()

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -320,13 +320,13 @@ std::string get_tls_toml_config_path (std::filesystem::path const & data_path)
 
 std::string nano::get_env_or_default (char const * variable_name, std::string default_value)
 {
-	auto value = nano::get_env (variable_name);
-	return value ? *value : default_value;
+	auto value = nano::env::get (variable_name);
+	return value.value_or (default_value);
 }
 
 int nano::get_env_int_or_default (const char * variable_name, const int default_value)
 {
-	auto value = nano::get_env (variable_name);
+	auto value = nano::env::get (variable_name);
 	if (value)
 	{
 		try

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -291,41 +291,85 @@ std::string get_tls_toml_config_path (std::filesystem::path const & data_path)
 
 uint16_t nano::test_node_port ()
 {
-	auto test_env = nano::env::get ("NANO_TEST_NODE_PORT").value_or ("17075");
-	return boost::lexical_cast<uint16_t> (test_env);
+	static auto const test_env = [] () -> std::optional<uint16_t> {
+		if (auto value = nano::env::get<uint16_t> ("NANO_TEST_NODE_PORT"))
+		{
+			std::cerr << "Node port overridden by NANO_TEST_NODE_PORT environment variable: " << *value << std::endl;
+			return *value;
+		}
+		return std::nullopt;
+	}();
+	return test_env.value_or (17075);
 }
 
 uint16_t nano::test_rpc_port ()
 {
-	auto test_env = nano::env::get ("NANO_TEST_RPC_PORT").value_or ("17076");
-	return boost::lexical_cast<uint16_t> (test_env);
+	static auto const test_env = [] () -> std::optional<uint16_t> {
+		if (auto value = nano::env::get<uint16_t> ("NANO_TEST_RPC_PORT"))
+		{
+			std::cerr << "RPC port overridden by NANO_TEST_RPC_PORT environment variable: " << *value << std::endl;
+			return *value;
+		}
+		return std::nullopt;
+	}();
+	return test_env.value_or (17076);
 }
 
 uint16_t nano::test_ipc_port ()
 {
-	auto test_env = nano::env::get ("NANO_TEST_IPC_PORT").value_or ("17077");
-	return boost::lexical_cast<uint16_t> (test_env);
+	static auto const test_env = [] () -> std::optional<uint16_t> {
+		if (auto value = nano::env::get<uint16_t> ("NANO_TEST_IPC_PORT"))
+		{
+			std::cerr << "IPC port overridden by NANO_TEST_IPC_PORT environment variable: " << *value << std::endl;
+			return *value;
+		}
+		return std::nullopt;
+	}();
+	return test_env.value_or (17077);
 }
 
 uint16_t nano::test_websocket_port ()
 {
-	auto test_env = nano::env::get ("NANO_TEST_WEBSOCKET_PORT").value_or ("17078");
-	return boost::lexical_cast<uint16_t> (test_env);
-}
-
-std::array<uint8_t, 2> nano::test_magic_number ()
-{
-	auto test_env = nano::env::get ("NANO_TEST_MAGIC_NUMBER").value_or ("RX");
-	release_assert (test_env.size () == 2);
-	std::array<uint8_t, 2> ret{};
-	std::copy (test_env.begin (), test_env.end (), ret.data ());
-	return ret;
+	static auto const test_env = [] () -> std::optional<uint16_t> {
+		if (auto value = nano::env::get<uint16_t> ("NANO_TEST_WEBSOCKET_PORT"))
+		{
+			std::cerr << "Websocket port overridden by NANO_TEST_WEBSOCKET_PORT environment variable: " << *value << std::endl;
+			return *value;
+		}
+		return std::nullopt;
+	}();
+	return test_env.value_or (17078);
 }
 
 uint32_t nano::test_scan_wallet_reps_delay ()
 {
-	auto test_env = nano::env::get ("NANO_TEST_WALLET_SCAN_REPS_DELAY").value_or ("900000"); // 15 minutes default
-	return boost::lexical_cast<uint32_t> (test_env);
+	static auto const test_env = [] () -> std::optional<uint32_t> {
+		if (auto value = nano::env::get<uint32_t> ("NANO_TEST_WALLET_SCAN_REPS_DELAY"))
+		{
+			std::cerr << "Wallet scan interval overridden by NANO_TEST_WALLET_SCAN_REPS_DELAY environment variable: " << *value << std::endl;
+			return *value;
+		}
+		return std::nullopt;
+	}();
+	return test_env.value_or (900000); // 15 minutes default
+}
+
+std::array<uint8_t, 2> nano::test_magic_number ()
+{
+	static auto const test_env = [] () -> std::optional<std::string> {
+		if (auto value = nano::env::get<std::string> ("NANO_TEST_MAGIC_NUMBER"))
+		{
+			std::cerr << "Magic number overridden by NANO_TEST_MAGIC_NUMBER environment variable: " << *value << std::endl;
+			return *value;
+		}
+		return std::nullopt;
+	}();
+
+	auto value = test_env.value_or ("RX");
+	release_assert (value.size () == 2);
+	std::array<uint8_t, 2> ret{};
+	std::copy (value.begin (), value.end (), ret.data ());
+	return ret;
 }
 
 std::string_view nano::to_string (nano::networks network)

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -89,14 +89,6 @@ uint8_t get_pre_release_node_version ();
  * Environment variables
  */
 
-/*
- * Get environment variable as string or `default_value` if variable is not present
- */
-std::string get_env_or_default (char const * variable_name, std::string const default_value);
-/*
- * Get environment variable as int or `default_value` if variable is not present
- */
-int get_env_int_or_default (char const * variable_name, int const default_value);
 uint64_t get_env_threshold_or_default (char const * variable_name, uint64_t const default_value);
 
 uint16_t test_node_port ();

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -28,55 +28,49 @@ char const * const NANO_PRE_RELEASE_VERSION_STRING = xstr (PRE_RELEASE_VERSION_S
 
 char const * const BUILD_INFO = xstr (GIT_COMMIT_HASH BOOST_COMPILER) " \"BOOST " xstr (BOOST_VERSION) "\" BUILT " xstr (__DATE__);
 
+/*
+ * Sanitizer info
+ */
+namespace nano
+{
+consteval bool is_asan_build ()
+{
 #if defined(__has_feature)
 #if __has_feature(address_sanitizer)
-inline bool is_asan_build ()
-{
 	return true;
-}
 #else
-inline bool is_asan_build ()
-{
 	return false;
-}
 #endif
 // GCC builds
 #elif defined(__SANITIZE_ADDRESS__)
-inline bool is_asan_build ()
-{
 	return true;
-}
 #else
-inline bool is_asan_build ()
-{
 	return false;
-}
 #endif
+}
 
+consteval bool is_tsan_build ()
+{
 #if defined(__has_feature)
 #if __has_feature(thread_sanitizer)
-inline bool is_tsan_build ()
-{
 	return true;
-}
 #else
-inline bool is_tsan_build ()
-{
 	return false;
-}
 #endif
 // GCC builds
 #elif defined(__SANITIZE_THREAD__)
-inline bool is_tsan_build ()
-{
 	return true;
-}
 #else
-inline bool is_tsan_build ()
-{
 	return false;
-}
 #endif
+}
+
+/** Checks if we are running with either AddressSanitizer or ThreadSanitizer */
+consteval bool is_sanitizer_build ()
+{
+	return is_asan_build () || is_tsan_build ();
+}
+}
 
 namespace nano
 {
@@ -403,9 +397,6 @@ bool memory_intensive_instrumentation ();
 /** Check if we're running with instrumentation that can greatly affect performance
 	Returns true if running within Valgrind or with ThreadSanitizer tooling*/
 bool slow_instrumentation ();
-
-/** Checks if we are running with either AddressSanitizer or ThreadSanitizer*/
-bool is_sanitizer_build ();
 
 /** Set the active network to the dev network */
 void force_nano_dev_network ();

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -79,20 +79,12 @@ uint8_t get_minor_node_version ();
 uint8_t get_patch_node_version ();
 uint8_t get_pre_release_node_version ();
 
-/*
- * Environment variables
- */
-
-uint64_t get_env_threshold_or_default (char const * variable_name, uint64_t const default_value);
-
 uint16_t test_node_port ();
 uint16_t test_rpc_port ();
 uint16_t test_ipc_port ();
 uint16_t test_websocket_port ();
 std::array<uint8_t, 2> test_magic_number ();
-/*
- * How often to scan for representatives in local wallet, in milliseconds
- */
+/// How often to scan for representatives in local wallet, in milliseconds
 uint32_t test_scan_wallet_reps_delay ();
 
 /**

--- a/nano/lib/env.cpp
+++ b/nano/lib/env.cpp
@@ -4,7 +4,7 @@
 
 #include <string>
 
-std::optional<std::string> nano::get_env (std::string_view name)
+std::optional<std::string> nano::env::get (std::string_view name)
 {
 	std::string name_str{ name };
 	if (auto value = std::getenv (name_str.c_str ()))
@@ -14,12 +14,12 @@ std::optional<std::string> nano::get_env (std::string_view name)
 	return std::nullopt;
 }
 
-std::optional<bool> nano::get_env_bool (std::string_view name)
+std::optional<bool> nano::env::get_bool (std::string_view name)
 {
 	std::vector<std::string> const on_values{ "1", "true", "on" };
 	std::vector<std::string> const off_values{ "0", "false", "off" };
 
-	if (auto value = get_env (name))
+	if (auto value = get (name))
 	{
 		// Using case-insensitive comparison
 		if (std::any_of (on_values.begin (), on_values.end (), [&value] (auto const & on) { return boost::iequals (*value, on); }))

--- a/nano/lib/env.cpp
+++ b/nano/lib/env.cpp
@@ -14,7 +14,8 @@ std::optional<std::string> nano::env::get (std::string_view name)
 	return std::nullopt;
 }
 
-std::optional<bool> nano::env::get_bool (std::string_view name)
+template <>
+std::optional<bool> nano::env::get (std::string_view name)
 {
 	std::vector<std::string> const on_values{ "1", "true", "on" };
 	std::vector<std::string> const off_values{ "0", "false", "off" };
@@ -32,38 +33,6 @@ std::optional<bool> nano::env::get_bool (std::string_view name)
 		}
 
 		throw std::invalid_argument ("Invalid environment boolean value: " + *value);
-	}
-	return std::nullopt;
-}
-
-std::optional<int> nano::env::get_int (std::string_view name)
-{
-	if (auto value = get (name))
-	{
-		try
-		{
-			return std::stoi (*value);
-		}
-		catch (std::invalid_argument const &)
-		{
-			throw std::invalid_argument ("Invalid environment integer value: " + *value);
-		}
-	}
-	return std::nullopt;
-}
-
-std::optional<unsigned> nano::env::get_uint (std::string_view name)
-{
-	if (auto value = get (name))
-	{
-		try
-		{
-			return std::stoul (*value);
-		}
-		catch (std::invalid_argument const &)
-		{
-			throw std::invalid_argument ("Invalid environment unsigned integer value: " + *value);
-		}
 	}
 	return std::nullopt;
 }

--- a/nano/lib/env.cpp
+++ b/nano/lib/env.cpp
@@ -35,3 +35,35 @@ std::optional<bool> nano::env::get_bool (std::string_view name)
 	}
 	return std::nullopt;
 }
+
+std::optional<int> nano::env::get_int (std::string_view name)
+{
+	if (auto value = get (name))
+	{
+		try
+		{
+			return std::stoi (*value);
+		}
+		catch (std::invalid_argument const &)
+		{
+			throw std::invalid_argument ("Invalid environment integer value: " + *value);
+		}
+	}
+	return std::nullopt;
+}
+
+std::optional<unsigned> nano::env::get_uint (std::string_view name)
+{
+	if (auto value = get (name))
+	{
+		try
+		{
+			return std::stoul (*value);
+		}
+		catch (std::invalid_argument const &)
+		{
+			throw std::invalid_argument ("Invalid environment unsigned integer value: " + *value);
+		}
+	}
+	return std::nullopt;
+}

--- a/nano/lib/env.hpp
+++ b/nano/lib/env.hpp
@@ -12,4 +12,10 @@ std::optional<std::string> get (std::string_view name);
 
 // @throws std::invalid_argument if the value is not a valid boolean
 std::optional<bool> get_bool (std::string_view name);
+
+// @throws std::invalid_argument if the value is not a valid integer
+std::optional<int> get_int (std::string_view name);
+
+// @throws std::invalid_argument if the value is not a valid integer
+std::optional<unsigned> get_uint (std::string_view name);
 }

--- a/nano/lib/env.hpp
+++ b/nano/lib/env.hpp
@@ -3,13 +3,13 @@
 #include <optional>
 #include <string_view>
 
-namespace nano
-{
 /*
  * Get environment variable as a specific type or none if variable is not present.
  */
-std::optional<std::string> get_env (std::string_view name);
+namespace nano::env
+{
+std::optional<std::string> get (std::string_view name);
 
 // @throws std::invalid_argument if the value is not a valid boolean
-std::optional<bool> get_env_bool (std::string_view name);
+std::optional<bool> get_bool (std::string_view name);
 }

--- a/nano/lib/env.hpp
+++ b/nano/lib/env.hpp
@@ -1,21 +1,42 @@
 #pragma once
 
+#include <boost/lexical_cast.hpp>
+
 #include <optional>
 #include <string_view>
 
-/*
- * Get environment variable as a specific type or none if variable is not present.
- */
 namespace nano::env
 {
+/**
+ * Get environment variable as a specific type or none if variable is not present.
+ */
 std::optional<std::string> get (std::string_view name);
 
-// @throws std::invalid_argument if the value is not a valid boolean
-std::optional<bool> get_bool (std::string_view name);
+/**
+ * Get environment variable as a specific type or none if variable is not present.
+ * @throws std::invalid_argument if the value cannot be converted
+ */
+template <typename T>
+std::optional<T> get (std::string_view name)
+{
+	if (auto value = get (name))
+	{
+		try
+		{
+			return boost::lexical_cast<T> (*value);
+		}
+		catch (boost::bad_lexical_cast const &)
+		{
+			throw std::invalid_argument ("Invalid environment value: " + *value);
+		}
+	}
+	return std::nullopt;
+}
 
-// @throws std::invalid_argument if the value is not a valid integer
-std::optional<int> get_int (std::string_view name);
-
-// @throws std::invalid_argument if the value is not a valid integer
-std::optional<unsigned> get_uint (std::string_view name);
+/**
+ * Specialization for boolean values.
+ * @throws std::invalid_argument if the value is not a valid boolean
+ */
+template <>
+std::optional<bool> get (std::string_view name);
 }

--- a/nano/lib/logging.cpp
+++ b/nano/lib/logging.cpp
@@ -461,7 +461,7 @@ nano::log_config nano::load_log_config (nano::log_config fallback, const std::fi
 		auto config = nano::load_config_file<nano::log_config> (fallback, config_filename, data_path, config_overrides);
 
 		// Parse default log level from environment variable, e.g. "NANO_LOG=debug"
-		auto env_level = nano::get_env ("NANO_LOG");
+		auto env_level = nano::env::get ("NANO_LOG");
 		if (env_level)
 		{
 			try
@@ -478,8 +478,7 @@ nano::log_config nano::load_log_config (nano::log_config fallback, const std::fi
 		}
 
 		// Parse per logger levels from environment variable, e.g. "NANO_LOG_LEVELS=ledger=debug,node=trace"
-		auto env_levels = nano::get_env ("NANO_LOG_LEVELS");
-		if (env_levels)
+		if (auto env_levels = nano::env::get ("NANO_LOG_LEVELS"))
 		{
 			std::map<nano::log::logger_id, nano::log::level> levels;
 			for (auto const & env_level_str : nano::util::split (*env_levels, ","))
@@ -516,8 +515,7 @@ nano::log_config nano::load_log_config (nano::log_config fallback, const std::fi
 			}
 		}
 
-		auto env_tracing_format = nano::get_env ("NANO_TRACE_FORMAT");
-		if (env_tracing_format)
+		if (auto env_tracing_format = nano::env::get ("NANO_TRACE_FORMAT"))
 		{
 			try
 			{

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -33,7 +33,7 @@ std::string nano::stat_log_sink::tm_to_string (tm & tm)
 nano::stats::stats (nano::logger & logger_a, nano::stats_config config_a) :
 	config{ std::move (config_a) },
 	logger{ logger_a },
-	enable_logging{ nano::env::get<bool> ("NANO_LOG_STATS").value_or (false) }
+	enable_logging{ is_stat_logging_enabled () }
 {
 }
 
@@ -363,6 +363,19 @@ std::string nano::stats::dump (category category)
 			debug_assert (false, "missing stat_category case");
 	}
 	return sink.to_string ();
+}
+
+bool nano::stats::is_stat_logging_enabled ()
+{
+	static auto const enabled = [] () {
+		if (auto value = nano::env::get<bool> ("NANO_LOG_STATS"))
+		{
+			std::cerr << "Stats logging enabled by NANO_LOG_STATS environment variable" << std::endl;
+			return *value;
+		}
+		return false;
+	}();
+	return enabled;
 }
 
 /*

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -33,7 +33,7 @@ std::string nano::stat_log_sink::tm_to_string (tm & tm)
 nano::stats::stats (nano::logger & logger_a, nano::stats_config config_a) :
 	config{ std::move (config_a) },
 	logger{ logger_a },
-	enable_logging{ nano::env::get_bool ("NANO_LOG_STATS").value_or (false) }
+	enable_logging{ nano::env::get<bool> ("NANO_LOG_STATS").value_or (false) }
 {
 }
 

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -33,7 +33,7 @@ std::string nano::stat_log_sink::tm_to_string (tm & tm)
 nano::stats::stats (nano::logger & logger_a, nano::stats_config config_a) :
 	config{ std::move (config_a) },
 	logger{ logger_a },
-	enable_logging{ nano::get_env_bool ("NANO_LOG_STATS").value_or (false) }
+	enable_logging{ nano::env::get_bool ("NANO_LOG_STATS").value_or (false) }
 {
 }
 

--- a/nano/lib/stats.hpp
+++ b/nano/lib/stats.hpp
@@ -199,6 +199,8 @@ private:
 	/** Unlocked implementation of log_samples() to avoid using recursive locking */
 	void log_samples_impl (stat_log_sink & sink, tm & tm);
 
+	static bool is_stat_logging_enabled ();
+
 private:
 	nano::stats_config const config;
 	nano::logger & logger;

--- a/nano/lib/threading.cpp
+++ b/nano/lib/threading.cpp
@@ -19,7 +19,7 @@ boost::thread::attributes nano::thread_attributes::get_default ()
 unsigned nano::hardware_concurrency ()
 {
 	static auto const concurrency = [] () {
-		if (auto value = nano::env::get_uint ("NANO_HARDWARE_CONCURRENCY"))
+		if (auto value = nano::env::get<unsigned> ("NANO_HARDWARE_CONCURRENCY"))
 		{
 			std::cerr << "Hardware concurrency overridden by NANO_HARDWARE_CONCURRENCY environment variable: " << *value << std::endl;
 			return *value;

--- a/nano/lib/threading.cpp
+++ b/nano/lib/threading.cpp
@@ -26,6 +26,7 @@ unsigned nano::hardware_concurrency ()
 		}
 		return std::thread::hardware_concurrency ();
 	}();
+	release_assert (concurrency > 0, "configured hardware concurrency must be non zero");
 	return concurrency;
 }
 

--- a/nano/lib/threading.hpp
+++ b/nano/lib/threading.hpp
@@ -16,7 +16,7 @@ namespace thread_attributes
 /**
  * Number of available logical processor cores. Might be overridden by setting `NANO_HARDWARE_CONCURRENCY` environment variable
  */
-unsigned int hardware_concurrency ();
+unsigned hardware_concurrency ();
 
 /**
  * If thread is joinable joins it, otherwise does nothing

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -286,13 +286,3 @@ std::string to_str (T const & val)
 	return boost::lexical_cast<std::string> (val);
 }
 }
-
-namespace nano
-{
-template <typename T>
-T min_max (T min, T max, T value)
-{
-	debug_assert (min <= max);
-	return std::min (max, std::max (min, value));
-}
-}

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -286,3 +286,13 @@ std::string to_str (T const & val)
 	return boost::lexical_cast<std::string> (val);
 }
 }
+
+namespace nano
+{
+template <typename T>
+T min_max (T min, T max, T value)
+{
+	debug_assert (min <= max);
+	return std::min (max, std::max (min, value));
+}
+}

--- a/nano/node/message_processor.hpp
+++ b/nano/node/message_processor.hpp
@@ -17,7 +17,7 @@ public:
 	nano::error serialize (nano::tomlconfig & toml) const;
 
 public:
-	size_t threads{ min_max (1u, 2u, nano::hardware_concurrency () / 4) };
+	size_t threads{ std::clamp (nano::hardware_concurrency () / 4, 1u, 2u) };
 	size_t max_queue{ 64 };
 };
 

--- a/nano/node/message_processor.hpp
+++ b/nano/node/message_processor.hpp
@@ -17,7 +17,7 @@ public:
 	nano::error serialize (nano::tomlconfig & toml) const;
 
 public:
-	size_t threads{ std::min (nano::hardware_concurrency () / 4, 2u) };
+	size_t threads{ min_max (1u, 2u, nano::hardware_concurrency () / 4) };
 	size_t max_queue{ 64 };
 };
 

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -1,6 +1,7 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
+#include <nano/lib/env.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/lib/rpcconfig.hpp>
 #include <nano/lib/tomlconfig.hpp>
@@ -16,9 +17,9 @@ namespace
 char const * preconfigured_peers_key = "preconfigured_peers";
 char const * signature_checker_threads_key = "signature_checker_threads";
 char const * pow_sleep_interval_key = "pow_sleep_interval";
-std::string const default_live_peer_network = nano::get_env_or_default ("NANO_DEFAULT_PEER", "peering.nano.org");
-std::string const default_beta_peer_network = nano::get_env_or_default ("NANO_DEFAULT_PEER", "peering-beta.nano.org");
-std::string const default_test_peer_network = nano::get_env_or_default ("NANO_DEFAULT_PEER", "peering-test.nano.org");
+std::string const default_live_peer_network = nano::env::get ("NANO_DEFAULT_PEER").value_or ("peering.nano.org");
+std::string const default_beta_peer_network = nano::env::get ("NANO_DEFAULT_PEER").value_or ("peering-beta.nano.org");
+std::string const default_test_peer_network = nano::env::get ("NANO_DEFAULT_PEER").value_or ("peering-test.nano.org");
 }
 
 nano::node_config::node_config (nano::network_params & network_params) :

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -657,3 +657,16 @@ nano::account nano::node_config::random_representative () const
 	auto result (preconfigured_representatives[index]);
 	return result;
 }
+
+std::optional<unsigned> nano::node_config::env_io_threads ()
+{
+	static auto const value = [] () {
+		auto value = nano::env::get<unsigned> ("NANO_IO_THREADS");
+		if (value)
+		{
+			std::cerr << "IO threads overridden by NANO_IO_THREADS environment variable: " << *value << std::endl;
+		}
+		return value;
+	}();
+	return value;
+}

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -82,7 +82,7 @@ public:
 	 */
 	nano::amount representative_vote_weight_minimum{ 10 * nano::Mxrb_ratio };
 	unsigned password_fanout{ 1024 };
-	unsigned io_threads{ std::max (4u, nano::hardware_concurrency ()) };
+	unsigned io_threads{ env_io_threads ().value_or (std::max (4u, nano::hardware_concurrency ())) };
 	unsigned network_threads{ std::max (4u, nano::hardware_concurrency ()) };
 	unsigned work_threads{ std::max (4u, nano::hardware_concurrency ()) };
 	unsigned background_threads{ std::max (4u, nano::hardware_concurrency ()) };
@@ -154,6 +154,9 @@ public:
 	nano::frontiers_confirmation_mode deserialize_frontiers_confirmation (std::string const &);
 	/** Entry is ignored if it cannot be parsed as a valid address:port */
 	void deserialize_address (std::string const &, std::vector<std::pair<std::string, uint16_t>> &) const;
+
+private:
+	static std::optional<unsigned> env_io_threads ();
 };
 
 class node_flags final

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -29,7 +29,7 @@ public:
 	nano::error serialize (nano::tomlconfig &) const;
 
 public:
-	size_t threads{ min_max (1u, 4u, nano::hardware_concurrency () / 2) };
+	size_t threads{ std::clamp (nano::hardware_concurrency () / 2, 1u, 4u) };
 	size_t max_queue{ 128 };
 	size_t batch_size{ 16 };
 };

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -29,7 +29,7 @@ public:
 	nano::error serialize (nano::tomlconfig &) const;
 
 public:
-	size_t threads{ std::min (nano::hardware_concurrency (), 4u) };
+	size_t threads{ min_max (1u, 4u, nano::hardware_concurrency () / 2) };
 	size_t max_queue{ 128 };
 	size_t batch_size{ 16 };
 };

--- a/nano/node/vote_processor.hpp
+++ b/nano/node/vote_processor.hpp
@@ -50,7 +50,7 @@ public:
 	size_t max_pr_queue{ 256 };
 	size_t max_non_pr_queue{ 32 };
 	size_t pr_priority{ 3 };
-	size_t threads{ min_max (1u, 4u, nano::hardware_concurrency () / 2) };
+	size_t threads{ std::clamp (nano::hardware_concurrency () / 2, 1u, 4u) };
 	size_t batch_size{ 1024 };
 };
 

--- a/nano/node/vote_processor.hpp
+++ b/nano/node/vote_processor.hpp
@@ -50,7 +50,7 @@ public:
 	size_t max_pr_queue{ 256 };
 	size_t max_non_pr_queue{ 32 };
 	size_t pr_priority{ 3 };
-	size_t threads{ std::min (4u, nano::hardware_concurrency () / 2) };
+	size_t threads{ min_max (1u, 4u, nano::hardware_concurrency () / 2) };
 	size_t batch_size{ 1024 };
 };
 

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -2,6 +2,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/config.hpp>
 #include <nano/lib/enum_util.hpp>
+#include <nano/lib/env.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/lib/utility.hpp>
@@ -26,7 +27,8 @@ char const * dev_private_key_data = "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E
 char const * dev_public_key_data = "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0"; // xrb_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo
 char const * beta_public_key_data = "259A438A8F9F9226130C84D902C237AF3E57C0981C7D709C288046B110D8C8AC"; // nano_1betagoxpxwykx4kw86dnhosc8t3s7ix8eeentwkcg1hbpez1outjrcyg4n1
 char const * live_public_key_data = "E89208DD038FBB269987689621D52292AE9C35941A7484756ECCED92A65093BA"; // xrb_3t6k35gi95xu6tergt6p69ck76ogmitsa8mnijtpxm9fkcm736xtoncuohr3
-std::string const test_public_key_data = nano::get_env_or_default ("NANO_TEST_GENESIS_PUB", "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED"); // nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j
+std::string const test_public_key_data = nano::env::get ("NANO_TEST_GENESIS_PUB").value_or ("45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED"); // nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j
+
 char const * dev_genesis_data = R"%%%({
 	"type": "open",
 	"source": "B0311EA55708D6A53C75CDBF88300259C6D018522FE3D4D0A242E431F9E8B6D0",
@@ -54,7 +56,7 @@ char const * live_genesis_data = R"%%%({
 	"signature": "9F0C933C8ADE004D808EA1985FA746A7E95BA2A38F867640F53EC8F180BDFE9E2C1268DEAD7C2664F356E37ABA362BC58E46DBA03E523A7B5A19E4B6EB12BB02"
     })%%%";
 
-std::string const test_genesis_data = nano::get_env_or_default ("NANO_TEST_GENESIS_BLOCK", R"%%%({
+std::string const test_genesis_data = nano::env::get ("NANO_TEST_GENESIS_BLOCK").value_or (R"%%%({
 	"type": "open",
 	"source": "45C6FF9D1706D61F0821327752671BDA9F9ED2DA40326B01935AB566FB9E08ED",
 	"representative": "nano_1jg8zygjg3pp5w644emqcbmjqpnzmubfni3kfe1s8pooeuxsw49fdq1mco9j",

--- a/nano/secure/plat/osx/working.mm
+++ b/nano/secure/plat/osx/working.mm
@@ -4,7 +4,7 @@
 
 namespace nano
 {
-std::filesystem::path app_path ()
+std::filesystem::path app_path_impl ()
 {
 	NSString * dir_string = [NSSearchPathForDirectoriesInDomains(NSLibraryDirectory, NSUserDomainMask, YES) lastObject];
 	char const * dir_chars = [dir_string UTF8String];

--- a/nano/secure/plat/posix/working.cpp
+++ b/nano/secure/plat/posix/working.cpp
@@ -6,7 +6,7 @@
 
 namespace nano
 {
-std::filesystem::path app_path ()
+std::filesystem::path app_path_impl ()
 {
 	auto entry (getpwuid (getuid ()));
 	debug_assert (entry != nullptr);

--- a/nano/secure/plat/windows/working.cpp
+++ b/nano/secure/plat/windows/working.cpp
@@ -4,7 +4,7 @@
 
 namespace nano
 {
-std::filesystem::path app_path ()
+std::filesystem::path app_path_impl ()
 {
 	std::filesystem::path result;
 	WCHAR path[MAX_PATH];

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -11,9 +11,9 @@ static std::vector<std::filesystem::path> all_unique_paths;
 
 std::filesystem::path nano::working_path (nano::networks network)
 {
-	auto result (nano::app_path ());
+	auto result = nano::app_path ();
 
-	if (auto path_override = nano::get_env ("NANO_APP_PATH"))
+	if (auto path_override = nano::env::get ("NANO_APP_PATH"))
 	{
 		result = *path_override;
 		std::cerr << "Application path overridden by NANO_APP_PATH environment variable: " << result << std::endl;

--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -9,15 +9,22 @@
 
 static std::vector<std::filesystem::path> all_unique_paths;
 
+std::filesystem::path nano::app_path ()
+{
+	static auto const path = [] () {
+		if (auto value = nano::env::get ("NANO_APP_PATH"))
+		{
+			std::cerr << "Application path overridden by NANO_APP_PATH environment variable: " << *value << std::endl;
+			return std::filesystem::path{ *value };
+		}
+		return nano::app_path_impl ();
+	}();
+	return path;
+}
+
 std::filesystem::path nano::working_path (nano::networks network)
 {
 	auto result = nano::app_path ();
-
-	if (auto path_override = nano::env::get ("NANO_APP_PATH"))
-	{
-		result = *path_override;
-		std::cerr << "Application path overridden by NANO_APP_PATH environment variable: " << result << std::endl;
-	}
 
 	switch (network)
 	{

--- a/nano/secure/utility.hpp
+++ b/nano/secure/utility.hpp
@@ -6,6 +6,7 @@
 
 namespace nano
 {
+std::filesystem::path app_path ();
 // OS-specific way of finding a path to a home directory.
 std::filesystem::path working_path (nano::networks network = nano::network_constants::active_network);
 // Get a unique path within the home directory, used for testing.

--- a/nano/secure/working.hpp
+++ b/nano/secure/working.hpp
@@ -4,5 +4,5 @@
 
 namespace nano
 {
-std::filesystem::path app_path ();
+std::filesystem::path app_path_impl ();
 }


### PR DESCRIPTION
This cleans up code related to overriding node configuration:
- Extracts environment variable reading, which is now done in a more generic, C++ way.
- Always prints info when an environment variable overrides config.
- Ensures that configured thread counts are in reasonable ranges. (And slightly tweaks default for `request_aggregator`)
- Converts `is_<sanitizer>` calls to constevals
- Adds ability to configure number of IO threads by environment variable