### PR TITLE
Enable large votes

### DIFF
--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -199,7 +199,7 @@ TEST (message, confirm_header_flags_max)
 TEST (message, confirm_ack_hash_serialization)
 {
 	std::vector<nano::block_hash> hashes;
-	for (auto i (hashes.size ()); i < nano::network::confirm_ack_hashes_max; i++)
+	for (auto i (hashes.size ()); i < 15; i++)
 	{
 		nano::keypair key1;
 		nano::block_hash previous;

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -262,7 +262,7 @@ TEST (request_aggregator, two_endpoints)
 
 TEST (request_aggregator, split)
 {
-	constexpr size_t max_vbh = nano::network::confirm_ack_hashes_max;
+	size_t max_vbh = nano::network::confirm_ack_hashes_max;
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
 	node_config.frontiers_confirmation = nano::frontiers_confirmation_mode::disabled;
@@ -303,7 +303,7 @@ TEST (request_aggregator, split)
 	// Two votes were sent, the first one for 12 hashes and the second one for 1 hash
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
-	ASSERT_TIMELY_EQ (3s, 13, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
+	ASSERT_TIMELY_EQ (3s, nano::network::confirm_ack_hashes_max + 1, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes));
 	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
 	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_unknown));
 	ASSERT_TIMELY_EQ (3s, 0, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_cached_hashes));

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -356,12 +356,12 @@ public:
 	static nano::networks active_network;
 
 	/** Current protocol version */
-	uint8_t const protocol_version = 0x14;
+	uint8_t const protocol_version = 0x15;
 	/** Minimum accepted protocol version */
-	uint8_t const protocol_version_min = 0x12;
+	uint8_t const protocol_version_min = 0x14;
 
 	/** Minimum accepted protocol version used when bootstrapping */
-	uint8_t const bootstrap_protocol_version_min = 0x13;
+	uint8_t const bootstrap_protocol_version_min = 0x14;
 };
 
 std::string get_node_toml_config_path (std::filesystem::path const & data_path);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -122,6 +122,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("block_processor_verification_size", boost::program_options::value<std::size_t>(), "Increase batch signature verification size in block processor, default 0 (limited by config signature_checker_threads), unlimited for fast_bootstrap")
 		("inactive_votes_cache_size", boost::program_options::value<std::size_t>(), "Increase cached votes without active elections size, default 16384")
 		("vote_processor_capacity", boost::program_options::value<std::size_t>(), "Vote processor queue size before dropping votes, default 144k")
+		("disable_large_votes", boost::program_options::value<bool>(), "Disable large votes")
 		;
 	// clang-format on
 }
@@ -182,6 +183,12 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 	if (vote_processor_capacity_it != vm.end ())
 	{
 		flags_a.vote_processor_capacity = vote_processor_capacity_it->second.as<std::size_t> ();
+	}
+	auto disable_large_votes_it = vm.find ("disable_large_votes");
+	if (disable_large_votes_it != vm.end ())
+	{
+		nano::network::confirm_req_hashes_max = 7;
+		nano::network::confirm_ack_hashes_max = 12;
 	}
 	// Config overriding
 	auto config (vm.find ("config"));

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -13,6 +13,10 @@
 
 using namespace std::chrono_literals;
 
+// TODO: Return to static const and remove "disable_large_votes" when rolled out
+std::size_t nano::network::confirm_req_hashes_max{ 255 };
+std::size_t nano::network::confirm_ack_hashes_max{ 255 };
+
 /*
  * network
  */

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -170,8 +170,8 @@ public:
 	static unsigned const broadcast_interval_ms = 10;
 	static std::size_t const buffer_size = 512;
 
-	static std::size_t const confirm_req_hashes_max = 7;
-	static std::size_t const confirm_ack_hashes_max = 12;
+	static std::size_t confirm_req_hashes_max;
+	static std::size_t confirm_ack_hashes_max;
 };
 
 std::unique_ptr<container_info_component> collect_container_info (network & network, std::string const & name);


### PR DESCRIPTION
This bumps the protocol version and also adds the "--disable_large_votes" command line option to disable large votes.