### PR TITLE
Bundle ledger transaction and write guard into a single object

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -1,7 +1,6 @@
-#include "nano/lib/numbers.hpp"
-
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/logging.hpp>
+#include <nano/lib/numbers.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/node/active_elections.hpp>
@@ -5643,4 +5642,92 @@ TEST (ledger_receivable, any_one)
 	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (ctx.ledger ().tx_begin_write (), send1));
 	ASSERT_TRUE (ctx.ledger ().any.receivable_exists (ctx.ledger ().tx_begin_read (), nano::dev::genesis_key.pub));
 	ASSERT_FALSE (ctx.ledger ().any.receivable_exists (ctx.ledger ().tx_begin_read (), key.pub));
+}
+
+TEST (ledger_transaction, write_refresh)
+{
+	auto ctx = nano::test::context::ledger_empty ();
+	nano::block_builder builder;
+	nano::keypair key;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis_key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*ctx.pool ().generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio)
+				 .link (key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*ctx.pool ().generate (send1->hash ()))
+				 .build ();
+
+	auto transaction = ctx.ledger ().tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (transaction, send1));
+	// Force refresh
+	ASSERT_TRUE (transaction.refresh_if_needed (0ms));
+	ASSERT_FALSE (transaction.refresh_if_needed ()); // Should not refresh again too soon
+	// Refreshed transaction should work just fine
+	ASSERT_EQ (nano::block_status::progress, ctx.ledger ().process (transaction, send2));
+}
+
+TEST (ledger_transaction, write_wait_order)
+{
+	nano::test::system system;
+
+	auto ctx = nano::test::context::ledger_empty ();
+
+	std::atomic<bool> acquired1{ false };
+	std::atomic<bool> acquired2{ false };
+	std::atomic<bool> acquired3{ false };
+
+	std::latch latch1{ 1 };
+	std::latch latch2{ 1 };
+	std::latch latch3{ 1 };
+
+	auto fut1 = std::async (std::launch::async, [&] {
+		auto tx = ctx.ledger ().tx_begin_write ({}, nano::store::writer::generic);
+		acquired1 = true;
+		latch1.wait (); // Wait for the signal to drop tx
+	});
+	WAIT (250ms); // Allow thread to start
+
+	auto fut2 = std::async (std::launch::async, [&ctx, &acquired2, &latch2] {
+		auto tx = ctx.ledger ().tx_begin_write ({}, nano::store::writer::blockprocessor);
+		acquired2 = true;
+		latch2.wait (); // Wait for the signal to drop tx
+	});
+	WAIT (250ms); // Allow thread to start
+
+	auto fut3 = std::async (std::launch::async, [&ctx, &acquired3, &latch3] {
+		auto tx = ctx.ledger ().tx_begin_write ({}, nano::store::writer::confirmation_height);
+		acquired3 = true;
+		latch3.wait (); // Wait for the signal to drop tx
+	});
+	WAIT (250ms); // Allow thread to start
+
+	// First transaction should be ready immediately, others should be waiting
+	ASSERT_TIMELY (5s, acquired1.load ());
+	ASSERT_NEVER (250ms, acquired2.load ());
+	ASSERT_NEVER (250ms, acquired3.load ());
+
+	// Signal to continue and drop the first transaction
+	latch1.count_down ();
+	ASSERT_TIMELY (5s, acquired2.load ());
+	ASSERT_NEVER (250ms, acquired3.load ());
+
+	// Signal to continue and drop the second transaction
+	latch2.count_down ();
+	ASSERT_TIMELY (5s, acquired3.load ());
+
+	// Signal to continue and drop the third transaction
+	latch3.count_down ();
 }

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -295,8 +295,7 @@ auto nano::block_processor::process_batch (nano::unique_lock<nano::mutex> & lock
 {
 	processed_batch_t processed;
 
-	auto scoped_write_guard = node.store.write_queue.wait (nano::store::writer::process_batch);
-	auto transaction = node.ledger.tx_begin_write ({ tables::accounts, tables::blocks, tables::pending, tables::rep_weights });
+	auto transaction = node.ledger.tx_begin_write ({ tables::accounts, tables::blocks, tables::pending, tables::rep_weights }, nano::store::writer::blockprocessor);
 	nano::timer<std::chrono::milliseconds> timer_l;
 
 	lock_a.lock ();

--- a/nano/node/confirming_set.cpp
+++ b/nano/node/confirming_set.cpp
@@ -133,13 +133,13 @@ void nano::confirming_set::run_batch (std::unique_lock<std::mutex> & lock)
 	lock.unlock ();
 
 	{
-		// TODO: Properly limiting batch times requires this <guard, transaction> combo to be wrapped in a single object that provides refresh functionality
-		auto guard = ledger.store.write_queue.wait (nano::store::writer::confirmation_height);
-		auto tx = ledger.tx_begin_write ({ nano::tables::confirmation_height });
+		auto transaction = ledger.tx_begin_write ({ nano::tables::confirmation_height }, nano::store::writer::confirmation_height);
 
 		for (auto const & hash : batch)
 		{
-			auto added = ledger.confirm (tx, hash);
+			transaction.refresh_if_needed ();
+
+			auto added = ledger.confirm (transaction, hash);
 			if (!added.empty ())
 			{
 				// Confirming this block may implicitly confirm more

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -617,7 +617,7 @@ void nano::node::process_active (std::shared_ptr<nano::block> const & incoming)
 
 nano::block_status nano::node::process (std::shared_ptr<nano::block> block)
 {
-	auto const transaction = ledger.tx_begin_write ({ tables::accounts, tables::blocks, tables::pending, tables::rep_weights });
+	auto const transaction = ledger.tx_begin_write ({ tables::accounts, tables::blocks, tables::pending, tables::rep_weights }, nano::store::writer::node);
 	return process (transaction, block);
 }
 
@@ -1033,8 +1033,7 @@ void nano::node::ledger_pruning (uint64_t const batch_size_a, bool bootstrap_wei
 		transaction_write_count = 0;
 		if (!pruning_targets.empty () && !stopped)
 		{
-			auto scoped_write_guard = store.write_queue.wait (nano::store::writer::pruning);
-			auto write_transaction = ledger.tx_begin_write ({ tables::blocks, tables::pruned });
+			auto write_transaction = ledger.tx_begin_write ({ tables::blocks, tables::pruned }, nano::store::writer::pruning);
 			while (!pruning_targets.empty () && transaction_write_count < batch_size_a && !stopped)
 			{
 				auto const & pruning_hash (pruning_targets.front ());

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -732,9 +732,11 @@ nano::ledger::~ledger ()
 {
 }
 
-auto nano::ledger::tx_begin_write (std::vector<nano::tables> const & tables_to_lock, std::vector<nano::tables> const & tables_no_lock) const -> secure::write_transaction
+auto nano::ledger::tx_begin_write (std::vector<nano::tables> const & tables_to_lock, nano::store::writer guard_type) const -> secure::write_transaction
 {
-	return secure::write_transaction{ store.tx_begin_write (tables_to_lock, tables_no_lock) };
+	auto guard = store.write_queue.wait (guard_type);
+	auto txn = store.tx_begin_write (tables_to_lock);
+	return secure::write_transaction{ std::move (txn), std::move (guard) };
 }
 
 auto nano::ledger::tx_begin_read () const -> secure::read_transaction

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -39,7 +39,7 @@ public:
 	~ledger ();
 
 	/** Start read-write transaction */
-	secure::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_to_lock = {}, std::vector<nano::tables> const & tables_no_lock = {}) const;
+	secure::write_transaction tx_begin_write (std::vector<nano::tables> const & tables_to_lock = {}, nano::store::writer guard_type = nano::store::writer::generic) const;
 	/** Start read-only transaction */
 	secure::read_transaction tx_begin_read () const;
 

--- a/nano/store/component.hpp
+++ b/nano/store/component.hpp
@@ -81,8 +81,10 @@ namespace store
 		store::final_vote & final_vote;
 		store::version & version;
 
+	public: // TODO: Shouldn't be public
 		store::write_queue write_queue;
 
+	public:
 		virtual unsigned max_block_write_batch_num () const = 0;
 
 		virtual bool copy_db (std::filesystem::path const & destination) = 0;

--- a/nano/store/write_queue.cpp
+++ b/nano/store/write_queue.cpp
@@ -78,6 +78,7 @@ void nano::store::write_queue::pop ()
 	{
 		queue.pop_front ();
 	}
+	condition.notify_all ();
 }
 
 void nano::store::write_queue::acquire (writer writer)


### PR DESCRIPTION
This change ensures that ledger write transactions and corresponding write queue guards are always acquired and released together. This in turn allows implementing `.refresh_if_needed ()` function that handles both transaction and guard, which simplifies bounding of write transaction lifetimes.