### PR TITLE
Clean up priority scheduler bucket look ups

### DIFF
--- a/nano/core_test/scheduler_buckets.cpp
+++ b/nano/core_test/scheduler_buckets.cpp
@@ -115,18 +115,6 @@ TEST (buckets, construction)
 	ASSERT_EQ (62, buckets.bucket_count ());
 }
 
-TEST (buckets, index_min)
-{
-	nano::scheduler::buckets buckets;
-	ASSERT_EQ (0, buckets.index (std::numeric_limits<nano::uint128_t>::min ()));
-}
-
-TEST (buckets, index_max)
-{
-	nano::scheduler::buckets buckets;
-	ASSERT_EQ (buckets.bucket_count () - 1, buckets.index (std::numeric_limits<nano::uint128_t>::max ()));
-}
-
 TEST (buckets, insert_Gxrb)
 {
 	nano::scheduler::buckets buckets;

--- a/nano/node/scheduler/bucket.cpp
+++ b/nano/node/scheduler/bucket.cpp
@@ -11,8 +11,9 @@ bool nano::scheduler::bucket::value_type::operator== (value_type const & other_a
 	return time == other_a.time && block->hash () == other_a.block->hash ();
 }
 
-nano::scheduler::bucket::bucket (size_t maximum) :
-	maximum{ maximum }
+nano::scheduler::bucket::bucket (nano::uint128_t minimum_balance, size_t maximum) :
+	maximum{ maximum },
+	minimum_balance{ minimum_balance }
 {
 	debug_assert (maximum > 0);
 }

--- a/nano/node/scheduler/bucket.hpp
+++ b/nano/node/scheduler/bucket.hpp
@@ -27,8 +27,11 @@ class bucket final
 	size_t const maximum;
 
 public:
-	bucket (size_t maximum);
+	bucket (nano::uint128_t minimum_balance, size_t maximum);
 	~bucket ();
+
+	nano::uint128_t const minimum_balance;
+
 	std::shared_ptr<nano::block> top () const;
 	void pop ();
 	void push (uint64_t time, std::shared_ptr<nano::block> block);

--- a/nano/node/scheduler/buckets.hpp
+++ b/nano/node/scheduler/buckets.hpp
@@ -41,6 +41,7 @@ class buckets final
 
 	void next ();
 	void seek ();
+	void setup_buckets (uint64_t maximum);
 
 public:
 	buckets (uint64_t maximum = 250000u);

--- a/nano/node/scheduler/buckets.hpp
+++ b/nano/node/scheduler/buckets.hpp
@@ -27,11 +27,7 @@ class bucket;
 class buckets final
 {
 	/** container for the buckets to be read in round robin fashion */
-	std::deque<std::unique_ptr<bucket>> buckets_m;
-
-	/** thresholds that define the bands for each bucket, the minimum balance an account must have to enter a bucket,
-	 *  the container writes a block to the lowest indexed bucket that has balance larger than the bucket's minimum value */
-	std::deque<nano::uint128_t> minimums;
+	std::vector<std::unique_ptr<bucket>> buckets_m;
 
 	/** index of bucket to read next */
 	decltype (buckets_m)::const_iterator current;
@@ -54,7 +50,7 @@ public:
 	std::size_t bucket_size (std::size_t index) const;
 	bool empty () const;
 	void dump () const;
-	std::size_t index (nano::uint128_t const & balance) const;
+	bucket & find_bucket (nano::uint128_t priority);
 
 	std::unique_ptr<nano::container_info_component> collect_container_info (std::string const &);
 };


### PR DESCRIPTION
This combines elements of changes from https://github.com/nanocurrency/nano-node/pull/4626 and https://github.com/nanocurrency/nano-node/pull/4623.

Bucket setup is encapsulated in its own function which cleans up the constructor.

"minimums" container is eliminated and each bucket object holds its minimum range value.
Searching for the bucket is done as a search on a sorted vector which should give the most efficient lookups given the vector contents doesn't change.