### PR TITLE
Revert ledger account iterator

### DIFF
--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -93,11 +93,11 @@ TEST (system, DISABLED_generate_send_new)
 	nano::thread_runner runner (system.io_ctx, system.logger, node1.config.io_threads);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	{
-		auto transaction (node1.ledger.tx_begin_read ());
-		auto iterator1 (node1.ledger.any.account_begin (transaction));
-		ASSERT_NE (node1.ledger.any.account_end (), iterator1);
+		auto transaction (node1.store.tx_begin_read ());
+		auto iterator1 (node1.store.account.begin (transaction));
+		ASSERT_NE (node1.store.account.end (), iterator1);
 		++iterator1;
-		ASSERT_EQ (node1.ledger.any.account_end (), iterator1);
+		ASSERT_EQ (node1.store.account.end (), iterator1);
 	}
 	nano::keypair stake_preserver;
 	auto send_block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, stake_preserver.pub, nano::dev::constants.genesis_amount / 3 * 2, true));

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -469,9 +469,9 @@ int main (int argc, char * const * argv)
 			std::cout << "Outputting any frontier hashes which have associated key hashes in the unchecked table (may take some time)...\n";
 
 			// Cache the account heads to make searching quicker against unchecked keys.
-			auto transaction (node->ledger.tx_begin_read ());
+			auto transaction (node->store.tx_begin_read ());
 			std::unordered_set<nano::block_hash> frontier_hashes;
-			for (auto i (node->ledger.any.account_begin (transaction)), n (node->ledger.any.account_end ()); i != n; ++i)
+			for (auto i (node->store.account.begin (transaction)), n (node->store.account.end ()); i != n; ++i)
 			{
 				frontier_hashes.insert (i->second.head);
 			}
@@ -1670,7 +1670,7 @@ int main (int argc, char * const * argv)
 			}
 			size_t const accounts_deque_overflow (32 * 1024);
 			auto transaction = node->ledger.tx_begin_read ();
-			for (auto i (node->ledger.any.account_begin (transaction)), n (node->ledger.any.account_end ()); i != n; ++i)
+			for (auto i (node->store.account.begin (transaction)), n (node->store.account.end ()); i != n; ++i)
 			{
 				{
 					nano::unique_lock<nano::mutex> lock{ mutex };
@@ -1838,7 +1838,7 @@ int main (int argc, char * const * argv)
 				auto transaction = source_node->ledger.tx_begin_read ();
 				block_count = source_node->ledger.block_count ();
 				std::cout << boost::str (boost::format ("Performing bootstrap emulation, %1% blocks in ledger...") % block_count) << std::endl;
-				for (auto i (source_node->ledger.any.account_begin (transaction)), n (source_node->ledger.any.account_end ()); i != n; ++i)
+				for (auto i (source_node->store.account.begin (transaction)), n (source_node->store.account.end ()); i != n; ++i)
 				{
 					nano::account const & account (i->first);
 					nano::account_info const & info (i->second);

--- a/nano/node/bootstrap/bootstrap_frontier.cpp
+++ b/nano/node/bootstrap/bootstrap_frontier.cpp
@@ -238,8 +238,8 @@ void nano::frontier_req_client::next ()
 	if (accounts.empty ())
 	{
 		std::size_t max_size (128);
-		auto transaction (node->ledger.tx_begin_read ());
-		for (auto i (node->ledger.any.account_upper_bound (transaction, current.number ())), n (node->ledger.any.account_end ()); i != n && accounts.size () != max_size; ++i)
+		auto transaction (node->store.tx_begin_read ());
+		for (auto i (node->store.account.begin (transaction, current.number () + 1)), n (node->store.account.end ()); i != n && accounts.size () != max_size; ++i)
 		{
 			nano::account_info const & info (i->second);
 			nano::account const & account (i->first);
@@ -378,10 +378,10 @@ void nano::frontier_req_server::next ()
 		auto now (nano::seconds_since_epoch ());
 		bool disable_age_filter (request->age == std::numeric_limits<decltype (request->age)>::max ());
 		std::size_t max_size (128);
-		auto transaction (node->ledger.tx_begin_read ());
+		auto transaction (node->store.tx_begin_read ());
 		if (!send_confirmed ())
 		{
-			for (auto i (node->ledger.any.account_upper_bound (transaction, current.number ())), n (node->ledger.any.account_end ()); i != n && accounts.size () != max_size; ++i)
+			for (auto i (node->store.account.begin (transaction, current.number () + 1)), n (node->store.account.end ()); i != n && accounts.size () != max_size; ++i)
 			{
 				nano::account_info const & info (i->second);
 				if (disable_age_filter || (now - info.modified) <= request->age)

--- a/nano/node/bootstrap_ascending/iterators.cpp
+++ b/nano/node/bootstrap_ascending/iterators.cpp
@@ -28,8 +28,8 @@ void nano::bootstrap_ascending::database_iterator::next (secure::transaction & t
 	{
 		case table_type::account:
 		{
-			auto item = ledger.any.account_upper_bound (tx, current.number ());
-			if (item != ledger.any.account_end ())
+			auto item = ledger.store.account.begin (tx, current.number () + 1);
+			if (item != ledger.store.account.end ())
 			{
 				current = item->first;
 			}

--- a/nano/node/epoch_upgrader.cpp
+++ b/nano/node/epoch_upgrader.cpp
@@ -114,9 +114,9 @@ void nano::epoch_upgrader::upgrade_impl (nano::raw_key const & prv_a, nano::epoc
 		while (!finished_accounts && count_limit != 0 && !stopped)
 		{
 			{
-				auto transaction (ledger.tx_begin_read ());
+				auto transaction (store.tx_begin_read ());
 				// Collect accounts to upgrade
-				for (auto i (ledger.any.account_begin (transaction)), n (ledger.any.account_end ()); i != n && accounts_list.size () < count_limit; ++i)
+				for (auto i (store.account.begin (transaction)), n (store.account.end ()); i != n && accounts_list.size () < count_limit; ++i)
 				{
 					nano::account const & account (i->first);
 					nano::account_info const & info (i->second);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2263,7 +2263,7 @@ void nano::json_handler::delegators ()
 	{
 		auto transaction (node.ledger.tx_begin_read ());
 		boost::property_tree::ptree delegators;
-		for (auto i (node.ledger.any.account_upper_bound (transaction, start_account)), n (node.ledger.any.account_end ()); i != n && delegators.size () < count; ++i)
+		for (auto i (node.store.account.begin (transaction, start_account.number () + 1)), n (node.store.account.end ()); i != n && delegators.size () < count; ++i)
 		{
 			nano::account_info const & info (i->second);
 			if (info.representative == representative)
@@ -2289,7 +2289,7 @@ void nano::json_handler::delegators_count ()
 	{
 		uint64_t count (0);
 		auto transaction (node.ledger.tx_begin_read ());
-		for (auto i (node.ledger.any.account_begin (transaction)), n (node.ledger.any.account_end ()); i != n; ++i)
+		for (auto i (node.store.account.begin (transaction)), n (node.store.account.end ()); i != n; ++i)
 		{
 			nano::account_info const & info (i->second);
 			if (info.representative == account)
@@ -2400,7 +2400,7 @@ void nano::json_handler::frontiers ()
 	{
 		boost::property_tree::ptree frontiers;
 		auto transaction (node.ledger.tx_begin_read ());
-		for (auto i (node.ledger.any.account_lower_bound (transaction, start)), n (node.ledger.any.account_end ()); i != n && frontiers.size () < count; ++i)
+		for (auto i (node.store.account.begin (transaction, start)), n (node.store.account.end ()); i != n && frontiers.size () < count; ++i)
 		{
 			frontiers.put (i->first.to_account (), i->second.head.to_string ());
 		}
@@ -2801,7 +2801,7 @@ void nano::json_handler::ledger ()
 		auto transaction = node.ledger.tx_begin_read ();
 		if (!ec && !sorting) // Simple
 		{
-			for (auto i (node.ledger.any.account_lower_bound (transaction, start)), n (node.ledger.any.account_end ()); i != n && accounts.size () < count; ++i)
+			for (auto i (node.store.account.begin (transaction, start)), n (node.store.account.end ()); i != n && accounts.size () < count; ++i)
 			{
 				nano::account_info const & info (i->second);
 				if (info.modified >= modified_since && (receivable || info.balance.number () >= threshold.number ()))
@@ -2842,7 +2842,7 @@ void nano::json_handler::ledger ()
 		else if (!ec) // Sorting
 		{
 			std::vector<std::pair<nano::uint128_union, nano::account>> ledger_l;
-			for (auto i (node.ledger.any.account_lower_bound (transaction, start)), n (node.ledger.any.account_end ()); i != n; ++i)
+			for (auto i (node.store.account.begin (transaction, start)), n (node.store.account.end ()); i != n; ++i)
 			{
 				nano::account_info const & info (i->second);
 				nano::uint128_union balance (info.balance);

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1973,7 +1973,7 @@ void nano_qt::advanced_actions::refresh_ledger ()
 {
 	ledger_model->removeRows (0, ledger_model->rowCount ());
 	auto transaction (wallet.node.ledger.tx_begin_read ());
-	for (auto i (wallet.node.ledger.any.account_begin (transaction)), j (wallet.node.ledger.any.account_end ()); i != j; ++i)
+	for (auto i (wallet.node.ledger.store.account.begin (transaction)), j (wallet.node.ledger.store.account.end ()); i != j; ++i)
 	{
 		QList<QStandardItem *> items;
 		items.push_back (new QStandardItem (QString (i->first.to_account ().c_str ())));

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6191,7 +6191,7 @@ TEST (rpc, epoch_upgrade)
 	{
 		auto transaction (node->ledger.tx_begin_read ());
 		ASSERT_EQ (2, node->store.account.count (transaction));
-		for (auto i (node->ledger.any.account_begin (transaction)); i != node->ledger.any.account_end (); ++i)
+		for (auto i (node->store.account.begin (transaction)); i != node->store.account.end (); ++i)
 		{
 			nano::account_info info (i->second);
 			ASSERT_EQ (info.epoch (), nano::epoch::epoch_0);
@@ -6209,7 +6209,7 @@ TEST (rpc, epoch_upgrade)
 	{
 		auto transaction (node->ledger.tx_begin_read ());
 		ASSERT_EQ (4, node->store.account.count (transaction));
-		for (auto i (node->ledger.any.account_begin (transaction)); i != node->ledger.any.account_end (); ++i)
+		for (auto i (node->store.account.begin (transaction)); i != node->store.account.end (); ++i)
 		{
 			nano::account_info info (i->second);
 			ASSERT_EQ (info.epoch (), nano::epoch::epoch_1);
@@ -6272,7 +6272,7 @@ TEST (rpc, epoch_upgrade)
 	{
 		auto transaction (node->ledger.tx_begin_read ());
 		ASSERT_EQ (5, node->store.account.count (transaction));
-		for (auto i (node->ledger.any.account_begin (transaction)); i != node->ledger.any.account_end (); ++i)
+		for (auto i (node->store.account.begin (transaction)); i != node->store.account.end (); ++i)
 		{
 			nano::account_info info (i->second);
 			ASSERT_EQ (info.epoch (), nano::epoch::epoch_2);
@@ -6354,7 +6354,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 	{
 		auto transaction (node->ledger.tx_begin_read ());
 		ASSERT_EQ (2, node->store.account.count (transaction));
-		for (auto i (node->ledger.any.account_begin (transaction)); i != node->ledger.any.account_end (); ++i)
+		for (auto i (node->store.account.begin (transaction)); i != node->store.account.end (); ++i)
 		{
 			nano::account_info info (i->second);
 			ASSERT_EQ (info.epoch (), nano::epoch::epoch_0);
@@ -6373,7 +6373,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 	{
 		auto transaction (node->ledger.tx_begin_read ());
 		ASSERT_EQ (4, node->store.account.count (transaction));
-		for (auto i (node->ledger.any.account_begin (transaction)); i != node->ledger.any.account_end (); ++i)
+		for (auto i (node->store.account.begin (transaction)); i != node->store.account.end (); ++i)
 		{
 			nano::account_info info (i->second);
 			ASSERT_EQ (info.epoch (), nano::epoch::epoch_1);
@@ -6436,7 +6436,7 @@ TEST (rpc, epoch_upgrade_multithreaded)
 	{
 		auto transaction (node->ledger.tx_begin_read ());
 		ASSERT_EQ (5, node->store.account.count (transaction));
-		for (auto i (node->ledger.any.account_begin (transaction)); i != node->ledger.any.account_end (); ++i)
+		for (auto i (node->store.account.begin (transaction)); i != node->store.account.end (); ++i)
 		{
 			nano::account_info info (i->second);
 			ASSERT_EQ (info.epoch (), nano::epoch::epoch_2);

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -52,8 +52,8 @@ TEST (system, generate_mass_activity)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	uint32_t count (20);
 	system.generate_mass_activity (count, *system.nodes[0]);
-	auto transaction (system.nodes[0]->ledger.tx_begin_read ());
-	for (auto i (system.nodes[0]->ledger.any.account_begin (transaction)), n (system.nodes[0]->ledger.any.account_end ()); i != n; ++i)
+	auto transaction (system.nodes[0]->store.tx_begin_read ());
+	for (auto i (system.nodes[0]->store.account.begin (transaction)), n (system.nodes[0]->store.account.end ()); i != n; ++i)
 	{
 	}
 }
@@ -74,8 +74,8 @@ TEST (system, generate_mass_activity_long)
 		std::cout << "count override due to env variable set, count=" << count << std::endl;
 	}
 	system.generate_mass_activity (count, *system.nodes[0]);
-	auto transaction (system.nodes[0]->ledger.tx_begin_read ());
-	for (auto i (system.nodes[0]->ledger.any.account_begin (transaction)), n (system.nodes[0]->ledger.any.account_end ()); i != n; ++i)
+	auto transaction (system.nodes[0]->store.tx_begin_read ());
+	for (auto i (system.nodes[0]->store.account.begin (transaction)), n (system.nodes[0]->store.account.end ()); i != n; ++i)
 	{
 	}
 	system.stop ();
@@ -692,8 +692,8 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	ASSERT_TIMELY (120s, node->ledger.confirmed.block_exists_or_pruned (node->ledger.tx_begin_read (), last_open_hash));
 
 	// All frontiers (except last) should have 2 blocks and both should be confirmed
-	auto transaction = node->ledger.tx_begin_read ();
-	for (auto i (node->ledger.any.account_begin (transaction)), n (node->ledger.any.account_end ()); i != n; ++i)
+	auto transaction = node->store.tx_begin_read ();
+	for (auto i (node->store.account.begin (transaction)), n (node->store.account.end ()); i != n; ++i)
 	{
 		auto & account = i->first;
 		auto & account_info = i->second;
@@ -1753,9 +1753,9 @@ TEST (node, mass_epoch_upgrader)
 		ASSERT_EQ (expected_blocks, node.ledger.block_count ());
 		// Check upgrade
 		{
-			auto transaction (node.ledger.tx_begin_read ());
+			auto transaction (node.store.tx_begin_read ());
 			size_t block_count_sum = 0;
-			for (auto i (node.ledger.any.account_begin (transaction)); i != node.ledger.any.account_end (); ++i)
+			for (auto i (node.store.account.begin (transaction)); i != node.store.account.end (); ++i)
 			{
 				nano::account_info info (i->second);
 				ASSERT_EQ (info.epoch (), nano::epoch::epoch_1);

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -511,12 +511,12 @@ void nano::test::system::generate_send_existing (nano::node & node_a, std::vecto
 		nano::account account;
 		random_pool::generate_block (account.bytes.data (), sizeof (account.bytes));
 		auto transaction = node_a.ledger.tx_begin_read ();
-		auto entry = node_a.ledger.any.account_lower_bound (transaction, account);
-		if (entry == node_a.ledger.any.account_end ())
+		store::iterator<nano::account, nano::account_info> entry (node_a.store.account.begin (transaction, account));
+		if (entry == node_a.store.account.end ())
 		{
-			entry = node_a.ledger.any.account_lower_bound (transaction, 0);
+			entry = node_a.store.account.begin (transaction);
 		}
-		debug_assert (entry != node_a.ledger.any.account_end ());
+		debug_assert (entry != node_a.store.account.end ());
 		destination = nano::account (entry->first);
 		source = get_random_account (accounts_a);
 		amount = get_random_amount (transaction, node_a, source);


### PR DESCRIPTION
The account iterator introduced a significant regression when iterating accounts sequentially. For completeness pending iterator should be reverted in the same way, but this is still TODO.