### PR TITLE
Use RocksDB TransactionDB rather than OptimisticTransactionDB

### DIFF
--- a/nano/store/rocksdb/rocksdb.hpp
+++ b/nano/store/rocksdb/rocksdb.hpp
@@ -22,7 +22,7 @@
 #include <rocksdb/options.h>
 #include <rocksdb/slice.h>
 #include <rocksdb/table.h>
-#include <rocksdb/utilities/optimistic_transaction_db.h>
+#include <rocksdb/utilities/transaction_db.h>
 
 namespace nano
 {
@@ -105,8 +105,7 @@ private:
 	bool error{ false };
 	nano::logger & logger;
 	nano::ledger_constants & constants;
-	// Optimistic transactions are used in write mode
-	::rocksdb::OptimisticTransactionDB * optimistic_db = nullptr;
+	::rocksdb::TransactionDB * transaction_db = nullptr;
 	std::unique_ptr<::rocksdb::DB> db;
 	std::vector<std::unique_ptr<::rocksdb::ColumnFamilyHandle>> handles;
 	std::shared_ptr<::rocksdb::TableFactory> small_table_factory;

--- a/nano/store/rocksdb/transaction.cpp
+++ b/nano/store/rocksdb/transaction.cpp
@@ -56,20 +56,7 @@ void nano::store::rocksdb::write_transaction_impl::commit ()
 	if (active)
 	{
 		auto status = txn->Commit ();
-
-		// If there are no available memtables try again a few more times
-		constexpr auto num_attempts = 10;
-		auto attempt_num = 0;
-		while (status.IsTryAgain () && attempt_num < num_attempts)
-		{
-			status = txn->Commit ();
-			++attempt_num;
-		}
-
-		if (!status.ok ())
-		{
-			release_assert (false && "Unable to write to the RocksDB database", status.ToString ());
-		}
+		release_assert (status.ok () && "Unable to write to the RocksDB database", status.ToString ());
 		active = false;
 	}
 }

--- a/nano/store/rocksdb/transaction.cpp
+++ b/nano/store/rocksdb/transaction.cpp
@@ -32,14 +32,14 @@ void * nano::store::rocksdb::read_transaction_impl::get_handle () const
 	return (void *)&options;
 }
 
-nano::store::rocksdb::write_transaction_impl::write_transaction_impl (::rocksdb::OptimisticTransactionDB * db_a, std::vector<nano::tables> const & tables_requiring_locks_a, std::vector<nano::tables> const & tables_no_locks_a, std::unordered_map<nano::tables, nano::mutex> & mutexes_a) :
+nano::store::rocksdb::write_transaction_impl::write_transaction_impl (::rocksdb::TransactionDB * db_a, std::vector<nano::tables> const & tables_requiring_locks_a, std::vector<nano::tables> const & tables_no_locks_a, std::unordered_map<nano::tables, nano::mutex> & mutexes_a) :
 	db (db_a),
 	tables_requiring_locks (tables_requiring_locks_a),
 	tables_no_locks (tables_no_locks_a),
 	mutexes (mutexes_a)
 {
 	lock ();
-	::rocksdb::OptimisticTransactionOptions txn_options;
+	::rocksdb::TransactionOptions txn_options;
 	txn_options.set_snapshot = true;
 	txn = db->BeginTransaction (::rocksdb::WriteOptions (), txn_options);
 }
@@ -76,7 +76,7 @@ void nano::store::rocksdb::write_transaction_impl::commit ()
 
 void nano::store::rocksdb::write_transaction_impl::renew ()
 {
-	::rocksdb::OptimisticTransactionOptions txn_options;
+	::rocksdb::TransactionOptions txn_options;
 	txn_options.set_snapshot = true;
 	db->BeginTransaction (::rocksdb::WriteOptions (), txn_options, txn);
 	active = true;

--- a/nano/store/rocksdb/transaction_impl.hpp
+++ b/nano/store/rocksdb/transaction_impl.hpp
@@ -4,8 +4,8 @@
 
 #include <rocksdb/db.h>
 #include <rocksdb/options.h>
-#include <rocksdb/utilities/optimistic_transaction_db.h>
 #include <rocksdb/utilities/transaction.h>
+#include <rocksdb/utilities/transaction_db.h>
 
 namespace nano::store::rocksdb
 {
@@ -26,7 +26,7 @@ private:
 class write_transaction_impl final : public store::write_transaction_impl
 {
 public:
-	write_transaction_impl (::rocksdb::OptimisticTransactionDB * db_a, std::vector<nano::tables> const & tables_requiring_locks_a, std::vector<nano::tables> const & tables_no_locks_a, std::unordered_map<nano::tables, nano::mutex> & mutexes_a);
+	write_transaction_impl (::rocksdb::TransactionDB * db_a, std::vector<nano::tables> const & tables_requiring_locks_a, std::vector<nano::tables> const & tables_no_locks_a, std::unordered_map<nano::tables, nano::mutex> & mutexes_a);
 	~write_transaction_impl ();
 	void commit () override;
 	void renew () override;
@@ -35,7 +35,7 @@ public:
 
 private:
 	::rocksdb::Transaction * txn;
-	::rocksdb::OptimisticTransactionDB * db;
+	::rocksdb::TransactionDB * db;
 	std::vector<nano::tables> tables_requiring_locks;
 	std::vector<nano::tables> tables_no_locks;
 	std::unordered_map<nano::tables, nano::mutex> & mutexes;


### PR DESCRIPTION
The performance difference is minimal and it eliminates the possibility of misconfiguration of memtable size which could lead to out-of-memory or a crash.