### PR TITLE
Optimize `vote_cache::collect_container_info`

### DIFF
--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -276,21 +276,8 @@ std::unique_ptr<nano::container_info_component> nano::vote_cache::collect_contai
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 
-	auto count_unique_votes = [this] () {
-		std::unordered_set<std::shared_ptr<nano::vote>> votes;
-		for (auto const & entry : cache)
-		{
-			for (auto const & vote : entry.votes ())
-			{
-				votes.insert (vote);
-			}
-		}
-		return votes.size ();
-	};
-
 	auto composite = std::make_unique<container_info_composite> (name);
 	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "cache", cache.size (), sizeof (ordered_cache::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "unique", count_unique_votes (), sizeof (nano::vote) }));
 	return composite;
 }
 


### PR DESCRIPTION
This single stat was taking unreasonably large chunk of total time spent in container info calls.