### PR TITLE
Limit number of rocksdb background threads

### DIFF
--- a/nano/lib/rocksdbconfig.cpp
+++ b/nano/lib/rocksdbconfig.cpp
@@ -6,7 +6,7 @@ nano::error nano::rocksdb_config::serialize_toml (nano::tomlconfig & toml) const
 {
 	toml.put ("enable", enable, "Whether to use the RocksDB backend for the ledger database.\ntype:bool");
 	toml.put ("memory_multiplier", memory_multiplier, "This will modify how much memory is used represented by 1 (low), 2 (medium), 3 (high). Default is 2.\ntype:uint8");
-	toml.put ("io_threads", io_threads, "Number of threads to use with the background compaction and flushing. Number of hardware threads is recommended.\ntype:uint32");
+	toml.put ("io_threads", io_threads, "Number of threads to use with the background compaction and flushing.\ntype:uint32");
 	return toml.get_error ();
 }
 

--- a/nano/lib/rocksdbconfig.hpp
+++ b/nano/lib/rocksdbconfig.hpp
@@ -17,14 +17,15 @@ public:
 		enable{ using_rocksdb_in_tests () }
 	{
 	}
-	nano::error serialize_toml (nano::tomlconfig & toml_a) const;
-	nano::error deserialize_toml (nano::tomlconfig & toml_a);
+
+	nano::error serialize_toml (nano::tomlconfig &) const;
+	nano::error deserialize_toml (nano::tomlconfig &);
 
 	/** To use RocksDB in tests make sure the environment variable TEST_USE_ROCKSDB=1 is set */
 	static bool using_rocksdb_in_tests ();
 
 	bool enable{ false };
 	uint8_t memory_multiplier{ 2 };
-	unsigned io_threads{ nano::hardware_concurrency () };
+	unsigned io_threads{ std::max (nano::hardware_concurrency () / 2, 1u) };
 };
 }


### PR DESCRIPTION
It seems like rocksdb has a tendency for higher CPU usage compared to lmdb. This modifies the default limit to use half the available CPU threads.