### PR TITLE
Use channel as telemetry data key

### DIFF
--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -365,6 +365,7 @@ enum class detail
 	failed_send_telemetry_req,
 	empty_payload,
 	cleanup_outdated,
+	erase_stale,
 
 	// vote generator
 	generator_broadcasts,

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -96,14 +96,11 @@ void nano::telemetry::process (const nano::telemetry_ack & telemetry, const std:
 
 	nano::unique_lock<nano::mutex> lock{ mutex };
 
-	const auto endpoint = channel->get_endpoint ();
-
-	if (auto it = telemetries.get<tag_endpoint> ().find (endpoint); it != telemetries.get<tag_endpoint> ().end ())
+	if (auto it = telemetries.get<tag_channel> ().find (channel); it != telemetries.get<tag_channel> ().end ())
 	{
 		stats.inc (nano::stat::type::telemetry, nano::stat::detail::update);
 
-		telemetries.get<tag_endpoint> ().modify (it, [&telemetry, &endpoint] (auto & entry) {
-			debug_assert (entry.endpoint == endpoint);
+		telemetries.get<tag_channel> ().modify (it, [&telemetry, &channel] (auto & entry) {
 			entry.data = telemetry.data;
 			entry.last_updated = std::chrono::steady_clock::now ();
 		});
@@ -111,7 +108,7 @@ void nano::telemetry::process (const nano::telemetry_ack & telemetry, const std:
 	else
 	{
 		stats.inc (nano::stat::type::telemetry, nano::stat::detail::insert);
-		telemetries.get<tag_endpoint> ().insert ({ endpoint, telemetry.data, std::chrono::steady_clock::now (), channel });
+		telemetries.get<tag_channel> ().insert ({ channel, telemetry.data, std::chrono::steady_clock::now () });
 
 		if (telemetries.size () > max_size)
 		{
@@ -283,7 +280,7 @@ std::unordered_map<nano::endpoint, nano::telemetry_data> nano::telemetry::get_al
 	{
 		if (check_timeout (entry))
 		{
-			result[entry.endpoint] = entry.data;
+			result[entry.endpoint ()] = entry.data;
 		}
 	}
 	return result;

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -244,10 +244,14 @@ void nano::telemetry::cleanup ()
 		// Remove if telemetry data is stale
 		if (!check_timeout (entry))
 		{
-			stats.inc (nano::stat::type::telemetry, nano::stat::detail::cleanup_outdated);
+			stats.inc (nano::stat::type::telemetry, nano::stat::detail::erase_stale);
 			return true; // Erase
 		}
-
+		if (!entry.channel->alive ())
+		{
+			stats.inc (nano::stat::type::telemetry, nano::stat::detail::erase_dead);
+			return true; // Erase
+		}
 		return false; // Do not erase
 	});
 }

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -100,10 +100,14 @@ private: // Dependencies
 private:
 	struct entry
 	{
-		nano::endpoint endpoint;
+		std::shared_ptr<nano::transport::channel> channel;
 		nano::telemetry_data data;
 		std::chrono::steady_clock::time_point last_updated;
-		std::shared_ptr<nano::transport::channel> channel;
+
+		nano::endpoint endpoint () const
+		{
+			return channel->get_endpoint ();
+		}
 	};
 
 private:
@@ -124,13 +128,16 @@ private:
 private:
 	// clang-format off
 	class tag_sequenced {};
+	class tag_channel {};
 	class tag_endpoint {};
 
 	using ordered_telemetries = boost::multi_index_container<entry,
 	mi::indexed_by<
 		mi::sequenced<mi::tag<tag_sequenced>>,
-		mi::hashed_unique<mi::tag<tag_endpoint>,
-			mi::member<entry, nano::endpoint, &entry::endpoint>>
+		mi::ordered_unique<mi::tag<tag_channel>,
+			mi::member<entry,  std::shared_ptr<nano::transport::channel>, &entry::channel>>,
+		mi::hashed_non_unique<mi::tag<tag_endpoint>,
+			mi::const_mem_fun<entry, nano::endpoint, &entry::endpoint>>
 	>>;
 	// clang-format on
 


### PR DESCRIPTION
This fixes a problem where telemetry data from a single peer would be duplicated, one under ephemeral and the other under peering port, like this: 

(thanks to @gr0vity-dev for noticing this problem)
```
{
    "metrics": [
      {
        "block_count": "300014",
        "cemented_count": "300014",
        "unchecked_count": "0",
        "account_count": "100006",
        "bandwidth_cap": "10485760",
        "peer_count": "4",
        "protocol_version": "21",
        "uptime": "180",
        "genesis_block": "E670DF81878460B76B3425EC399800E1219A4387B11A4841B16CE260A9F36917",
        "major_version": "28",
        "minor_version": "0",
        "patch_version": "0",
        "pre_release_version": "99",
        "maker": "0",
        "timestamp": "1723035548025",
        "active_difficulty": "000000000000000f",
        "node_id": "node_1wp7kh4cmz5adwwh8b6rujrh48kp8gaijjf1hadgsrpa3assj6uio8p66oj1",
        "signature": "89EC509E21A1CC3EBF970D57D520BE0420EC4B61E0AB00E12100EA1103C92B6A498C2D8BFD1357680F8000539CFD6C2C6EFD7209614BC01B70603A6C757FD508",
        "address": "::ffff:172.19.0.3",
        "port": "17075"
      },
...
      {
        "block_count": "300014",
        "cemented_count": "300014",
        "unchecked_count": "0",
        "account_count": "100006",
        "bandwidth_cap": "10485760",
        "peer_count": "4",
        "protocol_version": "21",
        "uptime": "240",
        "genesis_block": "E670DF81878460B76B3425EC399800E1219A4387B11A4841B16CE260A9F36917",
        "major_version": "28",
        "minor_version": "0",
        "patch_version": "0",
        "pre_release_version": "99",
        "maker": "0",
        "timestamp": "1723035608284",
        "active_difficulty": "000000000000000f",
        "node_id": "node_1wp7kh4cmz5adwwh8b6rujrh48kp8gaijjf1hadgsrpa3assj6uio8p66oj1",
        "signature": "F8F2E9337BD94C72A9F6482390D87912993E679E9D4848DE734C358134A1CB0122EE768BCFA1267F926B08354197A7A450F5AEC2FF727D8B822B5775043AEB0A",
        "address": "::ffff:172.19.0.3",
        "port": "35816"
      }
```