### PR TITLE
Incremental backoff for `local_block_broadcaster`

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3859,3 +3859,42 @@ TEST (node, process_local_overflow)
 	auto result = node.process_local (send1);
 	ASSERT_FALSE (result);
 }
+
+TEST (node, local_block_broadcast)
+{
+	nano::test::system system;
+
+	// Disable active elections to prevent the block from being broadcasted by the election
+	auto node_config = system.default_config ();
+	node_config.active_elections.size = 0;
+	node_config.local_block_broadcaster.rebroadcast_interval = 1s;
+	auto & node1 = *system.add_node (node_config);
+	auto & node2 = *system.make_disconnected_node ();
+
+	nano::keypair key1;
+	nano::send_block_builder builder;
+	auto latest_hash = nano::dev::genesis->hash ();
+	auto send1 = builder.make_block ()
+				 .previous (latest_hash)
+				 .destination (key1.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (latest_hash))
+				 .build ();
+
+	auto result = node1.process_local (send1);
+	ASSERT_TRUE (result);
+	ASSERT_NEVER (500ms, node1.active.active (send1->qualified_root ()));
+
+	// Wait until a broadcast is attempted
+	ASSERT_TIMELY_EQ (5s, node1.local_block_broadcaster.size (), 1);
+	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::local_block_broadcaster, nano::stat::detail::broadcast, nano::stat::dir::out) >= 1);
+
+	// The other node should not have received the block
+	ASSERT_NEVER (500ms, node2.block (send1->hash ()));
+
+	// Connect the nodes and check that the block is propagated
+	node1.network.merge_peer (node2.network.endpoint ());
+	ASSERT_TIMELY (5s, node1.network.find_node_id (node2.get_node_id ()));
+	ASSERT_TIMELY (10s, node2.block (send1->hash ()));
+}

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -79,6 +79,7 @@ enum class type
 	signal_manager,
 	peer_history,
 	message_processor,
+	local_block_broadcaster,
 
 	// bootstrap
 	bulk_pull_client,

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -9,6 +9,7 @@ namespace nano
 class active_elections;
 class confirming_set;
 class ledger;
+class local_block_broadcaster;
 class local_vote_history;
 class logger;
 class network;

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -7,6 +7,7 @@
 namespace nano
 {
 class active_elections;
+class confirming_set;
 class ledger;
 class local_vote_history;
 class logger;

--- a/nano/node/local_block_broadcaster.cpp
+++ b/nano/node/local_block_broadcaster.cpp
@@ -8,7 +8,8 @@
 #include <nano/node/node.hpp>
 #include <nano/secure/ledger.hpp>
 
-nano::local_block_broadcaster::local_block_broadcaster (nano::node & node_a, nano::block_processor & block_processor_a, nano::network & network_a, nano::confirming_set & confirming_set_a, nano::stats & stats_a, nano::logger & logger_a, bool enabled_a) :
+nano::local_block_broadcaster::local_block_broadcaster (local_block_broadcaster_config const & config_a, nano::node & node_a, nano::block_processor & block_processor_a, nano::network & network_a, nano::confirming_set & confirming_set_a, nano::stats & stats_a, nano::logger & logger_a, bool enabled_a) :
+	config{ config_a },
 	node{ node_a },
 	block_processor{ block_processor_a },
 	network{ network_a },

--- a/nano/node/local_block_broadcaster.cpp
+++ b/nano/node/local_block_broadcaster.cpp
@@ -2,16 +2,19 @@
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/blockprocessor.hpp>
+#include <nano/node/confirming_set.hpp>
 #include <nano/node/local_block_broadcaster.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node.hpp>
 #include <nano/secure/ledger.hpp>
 
-nano::local_block_broadcaster::local_block_broadcaster (nano::node & node_a, nano::block_processor & block_processor_a, nano::network & network_a, nano::stats & stats_a, bool enabled_a) :
+nano::local_block_broadcaster::local_block_broadcaster (nano::node & node_a, nano::block_processor & block_processor_a, nano::network & network_a, nano::confirming_set & confirming_set_a, nano::stats & stats_a, nano::logger & logger_a, bool enabled_a) :
 	node{ node_a },
 	block_processor{ block_processor_a },
 	network{ network_a },
+	confirming_set{ confirming_set_a },
 	stats{ stats_a },
+	logger{ logger_a },
 	enabled{ enabled_a },
 	limiter{ config.broadcast_rate_limit, config.broadcast_rate_burst_ratio }
 {
@@ -53,10 +56,14 @@ nano::local_block_broadcaster::local_block_broadcaster (nano::node & node_a, nan
 	block_processor.rolled_back.add ([this] (auto const & block) {
 		nano::lock_guard<nano::mutex> guard{ mutex };
 		auto erased = local_blocks.get<tag_hash> ().erase (block->hash ());
-		stats.add (nano::stat::type::local_block_broadcaster, nano::stat::detail::rollback, nano::stat::dir::in, erased);
+		stats.add (nano::stat::type::local_block_broadcaster, nano::stat::detail::rollback, erased);
 	});
 
-	// TODO: Listen for cemented callback
+	confirming_set.cemented_observers.add ([this] (auto const & block) {
+		nano::lock_guard<nano::mutex> guard{ mutex };
+		auto erased = local_blocks.get<tag_hash> ().erase (block->hash ());
+		stats.add (nano::stat::type::local_block_broadcaster, nano::stat::detail::cemented, erased);
+	});
 }
 
 nano::local_block_broadcaster::~local_block_broadcaster ()

--- a/nano/node/local_block_broadcaster.cpp
+++ b/nano/node/local_block_broadcaster.cpp
@@ -98,6 +98,12 @@ void nano::local_block_broadcaster::stop ()
 	nano::join_or_pass (thread);
 }
 
+size_t nano::local_block_broadcaster::size () const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return local_blocks.size ();
+}
+
 void nano::local_block_broadcaster::run ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };

--- a/nano/node/local_block_broadcaster.hpp
+++ b/nano/node/local_block_broadcaster.hpp
@@ -40,7 +40,7 @@ public:
 class local_block_broadcaster
 {
 public:
-	local_block_broadcaster (nano::node &, nano::block_processor &, nano::network &, nano::stats &, bool enabled = false);
+	local_block_broadcaster (nano::node &, nano::block_processor &, nano::network &, nano::confirming_set &, nano::stats &, nano::logger &, bool enabled = false);
 	~local_block_broadcaster ();
 
 	void start ();
@@ -59,7 +59,9 @@ private: // Dependencies
 	nano::node & node;
 	nano::block_processor & block_processor;
 	nano::network & network;
+	nano::confirming_set & confirming_set;
 	nano::stats & stats;
+	nano::logger & logger;
 
 private:
 	struct local_entry

--- a/nano/node/local_block_broadcaster.hpp
+++ b/nano/node/local_block_broadcaster.hpp
@@ -58,6 +58,8 @@ public:
 	void start ();
 	void stop ();
 
+	size_t size () const;
+
 	std::unique_ptr<container_info_component> collect_container_info (std::string const & name) const;
 
 private:

--- a/nano/node/local_block_broadcaster.hpp
+++ b/nano/node/local_block_broadcaster.hpp
@@ -22,10 +22,21 @@ namespace mi = boost::multi_index;
 
 namespace nano
 {
-class local_block_broadcaster_config
+class local_block_broadcaster_config final
 {
 public:
-	// TODO: Make these configurable
+	explicit local_block_broadcaster_config (nano::network_constants const & network)
+	{
+		if (network.is_dev_network ())
+		{
+			rebroadcast_interval = 1s;
+			cleanup_interval = 1s;
+		}
+	}
+
+	// TODO: Serialization & deserialization
+
+public:
 	std::size_t max_size{ 1024 * 8 };
 	std::chrono::seconds rebroadcast_interval{ 3 };
 	std::chrono::seconds max_rebroadcast_interval{ 60 };
@@ -38,10 +49,10 @@ public:
  * Broadcasts blocks to the network
  * Tracks local blocks for more aggressive propagation
  */
-class local_block_broadcaster
+class local_block_broadcaster final
 {
 public:
-	local_block_broadcaster (nano::node &, nano::block_processor &, nano::network &, nano::confirming_set &, nano::stats &, nano::logger &, bool enabled = false);
+	local_block_broadcaster (local_block_broadcaster_config const &, nano::node &, nano::block_processor &, nano::network &, nano::confirming_set &, nano::stats &, nano::logger &, bool enabled = false);
 	~local_block_broadcaster ();
 
 	void start ();
@@ -56,7 +67,7 @@ private:
 	std::chrono::milliseconds rebroadcast_interval (unsigned rebroadcasts) const;
 
 private: // Dependencies
-	local_block_broadcaster_config const config{}; // TODO: Pass in constructor
+	local_block_broadcaster_config const & config;
 	nano::node & node;
 	nano::block_processor & block_processor;
 	nano::network & network;

--- a/nano/node/local_block_broadcaster.hpp
+++ b/nano/node/local_block_broadcaster.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/locks.hpp>
 #include <nano/lib/processing_queue.hpp>
 #include <nano/node/bandwidth_limiter.hpp>
 #include <nano/node/blockprocessor.hpp>
+#include <nano/node/fwd.hpp>
 #include <nano/secure/common.hpp>
 
 #include <boost/multi_index/hashed_index.hpp>
@@ -20,24 +22,23 @@ namespace mi = boost::multi_index;
 
 namespace nano
 {
-class node;
-class network;
-}
-
-namespace nano
+class local_block_broadcaster_config
 {
+public:
+	// TODO: Make these configurable
+	static std::size_t constexpr max_size{ 1024 * 8 };
+	static std::chrono::seconds constexpr rebroadcast_interval{ 3 };
+	static std::chrono::seconds constexpr max_rebroadcast_interval{ 60 };
+	static std::size_t constexpr broadcast_rate_limit{ 32 };
+	static double constexpr broadcast_rate_burst_ratio{ 3 };
+};
+
 /**
  * Broadcasts blocks to the network
  * Tracks local blocks for more aggressive propagation
  */
 class local_block_broadcaster
 {
-	enum class broadcast_strategy
-	{
-		normal,
-		aggressive,
-	};
-
 public:
 	local_block_broadcaster (nano::node &, nano::block_processor &, nano::network &, nano::stats &, bool enabled = false);
 	~local_block_broadcaster ();
@@ -51,8 +52,10 @@ private:
 	void run ();
 	void run_broadcasts (nano::unique_lock<nano::mutex> &);
 	void cleanup ();
+	std::chrono::milliseconds rebroadcast_interval (unsigned rebroadcasts) const;
 
 private: // Dependencies
+	local_block_broadcaster_config const config{}; // TODO: Pass in constructor
 	nano::node & node;
 	nano::block_processor & block_processor;
 	nano::network & network;
@@ -61,22 +64,31 @@ private: // Dependencies
 private:
 	struct local_entry
 	{
-		std::shared_ptr<nano::block> const block;
-		std::chrono::steady_clock::time_point const arrival;
-		mutable std::chrono::steady_clock::time_point last_broadcast{}; // Not part of any index
+		std::shared_ptr<nano::block> block;
+		std::chrono::steady_clock::time_point arrival;
 
-		nano::block_hash hash () const;
+		std::chrono::steady_clock::time_point last_broadcast{};
+		std::chrono::steady_clock::time_point next_broadcast{};
+		unsigned rebroadcasts{ 0 };
+
+		nano::block_hash hash () const
+		{
+			return block->hash ();
+		}
 	};
 
 	// clang-format off
 	class tag_sequenced	{};
 	class tag_hash {};
+	class tag_broadcast {};
 
 	using ordered_locals = boost::multi_index_container<local_entry,
 	mi::indexed_by<
 		mi::sequenced<mi::tag<tag_sequenced>>,
 		mi::hashed_unique<mi::tag<tag_hash>,
-			mi::const_mem_fun<local_entry, nano::block_hash, &local_entry::hash>>
+			mi::const_mem_fun<local_entry, nano::block_hash, &local_entry::hash>>,
+		mi::ordered_non_unique<mi::tag<tag_broadcast>,
+			mi::member<local_entry, std::chrono::steady_clock::time_point, &local_entry::next_broadcast>>
 	>>;
 	// clang-format on
 
@@ -85,18 +97,11 @@ private:
 private:
 	bool enabled{ false };
 
-	nano::bandwidth_limiter limiter{ broadcast_rate_limit, broadcast_rate_burst_ratio };
+	nano::bandwidth_limiter limiter;
 
 	std::atomic<bool> stopped{ false };
 	nano::condition_variable condition;
 	mutable nano::mutex mutex;
 	std::thread thread;
-
-	// TODO: Make these configurable
-	static std::size_t constexpr max_size{ 1024 * 8 };
-	static std::chrono::seconds constexpr check_interval{ 30 };
-	static std::chrono::seconds constexpr broadcast_interval{ 60 };
-	static std::size_t constexpr broadcast_rate_limit{ 32 };
-	static double constexpr broadcast_rate_burst_ratio{ 3 };
 };
 }

--- a/nano/node/local_block_broadcaster.hpp
+++ b/nano/node/local_block_broadcaster.hpp
@@ -26,11 +26,12 @@ class local_block_broadcaster_config
 {
 public:
 	// TODO: Make these configurable
-	static std::size_t constexpr max_size{ 1024 * 8 };
-	static std::chrono::seconds constexpr rebroadcast_interval{ 3 };
-	static std::chrono::seconds constexpr max_rebroadcast_interval{ 60 };
-	static std::size_t constexpr broadcast_rate_limit{ 32 };
-	static double constexpr broadcast_rate_burst_ratio{ 3 };
+	std::size_t max_size{ 1024 * 8 };
+	std::chrono::seconds rebroadcast_interval{ 3 };
+	std::chrono::seconds max_rebroadcast_interval{ 60 };
+	std::size_t broadcast_rate_limit{ 32 };
+	double broadcast_rate_burst_ratio{ 3 };
+	std::chrono::seconds cleanup_interval{ 60 };
 };
 
 /**
@@ -51,7 +52,7 @@ public:
 private:
 	void run ();
 	void run_broadcasts (nano::unique_lock<nano::mutex> &);
-	void cleanup ();
+	void cleanup (nano::unique_lock<nano::mutex> &);
 	std::chrono::milliseconds rebroadcast_interval (unsigned rebroadcasts) const;
 
 private: // Dependencies
@@ -98,8 +99,8 @@ private:
 
 private:
 	bool enabled{ false };
-
 	nano::bandwidth_limiter limiter;
+	nano::interval cleanup_interval;
 
 	std::atomic<bool> stopped{ false };
 	nano::condition_variable condition;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -8,6 +8,7 @@
 #include <nano/node/confirming_set.hpp>
 #include <nano/node/daemonconfig.hpp>
 #include <nano/node/election_status.hpp>
+#include <nano/node/local_block_broadcaster.hpp>
 #include <nano/node/local_vote_history.hpp>
 #include <nano/node/make_store.hpp>
 #include <nano/node/message_processor.hpp>
@@ -217,7 +218,8 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	ascendboot{ config, block_processor, ledger, network, stats },
 	websocket{ config.websocket_config, observers, wallets, ledger, io_ctx, logger },
 	epoch_upgrader{ *this, ledger, store, network_params, logger },
-	local_block_broadcaster{ *this, block_processor, network, confirming_set, stats, logger, !flags.disable_block_processor_republishing },
+	local_block_broadcaster_impl{ std::make_unique<nano::local_block_broadcaster> (*this, block_processor, network, confirming_set, stats, logger, !flags.disable_block_processor_republishing) },
+	local_block_broadcaster{ *local_block_broadcaster_impl },
 	process_live_dispatcher{ ledger, scheduler.priority, vote_cache, websocket },
 	peer_history_impl{ std::make_unique<nano::peer_history> (config.peer_history, store, network, logger, stats) },
 	peer_history{ *peer_history_impl },

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -218,7 +218,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	ascendboot{ config, block_processor, ledger, network, stats },
 	websocket{ config.websocket_config, observers, wallets, ledger, io_ctx, logger },
 	epoch_upgrader{ *this, ledger, store, network_params, logger },
-	local_block_broadcaster_impl{ std::make_unique<nano::local_block_broadcaster> (*this, block_processor, network, confirming_set, stats, logger, !flags.disable_block_processor_republishing) },
+	local_block_broadcaster_impl{ std::make_unique<nano::local_block_broadcaster> (config.local_block_broadcaster, *this, block_processor, network, confirming_set, stats, logger, !flags.disable_block_processor_republishing) },
 	local_block_broadcaster{ *local_block_broadcaster_impl },
 	process_live_dispatcher{ ledger, scheduler.priority, vote_cache, websocket },
 	peer_history_impl{ std::make_unique<nano::peer_history> (config.peer_history, store, network, logger, stats) },

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -217,7 +217,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	ascendboot{ config, block_processor, ledger, network, stats },
 	websocket{ config.websocket_config, observers, wallets, ledger, io_ctx, logger },
 	epoch_upgrader{ *this, ledger, store, network_params, logger },
-	local_block_broadcaster{ *this, block_processor, network, stats, !flags.disable_block_processor_republishing },
+	local_block_broadcaster{ *this, block_processor, network, confirming_set, stats, logger, !flags.disable_block_processor_republishing },
 	process_live_dispatcher{ ledger, scheduler.priority, vote_cache, websocket },
 	peer_history_impl{ std::make_unique<nano::peer_history> (config.peer_history, store, network, logger, stats) },
 	peer_history{ *peer_history_impl },

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -16,7 +16,6 @@
 #include <nano/node/distributed_work_factory.hpp>
 #include <nano/node/epoch_upgrader.hpp>
 #include <nano/node/fwd.hpp>
-#include <nano/node/local_block_broadcaster.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node_observers.hpp>
 #include <nano/node/nodeconfig.hpp>
@@ -212,7 +211,8 @@ public:
 	nano::bootstrap_ascending::service ascendboot;
 	nano::websocket_server websocket;
 	nano::epoch_upgrader epoch_upgrader;
-	nano::local_block_broadcaster local_block_broadcaster;
+	std::unique_ptr<nano::local_block_broadcaster> local_block_broadcaster_impl;
+	nano::local_block_broadcaster & local_block_broadcaster;
 	nano::process_live_dispatcher process_live_dispatcher;
 	std::unique_ptr<nano::peer_history> peer_history_impl;
 	nano::peer_history & peer_history;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -39,7 +39,8 @@ nano::node_config::node_config (const std::optional<uint16_t> & peering_port_a, 
 	block_processor{ network_params.network },
 	peer_history{ network_params.network },
 	tcp{ network_params.network },
-	network{ network_params.network }
+	network{ network_params.network },
+	local_block_broadcaster{ network_params.network }
 {
 	if (peering_port == 0)
 	{

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -13,6 +13,7 @@
 #include <nano/node/bootstrap/bootstrap_config.hpp>
 #include <nano/node/bootstrap/bootstrap_server.hpp>
 #include <nano/node/ipc/ipc_config.hpp>
+#include <nano/node/local_block_broadcaster.hpp>
 #include <nano/node/message_processor.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/peer_history.hpp>
@@ -152,6 +153,7 @@ public:
 	nano::request_aggregator_config request_aggregator;
 	nano::message_processor_config message_processor;
 	nano::network_config network;
+	nano::local_block_broadcaster_config local_block_broadcaster;
 
 public:
 	std::string serialize_frontiers_confirmation (nano::frontiers_confirmation_mode) const;


### PR DESCRIPTION
This implements incremental backoff for block rebroadcasting. Previously block rebroadcasts happened every 60 seconds. This changes it, so that early on rebroadcasts happen more frequently, with 3 second interval increase. Ie. first rebroadcast happens after 3 seconds, second after 9, third after 18 etc.

Additionally there are improvements that were necessary to implement the above: avoiding unnecessary locking and config cleanup.