### PR TITLE
Fix handling of `gap_previous`

### DIFF
--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -12,6 +12,7 @@
 #include <nano/node/bootstrap_ascending/iterators.hpp>
 #include <nano/node/bootstrap_ascending/peer_scoring.hpp>
 #include <nano/node/bootstrap_ascending/throttle.hpp>
+#include <nano/node/fwd.hpp>
 
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
@@ -22,23 +23,8 @@
 
 namespace mi = boost::multi_index;
 
-namespace nano::secure
-{
-class transaction;
-}
-
 namespace nano
 {
-class block_processor;
-class ledger;
-class network;
-class node_config;
-
-namespace transport
-{
-	class channel;
-}
-
 namespace bootstrap_ascending
 {
 	class service

--- a/nano/node/bootstrap_ascending/service.hpp
+++ b/nano/node/bootstrap_ascending/service.hpp
@@ -108,7 +108,7 @@ namespace bootstrap_ascending
 
 	private:
 		/* Inspects a block that has been processed by the block processor */
-		void inspect (secure::transaction const &, nano::block_status const & result, nano::block const & block);
+		void inspect (secure::transaction const &, nano::block_status const & result, nano::block const & block, nano::block_source);
 
 		void run_priorities ();
 		void run_one_priority ();

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -8,6 +8,7 @@ namespace nano
 {
 class active_elections;
 class block;
+class block_processor;
 class confirming_set;
 class ledger;
 class local_block_broadcaster;
@@ -29,5 +30,6 @@ class vote_processor;
 class vote_router;
 class wallets;
 
+enum class block_source;
 enum class vote_code;
 }


### PR DESCRIPTION
It seems that the legacy bootstrap interferes with ascending bootstrap when handling `gap_previous` block result. This modifies the check, so that it's only triggered for live traffic (where it indicates that the account has some recent activity but we're still missing dependencies).