### PR TITLE
Fix test logging

### DIFF
--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -482,6 +482,8 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 	}
 	else if (vm.count ("migrate_database_lmdb_to_rocksdb"))
 	{
+		nano::logger::initialize (nano::log_config::daemon_default (), data_path);
+
 		auto data_path = vm.count ("data_path") ? std::filesystem::path (vm["data_path"].as<std::string> ()) : nano::working_path ();
 		auto node_flags = nano::inactive_node_flag_defaults ();
 		node_flags.config_overrides.push_back ("node.rocksdb.enable=false");

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1242,7 +1242,6 @@ uint64_t nano::ledger::pruning_action (secure::write_transaction & transaction_a
 bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_path_a) const
 {
 	nano::logger logger;
-	nano::logger::initialize (nano::log_config::daemon_default (), data_path_a);
 
 	logger.info (nano::log::type::ledger, "Migrating LMDB database to RocksDB. This will take a while...");
 


### PR DESCRIPTION
The `migrate_lmdb_to_rocksdb` function was changing logging format to daemon mode which is wrong because it's also being run as part of core test suite.