### PR TITLE
More vote cache optimizations

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -238,7 +238,10 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	});
 
 	vote_router.vote_processed.add ([this] (std::shared_ptr<nano::vote> const & vote, nano::vote_source source, std::unordered_map<nano::block_hash, nano::vote_code> const & results) {
-		vote_cache.observe (vote, source, results);
+		if (source != nano::vote_source::cache)
+		{
+			vote_cache.insert (vote, results);
+		}
 	});
 
 	// Republish vote if it is new and the node does not host a principal representative (or close to)

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -231,11 +231,11 @@ void nano::vote_cache::clear ()
 	cache.clear ();
 }
 
-std::vector<nano::vote_cache::top_entry> nano::vote_cache::top (const nano::uint128_t & min_tally)
+std::deque<nano::vote_cache::top_entry> nano::vote_cache::top (const nano::uint128_t & min_tally)
 {
 	stats.inc (nano::stat::type::vote_cache, nano::stat::detail::top);
 
-	std::vector<top_entry> results;
+	std::deque<top_entry> results;
 	{
 		nano::lock_guard<nano::mutex> lock{ mutex };
 

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -128,61 +128,66 @@ nano::vote_cache::vote_cache (vote_cache_config const & config_a, nano::stats & 
 {
 }
 
-void nano::vote_cache::observe (const std::shared_ptr<nano::vote> & vote, nano::vote_source source, std::unordered_map<nano::block_hash, nano::vote_code> results)
+void nano::vote_cache::insert (std::shared_ptr<nano::vote> const & vote, std::unordered_map<nano::block_hash, nano::vote_code> const & results)
 {
-	if (source != nano::vote_source::cache)
-	{
-		insert (vote, [&results] (nano::block_hash const & hash) {
-			// This filters which hashes should be included in the vote cache
-			if (auto it = results.find (hash); it != results.end ())
-			{
-				auto result = it->second;
-				// Cache votes with a corresponding active election (indicated by `vote_code::vote`) in case that election gets dropped
-				return result == nano::vote_code::vote || result == nano::vote_code::indeterminate;
-			}
-			debug_assert (false);
-			return false;
-		});
-	}
-}
+	// Results map should be empty or have the same hashes as the vote
+	debug_assert (results.empty () || std::all_of (vote->hashes.begin (), vote->hashes.end (), [&results] (auto const & hash) { return results.find (hash) != results.end (); }));
 
-void nano::vote_cache::insert (std::shared_ptr<nano::vote> const & vote, std::function<bool (nano::block_hash const &)> filter)
-{
 	auto const representative = vote->account;
-	auto const timestamp = vote->timestamp ();
 	auto const rep_weight = rep_weight_query (representative);
 
 	nano::lock_guard<nano::mutex> lock{ mutex };
 
-	for (auto const & hash : vote->hashes)
+	// Cache votes with a corresponding active election (indicated by `vote_code::vote`) in case that election gets dropped
+	auto filter = [] (auto code) {
+		return code == nano::vote_code::vote || code == nano::vote_code::indeterminate;
+	};
+
+	// If results map is empty, insert all hashes (meant for testing)
+	if (results.empty ())
 	{
-		// Using filter callback here to avoid unnecessary relocking when processing large votes
-		if (!filter (hash))
+		for (auto const & hash : vote->hashes)
 		{
-			continue;
+			insert_impl (vote, hash, rep_weight);
 		}
-
-		if (auto existing = cache.find (hash); existing != cache.end ())
+	}
+	else
+	{
+		for (auto const & [hash, code] : results)
 		{
-			stats.inc (nano::stat::type::vote_cache, nano::stat::detail::update);
-
-			cache.modify (existing, [this, &vote, &rep_weight] (entry & ent) {
-				ent.vote (vote, rep_weight, config.max_voters);
-			});
-		}
-		else
-		{
-			stats.inc (nano::stat::type::vote_cache, nano::stat::detail::insert);
-
-			entry cache_entry{ hash };
-			cache_entry.vote (vote, rep_weight, config.max_voters);
-			cache.insert (cache_entry);
-
-			// Remove the oldest entry if we have reached the capacity limit
-			if (cache.size () > config.max_size)
+			if (filter (code))
 			{
-				cache.get<tag_sequenced> ().pop_front ();
+				insert_impl (vote, hash, rep_weight);
 			}
+		}
+	}
+}
+
+void nano::vote_cache::insert_impl (std::shared_ptr<nano::vote> const & vote, nano::block_hash const & hash, nano::uint128_t const & rep_weight)
+{
+	debug_assert (!mutex.try_lock ());
+	debug_assert (std::any_of (vote->hashes.begin (), vote->hashes.end (), [&hash] (auto const & vote_hash) { return vote_hash == hash; }));
+
+	if (auto existing = cache.find (hash); existing != cache.end ())
+	{
+		stats.inc (nano::stat::type::vote_cache, nano::stat::detail::update);
+
+		cache.modify (existing, [this, &vote, &rep_weight] (entry & ent) {
+			ent.vote (vote, rep_weight, config.max_voters);
+		});
+	}
+	else
+	{
+		stats.inc (nano::stat::type::vote_cache, nano::stat::detail::insert);
+
+		entry cache_entry{ hash };
+		cache_entry.vote (vote, rep_weight, config.max_voters);
+		cache.insert (cache_entry);
+
+		// Remove the oldest entry if we have reached the capacity limit
+		if (cache.size () > config.max_size)
+		{
+			cache.get<tag_sequenced> ().pop_front ();
 		}
 	}
 }

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -246,11 +246,12 @@ std::vector<nano::vote_cache::top_entry> nano::vote_cache::top (const nano::uint
 
 		for (auto & entry : cache.get<tag_tally> ())
 		{
-			if (entry.tally () < min_tally)
+			auto tally = entry.tally ();
+			if (tally < min_tally)
 			{
 				break;
 			}
-			results.push_back ({ entry.hash (), entry.tally (), entry.final_tally () });
+			results.push_back ({ entry.hash (), tally, entry.final_tally () });
 		}
 	}
 

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -244,12 +244,13 @@ std::vector<nano::vote_cache::top_entry> nano::vote_cache::top (const nano::uint
 			cleanup ();
 		}
 
-		for (auto & entry : cache)
+		for (auto & entry : cache.get<tag_tally> ())
 		{
-			if (entry.tally () >= min_tally)
+			if (entry.tally () < min_tally)
 			{
-				results.push_back ({ entry.hash (), entry.tally (), entry.final_tally () });
+				break;
 			}
+			results.push_back ({ entry.hash (), entry.tally (), entry.final_tally () });
 		}
 	}
 

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -110,12 +110,7 @@ public:
 	 */
 	void insert (
 	std::shared_ptr<nano::vote> const & vote,
-	std::function<bool (nano::block_hash const &)> filter = [] (nano::block_hash const &) { return true; });
-
-	/**
-	 * Should be called for every processed vote, filters which votes should be added to cache
-	 */
-	void observe (std::shared_ptr<nano::vote> const & vote, nano::vote_source source, std::unordered_map<nano::block_hash, nano::vote_code>);
+	std::unordered_map<nano::block_hash, nano::vote_code> const & results = {});
 
 	/**
 	 * Tries to find an entry associated with block hash
@@ -161,6 +156,7 @@ private: // Dependencies
 	nano::stats & stats;
 
 private:
+	void insert_impl (std::shared_ptr<nano::vote> const &, nano::block_hash const & hash, nano::uint128_t const & rep_weight);
 	void cleanup ();
 
 	// clang-format off

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -68,14 +68,29 @@ public:
 	bool vote (std::shared_ptr<nano::vote> const & vote, nano::uint128_t const & rep_weight, std::size_t max_voters);
 
 	std::size_t size () const;
-	nano::block_hash hash () const;
-	nano::uint128_t tally () const;
-	nano::uint128_t final_tally () const;
 	std::vector<std::shared_ptr<nano::vote>> votes () const;
-	std::chrono::steady_clock::time_point last_vote () const;
+
+public: // Keep accessors inlined
+	nano::block_hash hash () const
+	{
+		return hash_m;
+	}
+	std::chrono::steady_clock::time_point last_vote () const
+	{
+		return last_vote_m;
+	}
+	nano::uint128_t tally () const
+	{
+		return tally_m;
+	}
+	nano::uint128_t final_tally () const
+	{
+		return final_tally_m;
+	}
 
 private:
 	bool vote_impl (std::shared_ptr<nano::vote> const & vote, nano::uint128_t const & rep_weight, std::size_t max_voters);
+	std::pair<nano::uint128_t, nano::uint128_t> calculate_tally () const; // <tally, final_tally>
 
 	// clang-format off
 	class tag_representative {};
@@ -95,6 +110,8 @@ private:
 
 	nano::block_hash const hash_m;
 	std::chrono::steady_clock::time_point last_vote_m{};
+	nano::uint128_t tally_m{ 0 };
+	nano::uint128_t final_tally_m{ 0 };
 };
 
 class vote_cache final

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -166,6 +166,7 @@ private:
 	// clang-format off
 	class tag_sequenced {};
 	class tag_hash {};
+	class tag_tally {};
 	// clang-format on
 
 	// clang-format off
@@ -173,7 +174,9 @@ private:
 	mi::indexed_by<
 		mi::hashed_unique<mi::tag<tag_hash>,
 			mi::const_mem_fun<entry, nano::block_hash, &entry::hash>>,
-		mi::sequenced<mi::tag<tag_sequenced>>
+		mi::sequenced<mi::tag<tag_sequenced>>,
+		mi::ordered_non_unique<mi::tag<tag_tally>,
+			mi::const_mem_fun<entry, nano::uint128_t, &entry::tally>, std::greater<>> // DESC
 	>>;
 	// clang-format on
 	ordered_cache cache;

--- a/nano/node/vote_cache.hpp
+++ b/nano/node/vote_cache.hpp
@@ -145,7 +145,7 @@ public:
 	 * The blocks are sorted in descending order by final tally, then by tally
 	 * @param min_tally minimum tally threshold, entries below with their voting weight below this will be ignored
 	 */
-	std::vector<top_entry> top (nano::uint128_t const & min_tally);
+	std::deque<top_entry> top (nano::uint128_t const & min_tally);
 
 public: // Container info
 	std::unique_ptr<nano::container_info_component> collect_container_info (std::string const & name) const;

--- a/nano/node/vote_router.hpp
+++ b/nano/node/vote_router.hpp
@@ -55,7 +55,7 @@ public:
 	void disconnect (nano::block_hash const & hash);
 	// Route vote to associated elections
 	// Distinguishes replay votes, cannot be determined if the block is not in any election
-	std::unordered_map<nano::block_hash, nano::vote_code> vote (std::shared_ptr<nano::vote> const &, nano::vote_source = nano::vote_source::live);
+	std::unordered_map<nano::block_hash, nano::vote_code> vote (std::shared_ptr<nano::vote> const &, nano::vote_source = nano::vote_source::live, nano::block_hash filter = { 0 });
 	bool trigger_vote_cache (nano::block_hash const & hash);
 	bool active (nano::block_hash const & hash) const;
 	std::shared_ptr<nano::election> election (nano::block_hash const & hash) const;

--- a/nano/node/vote_router.hpp
+++ b/nano/node/vote_router.hpp
@@ -55,6 +55,9 @@ public:
 	void disconnect (nano::block_hash const & hash);
 	// Route vote to associated elections
 	// Distinguishes replay votes, cannot be determined if the block is not in any election
+
+	// If 'filter' parameter is non-zero, only elections for the specified hash are notified.
+	// This eliminates duplicate processing when triggering votes from the vote_cache as the result of a specific election being created.
 	std::unordered_map<nano::block_hash, nano::vote_code> vote (std::shared_ptr<nano::vote> const &, nano::vote_source = nano::vote_source::live, nano::block_hash filter = { 0 });
 	bool trigger_vote_cache (nano::block_hash const & hash);
 	bool active (nano::block_hash const & hash) const;


### PR DESCRIPTION
This builds on top of https://github.com/nanocurrency/nano-node/pull/4627 and optimizes insertion of votes into the vote cache and fixes a significant performance regression in `trigger_vote_cache` function.