### PR TITLE
Fix stopping of bootstrap workers

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -733,6 +733,7 @@ void nano::node::stop ()
 
 	logger.info (nano::log::type::node, "Node stopping...");
 
+	tcp_listener.stop ();
 	bootstrap_workers.stop ();
 	wallet_workers.stop ();
 	election_workers.stop ();
@@ -759,7 +760,6 @@ void nano::node::stop ()
 	websocket.stop ();
 	bootstrap_server.stop ();
 	bootstrap_initiator.stop ();
-	tcp_listener.stop ();
 	port_mapping.stop ();
 	wallets.stop ();
 	stats.stop ();

--- a/nano/node/transport/tcp_listener.cpp
+++ b/nano/node/transport/tcp_listener.cpp
@@ -222,6 +222,11 @@ bool nano::transport::tcp_listener::connect (asio::ip::address ip, uint16_t port
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 
+	if (stopped)
+	{
+		return false; // Rejected
+	}
+
 	if (port == 0)
 	{
 		port = node.network_params.network.default_node_port;
@@ -370,6 +375,11 @@ auto nano::transport::tcp_listener::accept_one (asio::ip::tcp::socket raw_socket
 	auto const local_endpoint = raw_socket.local_endpoint ();
 
 	nano::unique_lock<nano::mutex> lock{ mutex };
+
+	if (stopped)
+	{
+		return { accept_result::rejected };
+	}
 
 	if (auto result = check_limits (remote_endpoint.address (), type); result != accept_result::accepted)
 	{


### PR DESCRIPTION
Without this node attempting to stop live node would sometimes get stuck on `bootstrap_workers.stop ();` call.