### PR TITLE
Use read/write transaction variant in vote generator

### DIFF
--- a/nano/store/write_queue.hpp
+++ b/nano/store/write_queue.hpp
@@ -14,7 +14,6 @@ enum class writer
 	confirmation_height,
 	process_batch,
 	pruning,
-	voting,
 	voting_final,
 	testing // Used in tests to emulate a write lock
 };


### PR DESCRIPTION
This is a refresh of https://github.com/nanocurrency/nano-node/pull/4321/files. This avoids acquiring a write transaction for non-final vote processing.