### PR TITLE
Ascending bootstrap dependency resolution

### DIFF
--- a/nano/core_test/bootstrap_ascending.cpp
+++ b/nano/core_test/bootstrap_ascending.cpp
@@ -78,7 +78,7 @@ TEST (account_sets, priority_base)
 	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
 	nano::bootstrap_ascending::account_sets sets{ system.stats };
-	ASSERT_EQ (1.0f, sets.priority (account));
+	ASSERT_EQ (0.0, sets.priority (account));
 }
 
 TEST (account_sets, priority_blocked)
@@ -90,7 +90,7 @@ TEST (account_sets, priority_blocked)
 	ASSERT_FALSE (store->init_error ());
 	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	sets.block (account, random_hash ());
-	ASSERT_EQ (0.0f, sets.priority (account));
+	ASSERT_EQ (0.0, sets.priority (account));
 }
 
 // When account is unblocked, check that it retains it former priority
@@ -107,7 +107,7 @@ TEST (account_sets, priority_unblock_keep)
 	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial + nano::bootstrap_ascending::account_sets::priority_increase);
 	auto hash = random_hash ();
 	sets.block (account, hash);
-	ASSERT_EQ (0.0f, sets.priority (account));
+	ASSERT_EQ (0.0, sets.priority (account));
 	sets.unblock (account, hash);
 	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial + nano::bootstrap_ascending::account_sets::priority_increase);
 }
@@ -126,7 +126,6 @@ TEST (account_sets, priority_up_down)
 	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial / nano::bootstrap_ascending::account_sets::priority_divide);
 }
 
-// Check that priority downward saturates to 1.0f
 TEST (account_sets, priority_down_sat)
 {
 	nano::test::system system;
@@ -136,7 +135,7 @@ TEST (account_sets, priority_down_sat)
 	ASSERT_FALSE (store->init_error ());
 	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	sets.priority_down (account);
-	ASSERT_EQ (1.0f, sets.priority (account));
+	ASSERT_EQ (0.0, sets.priority (account));
 }
 
 // Ensure priority value is bounded

--- a/nano/core_test/bootstrap_ascending.cpp
+++ b/nano/core_test/bootstrap_ascending.cpp
@@ -262,7 +262,7 @@ TEST (bootstrap_ascending, config_serialization)
 {
 	nano::bootstrap_ascending_config config1;
 	config1.requests_limit = 0x101;
-	config1.database_requests_limit = 0x102;
+	config1.database_rate_limit = 0x102;
 	config1.pull_count = 0x103;
 	config1.request_timeout = 0x104ms;
 	config1.throttle_coefficient = 0x105;
@@ -279,7 +279,7 @@ TEST (bootstrap_ascending, config_serialization)
 	nano::bootstrap_ascending_config config2;
 	ASSERT_FALSE (config2.deserialize (toml2));
 	ASSERT_EQ (config1.requests_limit, config2.requests_limit);
-	ASSERT_EQ (config1.database_requests_limit, config2.database_requests_limit);
+	ASSERT_EQ (config1.database_rate_limit, config2.database_rate_limit);
 	ASSERT_EQ (config1.pull_count, config2.pull_count);
 	ASSERT_EQ (config1.request_timeout, config2.request_timeout);
 	ASSERT_EQ (config1.throttle_coefficient, config2.throttle_coefficient);

--- a/nano/core_test/bootstrap_ascending.cpp
+++ b/nano/core_test/bootstrap_ascending.cpp
@@ -266,32 +266,3 @@ TEST (bootstrap_ascending, trace_base)
 	//	std::cerr << "node1: " << node1.network.endpoint () << std::endl;
 	ASSERT_TIMELY (10s, node1.block (receive1->hash ()) != nullptr);
 }
-
-TEST (bootstrap_ascending, config_serialization)
-{
-	nano::bootstrap_ascending_config config1;
-	config1.requests_limit = 0x101;
-	config1.database_rate_limit = 0x102;
-	config1.pull_count = 0x103;
-	config1.request_timeout = 0x104ms;
-	config1.throttle_coefficient = 0x105;
-	config1.throttle_wait = 0x106ms;
-	config1.block_wait_count = 0x107;
-	nano::tomlconfig toml1;
-	ASSERT_FALSE (config1.serialize (toml1));
-	std::stringstream stream1;
-	toml1.write (stream1);
-	auto string = stream1.str ();
-	std::stringstream stream2{ string };
-	nano::tomlconfig toml2;
-	toml2.read (stream2);
-	nano::bootstrap_ascending_config config2;
-	ASSERT_FALSE (config2.deserialize (toml2));
-	ASSERT_EQ (config1.requests_limit, config2.requests_limit);
-	ASSERT_EQ (config1.database_rate_limit, config2.database_rate_limit);
-	ASSERT_EQ (config1.pull_count, config2.pull_count);
-	ASSERT_EQ (config1.request_timeout, config2.request_timeout);
-	ASSERT_EQ (config1.throttle_coefficient, config2.throttle_coefficient);
-	ASSERT_EQ (config1.throttle_wait, config2.throttle_wait);
-	ASSERT_EQ (config1.block_wait_count, config2.block_wait_count);
-}

--- a/nano/core_test/bootstrap_ascending.cpp
+++ b/nano/core_test/bootstrap_ascending.cpp
@@ -30,7 +30,8 @@ TEST (account_sets, construction)
 	nano::test::system system;
 	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ system.stats };
+	nano::account_sets_config config;
+	nano::bootstrap_ascending::account_sets sets{ config, system.stats };
 }
 
 TEST (account_sets, empty_blocked)
@@ -40,7 +41,8 @@ TEST (account_sets, empty_blocked)
 	nano::account account{ 1 };
 	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ system.stats };
+	nano::account_sets_config config;
+	nano::bootstrap_ascending::account_sets sets{ config, system.stats };
 	ASSERT_FALSE (sets.blocked (account));
 }
 
@@ -51,7 +53,8 @@ TEST (account_sets, block)
 	nano::account account{ 1 };
 	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ system.stats };
+	nano::account_sets_config config;
+	nano::bootstrap_ascending::account_sets sets{ config, system.stats };
 	sets.block (account, random_hash ());
 	ASSERT_TRUE (sets.blocked (account));
 }
@@ -63,7 +66,8 @@ TEST (account_sets, unblock)
 	nano::account account{ 1 };
 	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ system.stats };
+	nano::account_sets_config config;
+	nano::bootstrap_ascending::account_sets sets{ config, system.stats };
 	auto hash = random_hash ();
 	sets.block (account, hash);
 	sets.unblock (account, hash);
@@ -77,7 +81,8 @@ TEST (account_sets, priority_base)
 	nano::account account{ 1 };
 	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ system.stats };
+	nano::account_sets_config config;
+	nano::bootstrap_ascending::account_sets sets{ config, system.stats };
 	ASSERT_EQ (0.0, sets.priority (account));
 }
 
@@ -88,7 +93,8 @@ TEST (account_sets, priority_blocked)
 	nano::account account{ 1 };
 	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ system.stats };
+	nano::account_sets_config config;
+	nano::bootstrap_ascending::account_sets sets{ config, system.stats };
 	sets.block (account, random_hash ());
 	ASSERT_EQ (0.0, sets.priority (account));
 }
@@ -101,7 +107,8 @@ TEST (account_sets, priority_unblock_keep)
 	nano::account account{ 1 };
 	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ system.stats };
+	nano::account_sets_config config;
+	nano::bootstrap_ascending::account_sets sets{ config, system.stats };
 	sets.priority_up (account);
 	sets.priority_up (account);
 	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial + nano::bootstrap_ascending::account_sets::priority_increase);
@@ -119,7 +126,8 @@ TEST (account_sets, priority_up_down)
 	nano::account account{ 1 };
 	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ system.stats };
+	nano::account_sets_config config;
+	nano::bootstrap_ascending::account_sets sets{ config, system.stats };
 	sets.priority_up (account);
 	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial);
 	sets.priority_down (account);
@@ -133,7 +141,8 @@ TEST (account_sets, priority_down_sat)
 	nano::account account{ 1 };
 	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ system.stats };
+	nano::account_sets_config config;
+	nano::bootstrap_ascending::account_sets sets{ config, system.stats };
 	sets.priority_down (account);
 	ASSERT_EQ (0.0, sets.priority (account));
 }
@@ -146,7 +155,8 @@ TEST (account_sets, saturate_priority)
 	nano::account account{ 1 };
 	auto store = nano::make_store (system.logger, nano::unique_path (), nano::dev::constants);
 	ASSERT_FALSE (store->init_error ());
-	nano::bootstrap_ascending::account_sets sets{ system.stats };
+	nano::account_sets_config config;
+	nano::bootstrap_ascending::account_sets sets{ config, system.stats };
 	for (int n = 0; n < 1000; ++n)
 	{
 		sets.priority_up (account);

--- a/nano/core_test/bootstrap_ascending.cpp
+++ b/nano/core_test/bootstrap_ascending.cpp
@@ -104,12 +104,12 @@ TEST (account_sets, priority_unblock_keep)
 	nano::bootstrap_ascending::account_sets sets{ system.stats };
 	sets.priority_up (account);
 	sets.priority_up (account);
-	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial * nano::bootstrap_ascending::account_sets::priority_increase);
+	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial + nano::bootstrap_ascending::account_sets::priority_increase);
 	auto hash = random_hash ();
 	sets.block (account, hash);
 	ASSERT_EQ (0.0f, sets.priority (account));
 	sets.unblock (account, hash);
-	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial * nano::bootstrap_ascending::account_sets::priority_increase);
+	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial + nano::bootstrap_ascending::account_sets::priority_increase);
 }
 
 TEST (account_sets, priority_up_down)
@@ -123,7 +123,7 @@ TEST (account_sets, priority_up_down)
 	sets.priority_up (account);
 	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial);
 	sets.priority_down (account);
-	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial - nano::bootstrap_ascending::account_sets::priority_decrease);
+	ASSERT_EQ (sets.priority (account), nano::bootstrap_ascending::account_sets::priority_initial / nano::bootstrap_ascending::account_sets::priority_divide);
 }
 
 // Check that priority downward saturates to 1.0f

--- a/nano/core_test/bootstrap_server.cpp
+++ b/nano/core_test/bootstrap_server.cpp
@@ -48,7 +48,7 @@ private:
 /**
  * Checks if both lists contain the same blocks, with `blocks_b` skipped by `skip` elements
  */
-bool compare_blocks (std::vector<std::shared_ptr<nano::block>> blocks_a, std::vector<std::shared_ptr<nano::block>> blocks_b, int skip = 0)
+bool compare_blocks (auto const & blocks_a, auto const & blocks_b, int skip = 0)
 {
 	debug_assert (blocks_b.size () >= blocks_a.size () + skip);
 

--- a/nano/core_test/rep_crawler.cpp
+++ b/nano/core_test/rep_crawler.cpp
@@ -291,7 +291,7 @@ TEST (rep_crawler, two_reps_one_node)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->insert_adhoc (second_rep.prv);
 
-	ASSERT_TIMELY_EQ (5s, node2.rep_crawler.representative_count (), 2);
+	ASSERT_TIMELY_EQ (15s, node2.rep_crawler.representative_count (), 2);
 	auto reps = node2.rep_crawler.representatives ();
 	ASSERT_EQ (2, reps.size ());
 

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -116,6 +116,8 @@ TEST (toml, daemon_config_deserialize_defaults)
 	std::stringstream ss;
 	ss << R"toml(
 	[node]
+	[node.bootstrap_ascending]
+	[node.bootstrap_server]
 	[node.block_processor]
 	[node.diagnostics.txn_tracking]
 	[node.httpcallback]
@@ -128,7 +130,6 @@ TEST (toml, daemon_config_deserialize_defaults)
 	[node.websocket]
 	[node.lmdb]
 	[node.rocksdb]
-	[node.bootstrap_server]
 	[opencl]
 	[rpc]
 	[rpc.child_process]
@@ -264,6 +265,18 @@ TEST (toml, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.vote_processor.pr_priority, defaults.node.vote_processor.pr_priority);
 	ASSERT_EQ (conf.node.vote_processor.threads, defaults.node.vote_processor.threads);
 	ASSERT_EQ (conf.node.vote_processor.batch_size, defaults.node.vote_processor.batch_size);
+
+	ASSERT_EQ (conf.node.bootstrap_ascending.enable, defaults.node.bootstrap_ascending.enable);
+	ASSERT_EQ (conf.node.bootstrap_ascending.enable_database_scan, defaults.node.bootstrap_ascending.enable_database_scan);
+	ASSERT_EQ (conf.node.bootstrap_ascending.enable_dependency_walker, defaults.node.bootstrap_ascending.enable_dependency_walker);
+	ASSERT_EQ (conf.node.bootstrap_ascending.requests_limit, defaults.node.bootstrap_ascending.requests_limit);
+	ASSERT_EQ (conf.node.bootstrap_ascending.database_rate_limit, defaults.node.bootstrap_ascending.database_rate_limit);
+	ASSERT_EQ (conf.node.bootstrap_ascending.pull_count, defaults.node.bootstrap_ascending.pull_count);
+	ASSERT_EQ (conf.node.bootstrap_ascending.request_timeout, defaults.node.bootstrap_ascending.request_timeout);
+	ASSERT_EQ (conf.node.bootstrap_ascending.throttle_coefficient, defaults.node.bootstrap_ascending.throttle_coefficient);
+	ASSERT_EQ (conf.node.bootstrap_ascending.throttle_wait, defaults.node.bootstrap_ascending.throttle_wait);
+	ASSERT_EQ (conf.node.bootstrap_ascending.block_wait_count, defaults.node.bootstrap_ascending.block_wait_count);
+	ASSERT_EQ (conf.node.bootstrap_ascending.max_requests, defaults.node.bootstrap_ascending.max_requests);
 
 	ASSERT_EQ (conf.node.bootstrap_server.max_queue, defaults.node.bootstrap_server.max_queue);
 	ASSERT_EQ (conf.node.bootstrap_server.threads, defaults.node.bootstrap_server.threads);
@@ -576,6 +589,19 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	threads = 999
 	batch_size = 999
 
+	[node.bootstrap_ascending]
+	enable = false
+	enable_database_scan = false
+	enable_dependency_walker = false
+	requests_limit = 999
+	database_rate_limit = 999
+	pull_count = 999
+	request_timeout = 999
+	throttle_coefficient = 999
+	throttle_wait = 999
+	block_wait_count = 999
+	max_requests = 999
+
 	[node.bootstrap_server]
 	max_queue = 999
 	threads = 999
@@ -739,6 +765,18 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.vote_processor.pr_priority, defaults.node.vote_processor.pr_priority);
 	ASSERT_NE (conf.node.vote_processor.threads, defaults.node.vote_processor.threads);
 	ASSERT_NE (conf.node.vote_processor.batch_size, defaults.node.vote_processor.batch_size);
+
+	ASSERT_NE (conf.node.bootstrap_ascending.enable, defaults.node.bootstrap_ascending.enable);
+	ASSERT_NE (conf.node.bootstrap_ascending.enable_database_scan, defaults.node.bootstrap_ascending.enable_database_scan);
+	ASSERT_NE (conf.node.bootstrap_ascending.enable_dependency_walker, defaults.node.bootstrap_ascending.enable_dependency_walker);
+	ASSERT_NE (conf.node.bootstrap_ascending.requests_limit, defaults.node.bootstrap_ascending.requests_limit);
+	ASSERT_NE (conf.node.bootstrap_ascending.database_rate_limit, defaults.node.bootstrap_ascending.database_rate_limit);
+	ASSERT_NE (conf.node.bootstrap_ascending.pull_count, defaults.node.bootstrap_ascending.pull_count);
+	ASSERT_NE (conf.node.bootstrap_ascending.request_timeout, defaults.node.bootstrap_ascending.request_timeout);
+	ASSERT_NE (conf.node.bootstrap_ascending.throttle_coefficient, defaults.node.bootstrap_ascending.throttle_coefficient);
+	ASSERT_NE (conf.node.bootstrap_ascending.throttle_wait, defaults.node.bootstrap_ascending.throttle_wait);
+	ASSERT_NE (conf.node.bootstrap_ascending.block_wait_count, defaults.node.bootstrap_ascending.block_wait_count);
+	ASSERT_NE (conf.node.bootstrap_ascending.max_requests, defaults.node.bootstrap_ascending.max_requests);
 
 	ASSERT_NE (conf.node.bootstrap_server.max_queue, defaults.node.bootstrap_server.max_queue);
 	ASSERT_NE (conf.node.bootstrap_server.threads, defaults.node.bootstrap_server.threads);

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -455,6 +455,7 @@ enum class detail
 	priority_erase_overflow,
 	deprioritize,
 	deprioritize_failed,
+	sync_dependencies,
 
 	request_blocks,
 	request_account_info,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -429,6 +429,7 @@ enum class detail
 	account_info_empty,
 	loop_database,
 	loop_dependencies,
+	duplicate_request,
 
 	// bootstrap ascending accounts
 	prioritize,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -421,6 +421,8 @@ enum class detail
 	track,
 	timeout,
 	nothing_new,
+	account_info_empty,
+	loop_dependencies,
 
 	// bootstrap ascending accounts
 	prioritize,
@@ -429,9 +431,10 @@ enum class detail
 	unblock,
 	unblock_failed,
 
+	next_none,
 	next_priority,
 	next_database,
-	next_none,
+	next_dependency,
 
 	blocking_insert,
 	blocking_erase_overflow,
@@ -442,6 +445,12 @@ enum class detail
 	deprioritize,
 	deprioritize_failed,
 
+	request_blocks,
+	request_account_info,
+
+	// active
+	started_hinted,
+	started_optimistic,
 	// rep_crawler
 	channel_dead,
 	query_target_failed,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -422,6 +422,7 @@ enum class detail
 	timeout,
 	nothing_new,
 	account_info_empty,
+	loop_database,
 	loop_dependencies,
 
 	// bootstrap ascending accounts

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -431,6 +431,7 @@ enum class detail
 	loop_dependencies,
 	duplicate_request,
 	invalid_response_type,
+	timestamp_reset,
 
 	// bootstrap ascending accounts
 	prioritize,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -58,6 +58,13 @@ enum class type
 	blockprocessor_source,
 	blockprocessor_result,
 	blockprocessor_overfill,
+	bootstrap_ascending,
+	bootstrap_ascending_accounts,
+	bootstrap_ascending_verify,
+	bootstrap_ascending_process,
+	bootstrap_ascending_request,
+	bootstrap_ascending_reply,
+	bootstrap_ascending_next,
 	bootstrap_server,
 	bootstrap_server_request,
 	bootstrap_server_overfill,
@@ -86,9 +93,6 @@ enum class type
 	message_processor,
 	message_processor_overfill,
 	message_processor_type,
-
-	bootstrap_ascending,
-	bootstrap_ascending_accounts,
 
 	_last // Must be the last enum
 };
@@ -129,6 +133,7 @@ enum class detail
 	unconfirmed,
 	cemented,
 	cooldown,
+	empty,
 
 	// processing queue
 	queue,
@@ -498,6 +503,11 @@ enum class detail
 	// election bucket
 	activate_success,
 	cancel_lowest,
+
+	// query_type
+	blocks_by_hash,
+	blocks_by_account,
+	account_info_by_hash,
 
 	_last // Must be the last enum
 };

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -430,6 +430,7 @@ enum class detail
 	loop_database,
 	loop_dependencies,
 	duplicate_request,
+	invalid_response_type,
 
 	// bootstrap ascending accounts
 	prioritize,
@@ -437,17 +438,20 @@ enum class detail
 	block,
 	unblock,
 	unblock_failed,
+	dependency_update,
+	dependency_update_failed,
 
 	next_none,
 	next_priority,
 	next_database,
+	next_blocking,
 	next_dependency,
 
 	blocking_insert,
 	blocking_erase_overflow,
 	priority_insert,
-	priority_erase_threshold,
-	priority_erase_block,
+	priority_erase_by_threshold,
+	priority_erase_by_blocking,
 	priority_erase_overflow,
 	deprioritize,
 	deprioritize_failed,

--- a/nano/lib/tomlconfig.hpp
+++ b/nano/lib/tomlconfig.hpp
@@ -147,7 +147,7 @@ public:
 	template <typename Duration>
 	tomlconfig & get_duration (std::string const & key, Duration & target)
 	{
-		uint64_t value;
+		uint64_t value = target.count ();
 		get (key, value);
 		target = Duration{ value };
 		return *this;

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -68,14 +68,16 @@ public: // Context
 	class context
 	{
 	public:
-		context (std::shared_ptr<nano::block> block, nano::block_source source);
-
-		std::shared_ptr<nano::block> const block;
-		nano::block_source const source;
-		std::chrono::steady_clock::time_point const arrival{ std::chrono::steady_clock::now () };
-
-	public:
 		using result_t = nano::block_status;
+		using callback_t = std::function<void (result_t)>;
+
+		context (std::shared_ptr<nano::block> block, nano::block_source source, callback_t callback = nullptr);
+
+		std::shared_ptr<nano::block> block;
+		nano::block_source source;
+		callback_t callback;
+		std::chrono::steady_clock::time_point arrival{ std::chrono::steady_clock::now () };
+
 		std::future<result_t> get_future ();
 
 	private:
@@ -94,7 +96,7 @@ public:
 
 	std::size_t size () const;
 	std::size_t size (nano::block_source) const;
-	bool add (std::shared_ptr<nano::block> const &, nano::block_source = nano::block_source::live, std::shared_ptr<nano::transport::channel> const & channel = nullptr);
+	bool add (std::shared_ptr<nano::block> const &, nano::block_source = nano::block_source::live, std::shared_ptr<nano::transport::channel> const & channel = nullptr, std::function<void (nano::block_status)> callback = {});
 	std::optional<nano::block_status> add_blocking (std::shared_ptr<nano::block> const & block, nano::block_source);
 	void force (std::shared_ptr<nano::block> const &);
 	bool should_log ();

--- a/nano/node/bootstrap/bootstrap_config.cpp
+++ b/nano/node/bootstrap/bootstrap_config.cpp
@@ -29,13 +29,18 @@ nano::error nano::account_sets_config::serialize (nano::tomlconfig & toml) const
  */
 nano::error nano::bootstrap_ascending_config::deserialize (nano::tomlconfig & toml)
 {
+	toml.get ("enable", enable);
+	toml.get ("enable_database_scan", enable_database_scan);
+	toml.get ("enable_dependency_walker", enable_dependency_walker);
+
 	toml.get ("requests_limit", requests_limit);
 	toml.get ("database_rate_limit", database_rate_limit);
 	toml.get ("pull_count", pull_count);
-	toml.get_duration ("timeout", request_timeout);
+	toml.get_duration ("request_timeout", request_timeout);
 	toml.get ("throttle_coefficient", throttle_coefficient);
 	toml.get_duration ("throttle_wait", throttle_wait);
 	toml.get ("block_wait_count", block_wait_count);
+	toml.get ("max_requests", max_requests);
 
 	if (toml.has_key ("account_sets"))
 	{
@@ -48,13 +53,18 @@ nano::error nano::bootstrap_ascending_config::deserialize (nano::tomlconfig & to
 
 nano::error nano::bootstrap_ascending_config::serialize (nano::tomlconfig & toml) const
 {
+	toml.put ("enable", enable, "Enable or disable the ascending bootstrap. Disabling it is not recommended and will prevent the node from syncing.\ntype:bool");
+	toml.put ("enable_database_scan", enable_database_scan, "Enable or disable the 'database scan` strategy for the ascending bootstrap.\ntype:bool");
+	toml.put ("enable_dependency_walker", enable_dependency_walker, "Enable or disable the 'dependency walker` strategy for the ascending bootstrap.\ntype:bool");
+
 	toml.put ("requests_limit", requests_limit, "Request limit to ascending bootstrap after which requests will be dropped.\nNote: changing to unlimited (0) is not recommended.\ntype:uint64");
 	toml.put ("database_rate_limit", database_rate_limit, "Rate limit on scanning accounts and pending entries from database.\nNote: changing to unlimited (0) is not recommended as this operation competes for resources on querying the database.\ntype:uint64");
 	toml.put ("pull_count", pull_count, "Number of requested blocks for ascending bootstrap request.\ntype:uint64");
-	toml.put ("timeout", request_timeout.count (), "Timeout in milliseconds for incoming ascending bootstrap messages to be processed.\ntype:milliseconds");
+	toml.put ("request_timeout", request_timeout.count (), "Timeout in milliseconds for incoming ascending bootstrap messages to be processed.\ntype:milliseconds");
 	toml.put ("throttle_coefficient", throttle_coefficient, "Scales the number of samples to track for bootstrap throttling.\ntype:uint64");
 	toml.put ("throttle_wait", throttle_wait.count (), "Length of time to wait between requests when throttled.\ntype:milliseconds");
 	toml.put ("block_wait_count", block_wait_count, "Asending bootstrap will wait while block processor has more than this many blocks queued.\ntype:uint64");
+	toml.put ("max_requests", max_requests, "Maximum total number of in flight requests.\ntype:uint64");
 
 	nano::tomlconfig account_sets_l;
 	account_sets.serialize (account_sets_l);

--- a/nano/node/bootstrap/bootstrap_config.cpp
+++ b/nano/node/bootstrap/bootstrap_config.cpp
@@ -30,7 +30,7 @@ nano::error nano::account_sets_config::serialize (nano::tomlconfig & toml) const
 nano::error nano::bootstrap_ascending_config::deserialize (nano::tomlconfig & toml)
 {
 	toml.get ("requests_limit", requests_limit);
-	toml.get ("database_requests_limit", database_requests_limit);
+	toml.get ("database_rate_limit", database_rate_limit);
 	toml.get ("pull_count", pull_count);
 	toml.get_duration ("timeout", request_timeout);
 	toml.get ("throttle_coefficient", throttle_coefficient);
@@ -49,7 +49,7 @@ nano::error nano::bootstrap_ascending_config::deserialize (nano::tomlconfig & to
 nano::error nano::bootstrap_ascending_config::serialize (nano::tomlconfig & toml) const
 {
 	toml.put ("requests_limit", requests_limit, "Request limit to ascending bootstrap after which requests will be dropped.\nNote: changing to unlimited (0) is not recommended.\ntype:uint64");
-	toml.put ("database_requests_limit", database_requests_limit, "Request limit for accounts from database after which requests will be dropped.\nNote: changing to unlimited (0) is not recommended as this operation competes for resources on querying the database.\ntype:uint64");
+	toml.put ("database_rate_limit", database_rate_limit, "Rate limit on scanning accounts and pending entries from database.\nNote: changing to unlimited (0) is not recommended as this operation competes for resources on querying the database.\ntype:uint64");
 	toml.put ("pull_count", pull_count, "Number of requested blocks for ascending bootstrap request.\ntype:uint64");
 	toml.put ("timeout", request_timeout.count (), "Timeout in milliseconds for incoming ascending bootstrap messages to be processed.\ntype:milliseconds");
 	toml.put ("throttle_coefficient", throttle_coefficient, "Scales the number of samples to track for bootstrap throttling.\ntype:uint64");

--- a/nano/node/bootstrap/bootstrap_config.hpp
+++ b/nano/node/bootstrap/bootstrap_config.hpp
@@ -33,7 +33,7 @@ public:
 	std::size_t database_rate_limit{ 1024 };
 	std::size_t pull_count{ nano::bootstrap_server::max_blocks };
 	std::chrono::milliseconds request_timeout{ 1000 * 5 };
-	std::size_t throttle_coefficient{ 16 };
+	std::size_t throttle_coefficient{ 8 * 1024 };
 	std::chrono::milliseconds throttle_wait{ 100 };
 	std::size_t block_wait_count{ 1000 };
 	std::size_t max_requests{ 1024 * 16 }; // TODO: Adjust for live network

--- a/nano/node/bootstrap/bootstrap_config.hpp
+++ b/nano/node/bootstrap/bootstrap_config.hpp
@@ -8,6 +8,7 @@ namespace nano
 {
 class tomlconfig;
 
+// TODO: This should be moved next to `account_sets` class
 class account_sets_config final
 {
 public:
@@ -20,6 +21,7 @@ public:
 	std::chrono::milliseconds cooldown{ 1000 * 3 };
 };
 
+// TODO: This should be moved next to `bootstrap_ascending` class
 class bootstrap_ascending_config final
 {
 public:

--- a/nano/node/bootstrap/bootstrap_config.hpp
+++ b/nano/node/bootstrap/bootstrap_config.hpp
@@ -15,6 +15,7 @@ public:
 	nano::error deserialize (nano::tomlconfig & toml);
 	nano::error serialize (nano::tomlconfig & toml) const;
 
+public:
 	std::size_t consideration_count{ 4 };
 	std::size_t priorities_max{ 256 * 1024 };
 	std::size_t blocking_max{ 256 * 1024 };
@@ -28,14 +29,19 @@ public:
 	nano::error deserialize (nano::tomlconfig & toml);
 	nano::error serialize (nano::tomlconfig & toml) const;
 
+public:
+	bool enable{ true };
+	bool enable_database_scan{ true };
+	bool enable_dependency_walker{ true };
+
 	// Maximum number of un-responded requests per channel
-	std::size_t requests_limit{ 64 };
-	std::size_t database_rate_limit{ 1024 };
-	std::size_t pull_count{ nano::bootstrap_server::max_blocks };
+	std::size_t requests_limit{ 64 }; // TODO: => channel_requests_limit
+	std::size_t database_rate_limit{ 1024 }; // TODO: Adjust for live network (lower)
+	std::size_t pull_count{ nano::bootstrap_server::max_blocks }; // TODO: => max_pull_count & use in requests
 	std::chrono::milliseconds request_timeout{ 1000 * 5 };
 	std::size_t throttle_coefficient{ 8 * 1024 };
 	std::chrono::milliseconds throttle_wait{ 100 };
-	std::size_t block_wait_count{ 1000 };
+	std::size_t block_wait_count{ 1000 }; // TODO: Block processor threshold
 	std::size_t max_requests{ 1024 * 16 }; // TODO: Adjust for live network
 
 	nano::account_sets_config account_sets;

--- a/nano/node/bootstrap/bootstrap_config.hpp
+++ b/nano/node/bootstrap/bootstrap_config.hpp
@@ -28,12 +28,13 @@ public:
 
 	// Maximum number of un-responded requests per channel
 	std::size_t requests_limit{ 64 };
-	std::size_t database_requests_limit{ 1024 };
+	std::size_t database_rate_limit{ 1024 };
 	std::size_t pull_count{ nano::bootstrap_server::max_blocks };
 	std::chrono::milliseconds request_timeout{ 1000 * 5 };
 	std::size_t throttle_coefficient{ 16 };
 	std::chrono::milliseconds throttle_wait{ 100 };
 	std::size_t block_wait_count{ 1000 };
+	std::size_t max_requests{ 1024 * 16 }; // TODO: Adjust for live network
 
 	nano::account_sets_config account_sets;
 };

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -313,11 +313,11 @@ nano::asc_pull_ack nano::bootstrap_server::prepare_empty_blocks_response (nano::
 	return response;
 }
 
-std::vector<std::shared_ptr<nano::block>> nano::bootstrap_server::prepare_blocks (secure::transaction const & transaction, nano::block_hash start_block, std::size_t count) const
+std::deque<std::shared_ptr<nano::block>> nano::bootstrap_server::prepare_blocks (secure::transaction const & transaction, nano::block_hash start_block, std::size_t count) const
 {
 	debug_assert (count <= max_blocks); // Should be filtered out earlier
 
-	std::vector<std::shared_ptr<nano::block>> result;
+	std::deque<std::shared_ptr<nano::block>> result;
 	if (!start_block.is_zero ())
 	{
 		std::shared_ptr<nano::block> current = ledger.any.block_get (transaction, start_block);

--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -64,7 +64,7 @@ private:
 	nano::asc_pull_ack process (secure::transaction const &, nano::asc_pull_req::id_t id, nano::asc_pull_req::blocks_payload const & request) const;
 	nano::asc_pull_ack prepare_response (secure::transaction const &, nano::asc_pull_req::id_t id, nano::block_hash start_block, std::size_t count) const;
 	nano::asc_pull_ack prepare_empty_blocks_response (nano::asc_pull_req::id_t id) const;
-	std::vector<std::shared_ptr<nano::block>> prepare_blocks (secure::transaction const &, nano::block_hash start_block, std::size_t count) const;
+	std::deque<std::shared_ptr<nano::block>> prepare_blocks (secure::transaction const &, nano::block_hash start_block, std::size_t count) const;
 
 	/*
 	 * Account info request

--- a/nano/node/bootstrap_ascending/account_sets.cpp
+++ b/nano/node/bootstrap_ascending/account_sets.cpp
@@ -208,13 +208,6 @@ void nano::bootstrap_ascending::account_sets::dependency_update (nano::block_has
 	}
 }
 
-// Returns false if the account is busy, true if the account is available for more requests
-bool nano::bootstrap_ascending::account_sets::check_timestamp (std::chrono::steady_clock::time_point timestamp) const
-{
-	auto const cutoff = std::chrono::steady_clock::now () - config.cooldown;
-	return timestamp < cutoff;
-}
-
 void nano::bootstrap_ascending::account_sets::trim_overflow ()
 {
 	while (priorities.size () > config.priorities_max)
@@ -238,9 +231,11 @@ nano::account nano::bootstrap_ascending::account_sets::next_priority (std::funct
 		return { 0 };
 	}
 
+	auto const cutoff = std::chrono::steady_clock::now () - config.cooldown;
+
 	for (auto const & entry : priorities.get<tag_priority> ())
 	{
-		if (!check_timestamp (entry.timestamp))
+		if (entry.timestamp > cutoff)
 		{
 			continue;
 		}

--- a/nano/node/bootstrap_ascending/account_sets.cpp
+++ b/nano/node/bootstrap_ascending/account_sets.cpp
@@ -238,7 +238,7 @@ nano::account nano::bootstrap_ascending::account_sets::next_priority ()
 		return { 0 };
 	}
 
-	std::vector<float> weights;
+	std::vector<double> weights;
 	std::vector<nano::account> candidates;
 
 	int iterations = 0;
@@ -344,18 +344,17 @@ std::size_t nano::bootstrap_ascending::account_sets::blocked_size () const
 	return blocking.size ();
 }
 
-float nano::bootstrap_ascending::account_sets::priority (nano::account const & account) const
+double nano::bootstrap_ascending::account_sets::priority (nano::account const & account) const
 {
-	if (blocked (account))
+	if (!blocked (account))
 	{
-		return 0.0f;
+		auto existing = priorities.get<tag_account> ().find (account);
+		if (existing != priorities.get<tag_account> ().end ())
+		{
+			return existing->priority;
+		}
 	}
-	auto existing = priorities.get<tag_account> ().find (account);
-	if (existing != priorities.get<tag_account> ().end ())
-	{
-		return existing->priority;
-	}
-	return account_sets::priority_cutoff;
+	return 0.0;
 }
 
 auto nano::bootstrap_ascending::account_sets::info () const -> nano::bootstrap_ascending::account_sets::info_t

--- a/nano/node/bootstrap_ascending/account_sets.cpp
+++ b/nano/node/bootstrap_ascending/account_sets.cpp
@@ -208,19 +208,11 @@ void nano::bootstrap_ascending::account_sets::dependency_update (nano::block_has
 	}
 }
 
-// Returns false if the account is busy
-bool nano::bootstrap_ascending::account_sets::check_timestamp (const nano::account & account) const
+// Returns false if the account is busy, true if the account is available for more requests
+bool nano::bootstrap_ascending::account_sets::check_timestamp (std::chrono::steady_clock::time_point timestamp) const
 {
-	auto iter = priorities.get<tag_account> ().find (account);
-	if (iter != priorities.get<tag_account> ().end ())
-	{
-		auto const cutoff = std::chrono::steady_clock::now () - config.cooldown;
-		if (iter->timestamp > cutoff)
-		{
-			return false;
-		}
-	}
-	return true;
+	auto const cutoff = std::chrono::steady_clock::now () - config.cooldown;
+	return timestamp < cutoff;
 }
 
 void nano::bootstrap_ascending::account_sets::trim_overflow ()
@@ -262,7 +254,7 @@ nano::account nano::bootstrap_ascending::account_sets::next_priority ()
 			it = priorities.get<tag_id> ().begin ();
 		}
 
-		if (check_timestamp (it->account))
+		if (check_timestamp (it->timestamp))
 		{
 			candidates.push_back (it->account);
 			weights.push_back (it->priority);

--- a/nano/node/bootstrap_ascending/account_sets.cpp
+++ b/nano/node/bootstrap_ascending/account_sets.cpp
@@ -11,9 +11,9 @@
  * account_sets
  */
 
-nano::bootstrap_ascending::account_sets::account_sets (nano::stats & stats_a, nano::account_sets_config config_a) :
-	stats{ stats_a },
-	config{ std::move (config_a) }
+nano::bootstrap_ascending::account_sets::account_sets (nano::account_sets_config const & config_a, nano::stats & stats_a) :
+	config{ config_a },
+	stats{ stats_a }
 {
 }
 

--- a/nano/node/bootstrap_ascending/account_sets.hpp
+++ b/nano/node/bootstrap_ascending/account_sets.hpp
@@ -59,8 +59,8 @@ namespace bootstrap_ascending
 		/**
 		 * Sampling
 		 */
-		nano::account next_priority ();
-		nano::block_hash next_blocking ();
+		nano::account next_priority (std::function<bool (nano::account const &)> const & filter);
+		nano::block_hash next_blocking (std::function<bool (nano::block_hash const &)> const & filter);
 
 	public:
 		bool blocked (nano::account const & account) const;

--- a/nano/node/bootstrap_ascending/account_sets.hpp
+++ b/nano/node/bootstrap_ascending/account_sets.hpp
@@ -152,10 +152,10 @@ namespace bootstrap_ascending
 		nano::account_sets_config config;
 
 	public: // Consts
-		static float constexpr priority_initial = 8.0f;
-		static float constexpr priority_increase = 2.0f;
-		static float constexpr priority_decrease = 0.5f;
-		static float constexpr priority_max = 32.0f;
+		static float constexpr priority_initial = 10.0f;
+		static float constexpr priority_increase = 1.0f;
+		static float constexpr priority_divide = 2.0f;
+		static float constexpr priority_max = 128.0f;
 		static float constexpr priority_cutoff = 1.0f;
 
 	public:

--- a/nano/node/bootstrap_ascending/account_sets.hpp
+++ b/nano/node/bootstrap_ascending/account_sets.hpp
@@ -26,7 +26,7 @@ namespace bootstrap_ascending
 	class account_sets
 	{
 	public:
-		explicit account_sets (nano::stats &, nano::account_sets_config config = {});
+		account_sets (account_sets_config const &, nano::stats &);
 
 		/**
 		 * If an account is not blocked, increase its priority.
@@ -75,6 +75,7 @@ namespace bootstrap_ascending
 		std::unique_ptr<nano::container_info_component> collect_container_info (std::string const & name);
 
 	private: // Dependencies
+		account_sets_config const & config;
 		nano::stats & stats;
 
 	private:
@@ -147,9 +148,6 @@ namespace bootstrap_ascending
 		ordered_blocking blocking;
 
 		std::default_random_engine rng;
-
-	private:
-		nano::account_sets_config config;
 
 	public: // Constants
 		static double constexpr priority_initial = 2.0;

--- a/nano/node/bootstrap_ascending/account_sets.hpp
+++ b/nano/node/bootstrap_ascending/account_sets.hpp
@@ -116,14 +116,16 @@ namespace bootstrap_ascending
 		class tag_id {};
 		class tag_dependency {};
 		class tag_dependency_account {};
+		class tag_priority {};
 
 		// Tracks the ongoing account priorities
-		// This only stores account priorities > 1.0f.
 		using ordered_priorities = boost::multi_index_container<priority_entry,
 		mi::indexed_by<
 			mi::sequenced<mi::tag<tag_sequenced>>,
 			mi::ordered_unique<mi::tag<tag_account>,
 				mi::member<priority_entry, nano::account, &priority_entry::account>>,
+			mi::ordered_non_unique<mi::tag<tag_priority>,
+				mi::member<priority_entry, double, &priority_entry::priority>, std::greater<>>, // Descending
 			mi::ordered_unique<mi::tag<tag_id>,
 				mi::member<priority_entry, id_t, &priority_entry::id>>
 		>>;
@@ -146,8 +148,6 @@ namespace bootstrap_ascending
 
 		ordered_priorities priorities;
 		ordered_blocking blocking;
-
-		std::default_random_engine rng;
 
 	public: // Constants
 		static double constexpr priority_initial = 2.0;

--- a/nano/node/bootstrap_ascending/account_sets.hpp
+++ b/nano/node/bootstrap_ascending/account_sets.hpp
@@ -51,13 +51,16 @@ namespace bootstrap_ascending
 		 * Sets information about the account chain that contains the block hash
 		 */
 		void dependency_update (nano::block_hash const & hash, nano::account const & dependency_account);
+		/**
+		 * Should be called periodically to reinsert missing dependencies into the priority set
+		 */
+		void sync_dependencies ();
 
 		/**
 		 * Sampling
 		 */
 		nano::account next_priority ();
 		nano::block_hash next_blocking ();
-		nano::account next_dependency ();
 
 	public:
 		bool blocked (nano::account const & account) const;

--- a/nano/node/bootstrap_ascending/account_sets.hpp
+++ b/nano/node/bootstrap_ascending/account_sets.hpp
@@ -79,7 +79,7 @@ namespace bootstrap_ascending
 
 	private:
 		void trim_overflow ();
-		bool check_timestamp (nano::account const & account) const;
+		bool check_timestamp (std::chrono::steady_clock::time_point timestamp) const;
 
 	private:
 		struct priority_entry

--- a/nano/node/bootstrap_ascending/account_sets.hpp
+++ b/nano/node/bootstrap_ascending/account_sets.hpp
@@ -67,7 +67,7 @@ namespace bootstrap_ascending
 		bool prioritized (nano::account const & account) const;
 		// Accounts in the ledger but not in priority list are assumed priority 1.0f
 		// Blocked accounts are assumed priority 0.0f
-		float priority (nano::account const & account) const;
+		double priority (nano::account const & account) const;
 
 		std::size_t priority_size () const;
 		std::size_t blocked_size () const;
@@ -85,7 +85,7 @@ namespace bootstrap_ascending
 		struct priority_entry
 		{
 			nano::account account;
-			float priority;
+			double priority;
 
 			id_t id{ generate_id () }; // Uniformly distributed, used for random querying
 			std::chrono::steady_clock::time_point timestamp{};
@@ -103,7 +103,7 @@ namespace bootstrap_ascending
 			{
 				return original_entry.account;
 			}
-			float priority () const
+			double priority () const
 			{
 				return original_entry.priority;
 			}
@@ -151,16 +151,16 @@ namespace bootstrap_ascending
 	private:
 		nano::account_sets_config config;
 
-	public: // Consts
-		static float constexpr priority_initial = 10.0f;
-		static float constexpr priority_increase = 1.0f;
-		static float constexpr priority_divide = 2.0f;
-		static float constexpr priority_max = 128.0f;
-		static float constexpr priority_cutoff = 1.0f;
+	public: // Constants
+		static double constexpr priority_initial = 2.0;
+		static double constexpr priority_increase = 2.0;
+		static double constexpr priority_divide = 2.0;
+		static double constexpr priority_max = 128.0;
+		static double constexpr priority_cutoff = 0.15;
 
 	public:
 		using info_t = std::tuple<decltype (blocking), decltype (priorities)>; // <blocking, priorities>
 		info_t info () const;
 	};
-} // bootstrap_ascending
-} // nano
+}
+}

--- a/nano/node/bootstrap_ascending/account_sets.hpp
+++ b/nano/node/bootstrap_ascending/account_sets.hpp
@@ -80,7 +80,6 @@ namespace bootstrap_ascending
 
 	private:
 		void trim_overflow ();
-		bool check_timestamp (std::chrono::steady_clock::time_point timestamp) const;
 
 	private:
 		struct priority_entry

--- a/nano/node/bootstrap_ascending/account_sets.hpp
+++ b/nano/node/bootstrap_ascending/account_sets.hpp
@@ -44,7 +44,8 @@ namespace bootstrap_ascending
 		void timestamp_set (nano::account const & account);
 		void timestamp_reset (nano::account const & account);
 
-		nano::account next ();
+		nano::account next_priority ();
+		nano::block_hash next_blocking ();
 
 	public:
 		bool blocked (nano::account const & account) const;
@@ -78,9 +79,11 @@ namespace bootstrap_ascending
 
 		struct blocking_entry
 		{
-			nano::account account{ 0 };
-			nano::block_hash dependency{ 0 };
-			priority_entry original_entry{ 0, 0 };
+			nano::account account;
+			nano::block_hash dependency;
+			priority_entry original_entry;
+
+			id_t id{ generate_id () }; // Uniformly distributed, used for random querying
 
 			float priority () const
 			{
@@ -115,7 +118,9 @@ namespace bootstrap_ascending
 			mi::ordered_unique<mi::tag<tag_account>,
 				mi::member<blocking_entry, nano::account, &blocking_entry::account>>,
 			mi::ordered_non_unique<mi::tag<tag_priority>,
-				mi::const_mem_fun<blocking_entry, float, &blocking_entry::priority>>
+				mi::const_mem_fun<blocking_entry, float, &blocking_entry::priority>>,
+			mi::ordered_unique<mi::tag<tag_id>,
+				mi::member<blocking_entry, nano::bootstrap_ascending::id_t, &blocking_entry::id>>
 		>>;
 		// clang-format on
 

--- a/nano/node/bootstrap_ascending/iterators.cpp
+++ b/nano/node/bootstrap_ascending/iterators.cpp
@@ -71,18 +71,25 @@ nano::account nano::bootstrap_ascending::buffered_iterator::operator* () const
 	return !buffer.empty () ? buffer.front () : nano::account{ 0 };
 }
 
-nano::account nano::bootstrap_ascending::buffered_iterator::next ()
+nano::account nano::bootstrap_ascending::buffered_iterator::next (std::function<bool (nano::account const &)> const & filter)
 {
-	if (!buffer.empty ())
-	{
-		buffer.pop_front ();
-	}
-	else
+	if (buffer.empty ())
 	{
 		fill ();
 	}
 
-	return *(*this);
+	while (!buffer.empty ())
+	{
+		auto result = buffer.front ();
+		buffer.pop_front ();
+
+		if (filter (result))
+		{
+			return result;
+		}
+	}
+
+	return { 0 };
 }
 
 bool nano::bootstrap_ascending::buffered_iterator::warmup () const

--- a/nano/node/bootstrap_ascending/iterators.hpp
+++ b/nano/node/bootstrap_ascending/iterators.hpp
@@ -39,8 +39,10 @@ class buffered_iterator
 {
 public:
 	explicit buffered_iterator (nano::ledger & ledger);
+
 	nano::account operator* () const;
-	nano::account next ();
+	nano::account next (std::function<bool (nano::account const &)> const & filter);
+
 	// Indicates if a full ledger iteration has taken place e.g. warmed up
 	bool warmup () const;
 

--- a/nano/node/bootstrap_ascending/peer_scoring.cpp
+++ b/nano/node/bootstrap_ascending/peer_scoring.cpp
@@ -6,9 +6,9 @@
  * peer_scoring
  */
 
-nano::bootstrap_ascending::peer_scoring::peer_scoring (nano::bootstrap_ascending_config & config, nano::network_constants const & network_constants) :
-	network_constants{ network_constants },
-	config{ config }
+nano::bootstrap_ascending::peer_scoring::peer_scoring (bootstrap_ascending_config const & config_a, nano::network_constants const & network_constants_a) :
+	config{ config_a },
+	network_constants{ network_constants_a }
 {
 }
 

--- a/nano/node/bootstrap_ascending/peer_scoring.hpp
+++ b/nano/node/bootstrap_ascending/peer_scoring.hpp
@@ -24,7 +24,8 @@ namespace bootstrap_ascending
 	class peer_scoring
 	{
 	public:
-		peer_scoring (nano::bootstrap_ascending_config & config, nano::network_constants const & network_constants);
+		peer_scoring (bootstrap_ascending_config const &, nano::network_constants const &);
+
 		// Returns true if channel limit has been exceeded
 		bool try_send_message (std::shared_ptr<nano::transport::channel> channel);
 		void received_message (std::shared_ptr<nano::transport::channel> channel);
@@ -34,6 +35,10 @@ namespace bootstrap_ascending
 		// Decays scores which become inaccurate over time due to message drops
 		void timeout ();
 		void sync (std::deque<std::shared_ptr<nano::transport::channel>> const & list);
+
+	private:
+		bootstrap_ascending_config const & config;
+		nano::network_constants const & network_constants;
 
 	private:
 		class peer_score
@@ -63,8 +68,6 @@ namespace bootstrap_ascending
 			uint64_t request_count_total{ 0 };
 			uint64_t response_count_total{ 0 };
 		};
-		nano::network_constants const & network_constants;
-		nano::bootstrap_ascending_config & config;
 
 		// clang-format off
 		// Indexes scores by their shared channel pointer

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -462,7 +462,8 @@ void nano::bootstrap_ascending::service::run_one_priority ()
 	{
 		return;
 	}
-	auto count = std::clamp (static_cast<size_t> (priority), 2ul, nano::bootstrap_server::max_blocks);
+	size_t const min_pull_count = 2;
+	auto count = std::clamp (static_cast<size_t> (priority), min_pull_count, nano::bootstrap_server::max_blocks);
 	request (account, count, channel, query_source::priority);
 }
 
@@ -813,8 +814,10 @@ auto nano::bootstrap_ascending::service::info () const -> nano::bootstrap_ascend
 
 std::size_t nano::bootstrap_ascending::service::compute_throttle_size () const
 {
-	std::size_t size_new = config.throttle_coefficient * static_cast<size_t> (std::log (ledger.account_count ()));
-	return std::max (size_new, 16ul);
+	auto ledger_size = ledger.account_count ();
+	size_t target = ledger_size > 0 ? config.throttle_coefficient * static_cast<size_t> (std::log (ledger_size)) : 0;
+	size_t min_size = 16;
+	return std::max (target, min_size);
 }
 
 std::unique_ptr<nano::container_info_component> nano::bootstrap_ascending::service::collect_container_info (std::string const & name)

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -19,14 +19,14 @@ using namespace std::chrono_literals;
  * bootstrap_ascending
  */
 
-nano::bootstrap_ascending::service::service (nano::node_config & config_a, nano::block_processor & block_processor_a, nano::ledger & ledger_a, nano::network & network_a, nano::stats & stat_a) :
+nano::bootstrap_ascending::service::service (nano::node_config const & config_a, nano::block_processor & block_processor_a, nano::ledger & ledger_a, nano::network & network_a, nano::stats & stat_a) :
 	config{ config_a },
 	network_consts{ config.network_params.network },
 	block_processor{ block_processor_a },
 	ledger{ ledger_a },
 	network{ network_a },
 	stats{ stat_a },
-	accounts{ stats },
+	accounts{ config.bootstrap_ascending.account_sets, stats },
 	iterator{ ledger },
 	throttle{ compute_throttle_size () },
 	scoring{ config.bootstrap_ascending, config.network_params.network },

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -295,14 +295,11 @@ std::pair<nano::account, float> nano::bootstrap_ascending::service::next_priorit
 {
 	debug_assert (!mutex.try_lock ());
 
-	auto account = accounts.next_priority ();
-	if (account.is_zero ())
-	{
-		return {};
-	}
+	auto account = accounts.next_priority ([this] (nano::account const & account) {
+		return count_tags (account, query_source::priority) < 4;
+	});
 
-	// Check if request for this account is already in progress
-	if (count_tags (account, query_source::priority) >= 4)
+	if (account.is_zero ())
 	{
 		return {};
 	}
@@ -343,14 +340,11 @@ nano::account nano::bootstrap_ascending::service::next_database (bool should_thr
 		return { 0 };
 	}
 
-	auto account = iterator.next ();
-	if (account.is_zero ())
-	{
-		return { 0 };
-	}
+	auto account = iterator.next ([this] (nano::account const & account) {
+		return count_tags (account, query_source::database) == 0;
+	});
 
-	// Check if request for this account is already in progress
-	if (count_tags (account, query_source::database) >= 1)
+	if (account.is_zero ())
 	{
 		return { 0 };
 	}
@@ -381,14 +375,11 @@ nano::block_hash nano::bootstrap_ascending::service::next_blocking ()
 {
 	debug_assert (!mutex.try_lock ());
 
-	auto blocking = accounts.next_blocking ();
-	if (blocking.is_zero ())
-	{
-		return { 0 };
-	}
+	auto blocking = accounts.next_blocking ([this] (nano::block_hash const & hash) {
+		return count_tags (hash, query_source::blocking) == 0;
+	});
 
-	// Check if request for this hash is already in progress
-	if (count_tags (blocking, query_source::blocking) >= 1)
+	if (blocking.is_zero ())
 	{
 		return { 0 };
 	}

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -800,10 +800,8 @@ auto nano::bootstrap_ascending::service::info () const -> nano::bootstrap_ascend
 
 std::size_t nano::bootstrap_ascending::service::compute_throttle_size () const
 {
-	// Scales logarithmically with ledger block
-	// Returns: config.throttle_coefficient * sqrt(block_count)
-	std::size_t size_new = config.bootstrap_ascending.throttle_coefficient * std::sqrt (ledger.block_count ());
-	return size_new == 0 ? 16 : size_new;
+	std::size_t size_new = config.bootstrap_ascending.throttle_coefficient * static_cast<size_t> (std::log (ledger.account_count ()));
+	return std::max (size_new, 16ul);
 }
 
 std::unique_ptr<nano::container_info_component> nano::bootstrap_ascending::service::collect_container_info (std::string const & name)

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -46,6 +46,8 @@ nano::bootstrap_ascending::service::service (nano::node_config const & config_a,
 		}
 		condition.notify_all ();
 	});
+
+	accounts.priority_set (config.network_params.ledger.genesis->account_field ().value ());
 }
 
 nano::bootstrap_ascending::service::~service ()

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -30,7 +30,7 @@ nano::bootstrap_ascending::service::service (nano::node_config & config_a, nano:
 	iterator{ ledger },
 	throttle{ compute_throttle_size () },
 	scoring{ config.bootstrap_ascending, config.network_params.network },
-	database_limiter{ config.bootstrap_ascending.database_requests_limit, 1.0 }
+	database_limiter{ config.bootstrap_ascending.database_rate_limit, 1.0 }
 {
 	// TODO: This is called from a very congested blockprocessor thread. Offload this work to a dedicated processing thread
 	block_processor.batch_processed.add ([this] (auto const & batch) {
@@ -253,7 +253,7 @@ void nano::bootstrap_ascending::service::wait_tags ()
 {
 	auto predicate = [this] () {
 		debug_assert (!mutex.try_lock ());
-		return tags.size () < max_tags;
+		return tags.size () < config.bootstrap_ascending.max_requests;
 	};
 	wait_backoff (predicate, { 1ms, 1ms, 1ms, 5ms, 10ms, 20ms, 40ms, 80ms, 160ms });
 }

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -176,6 +176,8 @@ std::size_t nano::bootstrap_ascending::service::score_size () const
  */
 void nano::bootstrap_ascending::service::inspect (secure::transaction const & tx, nano::block_status const & result, nano::block const & block)
 {
+	debug_assert (!mutex.try_lock ());
+
 	auto const hash = block.hash ();
 
 	switch (result)
@@ -203,18 +205,15 @@ void nano::bootstrap_ascending::service::inspect (secure::transaction const & tx
 
 			// Mark account as blocked because it is missing the source block
 			accounts.block (account, source);
-
-			// TODO: Track stats
-		}
-		break;
-		case nano::block_status::old:
-		{
-			// TODO: Track stats
 		}
 		break;
 		case nano::block_status::gap_previous:
 		{
-			// TODO: Track stats
+			if (block.type () == block_type::state)
+			{
+				const auto account = block.account_field ().value ();
+				accounts.priority_set (account);
+			}
 		}
 		break;
 		default: // No need to handle other cases

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -44,7 +44,7 @@ namespace bootstrap_ascending
 	class service
 	{
 	public:
-		service (nano::node_config const &, nano::block_processor &, nano::ledger &, nano::network &, nano::stats &);
+		service (nano::node_config const &, nano::block_processor &, nano::ledger &, nano::network &, nano::stats &, nano::logger &);
 		~service ();
 
 		void start ();
@@ -63,12 +63,13 @@ namespace bootstrap_ascending
 		nano::bootstrap_ascending::account_sets::info_t info () const;
 
 	private: // Dependencies
-		nano::node_config const & config;
-		nano::network_constants const & network_consts;
+		bootstrap_ascending_config const & config;
+		nano::network_constants const & network_constants;
 		nano::block_processor & block_processor;
 		nano::ledger & ledger;
 		nano::network & network;
 		nano::stats & stats;
+		nano::logger & logger;
 
 	public: // Tag
 		enum class query_type

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -118,7 +118,8 @@ namespace bootstrap_ascending
 		void run_timeouts ();
 		void cleanup_and_sync ();
 
-		void wait_backoff (std::function<bool ()> const & predicate, std::vector<std::chrono::milliseconds> const & intervals);
+		/* Waits for a condition to be satisfied with incremental backoff */
+		void wait (std::function<bool ()> const & predicate) const;
 
 		/* Avoid too many in-flight requests */
 		void wait_tags ();
@@ -127,8 +128,8 @@ namespace bootstrap_ascending
 		/* Waits for a channel that is not full */
 		std::shared_ptr<nano::transport::channel> wait_channel ();
 		/* Waits until a suitable account outside of cool down period is available */
-		std::pair<nano::account, float> next_priority ();
-		std::pair<nano::account, float> wait_priority ();
+		std::pair<nano::account, double> next_priority ();
+		std::pair<nano::account, double> wait_priority ();
 		/* Gets the next account from the database */
 		nano::account next_database (bool should_throttle);
 		nano::account wait_database (bool should_throttle);

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -94,6 +94,7 @@ namespace bootstrap_ascending
 			nano::hash_or_account start{ 0 };
 			nano::account account{ 0 };
 			nano::block_hash hash{ 0 };
+			size_t count{ 0 };
 
 			id_t id{ generate_id () };
 			std::chrono::steady_clock::time_point timestamp{ std::chrono::steady_clock::now () };
@@ -126,8 +127,8 @@ namespace bootstrap_ascending
 		/* Waits for a channel that is not full */
 		std::shared_ptr<nano::transport::channel> wait_channel ();
 		/* Waits until a suitable account outside of cool down period is available */
-		nano::account next_priority ();
-		nano::account wait_priority ();
+		std::pair<nano::account, float> next_priority ();
+		std::pair<nano::account, float> wait_priority ();
 		/* Gets the next account from the database */
 		nano::account next_database (bool should_throttle);
 		nano::account wait_database (bool should_throttle);
@@ -135,7 +136,7 @@ namespace bootstrap_ascending
 		nano::block_hash next_blocking ();
 		nano::block_hash wait_blocking ();
 
-		bool request (nano::account, std::shared_ptr<nano::transport::channel> const &, query_source);
+		bool request (nano::account, size_t count, std::shared_ptr<nano::transport::channel> const &, query_source);
 		bool request_info (nano::block_hash, std::shared_ptr<nano::transport::channel> const &, query_source);
 		void send (std::shared_ptr<nano::transport::channel> const &, async_tag tag);
 

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -79,9 +79,18 @@ namespace bootstrap_ascending
 			account_info_by_hash,
 		};
 
+		enum class query_source
+		{
+			invalid,
+			priority,
+			database,
+			blocking,
+		};
+
 		struct async_tag
 		{
 			query_type type{ query_type::invalid };
+			query_source source{ query_source::invalid };
 			nano::hash_or_account start{ 0 };
 			nano::account account{ 0 };
 			nano::block_hash hash{ 0 };
@@ -126,8 +135,8 @@ namespace bootstrap_ascending
 		nano::block_hash next_blocking ();
 		nano::block_hash wait_blocking ();
 
-		bool request (nano::account, std::shared_ptr<nano::transport::channel> const &);
-		bool request_info (nano::block_hash, std::shared_ptr<nano::transport::channel> const &);
+		bool request (nano::account, std::shared_ptr<nano::transport::channel> const &, query_source);
+		bool request_info (nano::block_hash, std::shared_ptr<nano::transport::channel> const &, query_source);
 		void send (std::shared_ptr<nano::transport::channel> const &, async_tag tag);
 
 		void process (nano::asc_pull_ack::blocks_payload const & response, async_tag const & tag);

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -103,6 +103,7 @@ namespace bootstrap_ascending
 		void run_database ();
 		void run_one_database (bool should_throttle);
 		void run_dependencies ();
+		void run_one_blocking ();
 		void run_one_dependency ();
 		void run_timeouts ();
 
@@ -120,9 +121,10 @@ namespace bootstrap_ascending
 		/* Gets the next account from the database */
 		nano::account next_database (bool should_throttle);
 		nano::account wait_database (bool should_throttle);
-		/* Waits for next available dependency (blocking block) */
-		nano::block_hash next_dependency ();
-		nano::block_hash wait_dependency ();
+		/* Waits for next available blocking block */
+		nano::block_hash next_blocking ();
+		nano::block_hash wait_blocking ();
+		nano::account next_dependency ();
 
 		bool request (nano::account, std::shared_ptr<nano::transport::channel> const &);
 		bool request_info (nano::block_hash, std::shared_ptr<nano::transport::channel> const &);

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -122,7 +122,6 @@ namespace bootstrap_ascending
 		bool request (nano::account, std::shared_ptr<nano::transport::channel> const &);
 		bool request_info (nano::block_hash, std::shared_ptr<nano::transport::channel> const &);
 		void send (std::shared_ptr<nano::transport::channel> const &, async_tag tag);
-		void track (async_tag const & tag);
 
 		void process (nano::asc_pull_ack::blocks_payload const & response, async_tag const & tag);
 		void process (nano::asc_pull_ack::account_info_payload const & response, async_tag const & tag);
@@ -181,5 +180,7 @@ namespace bootstrap_ascending
 		std::thread dependencies_thread;
 		std::thread timeout_thread;
 	};
+
+	nano::stat::detail to_stat_detail (service::query_type);
 }
 }

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -98,21 +98,26 @@ namespace bootstrap_ascending
 		void inspect (secure::transaction const &, nano::block_status const & result, nano::block const & block);
 
 		void run_priorities ();
+		void run_one_priority ();
+		void run_database ();
+		void run_one_database (bool should_throttle);
 		void run_dependencies ();
+		void run_one_dependency ();
 		void run_timeouts ();
-		bool run_one_priority ();
-		bool run_one_dependency ();
-		void throttle_if_needed (nano::unique_lock<nano::mutex> &) const;
 
-		/* Throttles requesting new blocks, not to overwhelm blockprocessor */
+		/* Ensure there is enough space in blockprocessor for queuing new blocks */
 		void wait_blockprocessor ();
-		/* Waits for channel with free capacity for bootstrap messages */
-		std::shared_ptr<nano::transport::channel> wait_available_channel ();
+		/* Waits for a channel that is not full */
+		std::shared_ptr<nano::transport::channel> wait_channel ();
 		/* Waits until a suitable account outside of cool down period is available */
-		nano::account available_account ();
-		nano::account wait_available_account ();
-		nano::block_hash available_dependency ();
-		nano::block_hash wait_available_dependency ();
+		nano::account next_priority ();
+		nano::account wait_priority ();
+		/* Gets the next account from the database */
+		nano::account next_database (bool should_throttle);
+		nano::account wait_database (bool should_throttle);
+		/* Waits for next available dependency (blocking block) */
+		nano::block_hash next_dependency ();
+		nano::block_hash wait_dependency ();
 
 		bool request (nano::account, std::shared_ptr<nano::transport::channel> const &);
 		bool request_info (nano::block_hash, std::shared_ptr<nano::transport::channel> const &);
@@ -172,6 +177,7 @@ namespace bootstrap_ascending
 		mutable nano::mutex mutex;
 		mutable nano::condition_variable condition;
 		std::thread priorities_thread;
+		std::thread database_thread;
 		std::thread dependencies_thread;
 		std::thread timeout_thread;
 	};

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/interval.hpp>
 #include <nano/lib/locks.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/observer_set.hpp>
@@ -104,8 +105,8 @@ namespace bootstrap_ascending
 		void run_one_database (bool should_throttle);
 		void run_dependencies ();
 		void run_one_blocking ();
-		void run_one_dependency ();
 		void run_timeouts ();
+		void cleanup_and_sync ();
 
 		void wait_backoff (std::function<bool ()> const & predicate, std::vector<std::chrono::milliseconds> const & intervals);
 
@@ -124,7 +125,6 @@ namespace bootstrap_ascending
 		/* Waits for next available blocking block */
 		nano::block_hash next_blocking ();
 		nano::block_hash wait_blocking ();
-		nano::account next_dependency ();
 
 		bool request (nano::account, std::shared_ptr<nano::transport::channel> const &);
 		bool request_info (nano::block_hash, std::shared_ptr<nano::transport::channel> const &);
@@ -181,6 +181,8 @@ namespace bootstrap_ascending
 		// Requests for accounts from database have much lower hitrate and could introduce strain on the network
 		// A separate (lower) limiter ensures that we always reserve resources for querying accounts from priority queue
 		nano::bandwidth_limiter database_limiter;
+
+		nano::interval sync_dependencies_interval;
 
 		bool stopped{ false };
 		mutable nano::mutex mutex;

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -52,13 +52,14 @@ namespace bootstrap_ascending
 		/**
 		 * Process `asc_pull_ack` message coming from network
 		 */
-		void process (nano::asc_pull_ack const & message, std::shared_ptr<nano::transport::channel> channel);
+		void process (nano::asc_pull_ack const & message, std::shared_ptr<nano::transport::channel> const &);
 
 	public: // Container info
 		std::unique_ptr<nano::container_info_component> collect_container_info (std::string const & name);
 		std::size_t blocked_size () const;
 		std::size_t priority_size () const;
 		std::size_t score_size () const;
+		nano::bootstrap_ascending::account_sets::info_t info () const;
 
 	private: // Dependencies
 		nano::node_config & config;
@@ -68,27 +69,27 @@ namespace bootstrap_ascending
 		nano::network & network;
 		nano::stats & stats;
 
-	public: // async_tag
+	public: // Tag
+		enum class query_type
+		{
+			invalid = 0, // Default initialization
+			blocks_by_hash,
+			blocks_by_account,
+			account_info_by_hash,
+		};
+
 		struct async_tag
 		{
-			enum class query_type
-			{
-				invalid = 0, // Default initialization
-				blocks_by_hash,
-				blocks_by_account,
-				// TODO: account_info,
-			};
-
 			query_type type{ query_type::invalid };
-			nano::bootstrap_ascending::id_t id{ 0 };
 			nano::hash_or_account start{ 0 };
 			nano::account account{ 0 };
 
+			id_t id{ generate_id () };
 			std::chrono::steady_clock::time_point timestamp{ std::chrono::steady_clock::now () };
 		};
 
 	public: // Events
-		nano::observer_set<async_tag const &, std::shared_ptr<nano::transport::channel> &> on_request;
+		nano::observer_set<async_tag const &, std::shared_ptr<nano::transport::channel> const &> on_request;
 		nano::observer_set<async_tag const &> on_reply;
 		nano::observer_set<async_tag const &> on_timeout;
 
@@ -96,10 +97,12 @@ namespace bootstrap_ascending
 		/* Inspects a block that has been processed by the block processor */
 		void inspect (secure::transaction const &, nano::block_status const & result, nano::block const & block);
 
-		void throttle_if_needed (nano::unique_lock<nano::mutex> & lock);
-		void run ();
-		bool run_one ();
+		void run_priorities ();
+		void run_dependencies ();
 		void run_timeouts ();
+		bool run_one_priority ();
+		bool run_one_dependency ();
+		void throttle_if_needed (nano::unique_lock<nano::mutex> &) const;
 
 		/* Throttles requesting new blocks, not to overwhelm blockprocessor */
 		void wait_blockprocessor ();
@@ -108,9 +111,12 @@ namespace bootstrap_ascending
 		/* Waits until a suitable account outside of cool down period is available */
 		nano::account available_account ();
 		nano::account wait_available_account ();
+		nano::block_hash available_dependency ();
+		nano::block_hash wait_available_dependency ();
 
-		bool request (nano::account &, std::shared_ptr<nano::transport::channel> &);
-		void send (std::shared_ptr<nano::transport::channel>, async_tag tag);
+		bool request (nano::account, std::shared_ptr<nano::transport::channel> const &);
+		bool request_info (nano::block_hash, std::shared_ptr<nano::transport::channel> const &);
+		void send (std::shared_ptr<nano::transport::channel> const &, async_tag tag);
 		void track (async_tag const & tag);
 
 		void process (nano::asc_pull_ack::blocks_payload const & response, async_tag const & tag);
@@ -133,15 +139,14 @@ namespace bootstrap_ascending
 		 */
 		verify_result verify (nano::asc_pull_ack::blocks_payload const & response, async_tag const & tag) const;
 
-	public: // account_sets
-		nano::bootstrap_ascending::account_sets::info_t info () const;
+		// Calculates a lookback size based on the size of the ledger where larger ledgers have a larger sample count
+		std::size_t compute_throttle_size () const;
 
 	private:
 		nano::bootstrap_ascending::account_sets accounts;
 		nano::bootstrap_ascending::buffered_iterator iterator;
 		nano::bootstrap_ascending::throttle throttle;
-		// Calculates a lookback size based on the size of the ledger where larger ledgers have a larger sample count
-		std::size_t compute_throttle_size () const;
+		nano::bootstrap_ascending::peer_scoring scoring;
 
 		// clang-format off
 		class tag_sequenced {};
@@ -159,7 +164,6 @@ namespace bootstrap_ascending
 		// clang-format on
 		ordered_tags tags;
 
-		nano::bootstrap_ascending::peer_scoring scoring;
 		// Requests for accounts from database have much lower hitrate and could introduce strain on the network
 		// A separate (lower) limiter ensures that we always reserve resources for querying accounts from priority queue
 		nano::bandwidth_limiter database_limiter;
@@ -167,7 +171,8 @@ namespace bootstrap_ascending
 		bool stopped{ false };
 		mutable nano::mutex mutex;
 		mutable nano::condition_variable condition;
-		std::thread thread;
+		std::thread priorities_thread;
+		std::thread dependencies_thread;
 		std::thread timeout_thread;
 	};
 }

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -44,7 +44,7 @@ namespace bootstrap_ascending
 	class service
 	{
 	public:
-		service (nano::node_config &, nano::block_processor &, nano::ledger &, nano::network &, nano::stats &);
+		service (nano::node_config const &, nano::block_processor &, nano::ledger &, nano::network &, nano::stats &);
 		~service ();
 
 		void start ();
@@ -63,8 +63,8 @@ namespace bootstrap_ascending
 		nano::bootstrap_ascending::account_sets::info_t info () const;
 
 	private: // Dependencies
-		nano::node_config & config;
-		nano::network_constants & network_consts;
+		nano::node_config const & config;
+		nano::network_constants const & network_consts;
 		nano::block_processor & block_processor;
 		nano::ledger & ledger;
 		nano::network & network;

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -159,6 +159,9 @@ namespace bootstrap_ascending
 		 */
 		verify_result verify (nano::asc_pull_ack::blocks_payload const & response, async_tag const & tag) const;
 
+		size_t count_tags (nano::account const & account, query_source source) const;
+		size_t count_tags (nano::block_hash const & hash, query_source source) const;
+
 		// Calculates a lookback size based on the size of the ledger where larger ledgers have a larger sample count
 		std::size_t compute_throttle_size () const;
 

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -204,8 +204,6 @@ namespace bootstrap_ascending
 		std::thread database_thread;
 		std::thread dependencies_thread;
 		std::thread timeout_thread;
-
-		static size_t constexpr max_tags{ 1024 };
 	};
 
 	nano::stat::detail to_stat_detail (service::query_type);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -5279,7 +5279,7 @@ void nano::json_handler::debug_bootstrap_priority_info ()
 			boost::property_tree::ptree response_blocking;
 			for (auto const & entry : blocking)
 			{
-				const auto account = entry.account;
+				const auto account = entry.account ();
 				const auto dependency = entry.dependency;
 
 				response_blocking.put (account.to_account (), dependency.to_string ());

--- a/nano/node/messages.hpp
+++ b/nano/node/messages.hpp
@@ -681,7 +681,7 @@ public: // Payload definitions
 		void deserialize (nano::stream &);
 
 	public: // Payload
-		std::vector<std::shared_ptr<nano::block>> blocks;
+		std::deque<std::shared_ptr<nano::block>> blocks;
 
 	public: // Logging
 		void operator() (nano::object_stream &) const;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -217,7 +217,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	aggregator{ *aggregator_impl },
 	wallets (wallets_store.init_error (), *this),
 	backlog{ nano::backlog_population_config (config), scheduler, ledger, stats },
-	ascendboot_impl{ std::make_unique<nano::bootstrap_ascending::service> (config, block_processor, ledger, network, stats) },
+	ascendboot_impl{ std::make_unique<nano::bootstrap_ascending::service> (config, block_processor, ledger, network, stats, logger) },
 	ascendboot{ *ascendboot_impl },
 	websocket{ config.websocket_config, observers, wallets, ledger, io_ctx, logger },
 	epoch_upgrader{ *this, ledger, store, network_params, logger },


### PR DESCRIPTION
This is the first part of our (mine & @gr0vity-dev) work on improving ascending bootstrapper. This part contains a new dependency resolution strategy among a few other smaller improvements.

An example of how it dependency resolution process works: let's have three accounts A, B, C. A depends on a transaction sent by B, and B depends on a transaction sent by C. Let's now assume we have a ledger that is not synced 100%, might be because we're doing an initial sync or our node was offline for a while. If account A performs a new live transaction, we can't process it immediately, because we're still missing chains for B & C. In the previous version resolving these dependencies was slow, as it was relying on sequential sampling of the whole ledger. With this improved algorithm, we first add account A to the blocking set, resolve its dependency as account B, since B is blocked we repeat the same process for B, finally arriving at account C that unblocks all these chains.