### PR TITLE
Fix rocksdb migration

### DIFF
--- a/nano/store/rocksdb/rocksdb.cpp
+++ b/nano/store/rocksdb/rocksdb.cpp
@@ -288,6 +288,15 @@ void nano::store::rocksdb::component::upgrade_v21_to_v22 (store::write_transacti
 void nano::store::rocksdb::component::upgrade_v22_to_v23 (store::write_transaction const & transaction_a)
 {
 	logger.info (nano::log::type::rocksdb, "Upgrading database from v22 to v23...");
+
+	if (!column_family_exists ("rep_weights"))
+	{
+		logger.info (nano::log::type::rocksdb, "Creating table rep_weights");
+		::rocksdb::ColumnFamilyOptions new_cf_options;
+		::rocksdb::ColumnFamilyHandle * new_cf_handle;
+		::rocksdb::Status status = db->CreateColumnFamily (new_cf_options, "rep_weights", &new_cf_handle);
+		handles.emplace_back (new_cf_handle);
+	}
 	auto i{ make_iterator<nano::account, nano::account_info_v22> (transaction_a, tables::accounts) };
 	auto end{ store::iterator<nano::account, nano::account_info_v22> (nullptr) };
 	uint64_t processed_accounts = 0;

--- a/nano/store/rocksdb/rocksdb.cpp
+++ b/nano/store/rocksdb/rocksdb.cpp
@@ -318,10 +318,10 @@ void nano::store::rocksdb::component::upgrade_v22_to_v23 (store::write_transacti
 		processed_accounts++;
 		if (processed_accounts % 250000 == 0)
 		{
-			logger.info (nano::log::type::lmdb, "Processed {} accounts", processed_accounts);
+			logger.info (nano::log::type::rocksdb, "Processed {} accounts", processed_accounts);
 		}
 	}
-	logger.info (nano::log::type::lmdb, "Processed {} accounts", processed_accounts);
+	logger.info (nano::log::type::rocksdb, "Processed {} accounts", processed_accounts);
 	version.put (transaction_a, 23);
 	logger.info (nano::log::type::rocksdb, "Upgrading database from v22 to v23 completed");
 }


### PR DESCRIPTION
Database migrations are currently failing on RocksDb because the rep_weights table does not exist. This PR creates the table if it does not exist.
It also fixes the wrong log types in the same migration