### PR TITLE
Revert account store iterator in `bootstrap_server`

### DIFF
--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -395,8 +395,7 @@ nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & 
 	response.type = nano::asc_pull_type::frontiers;
 
 	nano::asc_pull_ack::frontiers_payload response_payload{};
-
-	for (auto it = ledger.any.account_lower_bound (transaction, request.start), end = ledger.any.account_end (); it != end && response_payload.frontiers.size () < request.count; ++it)
+	for (auto it = store.account.begin (transaction, request.start), end = store.account.end (); it != end && response_payload.frontiers.size () < request.count; ++it)
 	{
 		response_payload.frontiers.emplace_back (it->first, it->second.head);
 	}


### PR DESCRIPTION
There was an account iterator performance degradation introduced recently, especially visible when using rocksdb (~10x slowdown when iterating consecutive entries). This reverts code responsible for serving frontier responses until a proper fix can be implemented.