### PR TITLE
Add New Bucket for Specific Amount Range

### DIFF
--- a/nano/core_test/scheduler_buckets.cpp
+++ b/nano/core_test/scheduler_buckets.cpp
@@ -112,7 +112,7 @@ TEST (buckets, construction)
 	nano::scheduler::buckets buckets;
 	ASSERT_EQ (0, buckets.size ());
 	ASSERT_TRUE (buckets.empty ());
-	ASSERT_EQ (62, buckets.bucket_count ());
+	ASSERT_EQ (63, buckets.bucket_count ());
 }
 
 TEST (buckets, insert_Gxrb)
@@ -120,7 +120,7 @@ TEST (buckets, insert_Gxrb)
 	nano::scheduler::buckets buckets;
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, buckets.size ());
-	ASSERT_EQ (1, buckets.bucket_size (48));
+	ASSERT_EQ (1, buckets.bucket_size (49));
 }
 
 TEST (buckets, insert_Mxrb)
@@ -128,7 +128,7 @@ TEST (buckets, insert_Mxrb)
 	nano::scheduler::buckets buckets;
 	buckets.push (1000, block1 (), nano::Mxrb_ratio);
 	ASSERT_EQ (1, buckets.size ());
-	ASSERT_EQ (1, buckets.bucket_size (13));
+	ASSERT_EQ (1, buckets.bucket_size (14));
 }
 
 // Test two blocks with the same priority
@@ -138,7 +138,7 @@ TEST (buckets, insert_same_priority)
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	buckets.push (1000, block2 (), nano::Gxrb_ratio);
 	ASSERT_EQ (2, buckets.size ());
-	ASSERT_EQ (2, buckets.bucket_size (48));
+	ASSERT_EQ (2, buckets.bucket_size (49));
 }
 
 // Test the same block inserted multiple times
@@ -148,7 +148,7 @@ TEST (buckets, insert_duplicate)
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	buckets.push (1000, block0 (), nano::Gxrb_ratio);
 	ASSERT_EQ (1, buckets.size ());
-	ASSERT_EQ (1, buckets.bucket_size (48));
+	ASSERT_EQ (1, buckets.bucket_size (49));
 }
 
 TEST (buckets, insert_older)

--- a/nano/node/scheduler/buckets.cpp
+++ b/nano/node/scheduler/buckets.cpp
@@ -27,7 +27,7 @@ void nano::scheduler::buckets::seek ()
 
 void nano::scheduler::buckets::setup_buckets (uint64_t maximum)
 {
-	auto const size_expected = 62;
+	auto const size_expected = 63;
 	auto bucket_max = std::max<size_t> (1u, maximum / size_expected);
 	auto build_region = [&] (uint128_t const & begin, uint128_t const & end, size_t count) {
 		auto width = (end - begin) / count;
@@ -36,7 +36,8 @@ void nano::scheduler::buckets::setup_buckets (uint64_t maximum)
 			buckets_m.push_back (std::make_unique<scheduler::bucket> (begin + i * width, bucket_max));
 		}
 	};
-	build_region (0, uint128_t{ 1 } << 88, 1);
+	build_region (0, uint128_t{ 1 } << 79, 1);
+	build_region (uint128_t{ 1 } << 79, uint128_t{ 1 } << 88, 1);
 	build_region (uint128_t{ 1 } << 88, uint128_t{ 1 } << 92, 2);
 	build_region (uint128_t{ 1 } << 92, uint128_t{ 1 } << 96, 4);
 	build_region (uint128_t{ 1 } << 96, uint128_t{ 1 } << 100, 8);


### PR DESCRIPTION
Related Issue: #4472

**Description:**

This PR adds an additional bucket for amounts between Ӿ0.000001 and Ӿ0.0003. The implementation details are as follows:

    - Amounts of Ӿ0.000001 will be included in the new bucket
    - More precisely amounts above Ӿ0.00000060 and below Ӿ0.000309 will fall in this new bucket.
    - All existing buckets remain unchanged to minimize the impact of bucket reallocation.

The reasoning behind adding an additional bucket is to ensure that all existing buckets retain their current allocation criteria.
