### PR TITLE
Use 'enable' in configs for consistency

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -544,12 +544,12 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	map_size = 999
 
 	[node.optimistic_scheduler]
-	enabled = false
+	enable = false
 	gap_threshold = 999
 	max_size = 999
 
 	[node.hinted_scheduler]
-	enabled = false
+	enable = false
 	hinting_threshold = 99
 	check_interval = 999
 	block_cooldown = 999

--- a/nano/node/monitor.cpp
+++ b/nano/node/monitor.cpp
@@ -123,7 +123,7 @@ nano::error nano::monitor_config::serialize (nano::tomlconfig & toml) const
 
 nano::error nano::monitor_config::deserialize (nano::tomlconfig & toml)
 {
-	toml.get ("enabled", enabled);
+	toml.get ("enable", enabled);
 	auto interval_l = interval.count ();
 	toml.get ("interval", interval_l);
 	interval = std::chrono::seconds{ interval_l };

--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -271,7 +271,7 @@ nano::error nano::scheduler::hinted_config::serialize (nano::tomlconfig & toml) 
 
 nano::error nano::scheduler::hinted_config::deserialize (nano::tomlconfig & toml)
 {
-	toml.get ("enabled", enabled);
+	toml.get ("enable", enabled);
 	toml.get ("hinting_threshold", hinting_threshold_percent);
 
 	auto check_interval_l = check_interval.count ();

--- a/nano/node/scheduler/optimistic.cpp
+++ b/nano/node/scheduler/optimistic.cpp
@@ -183,7 +183,7 @@ std::unique_ptr<nano::container_info_component> nano::scheduler::optimistic::col
 
 nano::error nano::scheduler::optimistic_config::deserialize (nano::tomlconfig & toml)
 {
-	toml.get ("enabled", enabled);
+	toml.get ("enable", enabled);
 	toml.get ("gap_threshold", gap_threshold);
 	toml.get ("max_size", max_size);
 


### PR DESCRIPTION
Changed 3 config options from 'enabled' to 'enable' for consistency with the rest of the codebase. 