### PR TITLE
Add environment variable NANO_MEMORY_INTENSIVE

### DIFF
--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -253,6 +253,11 @@ bool running_within_valgrind ()
 
 bool memory_intensive_instrumentation ()
 {
+	auto env = nano::env::get<bool> ("NANO_MEMORY_INTENSIVE");
+	if (env)
+	{
+		return env.value ();
+	}
 	return is_tsan_build () || nano::running_within_valgrind ();
 }
 


### PR DESCRIPTION
Add environment variable NANO_MEMORY_INTENSIVE to explicitly enable/disable the memory_intensive_instrumentation check.

running_within_valgrind doesn't always play well with arm and there may be other reasons to enable/disable this option.