### PR TITLE
Scheduler test cleanup

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -1006,12 +1006,7 @@ TEST (active_elections, confirmation_consistency)
 	{
 		auto block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, nano::public_key (), node.config.receive_minimum.number ()));
 		ASSERT_NE (nullptr, block);
-		system.deadline_set (5s);
-		while (!node.ledger.confirmed.block_exists_or_pruned (node.ledger.tx_begin_read (), block->hash ()))
-		{
-			node.scheduler.priority.activate (node.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
-			ASSERT_NO_ERROR (system.poll (5ms));
-		}
+		ASSERT_TIMELY (5s, node.block_confirmed (block->hash ()));
 		ASSERT_NO_ERROR (system.poll_until_true (1s, [&node, &block, i] {
 			nano::lock_guard<nano::mutex> guard (node.active.mutex);
 			EXPECT_EQ (i + 1, node.active.recently_confirmed.size ());

--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -425,9 +425,7 @@ TEST (inactive_votes_cache, multiple_votes)
 
 	ASSERT_TIMELY_EQ (5s, node.vote_cache.find (send1->hash ()).size (), 2);
 	ASSERT_EQ (1, node.vote_cache.size ());
-	node.scheduler.priority.activate (node.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
-	std::shared_ptr<nano::election> election;
-	ASSERT_TIMELY (5s, election = node.active.election (send1->qualified_root ()));
+	auto election = nano::test::start_election (system, node, send1->hash ());
 	ASSERT_TIMELY_EQ (5s, 3, election->votes ().size ()); // 2 votes and 1 default not_an_acount
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::election, nano::stat::detail::vote_cached));
 }
@@ -1320,13 +1318,11 @@ TEST (active_elections, vacancy)
 		ASSERT_EQ (nano::block_status::progress, node.process (send));
 		ASSERT_EQ (1, node.active.vacancy (nano::election_behavior::priority));
 		ASSERT_EQ (0, node.active.size ());
-		node.scheduler.priority.activate (node.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
+		auto election1 = nano::test::start_election (system, node, send->hash ());
 		ASSERT_TIMELY (1s, updated);
 		updated = false;
 		ASSERT_EQ (0, node.active.vacancy (nano::election_behavior::priority));
 		ASSERT_EQ (1, node.active.size ());
-		auto election1 = node.active.election (send->qualified_root ());
-		ASSERT_NE (nullptr, election1);
 		election1->force_confirm ();
 		ASSERT_TIMELY (1s, updated);
 		ASSERT_EQ (1, node.active.vacancy (nano::election_behavior::priority));

--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -346,11 +346,9 @@ TEST (inactive_votes_cache, existing_vote)
 				.sign (key.prv, key.pub)
 				.work (*system.work.generate (key.pub))
 				.build ();
-	node.process_active (send);
-	node.block_processor.add (open);
-	ASSERT_TIMELY_EQ (5s, node.active.size (), 1);
-	auto election (node.active.election (send->qualified_root ()));
-	ASSERT_NE (nullptr, election);
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send));
+	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), open));
+	auto election = nano::test::start_election (system, node, send->hash ());
 	ASSERT_GT (node.weight (key.pub), node.minimum_principal_weight ());
 	// Insert vote
 	auto vote1 = nano::test::make_vote (key, { send }, nano::vote::timestamp_min * 1, 0);

--- a/nano/core_test/confirming_set.cpp
+++ b/nano/core_test/confirming_set.cpp
@@ -133,10 +133,7 @@ TEST (confirmation_callback, confirmed_history)
 				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				.work (*system.work.generate (latest))
 				.build ();
-	{
-		auto transaction = node->ledger.tx_begin_write ();
-		ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send));
-	}
+	ASSERT_EQ (nano::block_status::progress, node->ledger.process (node->ledger.tx_begin_write (), send));
 
 	auto send1 = builder
 				 .send ()
@@ -146,8 +143,8 @@ TEST (confirmation_callback, confirmed_history)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (send->hash ()))
 				 .build ();
+	ASSERT_EQ (nano::block_status::progress, node->ledger.process (node->ledger.tx_begin_write (), send1));
 
-	node->process_active (send1);
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = nano::test::start_election (system, *node, send1->hash ()));
 	{

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -31,9 +31,7 @@ TEST (conflicts, start_stop)
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::block_status::progress, node1.process (send1));
 	ASSERT_EQ (0, node1.active.size ());
-	node1.scheduler.priority.activate (node1.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
-	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
-	auto election1 = node1.active.election (send1->qualified_root ());
+	auto election1 = nano::test::start_election (system, node1, send1->hash ());
 	ASSERT_EQ (1, node1.active.size ());
 	ASSERT_NE (nullptr, election1);
 	ASSERT_EQ (1, election1->votes ().size ());
@@ -64,7 +62,7 @@ TEST (conflicts, add_existing)
 	ASSERT_TIMELY (5s, node1.block (send1->hash ()));
 
 	// instruct the election scheduler to trigger an election for send1
-	node1.scheduler.priority.activate (node1.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
+	nano::test::start_election (system, node1, send1->hash ());
 
 	// wait for election to be started before processing send2
 	ASSERT_TIMELY (5s, node1.active.active (*send1));

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -152,9 +152,7 @@ TEST (election, quorum_minimum_confirm_success)
 				 .build ();
 	node1.work_generate_blocking (*send1);
 	node1.process_active (send1);
-	node1.scheduler.priority.activate (node1.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
-	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
-	auto election = node1.active.election (send1->qualified_root ());
+	auto election = nano::test::start_election (system, node1, send1->hash ());
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (1, election->blocks ().size ());
 	auto vote = nano::test::make_final_vote (nano::dev::genesis_key, { send1->hash () });

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -964,9 +964,7 @@ TEST (votes, check_signature)
 		auto transaction = node1.ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, send1));
 	}
-	node1.scheduler.priority.activate (node1.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
-	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
-	auto election1 = node1.active.election (send1->qualified_root ());
+	auto election1 = nano::test::start_election (system, node1, send1->hash ());
 	ASSERT_EQ (1, election1->votes ().size ());
 	auto vote1 = nano::test::make_vote (nano::dev::genesis_key, { send1 }, nano::vote::timestamp_min * 1, 0);
 	vote1->signature.bytes[0] ^= 1;
@@ -1035,9 +1033,7 @@ TEST (votes, add_existing)
 										 .build ();
 	node1.work_generate_blocking (*send1);
 	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (node1.ledger.tx_begin_write (), send1));
-	node1.scheduler.priority.activate (node1.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
-	ASSERT_TIMELY (5s, node1.active.election (send1->qualified_root ()));
-	auto election1 = node1.active.election (send1->qualified_root ());
+	auto election1 = nano::test::start_election (system, node1, send1->hash ());
 	auto vote1 = nano::test::make_vote (nano::dev::genesis_key, { send1 }, nano::vote::timestamp_min * 1, 0);
 	ASSERT_EQ (nano::vote_code::vote, node1.vote_router.vote (vote1).at (send1->hash ()));
 	// Block is already processed from vote

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1363,9 +1363,7 @@ TEST (node, rep_self_vote)
 	ASSERT_EQ (nano::block_status::progress, node0->process (block0));
 	auto & active = node0->active;
 	auto & scheduler = node0->scheduler;
-	scheduler.priority.activate (node0->ledger.tx_begin_read (), nano::dev::genesis_key.pub);
-	ASSERT_TIMELY (5s, active.election (block0->qualified_root ()));
-	auto election1 = active.election (block0->qualified_root ());
+	auto election1 = nano::test::start_election (system, *node0, block0->hash ());
 	ASSERT_NE (nullptr, election1);
 	// Wait until representatives are activated & make vote
 	ASSERT_TIMELY_EQ (1s, election1->votes ().size (), 3);


### PR DESCRIPTION
This is a number of unit test cleanups to eliminate directly calling the election scheduler when unrelated to the purpose of the test.