### PR TITLE
Optimize `active_elections::notify_observers`

### DIFF
--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -129,7 +129,7 @@ void nano::active_elections::notify_observers (nano::secure::read_transaction co
 {
 	auto block = status.winner;
 	auto account = block->account ();
-	auto amount = node.ledger.any.block_amount (transaction, block->hash ()).value_or (0).number ();
+	auto amount = node.ledger.any.block_amount (transaction, block).value_or (0).number ();
 	auto is_state_send = block->type () == block_type::state && block->is_send ();
 	auto is_state_epoch = block->type () == block_type::state && block->is_epoch ();
 	node.observers.blocks.notify (status, votes, account, amount, is_state_send, is_state_epoch);

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -125,26 +125,42 @@ void nano::active_elections::block_cemented_callback (std::shared_ptr<nano::bloc
 	}
 }
 
-void nano::active_elections::notify_observers (nano::secure::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes)
+void nano::active_elections::notify_observers (nano::secure::transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes) const
 {
 	auto block = status.winner;
 	auto account = block->account ();
-	auto amount = node.ledger.any.block_amount (transaction, block).value_or (0).number ();
-	auto is_state_send = block->type () == block_type::state && block->is_send ();
-	auto is_state_epoch = block->type () == block_type::state && block->is_epoch ();
-	node.observers.blocks.notify (status, votes, account, amount, is_state_send, is_state_epoch);
 
-	if (amount > 0)
+	switch (status.type)
 	{
-		node.observers.account_balance.notify (account, false);
-		if (block->is_send ())
-		{
-			node.observers.account_balance.notify (block->destination (), true);
-		}
+		case nano::election_status_type::active_confirmed_quorum:
+			node.stats.inc (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out);
+			break;
+		case nano::election_status_type::active_confirmation_height:
+			node.stats.inc (nano::stat::type::confirmation_observer, nano::stat::detail::active_conf_height, nano::stat::dir::out);
+			break;
+		case nano::election_status_type::inactive_confirmation_height:
+			node.stats.inc (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out);
+			break;
+		default:
+			break;
+	}
+
+	if (!node.observers.blocks.empty ())
+	{
+		auto amount = node.ledger.any.block_amount (transaction, block).value_or (0).number ();
+		auto is_state_send = block->type () == block_type::state && block->is_send ();
+		auto is_state_epoch = block->type () == block_type::state && block->is_epoch ();
+		node.observers.blocks.notify (status, votes, account, amount, is_state_send, is_state_epoch);
+	}
+
+	node.observers.account_balance.notify (account, false);
+	if (block->is_send ())
+	{
+		node.observers.account_balance.notify (block->destination (), true);
 	}
 }
 
-void nano::active_elections::activate_successors (nano::secure::read_transaction const & transaction, std::shared_ptr<nano::block> const & block)
+void nano::active_elections::activate_successors (nano::secure::transaction const & transaction, std::shared_ptr<nano::block> const & block)
 {
 	node.scheduler.priority.activate (transaction, block->account ());
 

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -39,7 +39,7 @@ class stats;
 }
 namespace nano::secure
 {
-class read_transaction;
+class transaction;
 }
 
 namespace nano
@@ -146,8 +146,8 @@ private:
 	nano::stat::type completion_type (nano::election const & election) const;
 	// Returns a list of elections sorted by difficulty, mutex must be locked
 	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t) const;
-	void activate_successors (nano::secure::read_transaction const & transaction, std::shared_ptr<nano::block> const & block);
-	void notify_observers (nano::secure::read_transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes);
+	void activate_successors (nano::secure::transaction const &, std::shared_ptr<nano::block> const & block);
+	void notify_observers (nano::secure::transaction const &, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes) const;
 
 private: // Dependencies
 	active_elections_config const & config;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -339,24 +339,6 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 			});
 		}
 
-		// Add block confirmation type stats regardless of http-callback and websocket subscriptions
-		observers.blocks.add ([this] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const & votes_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a, bool is_state_epoch_a) {
-			debug_assert (status_a.type != nano::election_status_type::ongoing);
-			switch (status_a.type)
-			{
-				case nano::election_status_type::active_confirmed_quorum:
-					this->stats.inc (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out);
-					break;
-				case nano::election_status_type::active_confirmation_height:
-					this->stats.inc (nano::stat::type::confirmation_observer, nano::stat::detail::active_conf_height, nano::stat::dir::out);
-					break;
-				case nano::election_status_type::inactive_confirmation_height:
-					this->stats.inc (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out);
-					break;
-				default:
-					break;
-			}
-		});
 		observers.endpoint.add ([this] (std::shared_ptr<nano::transport::channel> const & channel_a) {
 			this->network.send_keepalive_self (channel_a);
 		});

--- a/nano/secure/ledger_set_any.cpp
+++ b/nano/secure/ledger_set_any.cpp
@@ -89,12 +89,17 @@ std::optional<nano::amount> nano::ledger_set_any::block_amount (secure::transact
 	{
 		return std::nullopt;
 	}
-	auto block_balance = block_l->balance ();
-	if (block_l->previous ().is_zero ())
+	return block_amount (transaction, block_l);
+}
+
+std::optional<nano::amount> nano::ledger_set_any::block_amount (secure::transaction const & transaction, std::shared_ptr<nano::block> const & block) const
+{
+	auto block_balance = block->balance ();
+	if (block->previous ().is_zero ())
 	{
 		return block_balance.number ();
 	}
-	auto previous_balance = this->block_balance (transaction, block_l->previous ());
+	auto previous_balance = this->block_balance (transaction, block->previous ());
 	if (!previous_balance)
 	{
 		return std::nullopt;

--- a/nano/secure/ledger_set_any.hpp
+++ b/nano/secure/ledger_set_any.hpp
@@ -48,6 +48,7 @@ public: // Operations on accounts
 public: // Operations on blocks
 	std::optional<nano::account> block_account (secure::transaction const & transaction, nano::block_hash const & hash) const;
 	std::optional<nano::amount> block_amount (secure::transaction const & transaction, nano::block_hash const & hash) const;
+	std::optional<nano::amount> block_amount (secure::transaction const & transaction, std::shared_ptr<nano::block> const & block) const;
 	std::optional<nano::amount> block_balance (secure::transaction const & transaction, nano::block_hash const & hash) const;
 	bool block_exists (secure::transaction const & transaction, nano::block_hash const & hash) const;
 	bool block_exists_or_pruned (secure::transaction const & transaction, nano::block_hash const & hash) const;


### PR DESCRIPTION
This avoids a redundant database lookup in `block_amount` call and avoids it altogether in the common case where no websocket observers are configured.