### PR TITLE
Add block hash to websocket `new_block_arrived` 

### DIFF
--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -1079,6 +1079,7 @@ TEST (websocket, new_unconfirmed_block)
 	boost::property_tree::ptree event;
 	boost::property_tree::read_json (stream, event);
 	ASSERT_EQ (event.get<std::string> ("topic"), "new_unconfirmed_block");
+	ASSERT_EQ (event.get<std::string> ("hash"), send1->hash ().to_string ());
 
 	auto message_contents = event.get_child ("message");
 	ASSERT_EQ ("state", message_contents.get<std::string> ("type"));

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -957,7 +957,9 @@ nano::websocket::message nano::websocket::message_builder::new_block_arrived (na
 	auto subtype (nano::state_subtype (block_a.sideband ().details));
 	block_l.put ("subtype", subtype);
 
+	message_l.contents.put ("hash", block_a.hash ().to_string ());
 	message_l.contents.add_child ("message", block_l);
+
 	return message_l;
 }
 


### PR DESCRIPTION
This avoids one extra `block_info` RPC call, when you want to know the block hash, for example to match new blocks against confirmed blocks.