### PR TITLE
Disable telemetry replies

### DIFF
--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -59,7 +59,6 @@ TEST (telemetry, basic)
 	nano::test::system system;
 	nano::node_flags node_flags;
 	auto node_client = system.add_node (node_flags);
-	node_flags.disable_ongoing_telemetry_requests = true;
 	auto node_server = system.add_node (node_flags);
 
 	nano::test::wait_peer_connections (system);
@@ -135,7 +134,6 @@ TEST (telemetry, dos_tcp)
 	// Confirm that telemetry_reqs are not processed
 	nano::test::system system;
 	nano::node_flags node_flags;
-	node_flags.disable_ongoing_telemetry_requests = true;
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
@@ -203,7 +201,6 @@ TEST (telemetry, max_possible_size)
 {
 	nano::test::system system;
 	nano::node_flags node_flags;
-	node_flags.disable_ongoing_telemetry_requests = true;
 	node_flags.disable_providing_telemetry_metrics = true;
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
@@ -231,7 +228,6 @@ TEST (telemetry, maker_pruning)
 	node_flags.enable_pruning = true;
 	nano::node_config config;
 	config.enable_voting = false;
-	node_flags.disable_ongoing_telemetry_requests = true;
 	auto node_server = system.add_node (config, node_flags);
 
 	nano::test::wait_peer_connections (system);
@@ -281,7 +277,6 @@ TEST (telemetry, ongoing_broadcasts)
 {
 	nano::test::system system;
 	nano::node_flags node_flags;
-	node_flags.disable_ongoing_telemetry_requests = true;
 	auto & node1 = *system.add_node (node_flags);
 	auto & node2 = *system.add_node (node_flags);
 

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -111,7 +111,6 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_bootstrap_bulk_pull_server", "Disables the legacy bulk pull server for bootstrap operations")
 		("disable_bootstrap_bulk_push_client", "Disables the legacy bulk push client for bootstrap operations")
 		("disable_tcp_realtime", "Disables TCP realtime connections")
-		("disable_ongoing_telemetry_requests", "Disables ongoing telemetry requests to peers")
 		("disable_block_processor_republishing", "Disables block republishing by disabling the local_block_broadcaster component")
 		("disable_search_pending", "Disables the periodic search for pending transactions")
 		("enable_pruning", "Enable experimental ledger pruning")
@@ -145,7 +144,6 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 	flags_a.disable_bootstrap_bulk_pull_server = (vm.count ("disable_bootstrap_bulk_pull_server") > 0);
 	flags_a.disable_bootstrap_bulk_push_client = (vm.count ("disable_bootstrap_bulk_push_client") > 0);
 	flags_a.disable_tcp_realtime = (vm.count ("disable_tcp_realtime") > 0);
-	flags_a.disable_ongoing_telemetry_requests = (vm.count ("disable_ongoing_telemetry_requests") > 0);
 	flags_a.disable_block_processor_republishing = (vm.count ("disable_block_processor_republishing") > 0);
 	flags_a.disable_search_pending = (vm.count ("disable_search_pending") > 0);
 	if (!flags_a.inactive_node)

--- a/nano/node/message_processor.cpp
+++ b/nano/node/message_processor.cpp
@@ -242,15 +242,7 @@ public:
 
 	void telemetry_req (nano::telemetry_req const & message) override
 	{
-		// Send an empty telemetry_ack if we do not want, just to acknowledge that we have received the message to
-		// remove any timeouts on the server side waiting for a message.
-		nano::telemetry_ack telemetry_ack{ node.network_params.network };
-		if (!node.flags.disable_providing_telemetry_metrics)
-		{
-			auto telemetry_data = node.local_telemetry ();
-			telemetry_ack = nano::telemetry_ack{ node.network_params.network, telemetry_data };
-		}
-		channel->send (telemetry_ack, nullptr, nano::transport::buffer_drop_policy::no_socket_drop);
+		// Ignore telemetry requests as telemetry is being periodically broadcasted since V25+
 	}
 
 	void telemetry_ack (nano::telemetry_ack const & message) override

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -191,7 +191,7 @@ public:
 	bool disable_request_loop{ false }; // For testing only
 	bool disable_tcp_realtime{ false };
 	bool disable_providing_telemetry_metrics{ false };
-	bool disable_ongoing_telemetry_requests{ false };
+	bool disable_ongoing_telemetry_requests{ true };
 	bool disable_block_processor_unchecked_deletion{ false };
 	bool disable_block_processor_republishing{ false };
 	bool allow_bootstrap_peers_duplicates{ false };

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -191,7 +191,6 @@ public:
 	bool disable_request_loop{ false }; // For testing only
 	bool disable_tcp_realtime{ false };
 	bool disable_providing_telemetry_metrics{ false };
-	bool disable_ongoing_telemetry_requests{ true };
 	bool disable_block_processor_unchecked_deletion{ false };
 	bool disable_block_processor_republishing{ false };
 	bool allow_bootstrap_peers_duplicates{ false };

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -46,7 +46,7 @@ class telemetry
 public:
 	struct config
 	{
-		bool enable_ongoing_requests{ true };
+		bool enable_ongoing_requests{ false };
 		bool enable_ongoing_broadcasts{ true };
 
 		config (nano::node_config const & config, nano::node_flags const & flags) :

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -37,7 +37,6 @@ namespace transport
  * Those intervals are configurable via `telemetry_request_interval` & `telemetry_broadcast_interval` network constants
  * Telemetry datas are only removed after becoming stale (configurable via `telemetry_cache_cutoff` network constant), so peer data will still be available for a short period after that peer is disconnected
  *
- * Requests can be disabled via `disable_ongoing_telemetry_requests` node flag
  * Broadcasts can be disabled via `disable_providing_telemetry_metrics` node flag
  *
  */
@@ -50,7 +49,6 @@ public:
 		bool enable_ongoing_broadcasts{ true };
 
 		config (nano::node_config const & config, nano::node_flags const & flags) :
-			enable_ongoing_requests{ !flags.disable_ongoing_telemetry_requests },
 			enable_ongoing_broadcasts{ !flags.disable_providing_telemetry_metrics }
 		{
 		}

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1501,7 +1501,6 @@ TEST (telemetry, cache_read_and_timeout)
 {
 	nano::test::system system;
 	nano::node_flags node_flags;
-	node_flags.disable_ongoing_telemetry_requests = true;
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 


### PR DESCRIPTION
Since V25, telemetry is always periodically rebroadcasted. Peers should just listen for it passively. Sending replies directly in response to network messages is a bad practice.