### PR TITLE
Add `is_originator` flag to publish messages

### DIFF
--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -169,6 +169,7 @@ enum class detail
 
 	// block source
 	live,
+	live_originator,
 	bootstrap,
 	bootstrap_legacy,
 	unchecked,

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -54,6 +54,7 @@ nano::block_processor::block_processor (nano::node & node_a) :
 		switch (origin.source)
 		{
 			case nano::block_source::live:
+			case nano::block_source::live_originator:
 				return config.max_peer_queue;
 			default:
 				return config.max_system_queue;
@@ -64,6 +65,7 @@ nano::block_processor::block_processor (nano::node & node_a) :
 		switch (origin.source)
 		{
 			case nano::block_source::live:
+			case nano::block_source::live_originator:
 				return config.priority_live;
 			case nano::block_source::bootstrap:
 			case nano::block_source::bootstrap_legacy:

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -27,6 +27,7 @@ enum class block_source
 {
 	unknown = 0,
 	live,
+	live_originator,
 	bootstrap,
 	bootstrap_legacy,
 	unchecked,

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -68,10 +68,10 @@ public: // Context
 	class context
 	{
 	public:
-		context (std::shared_ptr<nano::block> block, block_source source);
+		context (std::shared_ptr<nano::block> block, nano::block_source source);
 
 		std::shared_ptr<nano::block> const block;
-		block_source const source;
+		nano::block_source const source;
 		std::chrono::steady_clock::time_point const arrival{ std::chrono::steady_clock::now () };
 
 	public:
@@ -86,18 +86,18 @@ public: // Context
 	};
 
 public:
-	block_processor (nano::node &);
+	explicit block_processor (nano::node &);
 	~block_processor ();
 
 	void start ();
 	void stop ();
 
 	std::size_t size () const;
-	std::size_t size (block_source) const;
+	std::size_t size (nano::block_source) const;
 	bool full () const;
 	bool half_full () const;
-	bool add (std::shared_ptr<nano::block> const &, block_source = block_source::live, std::shared_ptr<nano::transport::channel> const & channel = nullptr);
-	std::optional<nano::block_status> add_blocking (std::shared_ptr<nano::block> const & block, block_source);
+	bool add (std::shared_ptr<nano::block> const &, nano::block_source = nano::block_source::live, std::shared_ptr<nano::transport::channel> const & channel = nullptr);
+	std::optional<nano::block_status> add_blocking (std::shared_ptr<nano::block> const & block, nano::block_source);
 	void force (std::shared_ptr<nano::block> const &);
 	bool should_log ();
 
@@ -129,7 +129,7 @@ private: // Dependencies
 	nano::node & node;
 
 private:
-	nano::fair_queue<context, block_source> queue;
+	nano::fair_queue<context, nano::block_source> queue;
 
 	std::chrono::steady_clock::time_point next_log;
 

--- a/nano/node/messages.cpp
+++ b/nano/node/messages.cpp
@@ -433,11 +433,12 @@ nano::publish::publish (bool & error_a, nano::stream & stream_a, nano::message_h
 	}
 }
 
-nano::publish::publish (nano::network_constants const & constants, std::shared_ptr<nano::block> const & block_a) :
+nano::publish::publish (nano::network_constants const & constants, std::shared_ptr<nano::block> const & block_a, bool is_originator_a) :
 	message (constants, nano::message_type::publish),
 	block (block_a)
 {
 	header.block_type_set (block->type ());
+	header.flag_set (originator_flag, is_originator_a);
 }
 
 void nano::publish::serialize (nano::stream & stream_a) const
@@ -465,11 +466,17 @@ bool nano::publish::operator== (nano::publish const & other_a) const
 	return *block == *other_a.block;
 }
 
+bool nano::publish::is_originator () const
+{
+	return header.flag_test (originator_flag);
+}
+
 void nano::publish::operator() (nano::object_stream & obs) const
 {
 	nano::message::operator() (obs); // Write common data
 
 	obs.write ("block", block);
+	obs.write ("originator", is_originator ());
 }
 
 /*
@@ -682,6 +689,7 @@ void nano::confirm_ack::operator() (nano::object_stream & obs) const
 	nano::message::operator() (obs); // Write common data
 
 	obs.write ("vote", vote);
+	obs.write ("rebroadcasted", is_rebroadcasted ());
 }
 
 /*

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -183,16 +183,23 @@ public: // Logging
  *
  * Header extensions:
  * - [0x0f00] Block type: Identifies the specific type of the block.
+ * - [0x0004] Originator flag
  */
 class publish final : public message
 {
 public:
 	publish (bool &, nano::stream &, nano::message_header const &, nano::uint128_t const & = 0, nano::block_uniquer * = nullptr);
-	publish (nano::network_constants const & constants, std::shared_ptr<nano::block> const &);
-	void visit (nano::message_visitor &) const override;
+	publish (nano::network_constants const & constants, std::shared_ptr<nano::block> const &, bool is_originator = false);
+
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
+	void visit (nano::message_visitor &) const override;
 	bool operator== (nano::publish const &) const;
+
+	static uint8_t constexpr originator_flag = 2; // 0x0004
+	bool is_originator () const;
+
+public: // Payload
 	std::shared_ptr<nano::block> block;
 	nano::uint128_t digest{ 0 };
 

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -247,22 +247,22 @@ void nano::network::flood_keepalive_self (float const scale_a)
 	flood_message (message, nano::transport::buffer_drop_policy::limiter, scale_a);
 }
 
-void nano::network::flood_block (std::shared_ptr<nano::block> const & block_a, nano::transport::buffer_drop_policy const drop_policy_a)
+void nano::network::flood_block (std::shared_ptr<nano::block> const & block, nano::transport::buffer_drop_policy const drop_policy)
 {
-	nano::publish message (node.network_params.network, block_a);
-	flood_message (message, drop_policy_a);
+	nano::publish message{ node.network_params.network, block };
+	flood_message (message, drop_policy);
 }
 
-void nano::network::flood_block_initial (std::shared_ptr<nano::block> const & block_a)
+void nano::network::flood_block_initial (std::shared_ptr<nano::block> const & block)
 {
-	nano::publish message (node.network_params.network, block_a);
-	for (auto const & i : node.rep_crawler.principal_representatives ())
+	nano::publish message{ node.network_params.network, block, /* is_originator */ true };
+	for (auto const & rep : node.rep_crawler.principal_representatives ())
 	{
-		i.channel->send (message, nullptr, nano::transport::buffer_drop_policy::no_limiter_drop);
+		rep.channel->send (message, nullptr, nano::transport::buffer_drop_policy::no_limiter_drop);
 	}
-	for (auto & i : list_non_pr (fanout (1.0)))
+	for (auto & peer : list_non_pr (fanout (1.0)))
 	{
-		i->send (message, nullptr, nano::transport::buffer_drop_policy::no_limiter_drop);
+		peer->send (message, nullptr, nano::transport::buffer_drop_policy::no_limiter_drop);
 	}
 }
 


### PR DESCRIPTION
This adds a new flag to `publish` messages that indicates whether a block is coming from a node that performed initial flooding. This helps avoid a situation when under a high load, a legitimate block is dropped because blockprocessor queue for a peer is full of rebroadcasted blocks. However, the potential for exploiting this is limited, as both rebroadcasted and originator queues have the same max size and priority, so effectively this gives each peer two queues to spam the network - which is not much, but should be plenty for legitimate traffic.

Format of extended publish message:
```
/*
 * Binary Format:
 * [message_header] Common message header
 * [variable] Block (serialized according to the block type specified in the header)
 *
 * Header extensions:
 * - [0x0f00] Block type: Identifies the specific type of the block.
 * - [0x0004] Originator flag
 */
```