### PR TITLE
Address performance regression in vote_cache::top

### DIFF
--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -231,11 +231,11 @@ void nano::vote_cache::clear ()
 	cache.clear ();
 }
 
-std::vector<nano::vote_cache::top_entry> nano::vote_cache::top (const nano::uint128_t & min_tally)
+std::deque<nano::vote_cache::top_entry> nano::vote_cache::top (const nano::uint128_t & min_tally)
 {
 	stats.inc (nano::stat::type::vote_cache, nano::stat::detail::top);
 
-	std::vector<top_entry> results;
+	std::deque<top_entry> results;
 	{
 		nano::lock_guard<nano::mutex> lock{ mutex };
 

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -246,11 +246,12 @@ std::vector<nano::vote_cache::top_entry> nano::vote_cache::top (const nano::uint
 
 		for (auto & entry : cache.get<tag_tally> ())
 		{
-			if (entry.tally () < min_tally)
+			auto tally = entry.tally ();
+			if (tally < min_tally)
 			{
 				break;
 			}
-			results.push_back ({ entry.hash (), entry.tally (), entry.final_tally () });
+			results.push_back ({ entry.hash (), tally, entry.final_tally () });
 		}
 	}
 

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -244,12 +244,13 @@ std::vector<nano::vote_cache::top_entry> nano::vote_cache::top (const nano::uint
 			cleanup ();
 		}
 
-		for (auto & entry : cache)
+		for (auto & entry : cache.get<tag_tally> ())
 		{
-			if (entry.tally () >= min_tally)
+			if (entry.tally () < min_tally)
 			{
-				results.push_back ({ entry.hash (), entry.tally (), entry.final_tally () });
+				break;
 			}
+			results.push_back ({ entry.hash (), entry.tally (), entry.final_tally () });
 		}
 	}
 

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -166,6 +166,7 @@ private:
 	// clang-format off
 	class tag_sequenced {};
 	class tag_hash {};
+	class tag_tally {};
 	// clang-format on
 
 	// clang-format off
@@ -173,7 +174,9 @@ private:
 	mi::indexed_by<
 		mi::hashed_unique<mi::tag<tag_hash>,
 			mi::const_mem_fun<entry, nano::block_hash, &entry::hash>>,
-		mi::sequenced<mi::tag<tag_sequenced>>
+		mi::sequenced<mi::tag<tag_sequenced>>,
+		mi::ordered_non_unique<mi::tag<tag_tally>,
+			mi::const_mem_fun<entry, nano::uint128_t, &entry::tally>, std::greater<>> // DESC
 	>>;
 	// clang-format on
 	ordered_cache cache;

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -145,7 +145,7 @@ public:
 	 * The blocks are sorted in descending order by final tally, then by tally
 	 * @param min_tally minimum tally threshold, entries below with their voting weight below this will be ignored
 	 */
-	std::vector<top_entry> top (nano::uint128_t const & min_tally);
+	std::deque<top_entry> top (nano::uint128_t const & min_tally);
 
 public: // Container info
 	std::unique_ptr<nano::container_info_component> collect_container_info (std::string const & name) const;


### PR DESCRIPTION
Revert https://github.com/nanocurrency/nano-node/pull/4518/commits/c734caf4d1ad840df83983e40b86e5d2c1f56a69 which removed loop short-circuit checking for top voted-for elections.
Eliminate duplicate expression evaluation.
Use deque rather than vector for results to reduce backing reallocation.