### PR TITLE
Update boost to 1.86

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,6 +466,8 @@ set(BOOST_MODULE_LIBS
     ratio
     rational
     regex
+    scope
+    scope_exit
     serialization
     smart_ptr
     spirit

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -12,6 +12,7 @@
 
 #include <gtest/gtest.h>
 
+#include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <chrono>

--- a/nano/lib/config.cpp
+++ b/nano/lib/config.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/numeric/conversion/cast.hpp>
 
 #include <valgrind/valgrind.h>
 

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -18,6 +18,7 @@
 #include <nano/rpc/rpc.hpp>
 #include <nano/secure/working.hpp>
 
+#include <boost/format.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/json_parser.hpp>

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -4,6 +4,7 @@
 #include <nano/node/websocket.hpp>
 
 #include <boost/algorithm/string/erase.hpp>
+#include <boost/format.hpp>
 
 std::shared_ptr<request_type> nano::distributed_work::peer_request::get_prepared_json_request (std::string const & request_string_a) const
 {

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -14,6 +14,7 @@
 #include <nano/node/json_handler.hpp>
 #include <nano/node/node.hpp>
 
+#include <boost/array.hpp>
 #include <boost/endian/conversion.hpp>
 #include <boost/property_tree/json_parser.hpp>
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -37,6 +37,7 @@
 #include <nano/store/component.hpp>
 #include <nano/store/rocksdb/rocksdb.hpp>
 
+#include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <algorithm>

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -30,6 +30,7 @@
 
 #include <gtest/gtest.h>
 
+#include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <algorithm>

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -10,6 +10,7 @@
 #include <nano/test_common/testutil.hpp>
 
 #include <boost/asio.hpp>
+#include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <cstdlib>


### PR DESCRIPTION
Updating boost now gives us a lot of time to test and discover potential problems before the next release.