### PR TITLE
migrate_database_lmdb_to_rocksdb improvements

### DIFF
--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -66,6 +66,7 @@ enum class type
 	opencl_work,
 	upnp,
 	rep_crawler,
+	ledger,
 	lmdb,
 	rocksdb,
 	txn_tracker,

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -483,7 +483,6 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 		auto error (false);
 		if (!node.node->init_error ())
 		{
-			std::cout << "Migrating LMDB database to RocksDB, might take a while..." << std::endl;
 			error = node.node->ledger.migrate_lmdb_to_rocksdb (data_path);
 		}
 		else
@@ -491,12 +490,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 			error = true;
 		}
 
-		if (!error)
-		{
-			std::cout << "Migration completed. Make sure to enable RocksDb in the config file under [node.rocksdb]" << std::endl;
-			std::cout << "After confirming correct node operation, the data.ldb file can be deleted if no longer required" << std::endl;
-		}
-		else
+		if (error)
 		{
 			std::cerr << "There was an error migrating" << std::endl;
 		}

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -493,7 +493,8 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 
 		if (!error)
 		{
-			std::cout << "Migration completed, after confirming it is correct the data.ldb file can be deleted if no longer required" << std::endl;
+			std::cout << "Migration completed. Make sure to enable RocksDb in the config file under [node.rocksdb]" << std::endl;
+			std::cout << "After confirming correct node operation, the data.ldb file can be deleted if no longer required" << std::endl;
 		}
 		else
 		{

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1265,7 +1265,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 	// Open rocksdb database
 	nano::rocksdb_config rocksdb_config;
 	rocksdb_config.enable = true;
-	rocksdb_config.memory_multiplier = std::numeric_limits<uint8_t>::max ();
+	//rocksdb_config.memory_multiplier = 4;
 	auto rocksdb_store = nano::make_store (logger, data_path_a, nano::dev::constants, false, true, rocksdb_config);
 
 	if (!rocksdb_store->init_error ())
@@ -1273,7 +1273,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		auto table_size = store.count (store.tx_begin_read (), tables::blocks);
 		logger.info (nano::log::type::ledger, "Step 1 of 7: Converting {} million entries from blocks table", table_size / 1000000);
 		std::atomic<std::size_t> count = 0;
-		auto refresh_interval = 20ms;
+		auto refresh_interval = 100ms;
 		store.block.for_each_par (
 		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::blocks }));

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1241,13 +1241,18 @@ uint64_t nano::ledger::pruning_action (secure::write_transaction & transaction_a
 // A precondition is that the store is an LMDB store
 bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_path_a) const
 {
+	nano::logger logger;
+	nano::logger::initialize (nano::log_config::daemon_default (), data_path_a);
+
+	logger.info (nano::log::type::ledger, "Migrating LMDB database to RocksDB. This will take a while...");
+
 	std::filesystem::space_info si = std::filesystem::space (data_path_a);
 	auto file_size = std::filesystem::file_size (data_path_a / "data.ldb");
 	const auto estimated_required_space = file_size * 0.65; // RocksDb database size is approximately 65% of the lmdb size
 
 	if (si.available < estimated_required_space)
 	{
-		std::cout << "Warning. You may not have enough available disk space. Estimated free space requirement is " << estimated_required_space / 1024 / 1024 / 1024 << " GB" << std::endl;
+		logger.warn (nano::log::type::ledger, "You may not have enough available disk space. Estimated free space requirement is {} GB", estimated_required_space / 1024 / 1024 / 1024);
 	}
 
 	boost::system::error_code error_chmod;
@@ -1255,7 +1260,6 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 	auto rockdb_data_path = data_path_a / "rocksdb";
 	std::filesystem::remove_all (rockdb_data_path);
 
-	nano::logger logger;
 	auto error (false);
 
 	// Open rocksdb database
@@ -1265,11 +1269,11 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 
 	if (!rocksdb_store->init_error ())
 	{
-		std::cout << "Step 1 of 7: Converting blocks table..." << std::endl;
+		logger.info (nano::log::type::ledger, "Step 1 of 7: Converting blocks table");
 		std::size_t count = 0;
 		store.block.for_each_par (
-		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i, ++count)
+		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			for (; i != n; ++i)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::blocks }));
 
@@ -1281,104 +1285,118 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 				}
 				rocksdb_store->block.raw_put (rocksdb_transaction, vector, i->first);
 
-				if (count % 250000 == 0 && count != 0)
+				count++;
+				if (count % 5000000 == 0)
 				{
-					std::cout << "." << std::flush;
+					logger.info (nano::log::type::ledger, "{} million blocks converted", count / 1000000);
 				}
 			}
 		});
 
-		std::cout << "Step 2 of 7: Converting pending table..." << std::endl;
+		logger.info (nano::log::type::ledger, "Finished converting {} blocks", count);
+		logger.info (nano::log::type::ledger, "Step 2 of 7: Converting pending table");
 		count = 0;
 		store.pending.for_each_par (
-		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pending }));
 				rocksdb_store->pending.put (rocksdb_transaction, i->first, i->second);
-				if (count % 250000 == 0 && count != 0)
+				count++;
+				if (count % 500000 == 0)
 				{
-					std::cout << "." << std::flush;
+					logger.info (nano::log::type::ledger, "{} entries converted", count);
 				}
 			}
 		});
 
-		std::cout << "Step 3 of 7: Converting confirmation_height table..." << std::endl;
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
+		logger.info (nano::log::type::ledger, "Step 3 of 7: Converting confirmation_height table");
 		count = 0;
 		store.confirmation_height.for_each_par (
-		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::confirmation_height }));
 				rocksdb_store->confirmation_height.put (rocksdb_transaction, i->first, i->second);
-				if (count % 250000 == 0 && count != 0)
+				count++;
+				if (count % 500000 == 0)
 				{
-					std::cout << "." << std::flush;
+					logger.info (nano::log::type::ledger, "{} entries converted", count);
 				}
 			}
 		});
 
-		std::cout << "Step 4 of 7: Converting accounts height table..." << std::endl;
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
+		logger.info (nano::log::type::ledger, "Step 4 of 7: Converting accounts height table");
 		count = 0;
 		store.account.for_each_par (
-		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::accounts }));
 				rocksdb_store->account.put (rocksdb_transaction, i->first, i->second);
-				if (count % 250000 == 0 && count != 0)
+				count++;
+				if (count % 500000 == 0)
 				{
-					std::cout << "." << std::flush;
+					logger.info (nano::log::type::ledger, "{} entries converted", count);
 				}
 			}
 		});
 
-		std::cout << "Step 5 of 7: Converting rep_weights table..." << std::endl;
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
+		logger.info (nano::log::type::ledger, "Step 5 of 7: Converting rep_weights table");
 		count = 0;
 		store.rep_weight.for_each_par (
-		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::rep_weights }));
 				rocksdb_store->rep_weight.put (rocksdb_transaction, i->first, i->second.number ());
-				if (count % 250000 == 0 && count != 0)
+				count++;
+				if (count % 500000 == 0)
 				{
-					std::cout << "." << std::flush;
+					logger.info (nano::log::type::ledger, "{} entries converted", count);
 				}
 			}
 		});
 
-		std::cout << "Step 6 of 7: Converting pruned table..." << std::endl;
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
+		logger.info (nano::log::type::ledger, "Step 6 of 7: Converting pruned table");
 		count = 0;
 		store.pruned.for_each_par (
-		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pruned }));
 				rocksdb_store->pruned.put (rocksdb_transaction, i->first);
-				if (count % 250000 == 0 && count != 0)
+				count++;
+				if (count % 500000 == 0)
 				{
-					std::cout << "." << std::flush;
+					logger.info (nano::log::type::ledger, "{} entries converted", count);
 				}
 			}
 		});
 
-		std::cout << "Step 7 of 7: Converting final_votes table..." << std::endl;
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
+		logger.info (nano::log::type::ledger, "Step 7 of 7: Converting final_votes table");
 		count = 0;
 		store.final_vote.for_each_par (
-		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::final_votes }));
 				rocksdb_store->final_vote.put (rocksdb_transaction, i->first, i->second);
-				if (count % 250000 == 0 && count != 0)
+				count++;
+				if (count % 500000 == 0)
 				{
-					std::cout << "." << std::flush;
+					logger.info (nano::log::type::ledger, "{} entries converted", count);
 				}
 			}
 		});
+		logger.info (nano::log::type::ledger, "Finished converting {} entries" , count);
 
-		std::cout << "Finalizing migration..." << std::endl;
+		logger.info (nano::log::type::ledger, "Finalizing migration...");
 		auto lmdb_transaction (store.tx_begin_read ());
 		auto version = store.version.get (lmdb_transaction);
 		auto rocksdb_transaction (rocksdb_store->tx_begin_write ());
@@ -1415,6 +1433,9 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		{
 			error |= rocksdb_store->confirmation_height.get (rocksdb_transaction, account, confirmation_height_info);
 		}
+
+		logger.info (nano::log::type::ledger, "Migration completed. Make sure to enable RocksDb in the config file under [node.rocksdb]");
+		logger.info (nano::log::type::ledger, "After confirming correct node operation, the data.ldb file can be deleted if no longer required");
 	}
 	else
 	{

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1265,18 +1265,20 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 	// Open rocksdb database
 	nano::rocksdb_config rocksdb_config;
 	rocksdb_config.enable = true;
+	rocksdb_config.memory_multiplier = std::numeric_limits<uint8_t>::max ();
 	auto rocksdb_store = nano::make_store (logger, data_path_a, nano::dev::constants, false, true, rocksdb_config);
 
 	if (!rocksdb_store->init_error ())
 	{
 		logger.info (nano::log::type::ledger, "Step 1 of 7: Converting blocks table");
 		std::atomic<std::size_t> count = 0;
+		auto refresh_interval = 20ms;
 		store.block.for_each_par (
-		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::blocks }));
 			for (; i != n; ++i)
 			{
-				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::blocks }));
-
+				rocksdb_transaction.refresh_if_needed (refresh_interval);
 				std::vector<uint8_t> vector;
 				{
 					nano::vectorstream stream (vector);
@@ -1296,10 +1298,11 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		logger.info (nano::log::type::ledger, "Step 2 of 7: Converting pending table");
 		count = 0;
 		store.pending.for_each_par (
-		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pending }));
 			for (; i != n; ++i)
 			{
-				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pending }));
+				rocksdb_transaction.refresh_if_needed (refresh_interval);
 				rocksdb_store->pending.put (rocksdb_transaction, i->first, i->second);
 				if (auto count_l = ++count; count_l % 500000 == 0)
 				{
@@ -1312,10 +1315,11 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		logger.info (nano::log::type::ledger, "Step 3 of 7: Converting confirmation_height table");
 		count = 0;
 		store.confirmation_height.for_each_par (
-		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::confirmation_height }));
 			for (; i != n; ++i)
 			{
-				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::confirmation_height }));
+				rocksdb_transaction.refresh_if_needed (refresh_interval);
 				rocksdb_store->confirmation_height.put (rocksdb_transaction, i->first, i->second);
 				if (auto count_l = ++count; count_l % 500000 == 0)
 				{
@@ -1328,10 +1332,11 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		logger.info (nano::log::type::ledger, "Step 4 of 7: Converting accounts table");
 		count = 0;
 		store.account.for_each_par (
-		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::accounts }));
 			for (; i != n; ++i)
 			{
-				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::accounts }));
+				rocksdb_transaction.refresh_if_needed (refresh_interval);
 				rocksdb_store->account.put (rocksdb_transaction, i->first, i->second);
 				if (auto count_l = ++count; count_l % 500000 == 0)
 				{
@@ -1344,10 +1349,11 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		logger.info (nano::log::type::ledger, "Step 5 of 7: Converting rep_weights table");
 		count = 0;
 		store.rep_weight.for_each_par (
-		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::rep_weights }));
 			for (; i != n; ++i)
 			{
-				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::rep_weights }));
+				rocksdb_transaction.refresh_if_needed (refresh_interval);
 				rocksdb_store->rep_weight.put (rocksdb_transaction, i->first, i->second.number ());
 				if (auto count_l = ++count; count_l % 500000 == 0)
 				{
@@ -1360,10 +1366,11 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		logger.info (nano::log::type::ledger, "Step 6 of 7: Converting pruned table");
 		count = 0;
 		store.pruned.for_each_par (
-		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pruned }));
 			for (; i != n; ++i)
 			{
-				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pruned }));
+				rocksdb_transaction.refresh_if_needed (refresh_interval);
 				rocksdb_store->pruned.put (rocksdb_transaction, i->first);
 				if (auto count_l = ++count; count_l % 500000 == 0)
 				{
@@ -1376,10 +1383,11 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		logger.info (nano::log::type::ledger, "Step 7 of 7: Converting final_votes table");
 		count = 0;
 		store.final_vote.for_each_par (
-		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
+		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::final_votes }));
 			for (; i != n; ++i)
 			{
-				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::final_votes }));
+				rocksdb_transaction.refresh_if_needed (refresh_interval);
 				rocksdb_store->final_vote.put (rocksdb_transaction, i->first, i->second);
 				if (auto count_l = ++count; count_l % 500000 == 0)
 				{

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1394,7 +1394,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 				}
 			}
 		});
-		logger.info (nano::log::type::ledger, "Finished converting {} entries" , count);
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
 
 		logger.info (nano::log::type::ledger, "Finalizing migration...");
 		auto lmdb_transaction (store.tx_begin_read ());

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1242,11 +1242,12 @@ uint64_t nano::ledger::pruning_action (secure::write_transaction & transaction_a
 bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_path_a) const
 {
 	std::filesystem::space_info si = std::filesystem::space (data_path_a);
+	auto file_size = std::filesystem::file_size (data_path_a / "data.ldb");
+	const auto estimated_required_space = file_size * 0.65; // RocksDb database size is approximately 65% of the lmdb size
 
-	const uintmax_t required_space = 75ull * 1024 * 1024 * 1024; // 75 GB
-	if (si.available < required_space)
+	if (si.available < estimated_required_space)
 	{
-		std::cout << "Warning. You may not have enough available disk space. An estimated 75 GB of free space is required" << std::endl;
+		std::cout << "Warning. You may not have enough available disk space. Estimated free space requirement is " << estimated_required_space / 1024 / 1024 / 1024 << " GB" << std::endl;
 	}
 
 	boost::system::error_code error_chmod;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1241,6 +1241,14 @@ uint64_t nano::ledger::pruning_action (secure::write_transaction & transaction_a
 // A precondition is that the store is an LMDB store
 bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_path_a) const
 {
+	std::filesystem::space_info si = std::filesystem::space (data_path_a);
+
+	const uintmax_t required_space = 75ull * 1024 * 1024 * 1024; // 75 GB
+	if (si.available < required_space)
+	{
+		std::cout << "Warning. You may not have enough available disk space. An estimated 75 GB of free space is required" << std::endl;
+	}
+
 	boost::system::error_code error_chmod;
 	nano::set_secure_perm_directory (data_path_a, error_chmod);
 	auto rockdb_data_path = data_path_a / "rocksdb";
@@ -1256,6 +1264,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 
 	if (!rocksdb_store->init_error ())
 	{
+		std::cout << "Step 1 of 7: Converting blocks table..." << std::endl;
 		store.block.for_each_par (
 		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i)
@@ -1272,6 +1281,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			}
 		});
 
+		std::cout << "Step 2 of 7: Converting pending table..." << std::endl;
 		store.pending.for_each_par (
 		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i)
@@ -1281,6 +1291,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			}
 		});
 
+		std::cout << "Step 3 of 7: Converting confirmation_height table..." << std::endl;
 		store.confirmation_height.for_each_par (
 		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i)
@@ -1290,6 +1301,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			}
 		});
 
+		std::cout << "Step 4 of 7: Converting accounts height table..." << std::endl;
 		store.account.for_each_par (
 		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i)
@@ -1299,6 +1311,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			}
 		});
 
+		std::cout << "Step 5 of 7: Converting rep_weights table..." << std::endl;
 		store.rep_weight.for_each_par (
 		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i)
@@ -1308,6 +1321,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			}
 		});
 
+		std::cout << "Step 6 of 7: Converting pruned table..." << std::endl;
 		store.pruned.for_each_par (
 		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i)
@@ -1317,6 +1331,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			}
 		});
 
+		std::cout << "Step 7 of 7: Converting final_votes table..." << std::endl;
 		store.final_vote.for_each_par (
 		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i)

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1270,7 +1270,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 	if (!rocksdb_store->init_error ())
 	{
 		auto table_size = store.count (store.tx_begin_read (), tables::blocks);
-		logger.info (nano::log::type::ledger, "Step 1 of 7: Converting {} million entries from blocks table", table_size / 1000000);
+		logger.info (nano::log::type::ledger, "Step 1 of 7: Converting {} entries from blocks table", table_size);
 		std::atomic<std::size_t> count = 0;
 		store.block.for_each_par (
 		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
@@ -1288,7 +1288,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 
 				if (auto count_l = ++count; count_l % 5000000 == 0)
 				{
-					logger.info (nano::log::type::ledger, "{} million blocks converted", count_l / 1000000);
+					logger.info (nano::log::type::ledger, "{} blocks converted", count_l);
 				}
 			}
 		});
@@ -1330,8 +1330,8 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		});
 		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
 
-		table_size = store.count (store.tx_begin_read (), tables::confirmation_height);
-		logger.info (nano::log::type::ledger, "Step 4 of 7: Converting {} entries from confirmation_height table", table_size);
+		table_size = store.count (store.tx_begin_read (), tables::accounts);
+		logger.info (nano::log::type::ledger, "Step 4 of 7: Converting {} entries from accounts table", table_size);
 		count = 0;
 		store.account.for_each_par (
 		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
@@ -1392,7 +1392,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::final_votes }));
 			for (; i != n; ++i)
 			{
-				rocksdb_transaction.refresh_if_needed (refresh_interval);
+				rocksdb_transaction.refresh_if_needed ();
 				rocksdb_store->final_vote.put (rocksdb_transaction, i->first, i->second);
 				if (auto count_l = ++count; count_l % 500000 == 0)
 				{

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1298,7 +1298,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		count = 0;
 		store.pending.for_each_par (
 		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i, ++count)
+			for (; i != n; ++i)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pending }));
 				rocksdb_store->pending.put (rocksdb_transaction, i->first, i->second);
@@ -1315,7 +1315,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		count = 0;
 		store.confirmation_height.for_each_par (
 		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i, ++count)
+			for (; i != n; ++i)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::confirmation_height }));
 				rocksdb_store->confirmation_height.put (rocksdb_transaction, i->first, i->second);
@@ -1328,11 +1328,11 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		});
 
 		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
-		logger.info (nano::log::type::ledger, "Step 4 of 7: Converting accounts height table");
+		logger.info (nano::log::type::ledger, "Step 4 of 7: Converting accounts table");
 		count = 0;
 		store.account.for_each_par (
 		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i, ++count)
+			for (; i != n; ++i)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::accounts }));
 				rocksdb_store->account.put (rocksdb_transaction, i->first, i->second);
@@ -1349,7 +1349,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		count = 0;
 		store.rep_weight.for_each_par (
 		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i, ++count)
+			for (; i != n; ++i)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::rep_weights }));
 				rocksdb_store->rep_weight.put (rocksdb_transaction, i->first, i->second.number ());
@@ -1366,7 +1366,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		count = 0;
 		store.pruned.for_each_par (
 		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i, ++count)
+			for (; i != n; ++i)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pruned }));
 				rocksdb_store->pruned.put (rocksdb_transaction, i->first);
@@ -1383,7 +1383,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		count = 0;
 		store.final_vote.for_each_par (
 		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i, ++count)
+			for (; i != n; ++i)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::final_votes }));
 				rocksdb_store->final_vote.put (rocksdb_transaction, i->first, i->second);

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1266,9 +1266,10 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 	if (!rocksdb_store->init_error ())
 	{
 		std::cout << "Step 1 of 7: Converting blocks table..." << std::endl;
+		std::size_t count = 0;
 		store.block.for_each_par (
-		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i)
+		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::blocks }));
 
@@ -1279,69 +1280,105 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 					i->second.sideband.serialize (stream, i->second.block->type ());
 				}
 				rocksdb_store->block.raw_put (rocksdb_transaction, vector, i->first);
+
+				if (count % 250000 == 0 && count != 0)
+				{
+					std::cout << "." << std::flush;
+				}
 			}
 		});
 
 		std::cout << "Step 2 of 7: Converting pending table..." << std::endl;
+		count = 0;
 		store.pending.for_each_par (
-		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i)
+		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pending }));
 				rocksdb_store->pending.put (rocksdb_transaction, i->first, i->second);
+				if (count % 250000 == 0 && count != 0)
+				{
+					std::cout << "." << std::flush;
+				}
 			}
 		});
 
 		std::cout << "Step 3 of 7: Converting confirmation_height table..." << std::endl;
+		count = 0;
 		store.confirmation_height.for_each_par (
-		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i)
+		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::confirmation_height }));
 				rocksdb_store->confirmation_height.put (rocksdb_transaction, i->first, i->second);
+				if (count % 250000 == 0 && count != 0)
+				{
+					std::cout << "." << std::flush;
+				}
 			}
 		});
 
 		std::cout << "Step 4 of 7: Converting accounts height table..." << std::endl;
+		count = 0;
 		store.account.for_each_par (
-		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i)
+		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::accounts }));
 				rocksdb_store->account.put (rocksdb_transaction, i->first, i->second);
+				if (count % 250000 == 0 && count != 0)
+				{
+					std::cout << "." << std::flush;
+				}
 			}
 		});
 
 		std::cout << "Step 5 of 7: Converting rep_weights table..." << std::endl;
+		count = 0;
 		store.rep_weight.for_each_par (
-		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i)
+		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::rep_weights }));
 				rocksdb_store->rep_weight.put (rocksdb_transaction, i->first, i->second.number ());
+				if (count % 250000 == 0 && count != 0)
+				{
+					std::cout << "." << std::flush;
+				}
 			}
 		});
 
 		std::cout << "Step 6 of 7: Converting pruned table..." << std::endl;
+		count = 0;
 		store.pruned.for_each_par (
-		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i)
+		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pruned }));
 				rocksdb_store->pruned.put (rocksdb_transaction, i->first);
+				if (count % 250000 == 0 && count != 0)
+				{
+					std::cout << "." << std::flush;
+				}
 			}
 		});
 
 		std::cout << "Step 7 of 7: Converting final_votes table..." << std::endl;
+		count = 0;
 		store.final_vote.for_each_par (
-		[&rocksdb_store] (store::read_transaction const & /*unused*/, auto i, auto n) {
-			for (; i != n; ++i)
+		[&rocksdb_store, &count] (store::read_transaction const & /*unused*/, auto i, auto n) {
+			for (; i != n; ++i, ++count)
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::final_votes }));
 				rocksdb_store->final_vote.put (rocksdb_transaction, i->first, i->second);
+				if (count % 250000 == 0 && count != 0)
+				{
+					std::cout << "." << std::flush;
+				}
 			}
 		});
 
+		std::cout << "Finalizing migration..." << std::endl;
 		auto lmdb_transaction (store.tx_begin_read ());
 		auto version = store.version.get (lmdb_transaction);
 		auto rocksdb_transaction (rocksdb_store->tx_begin_write ());

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1270,7 +1270,8 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 
 	if (!rocksdb_store->init_error ())
 	{
-		logger.info (nano::log::type::ledger, "Step 1 of 7: Converting blocks table");
+		auto table_size = store.count (store.tx_begin_read (), tables::blocks);
+		logger.info (nano::log::type::ledger, "Step 1 of 7: Converting {} million entries from blocks table", table_size / 1000000);
 		std::atomic<std::size_t> count = 0;
 		auto refresh_interval = 20ms;
 		store.block.for_each_par (
@@ -1293,9 +1294,10 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 				}
 			}
 		});
-
 		logger.info (nano::log::type::ledger, "Finished converting {} blocks", count.load ());
-		logger.info (nano::log::type::ledger, "Step 2 of 7: Converting pending table");
+
+		table_size = store.count (store.tx_begin_read (), tables::pending);
+		logger.info (nano::log::type::ledger, "Step 2 of 7: Converting {} entries from pending table", table_size);
 		count = 0;
 		store.pending.for_each_par (
 		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
@@ -1310,9 +1312,10 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 				}
 			}
 		});
-
 		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
-		logger.info (nano::log::type::ledger, "Step 3 of 7: Converting confirmation_height table");
+
+		table_size = store.count (store.tx_begin_read (), tables::confirmation_height);
+		logger.info (nano::log::type::ledger, "Step 3 of 7: Converting {} entries from confirmation_height table", table_size);
 		count = 0;
 		store.confirmation_height.for_each_par (
 		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
@@ -1327,9 +1330,10 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 				}
 			}
 		});
-
 		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
-		logger.info (nano::log::type::ledger, "Step 4 of 7: Converting accounts table");
+
+		table_size = store.count (store.tx_begin_read (), tables::confirmation_height);
+		logger.info (nano::log::type::ledger, "Step 4 of 7: Converting {} entries from confirmation_height table", table_size);
 		count = 0;
 		store.account.for_each_par (
 		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
@@ -1344,9 +1348,10 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 				}
 			}
 		});
-
 		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
-		logger.info (nano::log::type::ledger, "Step 5 of 7: Converting rep_weights table");
+
+		table_size = store.count (store.tx_begin_read (), tables::rep_weights);
+		logger.info (nano::log::type::ledger, "Step 5 of 7: Converting {} entries from rep_weights table", table_size);
 		count = 0;
 		store.rep_weight.for_each_par (
 		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
@@ -1361,9 +1366,10 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 				}
 			}
 		});
-
 		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
-		logger.info (nano::log::type::ledger, "Step 6 of 7: Converting pruned table");
+
+		table_size = store.count (store.tx_begin_read (), tables::pruned);
+		logger.info (nano::log::type::ledger, "Step 6 of 7: Converting {} entries from pruned table", table_size);
 		count = 0;
 		store.pruned.for_each_par (
 		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {
@@ -1378,9 +1384,10 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 				}
 			}
 		});
-
 		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
-		logger.info (nano::log::type::ledger, "Step 7 of 7: Converting final_votes table");
+
+		table_size = store.count (store.tx_begin_read (), tables::final_votes);
+		logger.info (nano::log::type::ledger, "Step 7 of 7: Converting {} entries from final_votes table", table_size);
 		count = 0;
 		store.final_vote.for_each_par (
 		[&] (store::read_transaction const & /*unused*/, auto i, auto n) {

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1270,7 +1270,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 	if (!rocksdb_store->init_error ())
 	{
 		logger.info (nano::log::type::ledger, "Step 1 of 7: Converting blocks table");
-		std::size_t count = 0;
+		std::atomic<std::size_t> count = 0;
 		store.block.for_each_par (
 		[&rocksdb_store, &count, &logger] (store::read_transaction const & /*unused*/, auto i, auto n) {
 			for (; i != n; ++i)
@@ -1285,15 +1285,14 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 				}
 				rocksdb_store->block.raw_put (rocksdb_transaction, vector, i->first);
 
-				count++;
-				if (count % 5000000 == 0)
+				if (auto count_l = ++count; count_l % 5000000 == 0)
 				{
-					logger.info (nano::log::type::ledger, "{} million blocks converted", count / 1000000);
+					logger.info (nano::log::type::ledger, "{} million blocks converted", count_l / 1000000);
 				}
 			}
 		});
 
-		logger.info (nano::log::type::ledger, "Finished converting {} blocks", count);
+		logger.info (nano::log::type::ledger, "Finished converting {} blocks", count.load ());
 		logger.info (nano::log::type::ledger, "Step 2 of 7: Converting pending table");
 		count = 0;
 		store.pending.for_each_par (
@@ -1302,15 +1301,14 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pending }));
 				rocksdb_store->pending.put (rocksdb_transaction, i->first, i->second);
-				count++;
-				if (count % 500000 == 0)
+				if (auto count_l = ++count; count_l % 500000 == 0)
 				{
-					logger.info (nano::log::type::ledger, "{} entries converted", count);
+					logger.info (nano::log::type::ledger, "{} entries converted", count_l);
 				}
 			}
 		});
 
-		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
 		logger.info (nano::log::type::ledger, "Step 3 of 7: Converting confirmation_height table");
 		count = 0;
 		store.confirmation_height.for_each_par (
@@ -1319,15 +1317,14 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::confirmation_height }));
 				rocksdb_store->confirmation_height.put (rocksdb_transaction, i->first, i->second);
-				count++;
-				if (count % 500000 == 0)
+				if (auto count_l = ++count; count_l % 500000 == 0)
 				{
-					logger.info (nano::log::type::ledger, "{} entries converted", count);
+					logger.info (nano::log::type::ledger, "{} entries converted", count_l);
 				}
 			}
 		});
 
-		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
 		logger.info (nano::log::type::ledger, "Step 4 of 7: Converting accounts table");
 		count = 0;
 		store.account.for_each_par (
@@ -1336,15 +1333,14 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::accounts }));
 				rocksdb_store->account.put (rocksdb_transaction, i->first, i->second);
-				count++;
-				if (count % 500000 == 0)
+				if (auto count_l = ++count; count_l % 500000 == 0)
 				{
-					logger.info (nano::log::type::ledger, "{} entries converted", count);
+					logger.info (nano::log::type::ledger, "{} entries converted", count_l);
 				}
 			}
 		});
 
-		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
 		logger.info (nano::log::type::ledger, "Step 5 of 7: Converting rep_weights table");
 		count = 0;
 		store.rep_weight.for_each_par (
@@ -1353,15 +1349,14 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::rep_weights }));
 				rocksdb_store->rep_weight.put (rocksdb_transaction, i->first, i->second.number ());
-				count++;
-				if (count % 500000 == 0)
+				if (auto count_l = ++count; count_l % 500000 == 0)
 				{
-					logger.info (nano::log::type::ledger, "{} entries converted", count);
+					logger.info (nano::log::type::ledger, "{} entries converted", count_l);
 				}
 			}
 		});
 
-		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
 		logger.info (nano::log::type::ledger, "Step 6 of 7: Converting pruned table");
 		count = 0;
 		store.pruned.for_each_par (
@@ -1370,15 +1365,14 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::pruned }));
 				rocksdb_store->pruned.put (rocksdb_transaction, i->first);
-				count++;
-				if (count % 500000 == 0)
+				if (auto count_l = ++count; count_l % 500000 == 0)
 				{
-					logger.info (nano::log::type::ledger, "{} entries converted", count);
+					logger.info (nano::log::type::ledger, "{} entries converted", count_l);
 				}
 			}
 		});
 
-		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
 		logger.info (nano::log::type::ledger, "Step 7 of 7: Converting final_votes table");
 		count = 0;
 		store.final_vote.for_each_par (
@@ -1387,14 +1381,13 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			{
 				auto rocksdb_transaction (rocksdb_store->tx_begin_write ({}, { nano::tables::final_votes }));
 				rocksdb_store->final_vote.put (rocksdb_transaction, i->first, i->second);
-				count++;
-				if (count % 500000 == 0)
+				if (auto count_l = ++count; count_l % 500000 == 0)
 				{
-					logger.info (nano::log::type::ledger, "{} entries converted", count);
+					logger.info (nano::log::type::ledger, "{} entries converted", count_l);
 				}
 			}
 		});
-		logger.info (nano::log::type::ledger, "Finished converting {} entries", count);
+		logger.info (nano::log::type::ledger, "Finished converting {} entries", count.load ());
 
 		logger.info (nano::log::type::ledger, "Finalizing migration...");
 		auto lmdb_transaction (store.tx_begin_read ());


### PR DESCRIPTION
The `migrate_database_lmdb_to_rocksdb` option is running for a very long time with the current ledger size (almost 200 million blocks). On my local machine it took 65 minutes to complete. Nothing is written on screen during this process and users may think the process has stalled.
This PR adds some progress feedback. One update for each of the 7 tables that are migrated.
It also adds a simple disk space check to warn users if they might not have enough space to complete the migration.
~~The current converted RocksDb database is 73 GB, and the warning is given if the system has less than 75GB available.~~
The warning is given based on the size of the LMDB database that is being migrated. The final RocksDb size is approximately 65% of the LMDB space.