### PR TITLE
Configurable maximum votes per message

### DIFF
--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -44,7 +44,7 @@ TEST (confirmation_solicitor, batches)
 	send->sideband_set ({});
 	{
 		nano::lock_guard<nano::mutex> guard (node2.active.mutex);
-		for (size_t i (0); i < nano::network::confirm_req_hashes_max; ++i)
+		for (size_t i (0); i < node2.config.confirm_req_hashes_max; ++i)
 		{
 			auto election (std::make_shared<nano::election> (node2, send, nullptr, nullptr, nano::election_behavior::priority));
 			ASSERT_FALSE (solicitor.add (*election));

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -147,7 +147,7 @@ TEST (message, confirm_header_flags_max)
 TEST (message, confirm_ack_hash_serialization)
 {
 	std::vector<nano::block_hash> hashes;
-	for (auto i (hashes.size ()); i < nano::network::confirm_ack_hashes_max; i++)
+	for (auto i (hashes.size ()); i < 12; i++)
 	{
 		nano::keypair key1;
 		nano::block_hash previous;

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -255,9 +255,9 @@ TEST (request_aggregator, two_endpoints)
 
 TEST (request_aggregator, split)
 {
-	constexpr size_t max_vbh = nano::network::confirm_ack_hashes_max;
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
+	size_t max_vbh = node_config.confirm_ack_hashes_max;
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
 	auto & node (*system.add_node (node_config));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -98,7 +98,7 @@ void nano::confirmation_solicitor::flush ()
 		for (auto const & root_hash : request_queue.second)
 		{
 			roots_hashes_l.push_back (root_hash);
-			if (roots_hashes_l.size () == nano::network::confirm_req_hashes_max)
+			if (roots_hashes_l.size () == config.confirm_req_hashes_max)
 			{
 				nano::confirm_req req{ config.network_params.network, roots_hashes_l };
 				channel->send (req);

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -166,9 +166,6 @@ private:
 public:
 	static unsigned const broadcast_interval_ms = 10;
 	static std::size_t const buffer_size = 512;
-
-	static std::size_t const confirm_req_hashes_max = 7;
-	static std::size_t const confirm_ack_hashes_max = 12;
 };
 
 std::unique_ptr<container_info_component> collect_container_info (network & network, std::string const & name);

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -120,6 +120,8 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("vote_minimum", vote_minimum.to_string_dec (), "Local representatives do not vote if the delegated weight is under this threshold. Saves on system resources.\ntype:string,amount,raw");
 	toml.put ("vote_generator_delay", vote_generator_delay.count (), "Delay before votes are sent to allow for efficient bundling of hashes in votes.\ntype:milliseconds");
 	toml.put ("vote_generator_threshold", vote_generator_threshold, "Number of bundled hashes required for an additional generator delay.\ntype:uint64,[1..11]");
+	toml.put ("confirm_req_hashes_max", confirm_req_hashes_max, "Maximum number of votes per message requested. Defaults to 7. Maximum is 255 \ntype:uint64,[1.255]");
+	toml.put ("confirm_ack_hashes_max", confirm_ack_hashes_max, "Maximum number of votes per message broadcasted. Defaults to 12. Maximum is 255 \ntype:uint64,[1.255]");
 	toml.put ("unchecked_cutoff_time", unchecked_cutoff_time.count (), "Number of seconds before deleting an unchecked entry.\nWarning: lower values (e.g., 3600 seconds, or 1 hour) may result in unsuccessful bootstraps, especially a bootstrap from scratch.\ntype:seconds");
 	toml.put ("tcp_io_timeout", tcp_io_timeout.count (), "Timeout for TCP connect-, read- and write operations.\nWarning: a low value (e.g., below 5 seconds) may result in TCP connections failing.\ntype:seconds");
 	toml.put ("pow_sleep_interval", pow_sleep_interval.count (), "Time to sleep between batch work generation attempts. Reduces max CPU usage at the expense of a longer generation time.\ntype:nanoseconds");
@@ -444,6 +446,18 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		vote_generator_delay = std::chrono::milliseconds (delay_l);
 
 		toml.get<unsigned> ("vote_generator_threshold", vote_generator_threshold);
+
+		toml.get<std::size_t> ("confirm_req_hashes_max", confirm_req_hashes_max);
+		if (confirm_req_hashes_max < 1 || confirm_req_hashes_max > 255)
+		{
+			toml.get_error ().set ("confirm_req_hashes_max must be a number between 1 and 255");
+		}
+
+		toml.get<std::size_t> ("confirm_ack_hashes_max", confirm_ack_hashes_max);
+		if (confirm_ack_hashes_max < 1 || confirm_ack_hashes_max > 255)
+		{
+			toml.get_error ().set ("confirm_ack_hashes_max must be a number between 1 and 255");
+		}
 
 		auto block_processor_batch_max_time_l = block_processor_batch_max_time.count ();
 		toml.get ("block_processor_batch_max_time", block_processor_batch_max_time_l);

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -78,6 +78,8 @@ public:
 	nano::amount rep_crawler_weight_minimum{ "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" };
 	std::chrono::milliseconds vote_generator_delay{ std::chrono::milliseconds (100) };
 	unsigned vote_generator_threshold{ 3 };
+	std::size_t confirm_req_hashes_max = 7;
+	std::size_t confirm_ack_hashes_max = 12;
 	nano::amount online_weight_minimum{ 60000 * nano::Gxrb_ratio };
 	/*
 	 * The minimum vote weight that a representative must have for its vote to be counted.

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -136,7 +136,7 @@ void nano::vote_generator::process_batch (std::deque<queue_entry_t> & batch)
 	{
 		nano::unique_lock<nano::mutex> lock{ mutex };
 		candidates.insert (candidates.end (), verified.begin (), verified.end ());
-		if (candidates.size () >= nano::network::confirm_ack_hashes_max)
+		if (candidates.size () >= config.confirm_ack_hashes_max)
 		{
 			lock.unlock ();
 			condition.notify_all ();
@@ -181,9 +181,10 @@ void nano::vote_generator::broadcast (nano::unique_lock<nano::mutex> & lock_a)
 
 	std::vector<nano::block_hash> hashes;
 	std::vector<nano::root> roots;
-	hashes.reserve (nano::network::confirm_ack_hashes_max);
-	roots.reserve (nano::network::confirm_ack_hashes_max);
-	while (!candidates.empty () && hashes.size () < nano::network::confirm_ack_hashes_max)
+	hashes.reserve (config.confirm_ack_hashes_max);
+	roots.reserve (config.confirm_ack_hashes_max);
+
+	while (!candidates.empty () && hashes.size () < config.confirm_ack_hashes_max)
 	{
 		auto const & [root, hash] = candidates.front ();
 		if (std::find (roots.begin (), roots.end (), root) == roots.end ())
@@ -220,9 +221,9 @@ void nano::vote_generator::reply (nano::unique_lock<nano::mutex> & lock_a, reque
 	{
 		std::vector<nano::block_hash> hashes;
 		std::vector<nano::root> roots;
-		hashes.reserve (nano::network::confirm_ack_hashes_max);
-		roots.reserve (nano::network::confirm_ack_hashes_max);
-		for (; i != n && hashes.size () < nano::network::confirm_ack_hashes_max; ++i)
+		hashes.reserve (config.confirm_ack_hashes_max);
+		roots.reserve (config.confirm_ack_hashes_max);
+		for (; i != n && hashes.size () < config.confirm_ack_hashes_max; ++i)
 		{
 			auto const & [root, hash] = *i;
 			if (std::find (roots.begin (), roots.end (), root) == roots.end ())
@@ -284,7 +285,7 @@ void nano::vote_generator::run ()
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped)
 	{
-		if (candidates.size () >= nano::network::confirm_ack_hashes_max)
+		if (candidates.size () >= config.confirm_ack_hashes_max)
 		{
 			broadcast (lock);
 		}
@@ -296,10 +297,10 @@ void nano::vote_generator::run ()
 		}
 		else
 		{
-			condition.wait_for (lock, config.vote_generator_delay, [this] () { return this->candidates.size () >= nano::network::confirm_ack_hashes_max; });
-			if (candidates.size () >= config.vote_generator_threshold && candidates.size () < nano::network::confirm_ack_hashes_max)
+			condition.wait_for (lock, config.vote_generator_delay, [this] () { return this->candidates.size () >= config.confirm_ack_hashes_max; });
+			if (candidates.size () >= config.vote_generator_threshold && candidates.size () < config.confirm_ack_hashes_max)
 			{
-				condition.wait_for (lock, config.vote_generator_delay, [this] () { return this->candidates.size () >= nano::network::confirm_ack_hashes_max; });
+				condition.wait_for (lock, config.vote_generator_delay, [this] () { return this->candidates.size () >= config.confirm_ack_hashes_max; });
 			}
 			if (!candidates.empty ())
 			{


### PR DESCRIPTION
Makes confirm_req_hashes_max and confirm_ack_hashes_max configurable.
Defaults are kept at 7 and 12.
In `confirm_ack_hash_serialization` unit test, confirm_ack_hashes_max has been hardcoded to 12 to specifically verify v1 votes serialization. There is a v2 serialization right after that tests v2 vote serialization (255 votes)