### PR TITLE
Factor utility functions

### DIFF
--- a/nano/secure/utility.cpp
+++ b/nano/secure/utility.cpp
@@ -47,7 +47,7 @@ std::filesystem::path nano::working_path (nano::networks network)
 	return result;
 }
 
-std::filesystem::path nano::unique_path (nano::networks network)
+std::filesystem::path nano::random_filename ()
 {
 	std::random_device rd;
 	std::mt19937 gen (rd ());
@@ -61,8 +61,12 @@ std::filesystem::path nano::unique_path (nano::networks network)
 	{
 		random_string += hex_chars[dis (gen)];
 	}
+	return std::filesystem::path{ random_string };
+}
 
-	auto result = working_path (network) / random_string;
+std::filesystem::path nano::unique_path (nano::networks network)
+{
+	auto result = working_path (network) / random_filename ();
 
 	std::filesystem::create_directories (result);
 

--- a/nano/secure/utility.hpp
+++ b/nano/secure/utility.hpp
@@ -9,6 +9,8 @@ namespace nano
 std::filesystem::path app_path ();
 // OS-specific way of finding a path to a home directory.
 std::filesystem::path working_path (nano::networks network = nano::network_constants::active_network);
+// Construct a random filename
+std::filesystem::path random_filename ();
 // Get a unique path within the home directory, used for testing.
 // Any directories created at this location will be removed when a test finishes.
 std::filesystem::path unique_path (nano::networks network = nano::network_constants::active_network);

--- a/nano/store/CMakeLists.txt
+++ b/nano/store/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
   nano_store
   account.hpp
   block.hpp
+  block_w_sideband.hpp
   component.hpp
   confirmation_height.hpp
   db_val.hpp

--- a/nano/store/block.hpp
+++ b/nano/store/block.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/lib/block_sideband.hpp>
 #include <nano/lib/numbers.hpp>
+#include <nano/store/block_w_sideband.hpp>
 #include <nano/store/component.hpp>
 #include <nano/store/iterator.hpp>
 
@@ -15,12 +16,6 @@ class block_hash;
 }
 namespace nano::store
 {
-class block_w_sideband
-{
-public:
-	std::shared_ptr<nano::block> block;
-	nano::block_sideband sideband;
-};
 /**
  * Manages block storage and iteration
  */

--- a/nano/store/block_w_sideband.hpp
+++ b/nano/store/block_w_sideband.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <nano/lib/block_sideband.hpp>
+
+#include <memory>
+
+namespace nano
+{
+class block;
+}
+namespace nano::store
+{
+class block_w_sideband
+{
+public:
+	std::shared_ptr<nano::block> block;
+	nano::block_sideband sideband;
+};
+}


### PR DESCRIPTION
This moves block_w_sideband into its own file and splits nano::unique_path in to separate filename and path-generating components.