### PR TITLE
Fix rare race in `request_aggregator.one_update`

### DIFF
--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -112,7 +112,7 @@ TEST (request_aggregator, one_update)
 
 	// In the ledger but no vote generated yet
 	ASSERT_TIMELY (3s, 0 < node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes))
-	ASSERT_TRUE (node.aggregator.empty ());
+	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));


### PR DESCRIPTION
It seems that `node.aggregator.empty ()` is not guaranteed to be true immediately.
This testcase fails in ~ 1/2000 cases for me.