### PR TITLE
Rework `broadcast_block_on_arrival` test

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -1438,3 +1438,45 @@ TEST (active_elections, bound_election_winners)
 
 	ASSERT_TIMELY (5s, node.active.vacancy (nano::election_behavior::priority) > 0);
 }
+
+/*
+ * Blocks should only be broadcasted when they are active in the AEC
+ */
+TEST (active_elections, broadcast_block_on_activation)
+{
+	nano::test::system system;
+	nano::node_config config1 = system.default_config ();
+	// Deactivates elections on both nodes.
+	config1.active_elections.size = 0;
+	config1.bootstrap_ascending.enable = false;
+	nano::node_config config2 = system.default_config ();
+	config2.active_elections.size = 0;
+	config2.bootstrap_ascending.enable = false;
+	nano::node_flags flags;
+	// Disables bootstrap listener to make sure the block won't be shared by this channel.
+	flags.disable_bootstrap_listener = true;
+
+	auto node1 = system.add_node (config1, flags);
+	auto node2 = system.add_node (config2, flags);
+
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
+				 .link (nano::dev::genesis_key.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	// Adds a block to the first node
+	node1->process_active (send1);
+
+	// The second node should not have the block
+	ASSERT_NEVER (500ms, node2->block (send1->hash ()));
+
+	// Activating the election should broadcast the block
+	node1->scheduler.manual.push (send1);
+	ASSERT_TIMELY (5s, node1->active.active (send1->qualified_root ()));
+	ASSERT_TIMELY (5s, node2->block_or_pruned_exists (send1->hash ()));
+}

--- a/nano/core_test/blockprocessor.cpp
+++ b/nano/core_test/blockprocessor.cpp
@@ -10,33 +10,3 @@
 #include <gtest/gtest.h>
 
 using namespace std::chrono_literals;
-
-TEST (block_processor, broadcast_block_on_arrival)
-{
-	nano::test::system system;
-	nano::node_config config1 = system.default_config ();
-	// Deactivates elections on both nodes.
-	config1.active_elections.size = 0;
-	nano::node_config config2 = system.default_config ();
-	config2.active_elections.size = 0;
-	nano::node_flags flags;
-	// Disables bootstrap listener to make sure the block won't be shared by this channel.
-	flags.disable_bootstrap_listener = true;
-	auto node1 = system.add_node (config1, flags);
-	auto node2 = system.add_node (config2, flags);
-	nano::state_block_builder builder;
-	auto send1 = builder.make_block ()
-				 .account (nano::dev::genesis_key.pub)
-				 .previous (nano::dev::genesis->hash ())
-				 .representative (nano::dev::genesis_key.pub)
-				 .balance (nano::dev::constants.genesis_amount - nano::Gxrb_ratio)
-				 .link (nano::dev::genesis_key.pub)
-				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*system.work.generate (nano::dev::genesis->hash ()))
-				 .build ();
-	// Adds a block to the first node. process_active() -> (calls) block_processor.add() -> add() ->
-	// awakes process_block() -> process_batch() -> process_one() -> process_live()
-	node1->process_active (send1);
-	// Checks whether the block was broadcast.
-	ASSERT_TIMELY (5s, node2->block_or_pruned_exists (send1->hash ()));
-}


### PR DESCRIPTION
The previous version of `broadcast_block_on_arrival` test was testing behavior that is no longer present. Blocks are only broadcasted for active elections.