### PR TITLE
Add database information to telemetry data

### DIFF
--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -389,7 +389,7 @@ TEST (message, confirm_req_hash_batch_serialization_v2)
 /**
  * Test that a confirm_ack can encode an empty hash set
  */
-TEST (confirm_ack, empty_vote_hashes)
+TEST (message, confirm_ack_empty_vote_hashes)
 {
 	nano::keypair key;
 	auto vote = std::make_shared<nano::vote> (key.pub, key.prv, 0, 0, std::vector<nano::block_hash>{} /* empty */);
@@ -781,7 +781,7 @@ TEST (message, node_id_handshake_response_v2_serialization)
 	ASSERT_TRUE (nano::at_end (stream));
 }
 
-TEST (handshake, signature)
+TEST (message, handshake_signature)
 {
 	nano::keypair node_id{};
 	nano::keypair node_id_2{};
@@ -801,7 +801,7 @@ TEST (handshake, signature)
 	ASSERT_FALSE (response.validate (cookie));
 }
 
-TEST (handshake, signature_v2)
+TEST (message, handshake_signature_v2)
 {
 	nano::keypair node_id{};
 	nano::keypair node_id_2{};
@@ -842,4 +842,64 @@ TEST (handshake, signature_v2)
 		message.v2->salt = nano::random_pool::generate<nano::uint256_union> ();
 		ASSERT_FALSE (message.validate (cookie));
 	}
+}
+
+TEST (message, telemetry_data_serialization)
+{
+	nano::telemetry_data original;
+	original.node_id = nano::account{ 11111 };
+	original.account_count = 22222;
+	original.block_count = 33333;
+	original.cemented_count = 44444;
+	original.bandwidth_cap = 55555;
+	original.account_count = 66666;
+	original.bandwidth_cap = 77777;
+	original.uptime = 88888;
+	original.peer_count = 99999;
+	original.protocol_version = 1;
+	original.genesis_block = nano::block_hash{ 22222 };
+	original.major_version = 4;
+	original.minor_version = 3;
+	original.patch_version = 2;
+	original.pre_release_version = 1;
+	original.maker = 5;
+	original.timestamp = std::chrono::system_clock::time_point{ 123456789s };
+	original.active_difficulty = 42;
+	original.database_backend = "Test";
+
+	// Serialize
+	std::vector<uint8_t> bytes;
+	{
+		nano::vectorstream stream{ bytes };
+		original.serialize (stream);
+	}
+	nano::bufferstream stream{ bytes.data (), bytes.size () };
+
+	nano::telemetry_data telemetry;
+	ASSERT_NO_THROW (telemetry.deserialize (stream, bytes.size ()));
+
+	// Compare
+	ASSERT_EQ (original.node_id, telemetry.node_id);
+	ASSERT_EQ (original.account_count, telemetry.account_count);
+	ASSERT_EQ (original.block_count, telemetry.block_count);
+	ASSERT_EQ (original.cemented_count, telemetry.cemented_count);
+	ASSERT_EQ (original.bandwidth_cap, telemetry.bandwidth_cap);
+	ASSERT_EQ (original.account_count, telemetry.account_count);
+	ASSERT_EQ (original.bandwidth_cap, telemetry.bandwidth_cap);
+	ASSERT_EQ (original.uptime, telemetry.uptime);
+	ASSERT_EQ (original.peer_count, telemetry.peer_count);
+	ASSERT_EQ (original.protocol_version, telemetry.protocol_version);
+	ASSERT_EQ (original.genesis_block, telemetry.genesis_block);
+	ASSERT_EQ (original.major_version, telemetry.major_version);
+	ASSERT_EQ (original.minor_version, telemetry.minor_version);
+	ASSERT_EQ (original.patch_version, telemetry.patch_version);
+	ASSERT_EQ (original.pre_release_version, telemetry.pre_release_version);
+	ASSERT_EQ (original.maker, telemetry.maker);
+	ASSERT_EQ (original.timestamp, telemetry.timestamp);
+	ASSERT_EQ (original.active_difficulty, telemetry.active_difficulty);
+	ASSERT_EQ (original.database_backend, telemetry.database_backend);
+	ASSERT_EQ (original, telemetry);
+
+	ASSERT_EQ (nano::telemetry_data::size, bytes.size ());
+	ASSERT_TRUE (nano::at_end (stream));
 }

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -865,7 +865,7 @@ TEST (message, telemetry_data_serialization)
 	original.maker = 5;
 	original.timestamp = std::chrono::system_clock::time_point{ 123456789s };
 	original.active_difficulty = 42;
-	original.database_backend = "Test";
+	original.database_backend = 1;
 
 	// Serialize
 	std::vector<uint8_t> bytes;

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -572,12 +572,12 @@ TEST (telemetry, majority_database_backend_information_missing)
 	data2.maker = 1;
 	data2.timestamp = std::chrono::system_clock::time_point (100ms);
 	data2.active_difficulty = 10;
-	data1.database_backend = "RocksDb";
+	data1.database_backend = 1;
 
 	all_data.push_back (data2);
 
 	auto consolidated_telemetry_data2 = nano::consolidate_telemetry_data (all_data);
-	ASSERT_EQ (consolidated_telemetry_data2.database_backend, "Unknown");
+	ASSERT_EQ (consolidated_telemetry_data2.database_backend, 0);
 }
 
 TEST (telemetry, majority_database_backend_information_included)
@@ -600,7 +600,7 @@ TEST (telemetry, majority_database_backend_information_included)
 	data1.maker = 1;
 	data1.timestamp = std::chrono::system_clock::time_point (100ms);
 	data1.active_difficulty = 10;
-	data1.database_backend = "LMDB";
+	data1.database_backend = 1;
 	std::vector<nano::telemetry_data> all_data (100, data1);
 
 	nano::telemetry_data data2;
@@ -624,5 +624,5 @@ TEST (telemetry, majority_database_backend_information_included)
 	all_data.push_back (data2);
 
 	auto consolidated_telemetry_data2 = nano::consolidate_telemetry_data (all_data);
-	ASSERT_EQ (consolidated_telemetry_data2.database_backend, "LMDB");
+	ASSERT_EQ (consolidated_telemetry_data2.database_backend, 1);
 }

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -536,3 +536,97 @@ TEST (telemetry, DISABLED_mismatched_genesis)
 	// Ensure node with different genesis gets disconnected
 	ASSERT_TIMELY (5s, !node1.network.find_node_id (node2.get_node_id ()));
 }
+
+TEST (telemetry, majority_database_backend_information_missing)
+{
+	// Majority of nodes reporting no database info (Version 26.1 and earlier). One node reporting RocksDb backend
+	nano::telemetry_data data1;
+	data1.account_count = 2;
+	data1.block_count = 1;
+	data1.cemented_count = 1;
+	data1.protocol_version = 12;
+	data1.peer_count = 2;
+	data1.bandwidth_cap = 0;
+	data1.unchecked_count = 3;
+	data1.uptime = 6;
+	data1.genesis_block = nano::block_hash (3);
+	data1.major_version = 27;
+	data1.minor_version = 0;
+	data1.patch_version = 0;
+	data1.pre_release_version = 1;
+	data1.maker = 1;
+	data1.timestamp = std::chrono::system_clock::time_point (100ms);
+	data1.active_difficulty = 10;
+	std::vector<nano::telemetry_data> all_data (100, data1);
+
+	nano::telemetry_data data2;
+	data2.account_count = 2;
+	data2.block_count = 1;
+	data2.cemented_count = 1;
+	data2.protocol_version = 12;
+	data2.peer_count = 2;
+	data2.bandwidth_cap = 100;
+	data2.unchecked_count = 3;
+	data2.uptime = 6;
+	data2.genesis_block = nano::block_hash (3);
+	data2.major_version = 27;
+	data2.minor_version = 0;
+	data2.patch_version = 0;
+	data2.pre_release_version = 2;
+	data2.maker = 1;
+	data2.timestamp = std::chrono::system_clock::time_point (100ms);
+	data2.active_difficulty = 10;
+	data1.database_backend = "RocksDb";
+
+	all_data.push_back (data2);
+
+	auto consolidated_telemetry_data2 = nano::consolidate_telemetry_data (all_data);
+	ASSERT_EQ (consolidated_telemetry_data2.database_backend, "Unknown");
+}
+
+TEST (telemetry, majority_database_backend_information_included)
+{
+	// Majority of nodes with LMDB database. One node with no information
+	nano::telemetry_data data1;
+	data1.account_count = 2;
+	data1.block_count = 1;
+	data1.cemented_count = 1;
+	data1.protocol_version = 12;
+	data1.peer_count = 2;
+	data1.bandwidth_cap = 0;
+	data1.unchecked_count = 3;
+	data1.uptime = 6;
+	data1.genesis_block = nano::block_hash (3);
+	data1.major_version = 27;
+	data1.minor_version = 0;
+	data1.patch_version = 0;
+	data1.pre_release_version = 1;
+	data1.maker = 1;
+	data1.timestamp = std::chrono::system_clock::time_point (100ms);
+	data1.active_difficulty = 10;
+	data1.database_backend = "LMDB";
+	std::vector<nano::telemetry_data> all_data (100, data1);
+
+	nano::telemetry_data data2;
+	data2.account_count = 2;
+	data2.block_count = 1;
+	data2.cemented_count = 1;
+	data2.protocol_version = 12;
+	data2.peer_count = 2;
+	data2.bandwidth_cap = 100;
+	data2.unchecked_count = 3;
+	data2.uptime = 6;
+	data2.genesis_block = nano::block_hash (3);
+	data2.major_version = 27;
+	data2.minor_version = 0;
+	data2.patch_version = 0;
+	data2.pre_release_version = 2;
+	data2.maker = 1;
+	data2.timestamp = std::chrono::system_clock::time_point (100ms);
+	data2.active_difficulty = 10;
+
+	all_data.push_back (data2);
+
+	auto consolidated_telemetry_data2 = nano::consolidate_telemetry_data (all_data);
+	ASSERT_EQ (consolidated_telemetry_data2.database_backend, "LMDB");
+}

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -108,10 +108,6 @@ TEST (telemetry, consolidate_data)
 	ASSERT_TRUE (consolidated_telemetry_data1.protocol_version == 11 || consolidated_telemetry_data1.protocol_version == 12 || consolidated_telemetry_data1.protocol_version == 13);
 	ASSERT_EQ (consolidated_telemetry_data1.bandwidth_cap, 51);
 	ASSERT_EQ (consolidated_telemetry_data1.genesis_block, nano::block_hash (3));
-
-	// Test equality operator
-	ASSERT_FALSE (consolidated_telemetry_data == consolidated_telemetry_data1);
-	ASSERT_EQ (consolidated_telemetry_data, consolidated_telemetry_data);
 }
 
 TEST (telemetry, consolidate_data_remove_outliers)
@@ -433,7 +429,7 @@ TEST (telemetry, max_possible_size)
 	auto node_server = system.add_node (node_flags);
 
 	nano::telemetry_data data;
-	data.unknown_data.resize (nano::message_header::telemetry_size_mask.to_ulong () - nano::telemetry_data::latest_size);
+	data.unknown_data.resize (nano::message_header::telemetry_size_mask.to_ulong () - nano::telemetry_data::size);
 
 	nano::telemetry_ack message{ nano::dev::network_params.network, data };
 	nano::test::wait_peer_connections (system);

--- a/nano/node/messages.cpp
+++ b/nano/node/messages.cpp
@@ -1158,6 +1158,7 @@ nano::error nano::telemetry_data::serialize_json (nano::jsonconfig & json, bool 
 	json.put ("maker", maker);
 	json.put ("timestamp", std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ());
 	json.put ("active_difficulty", nano::to_string_hex (active_difficulty));
+	json.put ("database_backend", database_backend);
 	// Keep these last for UI purposes
 	if (!ignore_identification_metrics_a)
 	{

--- a/nano/node/messages.cpp
+++ b/nano/node/messages.cpp
@@ -1105,9 +1105,9 @@ void nano::telemetry_data::deserialize (nano::stream & stream_a, uint16_t payloa
 	timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (timestamp_l));
 	read (stream_a, active_difficulty);
 	boost::endian::big_to_native_inplace (active_difficulty);
-	if (payload_length_a > latest_size)
+	if (payload_length_a > size)
 	{
-		read (stream_a, unknown_data, payload_length_a - latest_size);
+		read (stream_a, unknown_data, payload_length_a - size);
 	}
 }
 
@@ -1221,16 +1221,6 @@ nano::error nano::telemetry_data::deserialize_json (nano::jsonconfig & json, boo
 	auto ec = nano::from_string_hex (current_active_difficulty_text, active_difficulty);
 	debug_assert (!ec);
 	return json.get_error ();
-}
-
-bool nano::telemetry_data::operator== (nano::telemetry_data const & data_a) const
-{
-	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp && active_difficulty == data_a.active_difficulty && unknown_data == data_a.unknown_data);
-}
-
-bool nano::telemetry_data::operator!= (nano::telemetry_data const & data_a) const
-{
-	return !(*this == data_a);
 }
 
 void nano::telemetry_data::sign (nano::keypair const & node_id_a)

--- a/nano/node/messages.cpp
+++ b/nano/node/messages.cpp
@@ -1105,6 +1105,7 @@ void nano::telemetry_data::deserialize (nano::stream & stream_a, uint16_t payloa
 	timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (timestamp_l));
 	read (stream_a, active_difficulty);
 	boost::endian::big_to_native_inplace (active_difficulty);
+	read (stream_a, database_backend);
 	if (payload_length_a > size)
 	{
 		read (stream_a, unknown_data, payload_length_a - size);
@@ -1131,6 +1132,7 @@ void nano::telemetry_data::serialize_without_signature (nano::stream & stream_a)
 	write (stream_a, maker);
 	write (stream_a, boost::endian::native_to_big (std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ()));
 	write (stream_a, boost::endian::native_to_big (active_difficulty));
+	write (stream_a, database_backend);
 	write (stream_a, unknown_data);
 }
 
@@ -1219,6 +1221,7 @@ nano::error nano::telemetry_data::deserialize_json (nano::jsonconfig & json, boo
 	timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (timestamp_l));
 	auto current_active_difficulty_text = json.get<std::string> ("active_difficulty");
 	auto ec = nano::from_string_hex (current_active_difficulty_text, active_difficulty);
+	json.get ("database_backend", database_backend);
 	debug_assert (!ec);
 	return json.get_error ();
 }

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -305,7 +305,7 @@ enum class telemetry_maker : uint8_t
 
 class telemetry_data
 {
-public:
+public: // Payload
 	nano::signature signature{ 0 };
 	nano::account node_id{};
 	uint64_t block_count{ 0 };
@@ -327,18 +327,22 @@ public:
 	std::string database_backend{ "Unknown" };
 	std::vector<uint8_t> unknown_data;
 
+public:
 	void serialize (nano::stream &) const;
-	void deserialize (nano::stream &, uint16_t);
-	nano::error serialize_json (nano::jsonconfig &, bool) const;
-	nano::error deserialize_json (nano::jsonconfig &, bool);
+	void deserialize (nano::stream &, uint16_t payload_length);
+
+	nano::error serialize_json (nano::jsonconfig &, bool ignore_identification_metrics) const;
+	nano::error deserialize_json (nano::jsonconfig &, bool ignore_identification_metrics);
+
 	void sign (nano::keypair const &);
 	bool validate_signature () const;
-	bool operator== (nano::telemetry_data const &) const;
-	bool operator!= (nano::telemetry_data const &) const;
+
+	bool operator== (nano::telemetry_data const &) const = default;
+	bool operator!= (nano::telemetry_data const &) const = default;
 
 	// Size does not include unknown_data
-	static auto constexpr size = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty);
-	static auto constexpr latest_size = size; // This needs to be updated for each new telemetry version
+	// This needs to be updated for each new telemetry version
+	static size_t constexpr size = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty);
 
 private:
 	void serialize_without_signature (nano::stream &) const;
@@ -372,6 +376,8 @@ public:
 	uint16_t size () const;
 	bool is_empty_payload () const;
 	static uint16_t size (nano::message_header const &);
+
+public: // Payload
 	nano::telemetry_data data;
 
 public: // Logging

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -324,6 +324,7 @@ public:
 	uint8_t maker{ static_cast<std::underlying_type_t<telemetry_maker>> (telemetry_maker::nf_node) }; // Where this telemetry information originated
 	std::chrono::system_clock::time_point timestamp;
 	uint64_t active_difficulty{ 0 };
+	std::string database_backend{ "Unknown" };
 	std::vector<uint8_t> unknown_data;
 
 	void serialize (nano::stream &) const;

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -324,7 +324,7 @@ public: // Payload
 	uint8_t maker{ static_cast<std::underlying_type_t<telemetry_maker>> (telemetry_maker::nf_node) }; // Where this telemetry information originated
 	std::chrono::system_clock::time_point timestamp;
 	uint64_t active_difficulty{ 0 };
-	std::string database_backend{ "Unknown" };
+	uint8_t database_backend{ 0 };
 	std::vector<uint8_t> unknown_data;
 
 public:
@@ -342,7 +342,7 @@ public:
 
 	// Size does not include unknown_data
 	// This needs to be updated for each new telemetry version
-	static size_t constexpr size = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty);
+	static size_t constexpr size = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty) + sizeof (database_backend);
 
 private:
 	void serialize_without_signature (nano::stream &) const;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1346,6 +1346,7 @@ nano::telemetry_data nano::node::local_telemetry () const
 	telemetry_data.maker = static_cast<std::underlying_type_t<telemetry_maker>> (ledger.pruning ? telemetry_maker::nf_pruned_node : telemetry_maker::nf_node);
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
 	telemetry_data.active_difficulty = default_difficulty (nano::work_version::work_1);
+	telemetry_data.database_backend = config.rocksdb_config.enable ? "RocksDb" : "LMDB";
 	// Make sure this is the final operation!
 	telemetry_data.sign (node_id);
 	return telemetry_data;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1346,7 +1346,7 @@ nano::telemetry_data nano::node::local_telemetry () const
 	telemetry_data.maker = static_cast<std::underlying_type_t<telemetry_maker>> (ledger.pruning ? telemetry_maker::nf_pruned_node : telemetry_maker::nf_node);
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
 	telemetry_data.active_difficulty = default_difficulty (nano::work_version::work_1);
-	telemetry_data.database_backend = config.rocksdb_config.enable ? "RocksDb" : "LMDB";
+	telemetry_data.database_backend = config.rocksdb_config.enable ? 2 : 1;
 	// Make sure this is the final operation!
 	telemetry_data.sign (node_id);
 	return telemetry_data;

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -312,7 +312,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 
 	std::unordered_map<uint8_t, int> protocol_versions;
 	std::unordered_map<std::string, int> vendor_versions;
-	std::unordered_map<std::string, int> database_backends;
+	std::unordered_map<uint8_t, int> database_backends;
 	std::unordered_map<uint64_t, int> bandwidth_caps;
 	std::unordered_map<nano::block_hash, int> genesis_blocks;
 

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -312,6 +312,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 
 	std::unordered_map<uint8_t, int> protocol_versions;
 	std::unordered_map<std::string, int> vendor_versions;
+	std::unordered_map<std::string, int> database_backends;
 	std::unordered_map<uint64_t, int> bandwidth_caps;
 	std::unordered_map<nano::block_hash, int> genesis_blocks;
 
@@ -349,6 +350,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 		++bandwidth_caps[telemetry_data.bandwidth_cap];
 		++genesis_blocks[telemetry_data.genesis_block];
 		active_difficulties.insert (telemetry_data.active_difficulty);
+		++database_backends[telemetry_data.database_backend];
 	}
 
 	// Remove 10% of the results from the lower and upper bounds to catch any outliers. Need at least 10 responses before any are removed.
@@ -424,6 +426,7 @@ nano::telemetry_data nano::consolidate_telemetry_data (std::vector<nano::telemet
 	set_mode_or_average (bandwidth_caps, consolidated_data.bandwidth_cap, bandwidth_sum, size);
 	set_mode (protocol_versions, consolidated_data.protocol_version, size);
 	set_mode (genesis_blocks, consolidated_data.genesis_block, size);
+	set_mode (database_backends, consolidated_data.database_backend, size);
 
 	// Vendor version, needs to be parsed out of the string
 	std::string version;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6775,7 +6775,12 @@ TEST (rpc, telemetry_all)
 		nano::telemetry_data telemetry_data;
 		auto const should_ignore_identification_metrics = true;
 		ASSERT_FALSE (telemetry_data.deserialize_json (config, should_ignore_identification_metrics));
-		ASSERT_TRUE (nano::test::compare_telemetry_data (telemetry_data, node->local_telemetry ()));
+		auto local_telemetry = node->local_telemetry ();
+		// Ignore the identification metrics
+		local_telemetry.signature.clear ();
+		local_telemetry.node_id.clear ();
+		local_telemetry.timestamp = telemetry_data.timestamp = {};
+		ASSERT_EQ (telemetry_data, local_telemetry);
 		ASSERT_FALSE (response.get_optional<std::string> ("node_id").is_initialized ());
 		ASSERT_FALSE (response.get_optional<std::string> ("signature").is_initialized ());
 	}

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -7,42 +7,16 @@
 
 namespace
 {
-void compare_telemetry_data_impl (const nano::telemetry_data & data_a, const nano::telemetry_data & data_b, bool & result)
-{
-	ASSERT_EQ (data_a.block_count, data_b.block_count);
-	ASSERT_EQ (data_a.cemented_count, data_b.cemented_count);
-	ASSERT_EQ (data_a.bandwidth_cap, data_b.bandwidth_cap);
-	ASSERT_EQ (data_a.peer_count, data_b.peer_count);
-	ASSERT_EQ (data_a.protocol_version, data_b.protocol_version);
-	ASSERT_EQ (data_a.unchecked_count, data_b.unchecked_count);
-	ASSERT_EQ (data_a.account_count, data_b.account_count);
-	ASSERT_LE (data_a.uptime, data_b.uptime);
-	ASSERT_EQ (data_a.genesis_block, data_b.genesis_block);
-	ASSERT_EQ (data_a.major_version, nano::get_major_node_version ());
-	ASSERT_EQ (data_a.minor_version, nano::get_minor_node_version ());
-	ASSERT_EQ (data_a.patch_version, nano::get_patch_node_version ());
-	ASSERT_EQ (data_a.pre_release_version, nano::get_pre_release_node_version ());
-	ASSERT_EQ (data_a.maker, static_cast<std::underlying_type_t<nano::telemetry_maker>> (nano::telemetry_maker::nf_node));
-	ASSERT_GT (data_a.timestamp, std::chrono::system_clock::now () - std::chrono::seconds (100));
-	ASSERT_EQ (data_a.active_difficulty, data_b.active_difficulty);
-	ASSERT_EQ (data_a.unknown_data, std::vector<uint8_t>{});
-	result = true;
-}
-}
-
-bool nano::test::compare_telemetry_data (const nano::telemetry_data & data_a, const nano::telemetry_data & data_b)
-{
-	bool result = false;
-	compare_telemetry_data_impl (data_a, data_b, result);
-	return result;
-}
-
-namespace
-{
-void compare_telemetry_impl (const nano::telemetry_data & data, nano::node const & node, bool & result)
+void compare_telemetry_impl (nano::telemetry_data data, nano::node const & node, bool & result)
 {
 	ASSERT_FALSE (data.validate_signature ());
 	ASSERT_EQ (data.node_id, node.node_id.pub);
+
+	auto data_node = node.local_telemetry ();
+
+	// Ignore timestamps and uptime
+	data.timestamp = data_node.timestamp = {};
+	data.uptime = data_node.uptime = {};
 
 	// Signature should be different because uptime/timestamp will have changed.
 	nano::telemetry_data data_l = data;
@@ -50,13 +24,17 @@ void compare_telemetry_impl (const nano::telemetry_data & data, nano::node const
 	data_l.sign (node.node_id);
 	ASSERT_NE (data.signature, data_l.signature);
 
-	ASSERT_TRUE (nano::test::compare_telemetry_data (data, node.local_telemetry ()));
+	// Clear signatures for comparison
+	data.signature.clear ();
+	data_node.signature.clear ();
+
+	ASSERT_EQ (data, data_node);
 
 	result = true;
 }
 }
 
-bool nano::test::compare_telemetry (const nano::telemetry_data & data, const nano::node & node)
+bool nano::test::compare_telemetry (nano::telemetry_data data, const nano::node & node)
 {
 	bool result = false;
 	compare_telemetry_impl (data, node, result);

--- a/nano/test_common/telemetry.hpp
+++ b/nano/test_common/telemetry.hpp
@@ -9,14 +9,8 @@ class telemetry_data;
 namespace nano::test
 {
 /**
- * Compares telemetry data without signatures
- * @return true if comparison OK
- */
-bool compare_telemetry_data (nano::telemetry_data const &, nano::telemetry_data const &);
-
-/**
  * Compares telemetry data and checks signature matches node_id
  * @return true if comparison OK
  */
-bool compare_telemetry (nano::telemetry_data const &, nano::node const &);
+bool compare_telemetry (nano::telemetry_data, nano::node const &);
 }


### PR DESCRIPTION
Adds telemetry information about the type of database backend the node is using.
The telemetry RPC function reports both individual database backend information or consolidated (average). The reported database backend for each node will be either 'RocksDb' , 'LMDB' or "Unknown". 
'Unknown' is for nodes running v26.1 or earlier that does not send any database information in telemetry data.