### PR TITLE
Do not wait for cancellation signal

### DIFF
--- a/nano/lib/async.hpp
+++ b/nano/lib/async.hpp
@@ -80,7 +80,7 @@ public:
 	// Only thread-like void tasks are supported for now
 	using value_type = void;
 
-	task (nano::async::strand & strand) :
+	explicit task (nano::async::strand & strand) :
 		strand{ strand },
 		cancellation{ strand }
 	{


### PR DESCRIPTION
Waiting for cancellation signal is unnecessary and was causing a deadlock in `tcp_listener` class.

```
Thread 37 (LWP 25214):
#0  0x00007fa2b77c388d in syscall () from target:/lib/x86_64-linux-gnu/libc.so.6
#1  0x000055dc7f386491 in std::__atomic_futex_unsigned_base::_M_futex_wait_until(unsigned int*, unsigned int, bool, std::chrono::duration<long, std::ratio<1l, 1l> >, std::chrono::duration<long, std::ratio<1l, 1000000000l> >) ()
#2  0x000055dc7e9d1175 in std::__atomic_futex_unsigned<2147483648u>::_M_load_and_test_until (__ns=..., __s=..., __has_timeout=<optimized out>, __mo=<optimized out>, __equal=<optimized out>, __operand=<optimized out>, __assumed=<optimized out>, this=<optimized out>) at /tmp/src/submodules/boost/libs/asio/include/boost/asio/scheduler.hpp:646
#3  std::__atomic_futex_unsigned<2147483648u>::_M_load_and_test (__mo=<optimized out>, __equal=<optimized out>, __operand=<optimized out>, __assumed=<optimized out>, this=<optimized out>) at /usr/include/x86_64-linux-gnu/bits/gthr-default.h:159
#4  std::__atomic_futex_unsigned<2147483648u>::_M_load_when_equal (__mo=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>, __val=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>, this=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at /usr/include/x86_64-linux-gnu/bits/gthr-default.h:213
#5  std::__future_base::_State_baseV2::wait (this=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at /tmp/src/submodules/boost/libs/asio/include/boost/asio/execution/impl/bad_address_cast.hpp:336
#6  std::__basic_future<void>::wait (this=0x7fa23cff73b0, this@entry=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at /tmp/src/submodules/boost/libs/asio/include/boost/asio/execution/impl/bad_address_cast.hpp:694
#7  nano::async::cancellation::emit (type=boost::asio::cancellation_type::all, type@entry=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>, this=0x7fa1e0074838, this@entry=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at /tmp/src/submodules/boost/libs/asio/include/boost/asio/detail/atomic_futex.h:57
#8  nano::async::task::cancel (this=0x7fa1e0074820, this@entry=<error reading variable: dwarf2_find_location_expression: Corrupted DWARF expression.>) at /tmp/src/submodules/boost/libs/asio/include/boost/asio/detail/atomic_futex.h:143
#9  nano::transport::tcp_listener::timeout() () at /tmp/src/submodules/boost/libs/asio/include/boost/asio/ip/string_view:212
#10 0x000055dc7e9d1369 in nano::transport::tcp_listener::run_cleanup() () at /tmp/src/submodules/boost/libs/asio/include/boost/asio/ip/string_view:171
#11 0x000055dc7f3b89f4 in execute_native_thread_routine ()
#12 0x00007fa2b7739ac3 in ?? () from target:/lib/x86_64-linux-gnu/libc.so.6
#13 0x00007fa2b77caa04 in clone () from target:/lib/x86_64-linux-gnu/libc.so.6

Thread 35 (LWP 25212):
#0  0x00007fa2b77362c0 in ?? () from target:/lib/x86_64-linux-gnu/libc.so.6
#1  0x00007fa2b773d002 in pthread_mutex_lock () from target:/lib/x86_64-linux-gnu/libc.so.6
#2  0x000055dc7e9d00d0 in __gthread_mutex_lock (__mutex=0x55dc847a67e8) at /tmp/src/submodules/boost/libs/asio/include/boost/asio/socket_holder.hpp:749
#3  std::mutex::lock (this=0x55dc847a67e8) at /tmp/src/build/nano/node/tcp_listener.cpp:100
#4  nano::mutex::lock (this=0x55dc847a67e8) at /tmp/src/submodules/boost/libs/asio/include/boost/asio/detail/std_mutex.h:77
#5  std::unique_lock<nano::mutex>::lock (this=0x7fa23dff8be0) at /tmp/src/submodules/boost/libs/system/include/boost/system/detail/use_awaitable.hpp:139
#6  std::unique_lock<nano::mutex>::unique_lock (__m=..., this=0x7fa23dff8be0) at /tmp/src/submodules/boost/libs/system/include/boost/system/detail/use_awaitable.hpp:69
#7  nano::transport::tcp_listener::connect(boost::asio::ip::address, unsigned short) () at /tmp/src/submodules/boost/libs/asio/include/boost/asio/ip/string_view:223
#8  0x000055dc7e9badc2 in nano::transport::tcp_channels::start_tcp (this=<optimized out>, endpoint=...) at /usr/include/x86_64-linux-gnu/bits/socket_ops.ipp:60
#9  0x000055dc7e919cda in nano::network::merge_peer (peer_a=..., this=<optimized out>) at /tmp/src/submodules/boost/libs/asio/include/boost/asio/detail/unordered_map.h:334
#10 nano::network::merge_peer (this=<optimized out>, peer_a=...) at /tmp/src/submodules/boost/libs/asio/include/boost/asio/detail/unordered_map.h:328
#11 0x000055dc7eaf6d65 in (anonymous namespace)::process_visitor::keepalive (this=0x7fa23dff8e20, message=...) at /tmp/src/build/nano/node/messages.hpp:177
#12 0x000055dc7eaf72c5 in nano::message_processor::process(nano::message const&, std::shared_ptr<nano::transport::channel> const&) () at /tmp/src/build/nano/node/messages.hpp:287
#13 0x000055dc7eaf8d45 in nano::message_processor::run_batch(std::unique_lock<nano::mutex>&) () at /tmp/src/build/nano/node/messages.hpp:146
#14 0x000055dc7eaf91c2 in nano::message_processor::run() () at /tmp/src/build/nano/node/messages.hpp:115
#15 0x000055dc7eaf92bd in operator() (__closure=0x55dc8036a388) at /tmp/src/build/nano/node/messages.hpp:35
#16 std::__invoke_impl<void, nano::message_processor::start()::<lambda()> > (__f=...) at /tmp/src/nano/lib/std_function.h:61
#17 std::__invoke<nano::message_processor::start()::<lambda()> > (__fn=...) at /tmp/src/nano/lib/std_function.h:96
#18 std::thread::_Invoker<std::tuple<nano::message_processor::start()::<lambda()> > >::_M_invoke<0> (this=0x55dc8036a388) at /usr/include/c++/11/exception_implementation.hpp:259
#19 std::thread::_Invoker<std::tuple<nano::message_processor::start()::<lambda()> > >::operator() (this=0x55dc8036a388) at /usr/include/c++/11/exception_implementation.hpp:266
#20 std::thread::_State_impl<std::thread::_Invoker<std::tuple<nano::message_processor::start()::{lambda()#1}> > >::_M_run() () at /usr/include/c++/11/exception_implementation.hpp:211
#21 0x000055dc7f3b89f4 in execute_native_thread_routine ()
#22 0x00007fa2b7739ac3 in ?? () from target:/lib/x86_64-linux-gnu/libc.so.6
#23 0x00007fa2b77caa04 in clone () from target:/lib/x86_64-linux-gnu/libc.so.6

// More IO threads with the same stacktrace
// ....
```