### PR TITLE
Fix mismatched channel owners

### DIFF
--- a/nano/core_test/bootstrap_server.cpp
+++ b/nano/core_test/bootstrap_server.cpp
@@ -92,7 +92,7 @@ TEST (bootstrap_server, serve_account_blocks)
 	request.payload = request_payload;
 	request.update_header ();
 
-	node.network.inbound (request, nano::test::fake_channel (node));
+	node.inbound (request, nano::test::fake_channel (node));
 
 	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
@@ -137,7 +137,7 @@ TEST (bootstrap_server, serve_hash)
 	request.payload = request_payload;
 	request.update_header ();
 
-	node.network.inbound (request, nano::test::fake_channel (node));
+	node.inbound (request, nano::test::fake_channel (node));
 
 	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
@@ -182,7 +182,7 @@ TEST (bootstrap_server, serve_hash_one)
 	request.payload = request_payload;
 	request.update_header ();
 
-	node.network.inbound (request, nano::test::fake_channel (node));
+	node.inbound (request, nano::test::fake_channel (node));
 
 	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
@@ -221,7 +221,7 @@ TEST (bootstrap_server, serve_end_of_chain)
 	request.payload = request_payload;
 	request.update_header ();
 
-	node.network.inbound (request, nano::test::fake_channel (node));
+	node.inbound (request, nano::test::fake_channel (node));
 
 	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
@@ -260,7 +260,7 @@ TEST (bootstrap_server, serve_missing)
 	request.payload = request_payload;
 	request.update_header ();
 
-	node.network.inbound (request, nano::test::fake_channel (node));
+	node.inbound (request, nano::test::fake_channel (node));
 
 	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
@@ -303,7 +303,7 @@ TEST (bootstrap_server, serve_multiple)
 			request.payload = request_payload;
 			request.update_header ();
 
-			node.network.inbound (request, nano::test::fake_channel (node));
+			node.inbound (request, nano::test::fake_channel (node));
 		}
 	}
 
@@ -359,7 +359,7 @@ TEST (bootstrap_server, serve_account_info)
 	request.payload = request_payload;
 	request.update_header ();
 
-	node.network.inbound (request, nano::test::fake_channel (node));
+	node.inbound (request, nano::test::fake_channel (node));
 
 	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
@@ -405,7 +405,7 @@ TEST (bootstrap_server, serve_account_info_missing)
 	request.payload = request_payload;
 	request.update_header ();
 
-	node.network.inbound (request, nano::test::fake_channel (node));
+	node.inbound (request, nano::test::fake_channel (node));
 
 	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
@@ -450,7 +450,7 @@ TEST (bootstrap_server, serve_frontiers)
 	request.payload = request_payload;
 	request.update_header ();
 
-	node.network.inbound (request, nano::test::fake_channel (node));
+	node.inbound (request, nano::test::fake_channel (node));
 
 	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
 
@@ -503,7 +503,7 @@ TEST (bootstrap_server, serve_frontiers_invalid_count)
 		request.payload = request_payload;
 		request.update_header ();
 
-		node.network.inbound (request, nano::test::fake_channel (node));
+		node.inbound (request, nano::test::fake_channel (node));
 	}
 
 	ASSERT_TIMELY_EQ (5s, node.stats.count (nano::stat::type::bootstrap_server, nano::stat::detail::invalid), 1);
@@ -521,7 +521,7 @@ TEST (bootstrap_server, serve_frontiers_invalid_count)
 		request.payload = request_payload;
 		request.update_header ();
 
-		node.network.inbound (request, nano::test::fake_channel (node));
+		node.inbound (request, nano::test::fake_channel (node));
 	}
 
 	ASSERT_TIMELY_EQ (5s, node.stats.count (nano::stat::type::bootstrap_server, nano::stat::detail::invalid), 2);
@@ -539,7 +539,7 @@ TEST (bootstrap_server, serve_frontiers_invalid_count)
 		request.payload = request_payload;
 		request.update_header ();
 
-		node.network.inbound (request, nano::test::fake_channel (node));
+		node.inbound (request, nano::test::fake_channel (node));
 	}
 
 	ASSERT_TIMELY_EQ (5s, node.stats.count (nano::stat::type::bootstrap_server, nano::stat::detail::invalid), 3);

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -743,10 +743,10 @@ TEST (network, duplicate_revert_publish)
 	auto channel = nano::test::establish_tcp (system, *other_node, node.network.endpoint ());
 	ASSERT_NE (nullptr, channel);
 	ASSERT_EQ (0, publish.digest);
-	node.inbound (publish, channel);
+	node.inbound (publish, nano::test::fake_channel (node));
 	ASSERT_TRUE (node.network.filter.apply (bytes.data (), bytes.size ()));
 	publish.digest = digest;
-	node.inbound (publish, channel);
+	node.inbound (publish, nano::test::fake_channel (node));
 	ASSERT_FALSE (node.network.filter.apply (bytes.data (), bytes.size ()));
 }
 

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -377,7 +377,7 @@ TEST (receivable_processor, confirm_insufficient_pos)
 	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
 	auto channel1 = std::make_shared<nano::transport::inproc::channel> (node1, node1);
 	ASSERT_EQ (1, election->votes ().size ());
-	node1.network.inbound (con1, channel1);
+	node1.inbound (con1, channel1);
 	ASSERT_TIMELY_EQ (5s, 2, election->votes ().size ())
 	ASSERT_FALSE (election->confirmed ());
 }
@@ -402,7 +402,7 @@ TEST (receivable_processor, confirm_sufficient_pos)
 	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
 	auto channel1 = std::make_shared<nano::transport::inproc::channel> (node1, node1);
 	ASSERT_EQ (1, election->votes ().size ());
-	node1.network.inbound (con1, channel1);
+	node1.inbound (con1, channel1);
 	ASSERT_TIMELY_EQ (5s, 2, election->votes ().size ())
 	ASSERT_TRUE (election->confirmed ());
 }
@@ -743,10 +743,10 @@ TEST (network, duplicate_revert_publish)
 	auto channel = nano::test::establish_tcp (system, *other_node, node.network.endpoint ());
 	ASSERT_NE (nullptr, channel);
 	ASSERT_EQ (0, publish.digest);
-	node.network.inbound (publish, channel);
+	node.inbound (publish, channel);
 	ASSERT_TRUE (node.network.filter.apply (bytes.data (), bytes.size ()));
 	publish.digest = digest;
-	node.network.inbound (publish, channel);
+	node.inbound (publish, channel);
 	ASSERT_FALSE (node.network.filter.apply (bytes.data (), bytes.size ()));
 }
 

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -688,16 +688,15 @@ TEST (node, fork_flip)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	nano::publish publish2{ nano::dev::network_params.network, send2 };
-	auto ignored_channel = nano::test::fake_channel (node1);
-	node1.inbound (publish1, ignored_channel);
-	node2.inbound (publish2, ignored_channel);
+	node1.inbound (publish1, nano::test::fake_channel (node1));
+	node2.inbound (publish2, nano::test::fake_channel (node2));
 	ASSERT_TIMELY_EQ (5s, 1, node1.active.size ());
 	ASSERT_TIMELY_EQ (5s, 1, node2.active.size ());
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	// Fill nodes with forked blocks
-	node1.inbound (publish2, ignored_channel);
+	node1.inbound (publish2, nano::test::fake_channel (node1));
 	ASSERT_TIMELY (5s, node1.active.active (*send2));
-	node2.inbound (publish1, ignored_channel);
+	node2.inbound (publish1, nano::test::fake_channel (node2));
 	ASSERT_TIMELY (5s, node2.active.active (*send1));
 	auto election1 (node2.active.election (nano::qualified_root (nano::dev::genesis->hash (), nano::dev::genesis->hash ())));
 	ASSERT_NE (nullptr, election1);

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -253,7 +253,7 @@ TEST (telemetry, invalid_signature)
 	telemetry.block_count = 9999; // Change data so signature is no longer valid
 
 	auto message = nano::telemetry_ack{ nano::dev::network_params.network, telemetry };
-	node.network.inbound (message, nano::test::fake_channel (node));
+	node.inbound (message, nano::test::fake_channel (node));
 
 	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::telemetry, nano::stat::detail::invalid_signature) > 0);
 	ASSERT_ALWAYS (1s, node.stats.count (nano::stat::type::telemetry, nano::stat::detail::process) == 0)
@@ -267,7 +267,7 @@ TEST (telemetry, mismatched_node_id)
 	auto telemetry = node.local_telemetry ();
 
 	auto message = nano::telemetry_ack{ nano::dev::network_params.network, telemetry };
-	node.network.inbound (message, nano::test::fake_channel (node, /* node id */ { 123 }));
+	node.inbound (message, nano::test::fake_channel (node, /* node id */ { 123 }));
 
 	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::telemetry, nano::stat::detail::node_id_mismatch) > 0);
 	ASSERT_ALWAYS (1s, node.stats.count (nano::stat::type::telemetry, nano::stat::detail::process) == 0)

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -165,7 +165,7 @@ TEST (websocket, started_election)
 				 .build ();
 	nano::publish publish1{ nano::dev::network_params.network, send1 };
 	auto channel1 = std::make_shared<nano::transport::fake::channel> (*node1);
-	node1->network.inbound (publish1, channel1);
+	node1->inbound (publish1, channel1);
 	ASSERT_TIMELY (1s, node1->active.election (send1->qualified_root ()));
 	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 
@@ -213,7 +213,7 @@ TEST (websocket, stopped_election)
 				 .build ();
 	nano::publish publish1{ nano::dev::network_params.network, send1 };
 	auto channel1 = std::make_shared<nano::transport::fake::channel> (*node1);
-	node1->network.inbound (publish1, channel1);
+	node1->inbound (publish1, channel1);
 	ASSERT_TIMELY (5s, node1->active.election (send1->qualified_root ()));
 	node1->active.erase (*send1);
 

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -314,14 +314,6 @@ void nano::network::flood_block_many (std::deque<std::shared_ptr<nano::block>> b
 	}
 }
 
-void nano::network::inbound (const nano::message & message, const std::shared_ptr<nano::transport::channel> & channel)
-{
-	debug_assert (message.header.network == node.network_params.network.current_network);
-	debug_assert (message.header.version_using >= node.network_params.network.protocol_version_min);
-
-	node.message_processor.process (message, channel);
-}
-
 // Send keepalives to all the peers we've been notified of
 void nano::network::merge_peers (std::array<nano::endpoint, 8> const & peers_a)
 {

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -127,7 +127,6 @@ public:
 	void erase (nano::transport::channel const &);
 	/** Disconnects and adds peer to exclusion list */
 	void exclude (std::shared_ptr<nano::transport::channel> const & channel);
-	void inbound (nano::message const &, std::shared_ptr<nano::transport::channel> const &);
 
 	nano::container_info container_info () const;
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -518,6 +518,14 @@ void nano::node::keepalive (std::string const & address_a, uint16_t port_a)
 	});
 }
 
+void nano::node::inbound (const nano::message & message, const std::shared_ptr<nano::transport::channel> & channel)
+{
+	debug_assert (message.header.network == network_params.network.current_network);
+	debug_assert (message.header.version_using >= network_params.network.protocol_version_min);
+
+	message_processor.process (message, channel);
+}
+
 void nano::node::process_active (std::shared_ptr<nano::block> const & incoming)
 {
 	block_processor.add (incoming);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -520,6 +520,8 @@ void nano::node::keepalive (std::string const & address_a, uint16_t port_a)
 
 void nano::node::inbound (const nano::message & message, const std::shared_ptr<nano::transport::channel> & channel)
 {
+	debug_assert (channel->owner () == shared_from_this ()); // This node should be the channel owner
+
 	debug_assert (message.header.network == network_params.network.current_network);
 	debug_assert (message.header.version_using >= network_params.network.protocol_version_min);
 

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -94,6 +94,7 @@ public:
 	bool copy_with_compaction (std::filesystem::path const &);
 	void keepalive (std::string const &, uint16_t);
 	int store_version ();
+	void inbound (nano::message const &, std::shared_ptr<nano::transport::channel> const &);
 	void process_confirmed (nano::election_status const &, uint64_t = 0);
 	void process_active (std::shared_ptr<nano::block> const &);
 	std::optional<nano::block_status> process_local (std::shared_ptr<nano::block> const &);

--- a/nano/node/transport/channel.cpp
+++ b/nano/node/transport/channel.cpp
@@ -63,6 +63,11 @@ nano::endpoint nano::transport::channel::get_peering_endpoint () const
 	}
 }
 
+std::shared_ptr<nano::node> nano::transport::channel::owner () const
+{
+	return node.shared ();
+}
+
 void nano::transport::channel::operator() (nano::object_stream & obs) const
 {
 	obs.write ("endpoint", get_endpoint ());

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -130,6 +130,8 @@ public:
 	nano::endpoint get_peering_endpoint () const;
 	void set_peering_endpoint (nano::endpoint endpoint);
 
+	std::shared_ptr<nano::node> owner () const;
+
 	mutable nano::mutex channel_mutex;
 
 private:

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -44,7 +44,7 @@ void nano::transport::inproc::channel::send_buffer (nano::shared_const_buffer co
 		// process message
 		{
 			node.stats.inc (nano::stat::type::message, to_stat_detail (message_a->type ()), nano::stat::dir::in);
-			destination.network.inbound (*message_a, remote_channel);
+			destination.inbound (*message_a, remote_channel);
 		}
 	});
 


### PR DESCRIPTION
There were a few testcases where messages were passed with channels belonging to other nodes, which was causing strange lifetime issues. This adds asserts to ensure this won't happen.