### PR TITLE
Fix correctness, sanity check, and resolve shutdown issue.

### DIFF
--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -506,6 +506,7 @@ bool nano::active_elections::erase (nano::qualified_root const & root_a)
 	auto root_it (roots.get<tag_root> ().find (root_a));
 	if (root_it != roots.get<tag_root> ().end ())
 	{
+		release_assert (root_it->election->qualified_root == root_a);
 		cleanup_election (lock, root_it->election);
 		return true;
 	}

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -452,8 +452,9 @@ std::vector<nano::representative> nano::rep_crawler::representatives (std::size_
 	}
 
 	std::vector<nano::representative> result;
-	for (auto const & [weight, rep] : ordered | std::views::take (count))
+	for (auto i = ordered.begin (), n = ordered.end (); i != n && result.size () < count; ++i)
 	{
+		auto const & [weight, rep] = *i;
 		result.push_back ({ rep.account, rep.channel });
 	}
 	return result;

--- a/nano/node/unchecked_map.cpp
+++ b/nano/node/unchecked_map.cpp
@@ -168,10 +168,14 @@ void nano::unchecked_map::query_impl (nano::block_hash const & hash)
 
 std::unique_ptr<nano::container_info_component> nano::unchecked_map::collect_container_info (const std::string & name)
 {
-	nano::lock_guard<nano::mutex> lock{ mutex };
-
 	auto composite = std::make_unique<container_info_composite> (name);
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "entries", entries.size (), sizeof (decltype (entries)::value_type) }));
-	composite->add_component (std::make_unique<container_info_leaf> (container_info{ "queries", buffer.size (), sizeof (decltype (buffer)::value_type) }));
+	{
+		std::lock_guard guard{ entries_mutex };
+		composite->add_component (std::make_unique<container_info_leaf> (container_info{ "entries", entries.size (), sizeof (decltype (entries)::value_type) }));
+	}
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		composite->add_component (std::make_unique<container_info_leaf> (container_info{ "queries", buffer.size (), sizeof (decltype (buffer)::value_type) }));
+	}
 	return composite;
 }

--- a/tsan_suppressions
+++ b/tsan_suppressions
@@ -2,3 +2,5 @@ race:mdb.c
 race:rocksdb
 race:Rijndael::Base::FillEncTable
 race:Rijndael::Base::FillDecTable
+race:CryptoPP::Rijndael
+race:boost::asio::detail::conditionally_enabled_mutex::scoped_lock::scoped_lock


### PR DESCRIPTION
There was a missing mutex lock entries_mutex in unchecked_map::collect_container_info.

Sanity check the equality of the iterator qualified root to the item searched for.

Consider stopped flag when wait-looping. Use condition_variable::wait rather than this_thread::sleep_for