### PR TITLE
Log node status periodically

### DIFF
--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -80,6 +80,7 @@ enum class type
 	peer_history,
 	message_processor,
 	local_block_broadcaster,
+	monitor,
 
 	// bootstrap
 	bulk_pull_client,

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -157,6 +157,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::vote_router:
 			thread_role_name_string = "Vote router";
 			break;
+		case nano::thread_role::name::monitor:
+			thread_role_name_string = "Monitor";
+			break;
 		default:
 			debug_assert (false && "nano::thread_role::get_string unhandled thread role");
 	}

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -59,6 +59,7 @@ enum class name
 	port_mapping,
 	stats,
 	vote_router,
+	monitor,
 };
 
 std::string_view to_string (name);

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -101,6 +101,10 @@ add_library(
   make_store.cpp
   message_processor.hpp
   message_processor.cpp
+  messages.hpp
+  messages.cpp
+  monitor.hpp
+  monitor.cpp
   network.hpp
   network.cpp
   nodeconfig.hpp
@@ -196,8 +200,6 @@ add_library(
   websocketconfig.cpp
   websocket_stream.hpp
   websocket_stream.cpp
-  messages.hpp
-  messages.cpp
   xorshift.hpp)
 
 target_link_libraries(

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -515,6 +515,14 @@ std::size_t nano::active_elections::size () const
 	return roots.size ();
 }
 
+std::size_t nano::active_elections::size (nano::election_behavior behavior) const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	auto count = count_by_behavior[behavior];
+	debug_assert (count >= 0);
+	return static_cast<std::size_t> (count);
+}
+
 bool nano::active_elections::publish (std::shared_ptr<nano::block> const & block_a)
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -120,6 +120,7 @@ public:
 	bool erase (nano::qualified_root const &);
 	bool empty () const;
 	std::size_t size () const;
+	std::size_t size (nano::election_behavior) const;
 	bool publish (std::shared_ptr<nano::block> const &);
 
 	/**
@@ -172,7 +173,7 @@ private:
 	std::chrono::seconds const election_time_to_live;
 
 	/** Keeps track of number of elections by election behavior (normal, hinted, optimistic) */
-	nano::enum_array<nano::election_behavior, int64_t> count_by_behavior;
+	nano::enum_array<nano::election_behavior, int64_t> count_by_behavior{};
 
 	nano::condition_variable condition;
 	bool stopped{ false };

--- a/nano/node/monitor.cpp
+++ b/nano/node/monitor.cpp
@@ -85,11 +85,17 @@ void nano::monitor::run_one ()
 		blocks_confirmed_rate,
 		blocks_checked_rate);
 
-		logger.info (nano::log::type::monitor, "Peers: {} (stake peered: {} | stake online: {} | quorum: {})",
+		logger.info (nano::log::type::monitor, "Peers: {} (realtime: {} | bootstrap: {} | inbound connections: {} | outbound connections: {})",
 		node.network.size (),
+		node.tcp_listener.realtime_count (),
+		node.tcp_listener.bootstrap_count (),
+		node.tcp_listener.connection_count (nano::transport::tcp_listener::connection_type::inbound),
+		node.tcp_listener.connection_count (nano::transport::tcp_listener::connection_type::outbound));
+
+		logger.info (nano::log::type::monitor, "Quorum: {} (stake peered: {} | stake online: {})",
+		nano::uint128_union{ node.online_reps.delta () }.format_balance (Mxrb_ratio, 1, true),
 		nano::uint128_union{ node.rep_crawler.total_weight () }.format_balance (Mxrb_ratio, 1, true),
-		nano::uint128_union{ node.online_reps.online () }.format_balance (Mxrb_ratio, 1, true),
-		nano::uint128_union{ node.online_reps.delta () }.format_balance (Mxrb_ratio, 1, true));
+		nano::uint128_union{ node.online_reps.online () }.format_balance (Mxrb_ratio, 1, true));
 
 		logger.info (nano::log::type::monitor, "Elections active: {} (priority: {} | hinted: {} | optimistic: {})",
 		node.active.size (),

--- a/nano/node/monitor.cpp
+++ b/nano/node/monitor.cpp
@@ -1,0 +1,126 @@
+#include "nano/secure/ledger.hpp"
+
+#include <nano/lib/thread_roles.hpp>
+#include <nano/lib/utility.hpp>
+#include <nano/node/monitor.hpp>
+#include <nano/node/node.hpp>
+
+nano::monitor::monitor (nano::monitor_config const & config_a, nano::node & node_a) :
+	config{ config_a },
+	node{ node_a },
+	logger{ node_a.logger }
+{
+}
+
+nano::monitor::~monitor ()
+{
+	debug_assert (!thread.joinable ());
+}
+
+void nano::monitor::start ()
+{
+	if (!config.enabled)
+	{
+		return;
+	}
+
+	thread = std::thread ([this] () {
+		nano::thread_role::set (nano::thread_role::name::monitor);
+		run ();
+	});
+}
+
+void nano::monitor::stop ()
+{
+	{
+		nano::lock_guard<nano::mutex> guard{ mutex };
+		stopped = true;
+	}
+	condition.notify_all ();
+	if (thread.joinable ())
+	{
+		thread.join ();
+	}
+}
+
+void nano::monitor::run ()
+{
+	std::unique_lock<nano::mutex> lock{ mutex };
+	while (!stopped)
+	{
+		run_one ();
+		condition.wait_until (lock, std::chrono::steady_clock::now () + config.interval, [this] { return stopped; });
+	}
+}
+
+void nano::monitor::run_one ()
+{
+	// Node status:
+	// - blocks (confirmed, total)
+	// - blocks rate (over last 5m, peak over last 5m)
+	// - peers
+	// - stake (online, peered, trended, quorum needed)
+	// - elections active (normal, hinted, optimistic)
+	// - election stats over last 5m (confirmed, dropped)
+
+	auto const now = std::chrono::steady_clock::now ();
+	auto blocks_cemented = node.ledger.cemented_count ();
+	auto blocks_total = node.ledger.block_count ();
+
+	// Wait for node to warm up before logging
+	if (last_time != std::chrono::steady_clock::time_point{})
+	{
+		// TODO: Maybe emphasize somehow that confirmed doesn't need to be equal to total; backlog is OK
+		logger.info (nano::log::type::monitor, "Blocks confirmed: {} | total: {}",
+		blocks_cemented,
+		blocks_total);
+
+		// Calculate the rates
+		auto elapsed_seconds = std::chrono::duration_cast<std::chrono::seconds> (now - last_time).count ();
+		auto blocks_confirmed_rate = static_cast<double> (blocks_cemented - last_blocks_cemented) / elapsed_seconds;
+		auto blocks_checked_rate = static_cast<double> (blocks_total - last_blocks_total) / elapsed_seconds;
+
+		logger.info (nano::log::type::monitor, "Blocks rate (average over last {}s): confirmed {:.2f}/s | total {:.2f}/s",
+		elapsed_seconds,
+		blocks_confirmed_rate,
+		blocks_checked_rate);
+
+		logger.info (nano::log::type::monitor, "Peers: {} (stake peered: {} | stake online: {} | quorum: {})",
+		node.network.size (),
+		nano::uint128_union{ node.rep_crawler.total_weight () }.format_balance (Mxrb_ratio, 1, true),
+		nano::uint128_union{ node.online_reps.online () }.format_balance (Mxrb_ratio, 1, true),
+		nano::uint128_union{ node.online_reps.delta () }.format_balance (Mxrb_ratio, 1, true));
+
+		logger.info (nano::log::type::monitor, "Elections active: {} (priority: {} | hinted: {} | optimistic: {})",
+		node.active.size (),
+		node.active.size (nano::election_behavior::priority),
+		node.active.size (nano::election_behavior::hinted),
+		node.active.size (nano::election_behavior::optimistic));
+	}
+
+	last_time = now;
+	last_blocks_cemented = blocks_cemented;
+	last_blocks_total = blocks_total;
+}
+
+/*
+ * monitor_config
+ */
+
+nano::error nano::monitor_config::serialize (nano::tomlconfig & toml) const
+{
+	toml.put ("enable", enabled, "Enable or disable periodic node status logging\ntype:bool");
+	toml.put ("interval", interval.count (), "Interval between status logs\ntype:seconds");
+
+	return toml.get_error ();
+}
+
+nano::error nano::monitor_config::deserialize (nano::tomlconfig & toml)
+{
+	toml.get ("enabled", enabled);
+	auto interval_l = interval.count ();
+	toml.get ("interval", interval_l);
+	interval = std::chrono::seconds{ interval_l };
+
+	return toml.get_error ();
+}

--- a/nano/node/monitor.hpp
+++ b/nano/node/monitor.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <nano/lib/locks.hpp>
+#include <nano/node/fwd.hpp>
+
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+namespace nano
+{
+class monitor_config final
+{
+public:
+	nano::error deserialize (nano::tomlconfig &);
+	nano::error serialize (nano::tomlconfig &) const;
+
+public:
+	bool enabled{ true };
+	std::chrono::seconds interval{ 60s };
+};
+
+class monitor final
+{
+public:
+	monitor (monitor_config const &, nano::node &);
+	~monitor ();
+
+	void start ();
+	void stop ();
+
+private: // Dependencies
+	monitor_config const & config;
+	nano::node & node;
+	nano::logger & logger;
+
+private:
+	void run ();
+	void run_one ();
+
+	std::chrono::steady_clock::time_point last_time{};
+
+	size_t last_blocks_cemented{ 0 };
+	size_t last_blocks_total{ 0 };
+
+	bool stopped{ false };
+	nano::condition_variable condition;
+	mutable nano::mutex mutex;
+	std::thread thread;
+};
+}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -445,7 +445,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 
 				ledger.bootstrap_weights = bootstrap_weights.second;
 
-				logger.info (nano::log::type::node, "************************************ Bootstrap weights ************************************");
+				logger.info (nano::log::type::node, "******************************************** Bootstrap weights ********************************************");
 
 				// Sort the weights
 				std::vector<std::pair<nano::account, nano::uint128_t>> sorted_weights (ledger.bootstrap_weights.begin (), ledger.bootstrap_weights.end ());
@@ -460,7 +460,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 					nano::uint128_union (rep.second).format_balance (Mxrb_ratio, 0, true));
 				}
 
-				logger.info (nano::log::type::node, "************************************ ================= ************************************");
+				logger.info (nano::log::type::node, "******************************************** ================= ********************************************");
 			}
 		}
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -374,7 +374,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 
 		auto const network_label = network_params.network.get_current_network_as_string ();
 
-		logger.info (nano::log::type::node, "Node starting, version: {}", NANO_VERSION_STRING);
+		logger.info (nano::log::type::node, "Version: {}", NANO_VERSION_STRING);
 		logger.info (nano::log::type::node, "Build information: {}", BUILD_INFO);
 		logger.info (nano::log::type::node, "Active network: {}", network_label);
 		logger.info (nano::log::type::node, "Database backend: {}", store.vendor_get ());

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -45,6 +45,7 @@ namespace nano
 class active_elections;
 class confirming_set;
 class message_processor;
+class monitor;
 class node;
 class vote_processor;
 class vote_cache_processor;
@@ -216,7 +217,10 @@ public:
 	nano::process_live_dispatcher process_live_dispatcher;
 	std::unique_ptr<nano::peer_history> peer_history_impl;
 	nano::peer_history & peer_history;
+	std::unique_ptr<nano::monitor> monitor_impl;
+	nano::monitor & monitor;
 
+public:
 	std::chrono::steady_clock::time_point const startup_time;
 	std::chrono::seconds unchecked_cutoff = std::chrono::seconds (7 * 24 * 60 * 60); // Week
 	std::atomic<bool> unresponsive_work_peers{ false };

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -249,6 +249,10 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	message_processor.serialize (message_processor_l);
 	toml.put_child ("message_processor", message_processor_l);
 
+	nano::tomlconfig monitor_l;
+	monitor.serialize (monitor_l);
+	toml.put_child ("monitor", monitor_l);
+
 	return toml.get_error ();
 }
 
@@ -364,6 +368,12 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			auto config_l = toml.get_required_child ("message_processor");
 			message_processor.deserialize (config_l);
+		}
+
+		if (toml.has_key ("monitor"))
+		{
+			auto config_l = toml.get_required_child ("monitor");
+			monitor.deserialize (config_l);
 		}
 
 		if (toml.has_key ("work_peers"))

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -16,6 +16,7 @@
 #include <nano/node/ipc/ipc_config.hpp>
 #include <nano/node/local_block_broadcaster.hpp>
 #include <nano/node/message_processor.hpp>
+#include <nano/node/monitor.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/peer_history.hpp>
 #include <nano/node/repcrawler.hpp>
@@ -156,6 +157,7 @@ public:
 	nano::network_config network;
 	nano::local_block_broadcaster_config local_block_broadcaster;
 	nano::confirming_set_config confirming_set;
+	nano::monitor_config monitor;
 
 public:
 	std::string serialize_frontiers_confirmation (nano::frontiers_confirmation_mode) const;

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -83,7 +83,7 @@ void nano::rep_crawler::validate_and_process (nano::unique_lock<nano::mutex> & l
 		nano::uint128_t const rep_weight = node.ledger.weight (vote->account);
 		if (rep_weight < minimum)
 		{
-			logger.debug (nano::log::type::rep_crawler, "Ignoring vote from account {} with too little voting weight: {}",
+			logger.debug (nano::log::type::rep_crawler, "Ignoring vote from account: {} with too little voting weight: {}",
 			vote->account.to_account (),
 			nano::util::to_str (rep_weight));
 			continue;
@@ -121,11 +121,11 @@ void nano::rep_crawler::validate_and_process (nano::unique_lock<nano::mutex> & l
 
 		if (inserted)
 		{
-			logger.info (nano::log::type::rep_crawler, "Found representative {} at {}", vote->account.to_account (), channel->to_string ());
+			logger.info (nano::log::type::rep_crawler, "Found representative: {} at: {}", vote->account.to_account (), channel->to_string ());
 		}
 		if (updated)
 		{
-			logger.warn (nano::log::type::rep_crawler, "Updated representative {} at {} (was at: {})", vote->account.to_account (), channel->to_string (), prev_channel->to_string ());
+			logger.warn (nano::log::type::rep_crawler, "Updated representative: {} at: {} (was at: {})", vote->account.to_account (), channel->to_string (), prev_channel->to_string ());
 		}
 	}
 }
@@ -202,7 +202,7 @@ void nano::rep_crawler::cleanup ()
 	erase_if (reps, [this] (rep_entry const & rep) {
 		if (!rep.channel->alive ())
 		{
-			logger.info (nano::log::type::rep_crawler, "Evicting representative {} with dead channel at {}", rep.account.to_account (), rep.channel->to_string ());
+			logger.info (nano::log::type::rep_crawler, "Evicting representative: {} with dead channel at: {}", rep.account.to_account (), rep.channel->to_string ());
 			stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::channel_dead);
 			return true; // Erase
 		}
@@ -215,12 +215,12 @@ void nano::rep_crawler::cleanup ()
 		{
 			if (query.replies == 0)
 			{
-				logger.debug (nano::log::type::rep_crawler, "Aborting unresponsive query for block {} from {}", query.hash.to_string (), query.channel->to_string ());
+				logger.debug (nano::log::type::rep_crawler, "Aborting unresponsive query for block: {} from: {}", query.hash.to_string (), query.channel->to_string ());
 				stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::query_timeout);
 			}
 			else
 			{
-				logger.debug (nano::log::type::rep_crawler, "Completion of query with {} replies for block {} from {}", query.replies, query.hash.to_string (), query.channel->to_string ());
+				logger.debug (nano::log::type::rep_crawler, "Completion of query with: {} replies for block: {} from: {}", query.replies, query.hash.to_string (), query.channel->to_string ());
 				stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::query_completion);
 			}
 			return true; // Erase
@@ -350,7 +350,7 @@ void nano::rep_crawler::query (std::vector<std::shared_ptr<nano::transport::chan
 		bool tracked = track_rep_request (hash_root, channel);
 		if (tracked)
 		{
-			logger.debug (nano::log::type::rep_crawler, "Sending query for block {} to {}", hash_root.first.to_string (), channel->to_string ());
+			logger.debug (nano::log::type::rep_crawler, "Sending query for block: {} to: {}", hash_root.first.to_string (), channel->to_string ());
 			stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::query_sent);
 
 			auto const & [hash, root] = hash_root;
@@ -368,7 +368,7 @@ void nano::rep_crawler::query (std::vector<std::shared_ptr<nano::transport::chan
 		}
 		else
 		{
-			logger.debug (nano::log::type::rep_crawler, "Ignoring duplicate query for block {} to {}", hash_root.first.to_string (), channel->to_string ());
+			logger.debug (nano::log::type::rep_crawler, "Ignoring duplicate query for block: {} to: {}", hash_root.first.to_string (), channel->to_string ());
 			stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::query_duplicate);
 		}
 	}
@@ -404,7 +404,7 @@ bool nano::rep_crawler::process (std::shared_ptr<nano::vote> const & vote, std::
 		});
 		if (found)
 		{
-			logger.debug (nano::log::type::rep_crawler, "Processing response for block {} from {}", target_hash.to_string (), channel->to_string ());
+			logger.debug (nano::log::type::rep_crawler, "Processing response for block: {} from: {}", target_hash.to_string (), channel->to_string ());
 			stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::response);
 
 			// Track response time

--- a/nano/node/transport/tcp_listener.cpp
+++ b/nano/node/transport/tcp_listener.cpp
@@ -499,6 +499,12 @@ size_t nano::transport::tcp_listener::connection_count () const
 	return connections.size ();
 }
 
+size_t nano::transport::tcp_listener::connection_count (connection_type type) const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return count_per_type (type);
+}
+
 size_t nano::transport::tcp_listener::attempt_count () const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };

--- a/nano/node/transport/tcp_listener.hpp
+++ b/nano/node/transport/tcp_listener.hpp
@@ -54,6 +54,13 @@ public:
 class tcp_listener final
 {
 public:
+	enum class connection_type
+	{
+		inbound,
+		outbound,
+	};
+
+public:
 	tcp_listener (uint16_t port, tcp_config const &, nano::node &);
 	~tcp_listener ();
 
@@ -69,6 +76,7 @@ public:
 	nano::tcp_endpoint endpoint () const;
 
 	size_t connection_count () const;
+	size_t connection_count (connection_type) const;
 	size_t attempt_count () const;
 	size_t realtime_count () const;
 	size_t bootstrap_count () const;
@@ -102,12 +110,6 @@ private:
 		accepted,
 		rejected,
 		error,
-	};
-
-	enum class connection_type
-	{
-		inbound,
-		outbound,
 	};
 
 	asio::awaitable<void> connect_impl (asio::ip::tcp::endpoint);


### PR DESCRIPTION
This logs node status (block count, block rates, peers, quorum info, election count) every 60 seconds. This should provide immediate and easy to access way to check node status for node operators.

Final output looks like this:

<img width="1086" alt="Screenshot 2024-07-09 at 14 43 45" src="https://github.com/nanocurrency/nano-node/assets/3044353/b8123f91-a1d6-414e-804b-6ebfbbfee19a">

