### PR TITLE
Legacy bootstrap throttling

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2602,51 +2602,6 @@ TEST (node, block_processor_reject_state)
 	ASSERT_TIMELY (5s, node.block_or_pruned_exists (send2->hash ()));
 }
 
-TEST (node, block_processor_full)
-{
-	nano::test::system system;
-	nano::node_flags node_flags;
-	node_flags.force_use_write_queue = true;
-	node_flags.block_processor_full_size = 3;
-	auto & node = *system.add_node (nano::node_config (system.get_available_port ()), node_flags);
-	nano::state_block_builder builder;
-	auto send1 = builder.make_block ()
-				 .account (nano::dev::genesis_key.pub)
-				 .previous (nano::dev::genesis->hash ())
-				 .representative (nano::dev::genesis_key.pub)
-				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
-				 .link (nano::dev::genesis_key.pub)
-				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
-				 .build ();
-	auto send2 = builder.make_block ()
-				 .account (nano::dev::genesis_key.pub)
-				 .previous (nano::dev::genesis->hash ())
-				 .representative (nano::dev::genesis_key.pub)
-				 .balance (nano::dev::constants.genesis_amount - 2 * nano::Gxrb_ratio)
-				 .link (nano::dev::genesis_key.pub)
-				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
-				 .build ();
-	auto send3 = builder.make_block ()
-				 .account (nano::dev::genesis_key.pub)
-				 .previous (nano::dev::genesis->hash ())
-				 .representative (nano::dev::genesis_key.pub)
-				 .balance (nano::dev::constants.genesis_amount - 3 * nano::Gxrb_ratio)
-				 .link (nano::dev::genesis_key.pub)
-				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
-				 .build ();
-	node.block_processor.stop (); // Stop processing the block queue
-	node.block_processor.add (send1);
-	ASSERT_FALSE (node.block_processor.full ());
-	node.block_processor.add (send2);
-	ASSERT_FALSE (node.block_processor.full ());
-	node.block_processor.add (send3);
-	// Block processor may be not full during state blocks signatures verification
-	ASSERT_TIMELY (5s, node.block_processor.full ());
-}
-
 TEST (node, confirm_back)
 {
 	nano::test::system system (1);

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -119,16 +119,6 @@ std::size_t nano::block_processor::size (nano::block_source source) const
 	return queue.size ({ source });
 }
 
-bool nano::block_processor::full () const
-{
-	return size () >= node.flags.block_processor_full_size;
-}
-
-bool nano::block_processor::half_full () const
-{
-	return size () >= node.flags.block_processor_full_size / 2;
-}
-
 bool nano::block_processor::add (std::shared_ptr<nano::block> const & block, block_source const source, std::shared_ptr<nano::transport::channel> const & channel)
 {
 	if (node.network_params.work.validate_entry (*block)) // true => error

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -98,10 +98,6 @@ public:
 	void force (std::shared_ptr<nano::block> const &);
 	bool should_log ();
 
-	// TODO: Remove, used by legacy bootstrap
-	bool full () const;
-	bool half_full () const;
-
 	std::unique_ptr<container_info_component> collect_container_info (std::string const & name);
 
 	std::atomic<bool> flushing{ false };

--- a/nano/node/bootstrap/bootstrap_bulk_pull.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_pull.cpp
@@ -120,7 +120,7 @@ void nano::bulk_pull_client::throttled_receive_block ()
 		return;
 	}
 	debug_assert (!network_error);
-	if (!node->block_processor.half_full () && !node->block_processor.flushing)
+	if (node->block_processor.size (nano::block_source::bootstrap_legacy) < 1024 && !node->block_processor.flushing)
 	{
 		receive_block ();
 	}

--- a/nano/node/bootstrap/bootstrap_bulk_push.cpp
+++ b/nano/node/bootstrap/bootstrap_bulk_push.cpp
@@ -137,7 +137,7 @@ void nano::bulk_push_server::throttled_receive ()
 	{
 		return;
 	}
-	if (!node->block_processor.half_full ())
+	if (node->block_processor.size (nano::block_source::bootstrap_legacy) < 1024)
 	{
 		receive ();
 	}

--- a/nano/node/bootstrap/bootstrap_frontier.cpp
+++ b/nano/node/bootstrap/bootstrap_frontier.cpp
@@ -70,7 +70,9 @@ void nano::frontier_req_client::receive_frontier ()
 		// we simply get a size of 0.
 		if (size_a == nano::frontier_req_client::size_frontier)
 		{
-			this_l->received_frontier (ec, size_a);
+			node->bootstrap_workers.push_task ([this_l, ec, size_a] () {
+				this_l->received_frontier (ec, size_a);
+			});
 		}
 		else
 		{


### PR DESCRIPTION
This should reduce the load on IO threads caused by legacy bootstrap. 

![image](https://github.com/nanocurrency/nano-node/assets/3044353/bcd891f2-2862-40c1-8d13-31caf7ac49bc)
