### PR TITLE
Offload vote cache lookup to a separate thread

### DIFF
--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -48,6 +48,7 @@ enum class type
 	telemetry,
 	vote_generator,
 	vote_cache,
+	vote_cache_processor,
 	hinting,
 	blockprocessor,
 	blockprocessor_source,
@@ -112,6 +113,7 @@ enum class detail
 	cache,
 	rebroadcast,
 	queue_overflow,
+	triggered,
 
 	// processing queue
 	queue,

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -28,6 +28,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::vote_processing:
 			thread_role_name_string = "Vote processing";
 			break;
+		case nano::thread_role::name::vote_cache_processing:
+			thread_role_name_string = "Vote cache proc";
+			break;
 		case nano::thread_role::name::block_processing:
 			thread_role_name_string = "Blck processing";
 			break;

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -14,6 +14,7 @@ enum class name
 	work,
 	message_processing,
 	vote_processing,
+	vote_cache_processing,
 	block_processing,
 	request_loop,
 	wallet_actions,

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -424,7 +424,7 @@ nano::election_insertion_result nano::active_elections::insert (std::shared_ptr<
 	{
 		debug_assert (result.election);
 
-		node.vote_router.trigger_vote_cache (hash);
+		node.vote_cache_processor.trigger (hash);
 		node.observers.active_started.notify (hash);
 		vacancy_update ();
 	}
@@ -507,7 +507,7 @@ bool nano::active_elections::publish (std::shared_ptr<nano::block> const & block
 			node.vote_router.connect (block_a->hash (), election);
 			lock.unlock ();
 
-			node.vote_router.trigger_vote_cache (block_a->hash ());
+			node.vote_cache_processor.trigger (block_a->hash ());
 
 			node.stats.inc (nano::stat::type::active, nano::stat::detail::election_block_conflict);
 		}

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -11,10 +11,20 @@ class ledger;
 class local_vote_history;
 class logger;
 class network;
+class network_params;
 class node;
 class node_config;
+class node_flags;
+class node_observers;
+class online_reps;
+class rep_crawler;
+class rep_tiers;
 class stats;
+class vote_cache;
 class vote_generator;
+class vote_processor;
 class vote_router;
 class wallets;
+
+enum class vote_code;
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -200,6 +200,8 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	vote_router{ *vote_router_impl },
 	vote_processor_impl{ std::make_unique<nano::vote_processor> (config.vote_processor, vote_router, observers, stats, flags, logger, online_reps, rep_crawler, ledger, network_params, rep_tiers) },
 	vote_processor{ *vote_processor_impl },
+	vote_cache_processor_impl{ std::make_unique<nano::vote_cache_processor> (config.vote_processor, vote_router, vote_cache, stats, logger) },
+	vote_cache_processor{ *vote_cache_processor_impl },
 	generator_impl{ std::make_unique<nano::vote_generator> (config, *this, ledger, wallets, vote_processor, history, network, stats, logger, /* non-final */ false) },
 	generator{ *generator_impl },
 	final_generator_impl{ std::make_unique<nano::vote_generator> (config, *this, ledger, wallets, vote_processor, history, network, stats, logger, /* final */ true) },
@@ -595,6 +597,7 @@ std::unique_ptr<nano::container_info_component> nano::collect_container_info (no
 	composite->add_component (collect_container_info (node.observers, "observers"));
 	composite->add_component (collect_container_info (node.wallets, "wallets"));
 	composite->add_component (node.vote_processor.collect_container_info ("vote_processor"));
+	composite->add_component (node.vote_cache_processor.collect_container_info ("vote_cache_processor"));
 	composite->add_component (node.rep_crawler.collect_container_info ("rep_crawler"));
 	composite->add_component (node.block_processor.collect_container_info ("block_processor"));
 	composite->add_component (collect_container_info (node.online_reps, "online_reps"));
@@ -713,6 +716,7 @@ void nano::node::start ()
 	wallets.start ();
 	rep_tiers.start ();
 	vote_processor.start ();
+	vote_cache_processor.start ();
 	block_processor.start ();
 	active.start ();
 	generator.start ();
@@ -757,6 +761,7 @@ void nano::node::stop ()
 	unchecked.stop ();
 	block_processor.stop ();
 	aggregator.stop ();
+	vote_cache_processor.stop ();
 	vote_processor.stop ();
 	rep_tiers.stop ();
 	scheduler.stop ();

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -48,6 +48,7 @@ class confirming_set;
 class message_processor;
 class node;
 class vote_processor;
+class vote_cache_processor;
 class vote_router;
 class work_pool;
 class peer_history;
@@ -194,6 +195,8 @@ public:
 	nano::vote_router & vote_router;
 	std::unique_ptr<nano::vote_processor> vote_processor_impl;
 	nano::vote_processor & vote_processor;
+	std::unique_ptr<nano::vote_cache_processor> vote_cache_processor_impl;
+	nano::vote_cache_processor & vote_cache_processor;
 	std::unique_ptr<nano::vote_generator> generator_impl;
 	nano::vote_generator & generator;
 	std::unique_ptr<nano::vote_generator> final_generator_impl;

--- a/nano/node/vote_router.cpp
+++ b/nano/node/vote_router.cpp
@@ -123,16 +123,6 @@ std::unordered_map<nano::block_hash, nano::vote_code> nano::vote_router::vote (s
 	return results;
 }
 
-bool nano::vote_router::trigger_vote_cache (nano::block_hash const & hash)
-{
-	auto cached = cache.find (hash);
-	for (auto const & cached_vote : cached)
-	{
-		vote (cached_vote, nano::vote_source::cache, hash);
-	}
-	return !cached.empty ();
-}
-
 bool nano::vote_router::active (nano::block_hash const & hash) const
 {
 	std::shared_lock lock{ mutex };

--- a/nano/node/vote_router.hpp
+++ b/nano/node/vote_router.hpp
@@ -59,7 +59,6 @@ public:
 	// If 'filter' parameter is non-zero, only elections for the specified hash are notified.
 	// This eliminates duplicate processing when triggering votes from the vote_cache as the result of a specific election being created.
 	std::unordered_map<nano::block_hash, nano::vote_code> vote (std::shared_ptr<nano::vote> const &, nano::vote_source = nano::vote_source::live, nano::block_hash filter = { 0 });
-	bool trigger_vote_cache (nano::block_hash const & hash);
 	bool active (nano::block_hash const & hash) const;
 	std::shared_ptr<nano::election> election (nano::block_hash const & hash) const;
 


### PR DESCRIPTION
This moves processing of cached votes away from congested election schedulers threads.