### PR TITLE
Fix channel lifetimes

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1024,14 +1024,13 @@ TEST (network, loopback_channel)
 	auto & node2 = *system.nodes[1];
 	nano::transport::inproc::channel channel1 (node1, node1);
 	ASSERT_EQ (channel1.get_type (), nano::transport::transport_type::loopback);
-	ASSERT_EQ (channel1.get_endpoint (), node1.network.endpoint ());
-	ASSERT_EQ (channel1.get_tcp_endpoint (), nano::transport::map_endpoint_to_tcp (node1.network.endpoint ()));
+	ASSERT_EQ (channel1.get_remote_endpoint (), node1.network.endpoint ());
 	ASSERT_EQ (channel1.get_network_version (), node1.network_params.network.protocol_version);
 	ASSERT_EQ (channel1.get_node_id (), node1.node_id.pub);
 	ASSERT_EQ (channel1.get_node_id_optional ().value_or (0), node1.node_id.pub);
 	nano::transport::inproc::channel channel2 (node2, node2);
 	++node1.network.port;
-	ASSERT_NE (channel1.get_endpoint (), node1.network.endpoint ());
+	ASSERT_NE (channel1.get_remote_endpoint (), node1.network.endpoint ());
 }
 
 // Ensure the network filters messages with the incorrect magic number

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -614,7 +614,7 @@ TEST (tcp_listener, tcp_listener_timeout_node_id_handshake)
 	ASSERT_TRUE (cookie);
 	nano::node_id_handshake::query_payload query{ *cookie };
 	nano::node_id_handshake node_id_handshake{ nano::dev::network_params.network, query };
-	auto channel = std::make_shared<nano::transport::tcp_channel> (*node0, socket);
+	auto channel = std::make_shared<nano::transport::tcp_channel> (node0, socket);
 	socket->async_connect (node0->tcp_listener.endpoint (), [&node_id_handshake, channel] (boost::system::error_code const & ec) {
 		ASSERT_FALSE (ec);
 		channel->send (node_id_handshake, [] (boost::system::error_code const & ec, size_t size_a) {

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2704,7 +2704,7 @@ TEST (node, peer_history_restart)
 		ASSERT_TIMELY (10s, !node2->network.empty ());
 		// Confirm that the peers match with the endpoints we are expecting
 		auto list (node2->network.list (2));
-		ASSERT_EQ (node1->network.endpoint (), list[0]->get_endpoint ());
+		ASSERT_EQ (node1->network.endpoint (), list[0]->get_remote_endpoint ());
 		ASSERT_EQ (1, node2->network.size ());
 		system.stop_node (*node2);
 	}
@@ -2727,7 +2727,7 @@ TEST (node, peer_history_restart)
 		ASSERT_TIMELY (10s, !node3->network.empty ());
 		// Confirm that the peers match with the endpoints we are expecting
 		auto list (node3->network.list (2));
-		ASSERT_EQ (node1->network.endpoint (), list[0]->get_endpoint ());
+		ASSERT_EQ (node1->network.endpoint (), list[0]->get_remote_endpoint ());
 		ASSERT_EQ (1, node3->network.size ());
 		system.stop_node (*node3);
 	}
@@ -2789,11 +2789,11 @@ TEST (node, bidirectional_tcp)
 	ASSERT_EQ (1, node2->network.size ());
 	auto list1 (node1->network.list (1));
 	ASSERT_EQ (nano::transport::transport_type::tcp, list1[0]->get_type ());
-	ASSERT_NE (node2->network.endpoint (), list1[0]->get_endpoint ()); // Ephemeral port
+	ASSERT_NE (node2->network.endpoint (), list1[0]->get_remote_endpoint ()); // Ephemeral port
 	ASSERT_EQ (node2->node_id.pub, list1[0]->get_node_id ());
 	auto list2 (node2->network.list (1));
 	ASSERT_EQ (nano::transport::transport_type::tcp, list2[0]->get_type ());
-	ASSERT_EQ (node1->network.endpoint (), list2[0]->get_endpoint ());
+	ASSERT_EQ (node1->network.endpoint (), list2[0]->get_remote_endpoint ());
 	ASSERT_EQ (node1->node_id.pub, list2[0]->get_node_id ());
 	// Test block propagation from node 1
 	nano::keypair key;

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -79,16 +79,12 @@ TEST (peer_container, tcp_channel_cleanup_works)
 	ASSERT_NE (nullptr, channel1);
 	// set the last packet sent for channel1 only to guarantee it contains a value.
 	// it won't be necessarily the same use by the cleanup cutoff time
-	node1.network.tcp_channels.modify (channel1, [&now] (auto channel) {
-		channel->set_last_packet_sent (now - std::chrono::seconds (5));
-	});
+	channel1->set_last_packet_sent (now - std::chrono::seconds (5));
 	auto channel2 = nano::test::establish_tcp (system, node1, outer_node2->network.endpoint ());
 	ASSERT_NE (nullptr, channel2);
 	// set the last packet sent for channel2 only to guarantee it contains a value.
 	// it won't be necessarily the same use by the cleanup cutoff time
-	node1.network.tcp_channels.modify (channel2, [&now] (auto channel) {
-		channel->set_last_packet_sent (now + std::chrono::seconds (1));
-	});
+	channel2->set_last_packet_sent (now + std::chrono::seconds (1));
 	ASSERT_EQ (2, node1.network.size ());
 	ASSERT_EQ (2, node1.network.tcp_channels.size ());
 

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -230,7 +230,7 @@ TEST (request_aggregator, two_endpoints)
 
 	auto dummy_channel1 = std::make_shared<nano::transport::inproc::channel> (node1, node1);
 	auto dummy_channel2 = std::make_shared<nano::transport::inproc::channel> (node2, node2);
-	ASSERT_NE (nano::transport::map_endpoint_to_v6 (dummy_channel1->get_endpoint ()), nano::transport::map_endpoint_to_v6 (dummy_channel2->get_endpoint ()));
+	ASSERT_NE (nano::transport::map_endpoint_to_v6 (dummy_channel1->get_remote_endpoint ()), nano::transport::map_endpoint_to_v6 (dummy_channel2->get_remote_endpoint ()));
 
 	std::vector<std::pair<nano::block_hash, nano::root>> request{ { send1->hash (), send1->root () } };
 

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -38,7 +38,7 @@ TEST (request_aggregator, one)
 	std::vector<std::pair<nano::block_hash, nano::root>> request{ { send1->hash (), send1->root () } };
 
 	auto client = std::make_shared<nano::transport::tcp_socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node.shared (), client);
 
 	// Not yet in the ledger
 	node.aggregator.request (request, dummy_channel);
@@ -179,7 +179,7 @@ TEST (request_aggregator, two)
 	request.emplace_back (send2->hash (), send2->root ());
 	request.emplace_back (receive1->hash (), receive1->root ());
 	auto client = std::make_shared<nano::transport::tcp_socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node.shared (), client);
 	// Process both blocks
 	node.aggregator.request (request, dummy_channel);
 	// One vote should be generated for both blocks
@@ -298,7 +298,7 @@ TEST (request_aggregator, split)
 	ASSERT_TIMELY_EQ (5s, max_vbh + 2, node.ledger.cemented_count ());
 	ASSERT_EQ (max_vbh + 1, request.size ());
 	auto client = std::make_shared<nano::transport::tcp_socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node.shared (), client);
 	node.aggregator.request (request, dummy_channel);
 	// In the ledger but no vote generated yet
 	ASSERT_TIMELY_EQ (3s, 2, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes));
@@ -337,7 +337,7 @@ TEST (request_aggregator, channel_max_queue)
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	auto client = std::make_shared<nano::transport::tcp_socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node.shared (), client);
 	node.aggregator.request (request, dummy_channel);
 	node.aggregator.request (request, dummy_channel);
 	ASSERT_LT (0, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_dropped));
@@ -366,7 +366,7 @@ TEST (request_aggregator, DISABLED_unique)
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	request.emplace_back (send1->hash (), send1->root ());
 	auto client = std::make_shared<nano::transport::tcp_socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node.shared (), client);
 	node.aggregator.request (request, dummy_channel);
 	node.aggregator.request (request, dummy_channel);
 	node.aggregator.request (request, dummy_channel);
@@ -410,7 +410,7 @@ TEST (request_aggregator, cannot_vote)
 	request.emplace_back (1, send2->root ());
 
 	auto client = std::make_shared<nano::transport::tcp_socket> (node);
-	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node, client);
+	std::shared_ptr<nano::transport::channel> dummy_channel = std::make_shared<nano::transport::tcp_channel> (node.shared (), client);
 	node.aggregator.request (request, dummy_channel);
 	ASSERT_TIMELY (3s, node.aggregator.empty ());
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::aggregator, nano::stat::detail::aggregator_accepted));

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -331,7 +331,7 @@ TEST (socket, drop_policy)
 		});
 
 		auto client = std::make_shared<nano::transport::tcp_socket> (*node);
-		auto channel = std::make_shared<nano::transport::tcp_channel> (*node, client);
+		auto channel = std::make_shared<nano::transport::tcp_channel> (node, client);
 
 		std::atomic completed_writes{ 0 };
 

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -68,18 +68,18 @@ TEST (telemetry, basic)
 	ASSERT_NE (nullptr, channel);
 
 	std::optional<nano::telemetry_data> telemetry_data;
-	ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (channel->get_endpoint ()));
+	ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 	ASSERT_EQ (node_server->get_node_id (), telemetry_data->node_id);
 
 	// Check the metrics are correct
 	ASSERT_TRUE (nano::test::compare_telemetry (*telemetry_data, *node_server));
 
 	// Call again straight away
-	auto telemetry_data_2 = node_client->telemetry.get_telemetry (channel->get_endpoint ());
+	auto telemetry_data_2 = node_client->telemetry.get_telemetry (channel->get_remote_endpoint ());
 	ASSERT_TRUE (telemetry_data_2);
 
 	// Call again straight away
-	auto telemetry_data_3 = node_client->telemetry.get_telemetry (channel->get_endpoint ());
+	auto telemetry_data_3 = node_client->telemetry.get_telemetry (channel->get_remote_endpoint ());
 	ASSERT_TRUE (telemetry_data_3);
 
 	// we expect at least one consecutive repeat of telemetry
@@ -89,7 +89,7 @@ TEST (telemetry, basic)
 	WAIT (3s);
 
 	std::optional<nano::telemetry_data> telemetry_data_4;
-	ASSERT_TIMELY (5s, telemetry_data_4 = node_client->telemetry.get_telemetry (channel->get_endpoint ()));
+	ASSERT_TIMELY (5s, telemetry_data_4 = node_client->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 	ASSERT_NE (*telemetry_data, *telemetry_data_4);
 }
 
@@ -120,13 +120,13 @@ TEST (telemetry, disconnected)
 	ASSERT_NE (nullptr, channel);
 
 	// Ensure telemetry is available before disconnecting
-	ASSERT_TIMELY (5s, node_client->telemetry.get_telemetry (channel->get_endpoint ()));
+	ASSERT_TIMELY (5s, node_client->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 
 	system.stop_node (*node_server);
 	ASSERT_TRUE (channel);
 
 	// Ensure telemetry from disconnected peer is removed
-	ASSERT_TIMELY (5s, !node_client->telemetry.get_telemetry (channel->get_endpoint ()));
+	ASSERT_TIMELY (5s, !node_client->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 }
 
 TEST (telemetry, dos_tcp)
@@ -185,14 +185,14 @@ TEST (telemetry, disable_metrics)
 
 	node_client->telemetry.trigger ();
 
-	ASSERT_NEVER (1s, node_client->telemetry.get_telemetry (channel->get_endpoint ()));
+	ASSERT_NEVER (1s, node_client->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 
 	// It should still be able to receive metrics though
 	auto channel1 = node_server->network.find_node_id (node_client->get_node_id ());
 	ASSERT_NE (nullptr, channel1);
 
 	std::optional<nano::telemetry_data> telemetry_data;
-	ASSERT_TIMELY (5s, telemetry_data = node_server->telemetry.get_telemetry (channel1->get_endpoint ()));
+	ASSERT_TIMELY (5s, telemetry_data = node_server->telemetry.get_telemetry (channel1->get_remote_endpoint ()));
 
 	ASSERT_TRUE (nano::test::compare_telemetry (*telemetry_data, *node_client));
 }
@@ -237,7 +237,7 @@ TEST (telemetry, maker_pruning)
 	ASSERT_NE (nullptr, channel);
 
 	std::optional<nano::telemetry_data> telemetry_data;
-	ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (channel->get_endpoint ()));
+	ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 	ASSERT_EQ (node_server->get_node_id (), telemetry_data->node_id);
 
 	// Ensure telemetry response indicates pruned node

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -1005,7 +1005,7 @@ TEST (websocket, telemetry)
 
 	auto channel = node1->network.find_node_id (node2->get_node_id ());
 	ASSERT_NE (channel, nullptr);
-	ASSERT_TIMELY (5s, node1->telemetry.get_telemetry (channel->get_endpoint ()));
+	ASSERT_TIMELY (5s, node1->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 
 	ASSERT_TIMELY_EQ (10s, future.wait_for (0s), std::future_status::ready);
 

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -84,6 +84,7 @@ nano::block_processor::~block_processor ()
 {
 	// Thread must be stopped before destruction
 	debug_assert (!thread.joinable ());
+	debug_assert (queue.empty ());
 }
 
 void nano::block_processor::start ()
@@ -107,6 +108,7 @@ void nano::block_processor::stop ()
 	{
 		thread.join ();
 	}
+	queue.clear ();
 }
 
 // TODO: Remove and replace all checks with calls to size (block_source)

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -102,7 +102,7 @@ void nano::bootstrap_connections::pool_connection (std::shared_ptr<nano::bootstr
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	auto const & socket_l = client_a->socket;
-	if (!stopped && !client_a->pending_stop && !node.network.excluded_peers.check (client_a->channel->get_tcp_endpoint ()))
+	if (!stopped && !client_a->pending_stop && !node.network.excluded_peers.check (client_a->channel->get_remote_endpoint ()))
 	{
 		socket_l->set_timeout (node.network_params.network.idle_timeout);
 		// Push into idle deque
@@ -138,7 +138,7 @@ std::shared_ptr<nano::bootstrap_client> nano::bootstrap_connections::find_connec
 	std::shared_ptr<nano::bootstrap_client> result;
 	for (auto i (idle.begin ()), end (idle.end ()); i != end && !stopped; ++i)
 	{
-		if ((*i)->channel->get_tcp_endpoint () == endpoint_a)
+		if ((*i)->channel->get_remote_endpoint () == endpoint_a)
 		{
 			result = *i;
 			idle.erase (i);

--- a/nano/node/bootstrap/bootstrap_connections.cpp
+++ b/nano/node/bootstrap/bootstrap_connections.cpp
@@ -159,7 +159,7 @@ void nano::bootstrap_connections::connect_client (nano::tcp_endpoint const & end
 		{
 			this_l->node.logger.debug (nano::log::type::bootstrap, "Connection established to: {}", nano::util::to_str (endpoint_a));
 
-			auto client (std::make_shared<nano::bootstrap_client> (this_l->node.shared (), std::make_shared<nano::transport::tcp_channel> (*this_l->node.shared (), socket), socket));
+			auto client (std::make_shared<nano::bootstrap_client> (this_l->node.shared (), std::make_shared<nano::transport::tcp_channel> (this_l->node.shared (), socket), socket));
 			this_l->pool_connection (client, true, push_front);
 		}
 		else

--- a/nano/node/bootstrap/bootstrap_legacy.cpp
+++ b/nano/node/bootstrap/bootstrap_legacy.cpp
@@ -138,7 +138,7 @@ bool nano::bootstrap_attempt_legacy::request_frontier (nano::unique_lock<nano::m
 	lock_a.lock ();
 	if (connection_l && !stopped)
 	{
-		endpoint_frontier_request = connection_l->channel->get_tcp_endpoint ();
+		endpoint_frontier_request = connection_l->channel->get_remote_endpoint ();
 		std::future<bool> future;
 		{
 			auto this_l = std::dynamic_pointer_cast<nano::bootstrap_attempt_legacy> (shared_from_this ());

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -58,6 +58,7 @@ void nano::bootstrap_server::stop ()
 		thread.join ();
 	}
 	threads.clear ();
+	queue.clear ();
 }
 
 bool nano::bootstrap_server::verify_request_type (nano::asc_pull_type type) const

--- a/nano/node/fair_queue.hpp
+++ b/nano/node/fair_queue.hpp
@@ -139,6 +139,7 @@ public:
 	void clear ()
 	{
 		queues.clear ();
+		total_size = 0;
 	}
 
 	/**

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2991,7 +2991,7 @@ void nano::json_handler::peers ()
 	bool const peer_details = request.get<bool> ("peer_details", false);
 	auto peers_list (node.network.list (std::numeric_limits<std::size_t>::max ()));
 	std::sort (peers_list.begin (), peers_list.end (), [] (auto const & lhs, auto const & rhs) {
-		return lhs->get_endpoint () < rhs->get_endpoint ();
+		return lhs->get_remote_endpoint () < rhs->get_remote_endpoint ();
 	});
 	for (auto i (peers_list.begin ()), n (peers_list.end ()); i != n; ++i)
 	{

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3003,9 +3003,9 @@ void nano::json_handler::peers ()
 			boost::property_tree::ptree pending_tree;
 			pending_tree.put ("protocol_version", std::to_string (channel->get_network_version ()));
 			auto node_id_l (channel->get_node_id_optional ());
-			if (node_id_l.is_initialized ())
+			if (node_id_l.has_value ())
 			{
-				pending_tree.put ("node_id", node_id_l.get ().to_node_id ());
+				pending_tree.put ("node_id", node_id_l.value ().to_node_id ());
 			}
 			else
 			{

--- a/nano/node/message_processor.cpp
+++ b/nano/node/message_processor.cpp
@@ -175,7 +175,7 @@ public:
 		if (peer0.address () == boost::asio::ip::address_v6{} && peer0.port () != 0)
 		{
 			// TODO: Remove this as we do not need to establish a second connection to the same peer
-			nano::endpoint new_endpoint (channel->get_tcp_endpoint ().address (), peer0.port ());
+			nano::endpoint new_endpoint (channel->get_remote_endpoint ().address (), peer0.port ());
 			node.network.merge_peer (new_endpoint);
 
 			// Remember this for future forwarding to other peers

--- a/nano/node/message_processor.cpp
+++ b/nano/node/message_processor.cpp
@@ -22,6 +22,7 @@ nano::message_processor::message_processor (message_processor_config const & con
 nano::message_processor::~message_processor ()
 {
 	debug_assert (threads.empty ());
+	debug_assert (queue.empty ());
 }
 
 void nano::message_processor::start ()
@@ -76,6 +77,7 @@ void nano::message_processor::stop ()
 		}
 	}
 	threads.clear ();
+	queue.clear ();
 }
 
 bool nano::message_processor::put (std::unique_ptr<nano::message> message, std::shared_ptr<nano::transport::channel> const & channel)

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -504,14 +504,14 @@ void nano::network::erase (nano::transport::channel const & channel_a)
 	auto const channel_type = channel_a.get_type ();
 	if (channel_type == nano::transport::transport_type::tcp)
 	{
-		tcp_channels.erase (channel_a.get_tcp_endpoint ());
+		tcp_channels.erase (channel_a.get_remote_endpoint ());
 	}
 }
 
 void nano::network::exclude (std::shared_ptr<nano::transport::channel> const & channel)
 {
 	// Add to peer exclusion list
-	excluded_peers.add (channel->get_tcp_endpoint ());
+	excluded_peers.add (channel->get_remote_endpoint ());
 
 	// Disconnect
 	erase (*channel);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -650,6 +650,9 @@ void nano::node::stop ()
 	logger.info (nano::log::type::node, "Node stopping...");
 
 	tcp_listener.stop ();
+	network.stop ();
+	message_processor.stop ();
+	workers.stop ();
 	bootstrap_workers.stop ();
 	wallet_workers.stop ();
 	election_workers.stop ();
@@ -664,13 +667,13 @@ void nano::node::stop ()
 	unchecked.stop ();
 	block_processor.stop ();
 	aggregator.stop ();
-	vote_cache_processor.stop ();
-	vote_processor.stop ();
 	rep_tiers.stop ();
 	scheduler.stop ();
 	active.stop ();
 	generator.stop ();
 	final_generator.stop ();
+	vote_processor.stop ();
+	vote_cache_processor.stop ();
 	confirming_set.stop ();
 	telemetry.stop ();
 	websocket.stop ();
@@ -680,10 +683,7 @@ void nano::node::stop ()
 	wallets.stop ();
 	stats.stop ();
 	epoch_upgrader.stop ();
-	workers.stop ();
 	local_block_broadcaster.stop ();
-	message_processor.stop ();
-	network.stop (); // Stop network last to avoid killing in-use sockets
 	monitor.stop ();
 
 	// work pool is not stopped on purpose due to testing setup

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -102,7 +102,7 @@ void nano::rep_crawler::validate_and_process (nano::unique_lock<nano::mutex> & l
 				rep.last_response = std::chrono::steady_clock::now ();
 
 				// Update if representative channel was changed
-				if (rep.channel->get_endpoint () != channel->get_endpoint ())
+				if (rep.channel->get_remote_endpoint () != channel->get_remote_endpoint ())
 				{
 					debug_assert (rep.account == vote->account);
 					updated = true;

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -25,6 +25,9 @@ nano::rep_crawler::~rep_crawler ()
 {
 	// Thread must be stopped before destruction
 	debug_assert (!thread.joinable ());
+	debug_assert (responses.empty ());
+	debug_assert (reps.empty ());
+	debug_assert (queries.empty ());
 }
 
 void nano::rep_crawler::start ()
@@ -48,6 +51,9 @@ void nano::rep_crawler::stop ()
 	{
 		thread.join ();
 	}
+	responses.clear ();
+	reps.clear ();
+	queries.clear ();
 }
 
 // Exits with the lock unlocked

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -43,6 +43,7 @@ nano::request_aggregator::request_aggregator (request_aggregator_config const & 
 nano::request_aggregator::~request_aggregator ()
 {
 	debug_assert (threads.empty ());
+	debug_assert (queue.empty ());
 }
 
 void nano::request_aggregator::start ()
@@ -73,6 +74,7 @@ void nano::request_aggregator::stop ()
 		}
 	}
 	threads.clear ();
+	queue.clear ();
 }
 
 std::size_t nano::request_aggregator::size () const

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -96,7 +96,7 @@ void nano::telemetry::process (const nano::telemetry_ack & telemetry, const std:
 
 	nano::unique_lock<nano::mutex> lock{ mutex };
 
-	const auto endpoint = channel->get_endpoint ();
+	const auto endpoint = channel->get_remote_endpoint ();
 
 	if (auto it = telemetries.get<tag_endpoint> ().find (endpoint); it != telemetries.get<tag_endpoint> ().end ())
 	{

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -32,6 +32,7 @@ nano::telemetry::~telemetry ()
 {
 	// Thread must be stopped before destruction
 	debug_assert (!thread.joinable ());
+	debug_assert (telemetries.empty ());
 }
 
 void nano::telemetry::start ()
@@ -51,7 +52,8 @@ void nano::telemetry::stop ()
 		stopped = true;
 	}
 	condition.notify_all ();
-	nano::join_or_pass (thread);
+	join_or_pass (thread);
+	telemetries.clear ();
 }
 
 bool nano::telemetry::verify (const nano::telemetry_ack & telemetry, const std::shared_ptr<nano::transport::channel> & channel) const

--- a/nano/node/transport/channel.cpp
+++ b/nano/node/transport/channel.cpp
@@ -45,14 +45,14 @@ void nano::transport::channel::send (nano::message & message_a, std::function<vo
 
 void nano::transport::channel::set_peering_endpoint (nano::endpoint endpoint)
 {
-	nano::lock_guard<nano::mutex> lock{ channel_mutex };
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	peering_endpoint = endpoint;
 }
 
 nano::endpoint nano::transport::channel::get_peering_endpoint () const
 {
 	{
-		nano::lock_guard<nano::mutex> lock{ channel_mutex };
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		if (peering_endpoint)
 		{
 			return *peering_endpoint;

--- a/nano/node/transport/channel.cpp
+++ b/nano/node/transport/channel.cpp
@@ -51,21 +51,20 @@ void nano::transport::channel::set_peering_endpoint (nano::endpoint endpoint)
 
 nano::endpoint nano::transport::channel::get_peering_endpoint () const
 {
-	nano::unique_lock<nano::mutex> lock{ channel_mutex };
-	if (peering_endpoint)
 	{
-		return *peering_endpoint;
+		nano::lock_guard<nano::mutex> lock{ channel_mutex };
+		if (peering_endpoint)
+		{
+			return *peering_endpoint;
+		}
 	}
-	else
-	{
-		lock.unlock ();
-		return get_endpoint ();
-	}
+	return get_remote_endpoint ();
 }
 
 void nano::transport::channel::operator() (nano::object_stream & obs) const
 {
-	obs.write ("endpoint", get_endpoint ());
+	obs.write ("remote_endpoint", get_remote_endpoint ());
+	obs.write ("local_endpoint", get_local_endpoint ());
 	obs.write ("peering_endpoint", get_peering_endpoint ());
 	obs.write ("node_id", get_node_id ().to_node_id ());
 }

--- a/nano/node/transport/channel.cpp
+++ b/nano/node/transport/channel.cpp
@@ -8,10 +8,16 @@
 #include <boost/asio/ip/address_v6.hpp>
 #include <boost/format.hpp>
 
-nano::transport::channel::channel (nano::node & node_a) :
-	node{ node_a }
+nano::transport::channel::channel (std::shared_ptr<nano::node> node_a) :
+	node_w{ node_a },
+	node{ *node_a }
 {
-	set_network_version (node_a.network_params.network.protocol_version);
+	set_network_version (node.network_params.network.protocol_version);
+}
+
+nano::transport::channel::~channel ()
+{
+	release_assert (node_w.lock (), "channel lifetime problem detected"); // Channel must not outlive the node
 }
 
 void nano::transport::channel::send (nano::message & message_a, std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a, nano::transport::buffer_drop_policy drop_policy_a, nano::transport::traffic_type traffic_type)

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -40,10 +40,10 @@ public:
 
 	virtual void close () = 0;
 
-	virtual std::string to_string () const = 0;
-	virtual nano::endpoint get_endpoint () const = 0;
-	virtual nano::tcp_endpoint get_tcp_endpoint () const = 0;
+	virtual nano::endpoint get_remote_endpoint () const = 0;
 	virtual nano::endpoint get_local_endpoint () const = 0;
+
+	virtual std::string to_string () const = 0;
 	virtual nano::transport::transport_type get_type () const = 0;
 
 	virtual bool max (nano::transport::traffic_type = nano::transport::traffic_type::generic)

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -58,49 +58,49 @@ public:
 
 	std::chrono::steady_clock::time_point get_last_bootstrap_attempt () const
 	{
-		nano::lock_guard<nano::mutex> lk (channel_mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		return last_bootstrap_attempt;
 	}
 
 	void set_last_bootstrap_attempt (std::chrono::steady_clock::time_point const time_a)
 	{
-		nano::lock_guard<nano::mutex> lk (channel_mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		last_bootstrap_attempt = time_a;
 	}
 
 	std::chrono::steady_clock::time_point get_last_packet_received () const
 	{
-		nano::lock_guard<nano::mutex> lk (channel_mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		return last_packet_received;
 	}
 
 	void set_last_packet_received (std::chrono::steady_clock::time_point const time_a)
 	{
-		nano::lock_guard<nano::mutex> lk (channel_mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		last_packet_received = time_a;
 	}
 
 	std::chrono::steady_clock::time_point get_last_packet_sent () const
 	{
-		nano::lock_guard<nano::mutex> lk (channel_mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		return last_packet_sent;
 	}
 
 	void set_last_packet_sent (std::chrono::steady_clock::time_point const time_a)
 	{
-		nano::lock_guard<nano::mutex> lk (channel_mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		last_packet_sent = time_a;
 	}
 
 	boost::optional<nano::account> get_node_id_optional () const
 	{
-		nano::lock_guard<nano::mutex> lk (channel_mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		return node_id;
 	}
 
 	nano::account get_node_id () const
 	{
-		nano::lock_guard<nano::mutex> lk (channel_mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		if (node_id.is_initialized ())
 		{
 			return node_id.get ();
@@ -113,7 +113,7 @@ public:
 
 	void set_node_id (nano::account node_id_a)
 	{
-		nano::lock_guard<nano::mutex> lk (channel_mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		node_id = node_id_a;
 	}
 
@@ -130,7 +130,9 @@ public:
 	nano::endpoint get_peering_endpoint () const;
 	void set_peering_endpoint (nano::endpoint endpoint);
 
-	mutable nano::mutex channel_mutex;
+protected:
+	nano::node & node;
+	mutable nano::mutex mutex;
 
 private:
 	std::chrono::steady_clock::time_point last_bootstrap_attempt{ std::chrono::steady_clock::time_point () };
@@ -139,9 +141,6 @@ private:
 	boost::optional<nano::account> node_id{ boost::none };
 	std::atomic<uint8_t> network_version{ 0 };
 	std::optional<nano::endpoint> peering_endpoint{};
-
-protected:
-	nano::node & node;
 
 public: // Logging
 	virtual void operator() (nano::object_stream &) const;

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -23,8 +23,8 @@ enum class transport_type : uint8_t
 class channel
 {
 public:
-	explicit channel (nano::node &);
-	virtual ~channel () = default;
+	explicit channel (std::shared_ptr<nano::node>);
+	virtual ~channel ();
 
 	void send (nano::message & message_a,
 	std::function<void (boost::system::error_code const &, std::size_t)> const & callback_a = nullptr,
@@ -124,7 +124,9 @@ public:
 	void set_peering_endpoint (nano::endpoint endpoint);
 
 protected:
+	std::weak_ptr<nano::node> node_w;
 	nano::node & node;
+
 	mutable nano::mutex mutex;
 
 private:

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -92,7 +92,7 @@ public:
 		last_packet_sent = time_a;
 	}
 
-	boost::optional<nano::account> get_node_id_optional () const
+	std::optional<nano::account> get_node_id_optional () const
 	{
 		nano::lock_guard<nano::mutex> lock{ mutex };
 		return node_id;
@@ -101,14 +101,7 @@ public:
 	nano::account get_node_id () const
 	{
 		nano::lock_guard<nano::mutex> lock{ mutex };
-		if (node_id.is_initialized ())
-		{
-			return node_id.get ();
-		}
-		else
-		{
-			return 0;
-		}
+		return node_id.value_or (0);
 	}
 
 	void set_node_id (nano::account node_id_a)
@@ -138,7 +131,7 @@ private:
 	std::chrono::steady_clock::time_point last_bootstrap_attempt{ std::chrono::steady_clock::time_point () };
 	std::chrono::steady_clock::time_point last_packet_received{ std::chrono::steady_clock::now () };
 	std::chrono::steady_clock::time_point last_packet_sent{ std::chrono::steady_clock::now () };
-	boost::optional<nano::account> node_id{ boost::none };
+	std::optional<nano::account> node_id{};
 	std::atomic<uint8_t> network_version{ 0 };
 	std::optional<nano::endpoint> peering_endpoint{};
 

--- a/nano/node/transport/fake.cpp
+++ b/nano/node/transport/fake.cpp
@@ -4,7 +4,7 @@
 #include <boost/format.hpp>
 
 nano::transport::fake::channel::channel (nano::node & node) :
-	transport::channel{ node },
+	transport::channel{ node.shared () },
 	endpoint{ node.network.endpoint () }
 {
 	set_node_id (node.node_id.pub);

--- a/nano/node/transport/fake.hpp
+++ b/nano/node/transport/fake.hpp
@@ -30,14 +30,9 @@ namespace transport
 				endpoint = endpoint_a;
 			}
 
-			nano::endpoint get_endpoint () const override
+			nano::endpoint get_remote_endpoint () const override
 			{
 				return endpoint;
-			}
-
-			nano::tcp_endpoint get_tcp_endpoint () const override
-			{
-				return nano::transport::map_endpoint_to_tcp (endpoint);
 			}
 
 			nano::endpoint get_local_endpoint () const override

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -6,7 +6,7 @@
 #include <boost/format.hpp>
 
 nano::transport::inproc::channel::channel (nano::node & node, nano::node & destination) :
-	transport::channel{ node },
+	transport::channel{ node.shared () },
 	destination{ destination },
 	endpoint{ node.network.endpoint () }
 {

--- a/nano/node/transport/inproc.hpp
+++ b/nano/node/transport/inproc.hpp
@@ -22,14 +22,9 @@ namespace transport
 
 			std::string to_string () const override;
 
-			nano::endpoint get_endpoint () const override
+			nano::endpoint get_remote_endpoint () const override
 			{
 				return endpoint;
-			}
-
-			nano::tcp_endpoint get_tcp_endpoint () const override
-			{
-				return nano::transport::map_endpoint_to_tcp (endpoint);
 			}
 
 			nano::endpoint get_local_endpoint () const override

--- a/nano/node/transport/tcp_channel.cpp
+++ b/nano/node/transport/tcp_channel.cpp
@@ -8,10 +8,11 @@
  * tcp_channel
  */
 
-nano::transport::tcp_channel::tcp_channel (nano::node & node_a, std::weak_ptr<nano::transport::tcp_socket> socket_a) :
-	channel (node_a),
-	socket (std::move (socket_a))
+nano::transport::tcp_channel::tcp_channel (std::shared_ptr<nano::node> node_a, std::shared_ptr<nano::transport::tcp_socket> socket_a) :
+	nano::transport::channel (node_a),
+	socket{ socket_a }
 {
+	release_assert (socket_a);
 }
 
 nano::transport::tcp_channel::~tcp_channel ()

--- a/nano/node/transport/tcp_channel.cpp
+++ b/nano/node/transport/tcp_channel.cpp
@@ -16,8 +16,6 @@ nano::transport::tcp_channel::tcp_channel (nano::node & node_a, std::weak_ptr<na
 
 nano::transport::tcp_channel::~tcp_channel ()
 {
-	nano::lock_guard<nano::mutex> lk{ channel_mutex };
-	// Close socket. Exception: socket is used by tcp_server
 	if (auto socket_l = socket.lock ())
 	{
 		socket_l->close ();
@@ -26,7 +24,7 @@ nano::transport::tcp_channel::~tcp_channel ()
 
 void nano::transport::tcp_channel::update_endpoints ()
 {
-	nano::lock_guard<nano::mutex> lk (channel_mutex);
+	nano::lock_guard<nano::mutex> lock{ mutex };
 
 	debug_assert (remote_endpoint == nano::endpoint{}); // Not initialized endpoint value
 	debug_assert (local_endpoint == nano::endpoint{}); // Not initialized endpoint value

--- a/nano/node/transport/tcp_channel.cpp
+++ b/nano/node/transport/tcp_channel.cpp
@@ -28,12 +28,12 @@ void nano::transport::tcp_channel::update_endpoints ()
 {
 	nano::lock_guard<nano::mutex> lk (channel_mutex);
 
-	debug_assert (endpoint == nano::endpoint{}); // Not initialized endpoint value
+	debug_assert (remote_endpoint == nano::endpoint{}); // Not initialized endpoint value
 	debug_assert (local_endpoint == nano::endpoint{}); // Not initialized endpoint value
 
 	if (auto socket_l = socket.lock ())
 	{
-		endpoint = socket_l->remote_endpoint ();
+		remote_endpoint = socket_l->remote_endpoint ();
 		local_endpoint = socket_l->local_endpoint ();
 	}
 }
@@ -90,7 +90,7 @@ void nano::transport::tcp_channel::send_buffer (nano::shared_const_buffer const 
 
 std::string nano::transport::tcp_channel::to_string () const
 {
-	return nano::util::to_str (get_tcp_endpoint ());
+	return nano::util::to_str (get_remote_endpoint ());
 }
 
 void nano::transport::tcp_channel::operator() (nano::object_stream & obs) const

--- a/nano/node/transport/tcp_channel.hpp
+++ b/nano/node/transport/tcp_channel.hpp
@@ -14,7 +14,7 @@ class tcp_channel : public nano::transport::channel, public std::enable_shared_f
 	friend class nano::transport::tcp_channels;
 
 public:
-	tcp_channel (nano::node &, std::weak_ptr<nano::transport::tcp_socket>);
+	tcp_channel (std::shared_ptr<nano::node>, std::shared_ptr<nano::transport::tcp_socket>);
 	~tcp_channel () override;
 
 	void update_endpoints ();

--- a/nano/node/transport/tcp_channel.hpp
+++ b/nano/node/transport/tcp_channel.hpp
@@ -26,13 +26,13 @@ public:
 
 	nano::endpoint get_remote_endpoint () const override
 	{
-		nano::lock_guard<nano::mutex> lk (channel_mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		return remote_endpoint;
 	}
 
 	nano::endpoint get_local_endpoint () const override
 	{
-		nano::lock_guard<nano::mutex> lk (channel_mutex);
+		nano::lock_guard<nano::mutex> lock{ mutex };
 		return local_endpoint;
 	}
 

--- a/nano/node/transport/tcp_channel.hpp
+++ b/nano/node/transport/tcp_channel.hpp
@@ -24,15 +24,10 @@ public:
 
 	std::string to_string () const override;
 
-	nano::endpoint get_endpoint () const override
-	{
-		return nano::transport::map_tcp_to_endpoint (get_tcp_endpoint ());
-	}
-
-	nano::tcp_endpoint get_tcp_endpoint () const override
+	nano::endpoint get_remote_endpoint () const override
 	{
 		nano::lock_guard<nano::mutex> lk (channel_mutex);
-		return endpoint;
+		return remote_endpoint;
 	}
 
 	nano::endpoint get_local_endpoint () const override
@@ -77,7 +72,7 @@ public:
 	std::weak_ptr<nano::transport::tcp_socket> socket;
 
 private:
-	nano::endpoint endpoint;
+	nano::endpoint remote_endpoint;
 	nano::endpoint local_endpoint;
 
 public: // Logging

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -117,7 +117,7 @@ std::shared_ptr<nano::transport::tcp_channel> nano::transport::tcp_channels::cre
 	fmt::streamed (socket->remote_endpoint ()),
 	node_id.to_node_id ());
 
-	auto channel = std::make_shared<nano::transport::tcp_channel> (node, socket);
+	auto channel = std::make_shared<nano::transport::tcp_channel> (node.shared (), socket);
 	channel->update_endpoints ();
 	channel->set_node_id (node_id);
 

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -417,18 +417,6 @@ void nano::transport::tcp_channels::list (std::deque<std::shared_ptr<nano::trans
 	// clang-format on
 }
 
-void nano::transport::tcp_channels::modify (std::shared_ptr<nano::transport::tcp_channel> const & channel_a, std::function<void (std::shared_ptr<nano::transport::tcp_channel> const &)> modify_callback_a)
-{
-	nano::lock_guard<nano::mutex> lock{ mutex };
-	auto existing (channels.get<endpoint_tag> ().find (channel_a->get_tcp_endpoint ()));
-	if (existing != channels.get<endpoint_tag> ().end ())
-	{
-		channels.get<endpoint_tag> ().modify (existing, [modify_callback = std::move (modify_callback_a)] (channel_entry & wrapper_a) {
-			modify_callback (wrapper_a.channel);
-		});
-	}
-}
-
 void nano::transport::tcp_channels::start_tcp (nano::endpoint const & endpoint)
 {
 	node.tcp_listener.connect (endpoint.address (), endpoint.port ());

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -196,9 +196,9 @@ void nano::transport::tcp_channels::random_fill (std::array<nano::endpoint, 8> &
 	auto j (target_a.begin ());
 	for (auto i (peers.begin ()), n (peers.end ()); i != n; ++i, ++j)
 	{
-		debug_assert ((*i)->get_endpoint ().address ().is_v6 ());
+		debug_assert ((*i)->get_remote_endpoint ().address ().is_v6 ());
 		debug_assert (j < target_a.end ());
-		*j = (*i)->get_endpoint ();
+		*j = (*i)->get_remote_endpoint ();
 	}
 }
 

--- a/nano/node/transport/tcp_channels.hpp
+++ b/nano/node/transport/tcp_channels.hpp
@@ -80,7 +80,7 @@ private:
 		}
 		nano::tcp_endpoint endpoint () const
 		{
-			return channel->get_tcp_endpoint ();
+			return channel->get_remote_endpoint ();
 		}
 		std::chrono::steady_clock::time_point last_bootstrap_attempt () const
 		{

--- a/nano/node/transport/tcp_channels.hpp
+++ b/nano/node/transport/tcp_channels.hpp
@@ -50,7 +50,6 @@ public:
 	bool track_reachout (nano::endpoint const &);
 	void purge (std::chrono::steady_clock::time_point cutoff_deadline);
 	void list (std::deque<std::shared_ptr<nano::transport::channel>> &, uint8_t = 0, bool = true);
-	void modify (std::shared_ptr<nano::transport::tcp_channel> const &, std::function<void (std::shared_ptr<nano::transport::tcp_channel> const &)>);
 	void keepalive ();
 	std::optional<nano::keepalive> sample_keepalive ();
 

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -39,6 +39,8 @@ nano::vote_generator::~vote_generator ()
 {
 	debug_assert (stopped);
 	debug_assert (!thread.joinable ());
+	debug_assert (requests.empty ());
+	debug_assert (candidates.empty ());
 }
 
 bool nano::vote_generator::should_vote (transaction_variant_t const & transaction_variant, nano::root const & root_a, nano::block_hash const & hash_a) const
@@ -96,8 +98,9 @@ void nano::vote_generator::stop ()
 	{
 		thread.join ();
 	}
-
 	inproc_channel = nullptr;
+	requests.clear ();
+	candidates.clear ();
 }
 
 void nano::vote_generator::add (const root & root, const block_hash & hash)

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -65,6 +65,7 @@ nano::vote_processor::vote_processor (vote_processor_config const & config_a, na
 nano::vote_processor::~vote_processor ()
 {
 	debug_assert (threads.empty ());
+	debug_assert (queue.empty ());
 }
 
 void nano::vote_processor::start ()
@@ -98,6 +99,7 @@ void nano::vote_processor::stop ()
 		thread.join ();
 	}
 	threads.clear ();
+	queue.clear ();
 }
 
 bool nano::vote_processor::vote (std::shared_ptr<nano::vote> const & vote, std::shared_ptr<nano::transport::channel> const & channel, nano::vote_source source)

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -1050,7 +1050,7 @@ nano::websocket_server::websocket_server (nano::websocket::config & config_a, na
 		if (server->any_subscriber (nano::websocket::topic::telemetry))
 		{
 			nano::websocket::message_builder builder;
-			server->broadcast (builder.telemetry_received (telemetry_data, channel->get_endpoint ()));
+			server->broadcast (builder.telemetry_received (telemetry_data, channel->get_remote_endpoint ()));
 		}
 	});
 

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1959,9 +1959,9 @@ void nano_qt::advanced_actions::refresh_peers ()
 		items.push_back (version);
 		QString node_id ("");
 		auto node_id_l (channel->get_node_id_optional ());
-		if (node_id_l.is_initialized ())
+		if (node_id_l.has_value ())
 		{
-			node_id = node_id_l.get ().to_account ().c_str ();
+			node_id = node_id_l.value ().to_account ().c_str ();
 		}
 		items.push_back (new QStandardItem (node_id));
 		peers_model->appendRow (items);

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1944,7 +1944,7 @@ void nano_qt::advanced_actions::refresh_peers ()
 	peers_model->removeRows (0, peers_model->rowCount ());
 	auto list (wallet.node.network.list (std::numeric_limits<size_t>::max ()));
 	std::sort (list.begin (), list.end (), [] (auto const & lhs, auto const & rhs) {
-		return lhs->get_endpoint () < rhs->get_endpoint ();
+		return lhs->get_remote_endpoint () < rhs->get_remote_endpoint ();
 	});
 	for (auto i (list.begin ()), n (list.end ()); i != n; ++i)
 	{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6786,7 +6786,7 @@ TEST (rpc, telemetry_all)
 
 	auto channel = node1->network.find_node_id (node->get_node_id ());
 	ASSERT_TRUE (channel);
-	ASSERT_TIMELY (10s, node1->telemetry.get_telemetry (channel->get_endpoint ()));
+	ASSERT_TIMELY (10s, node1->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 
 	boost::property_tree::ptree request;
 	request.put ("action", "telemetry");

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1383,7 +1383,7 @@ namespace transport
 							// Pick first peer to be consistent
 							auto peer = data.node->network.tcp_channels.channels[0].channel;
 
-							auto maybe_telemetry = data.node->telemetry.get_telemetry (peer->get_endpoint ());
+							auto maybe_telemetry = data.node->telemetry.get_telemetry (peer->get_remote_endpoint ());
 							if (maybe_telemetry)
 							{
 								callback_process (shared_data, data, node_data, maybe_telemetry->timestamp);
@@ -1513,7 +1513,7 @@ TEST (telemetry, cache_read_and_timeout)
 	ASSERT_NE (channel, nullptr);
 
 	node_client->telemetry.trigger ();
-	ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (channel->get_endpoint ()));
+	ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 
 	auto responses = node_client->telemetry.get_all_telemetries ();
 	ASSERT_TRUE (!responses.empty ());
@@ -1536,7 +1536,7 @@ TEST (telemetry, cache_read_and_timeout)
 
 	// Request telemetry metrics again
 	node_client->telemetry.trigger ();
-	ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (channel->get_endpoint ()));
+	ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 
 	responses = node_client->telemetry.get_all_telemetries ();
 	ASSERT_TRUE (!responses.empty ());
@@ -1611,7 +1611,7 @@ TEST (telemetry, many_nodes)
 	for (auto const & peer : peers)
 	{
 		std::optional<nano::telemetry_data> telemetry_data;
-		ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (peer->get_endpoint ()));
+		ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (peer->get_remote_endpoint ()));
 		telemetry_datas.push_back (*telemetry_data);
 	}
 


### PR DESCRIPTION
This adds asserts to ensure that channel lifetimes won't exceed the node. All channels should be closed and destroyed during the `node.stop ()` execution. Doing this required cleaning up several components.