### PR TITLE
Automatic database backend

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -578,7 +578,6 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	vacancy_threshold = 99
 
 	[node.rocksdb]
-	enable = true
 	io_threads = 99
 	read_cache = 99
 	write_cache = 99
@@ -748,8 +747,6 @@ TEST (toml, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.lmdb_config.max_databases, defaults.node.lmdb_config.max_databases);
 	ASSERT_NE (conf.node.lmdb_config.map_size, defaults.node.lmdb_config.map_size);
 
-	ASSERT_TRUE (conf.node.rocksdb_config.enable);
-	ASSERT_EQ (nano::rocksdb_config::using_rocksdb_in_tests (), defaults.node.rocksdb_config.enable);
 	ASSERT_NE (conf.node.rocksdb_config.io_threads, defaults.node.rocksdb_config.io_threads);
 	ASSERT_NE (conf.node.rocksdb_config.read_cache, defaults.node.rocksdb_config.read_cache);
 	ASSERT_NE (conf.node.rocksdb_config.write_cache, defaults.node.rocksdb_config.write_cache);

--- a/nano/lib/rocksdbconfig.cpp
+++ b/nano/lib/rocksdbconfig.cpp
@@ -4,7 +4,6 @@
 
 nano::error nano::rocksdb_config::serialize_toml (nano::tomlconfig & toml) const
 {
-	toml.put ("enable", enable, "Whether to use the RocksDB backend for the ledger database.\ntype:bool");
 	toml.put ("io_threads", io_threads, "Number of threads to use with the background compaction and flushing.\ntype:uint32");
 	toml.put ("read_cache", read_cache, "Amount of megabytes per table allocated to read cache. Valid range is 1 - 1024. Default is 32.\nCarefully monitor memory usage if non-default values are used\ntype:long");
 	toml.put ("write_cache", write_cache, "Total amount of megabytes allocated to write cache. Valid range is 1 - 256. Default is 64.\nCarefully monitor memory usage if non-default values are used\ntype:long");
@@ -14,7 +13,6 @@ nano::error nano::rocksdb_config::serialize_toml (nano::tomlconfig & toml) const
 
 nano::error nano::rocksdb_config::deserialize_toml (nano::tomlconfig & toml)
 {
-	toml.get_optional<bool> ("enable", enable);
 	toml.get_optional<unsigned> ("io_threads", io_threads);
 	toml.get_optional<long> ("read_cache", read_cache);
 	toml.get_optional<long> ("write_cache", write_cache);

--- a/nano/lib/rocksdbconfig.hpp
+++ b/nano/lib/rocksdbconfig.hpp
@@ -13,11 +13,6 @@ class tomlconfig;
 class rocksdb_config final
 {
 public:
-	rocksdb_config () :
-		enable{ using_rocksdb_in_tests () }
-	{
-	}
-
 	nano::error serialize_toml (nano::tomlconfig &) const;
 	nano::error deserialize_toml (nano::tomlconfig &);
 

--- a/nano/node/make_store.cpp
+++ b/nano/node/make_store.cpp
@@ -3,7 +3,8 @@
 #include <nano/store/lmdb/lmdb.hpp>
 #include <nano/store/rocksdb/rocksdb.hpp>
 
-std::unique_ptr<nano::store::component> nano::make_store (nano::logger & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::rocksdb_config const & rocksdb_config, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade)
+std::unique_ptr<nano::store::component> nano::make_store (
+nano::logger & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::rocksdb_config const & rocksdb_config, nano::node_config const & node_config, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade)
 {
 	if (rocksdb_config.enable)
 	{

--- a/nano/node/make_store.cpp
+++ b/nano/node/make_store.cpp
@@ -3,8 +3,7 @@
 #include <nano/store/lmdb/lmdb.hpp>
 #include <nano/store/rocksdb/rocksdb.hpp>
 
-std::unique_ptr<nano::store::component> nano::make_store (
-nano::logger & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::node_config const & node_config, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade)
+std::unique_ptr<nano::store::component> nano::make_store (nano::logger & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::node_config const & node_config)
 {
 	if (node_config.database_backend == nano::database_backend::rocksdb)
 	{
@@ -12,7 +11,7 @@ nano::logger & logger, std::filesystem::path const & path, nano::ledger_constant
 	}
 	else if (node_config.database_backend == nano::database_backend::lmdb)
 	{
-		return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, txn_tracking_config_a, block_processor_batch_max_time_a, lmdb_config_a, backup_before_upgrade);
+		return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, node_config.diagnostics_config.txn_tracking, node_config.block_processor_batch_max_time, node_config.lmdb_config, node_config.backup_before_upgrade);
 	}
 	else if (node_config.database_backend == nano::database_backend::automatic)
 	{
@@ -26,7 +25,7 @@ nano::logger & logger, std::filesystem::path const & path, nano::ledger_constant
 		else if (lmdb_ledger_found)
 		{
 			logger.info (nano::log::type::ledger, "Using existing LMDB ledger");
-			return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, txn_tracking_config_a, block_processor_batch_max_time_a, lmdb_config_a, backup_before_upgrade);
+			return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, node_config.diagnostics_config.txn_tracking, node_config.block_processor_batch_max_time, node_config.lmdb_config, node_config.backup_before_upgrade);
 		}
 		else if (rocks_ledger_found)
 		{

--- a/nano/node/make_store.cpp
+++ b/nano/node/make_store.cpp
@@ -4,12 +4,40 @@
 #include <nano/store/rocksdb/rocksdb.hpp>
 
 std::unique_ptr<nano::store::component> nano::make_store (
-nano::logger & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::rocksdb_config const & rocksdb_config, nano::node_config const & node_config, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade)
+nano::logger & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::node_config const & node_config, nano::txn_tracking_config const & txn_tracking_config_a, std::chrono::milliseconds block_processor_batch_max_time_a, nano::lmdb_config const & lmdb_config_a, bool backup_before_upgrade)
 {
-	if (rocksdb_config.enable)
+	if (node_config.database_backend == nano::database_backend::rocksdb)
 	{
-		return std::make_unique<nano::store::rocksdb::component> (logger, add_db_postfix ? path / "rocksdb" : path, constants, rocksdb_config, read_only);
+		return std::make_unique<nano::store::rocksdb::component> (logger, add_db_postfix ? path / "rocksdb" : path, constants, node_config.rocksdb_config, read_only);
 	}
-
-	return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, txn_tracking_config_a, block_processor_batch_max_time_a, lmdb_config_a, backup_before_upgrade);
+	else if (node_config.database_backend == nano::database_backend::lmdb)
+	{
+		return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, txn_tracking_config_a, block_processor_batch_max_time_a, lmdb_config_a, backup_before_upgrade);
+	}
+	else if (node_config.database_backend == nano::database_backend::automatic)
+	{
+		bool lmdb_ledger_found = std::filesystem::exists (path / "data.ldb");
+		bool rocks_ledger_found = std::filesystem::exists (path / "rocksdb");
+		if (lmdb_ledger_found && rocks_ledger_found)
+		{
+			logger.warn (nano::log::type::ledger, "Multiple ledgers were found! Using RocksDb ledger");
+			return std::make_unique<nano::store::rocksdb::component> (logger, add_db_postfix ? path / "rocksdb" : path, constants, node_config.rocksdb_config, read_only);
+		}
+		else if (lmdb_ledger_found)
+		{
+			logger.info (nano::log::type::ledger, "Using existing LMDB ledger");
+			return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, txn_tracking_config_a, block_processor_batch_max_time_a, lmdb_config_a, backup_before_upgrade);
+		}
+		else if (rocks_ledger_found)
+		{
+			logger.info (nano::log::type::ledger, "Using existing RocksDb ledger");
+			return std::make_unique<nano::store::rocksdb::component> (logger, add_db_postfix ? path / "rocksdb" : path, constants, node_config.rocksdb_config, read_only);
+		}
+		else if (!lmdb_ledger_found && !rocks_ledger_found)
+		{
+			logger.info (nano::log::type::ledger, "No ledger found. Creating new RocksDb ledger");
+			return std::make_unique<nano::store::rocksdb::component> (logger, add_db_postfix ? path / "rocksdb" : path, constants, node_config.rocksdb_config, read_only);
+		}
+	}
+	debug_assert (false);
 }

--- a/nano/node/make_store.cpp
+++ b/nano/node/make_store.cpp
@@ -34,8 +34,8 @@ std::unique_ptr<nano::store::component> nano::make_store (nano::logger & logger,
 		}
 		else if (!lmdb_ledger_found && !rocks_ledger_found)
 		{
-			logger.info (nano::log::type::ledger, "No ledger found. Creating new RocksDb ledger");
-			return std::make_unique<nano::store::rocksdb::component> (logger, add_db_postfix ? path / "rocksdb" : path, constants, node_config.rocksdb_config, read_only);
+			logger.info (nano::log::type::ledger, "No ledger found. Creating new LMDB ledger");
+			return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, node_config.diagnostics_config.txn_tracking, node_config.block_processor_batch_max_time, node_config.lmdb_config, node_config.backup_before_upgrade);
 		}
 	}
 	debug_assert (false);

--- a/nano/node/make_store.hpp
+++ b/nano/node/make_store.hpp
@@ -25,5 +25,5 @@ class component;
 namespace nano
 {
 std::unique_ptr<nano::store::component> make_store (
-nano::logger &, std::filesystem::path const & path, nano::ledger_constants & constants, bool open_read_only = false, bool add_db_postfix = true, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::node_config const & node_config = nano::node_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
+nano::logger &, std::filesystem::path const & path, nano::ledger_constants & constants, bool open_read_only = false, bool add_db_postfix = true, nano::node_config const & node_config = nano::node_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
 }

--- a/nano/node/make_store.hpp
+++ b/nano/node/make_store.hpp
@@ -4,6 +4,7 @@
 #include <nano/lib/lmdbconfig.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/rocksdbconfig.hpp>
+#include <nano/node/nodeconfig.hpp>
 
 #include <chrono>
 
@@ -12,6 +13,7 @@ namespace nano
 class ledger_constants;
 class lmdb_config;
 class rocksdb_config;
+class node_config;
 class txn_tracking_config;
 }
 
@@ -22,5 +24,6 @@ class component;
 
 namespace nano
 {
-std::unique_ptr<nano::store::component> make_store (nano::logger &, std::filesystem::path const & path, nano::ledger_constants & constants, bool open_read_only = false, bool add_db_postfix = true, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
+std::unique_ptr<nano::store::component> make_store (
+nano::logger &, std::filesystem::path const & path, nano::ledger_constants & constants, bool open_read_only = false, bool add_db_postfix = true, nano::rocksdb_config const & rocksdb_config = nano::rocksdb_config{}, nano::node_config const & node_config = nano::node_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
 }

--- a/nano/node/make_store.hpp
+++ b/nano/node/make_store.hpp
@@ -25,5 +25,5 @@ class component;
 namespace nano
 {
 std::unique_ptr<nano::store::component> make_store (
-nano::logger &, std::filesystem::path const & path, nano::ledger_constants & constants, bool open_read_only = false, bool add_db_postfix = true, nano::node_config const & node_config = nano::node_config{}, nano::txn_tracking_config const & txn_tracking_config_a = nano::txn_tracking_config{}, std::chrono::milliseconds block_processor_batch_max_time_a = std::chrono::milliseconds (5000), nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{}, bool backup_before_upgrade = false);
+nano::logger &, std::filesystem::path const & path, nano::ledger_constants & constants, bool open_read_only = false, bool add_db_postfix = true, nano::node_config const & node_config = nano::node_config{});
 }

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -83,7 +83,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	flags (flags_a),
 	work (work_a),
 	distributed_work (*this),
-	store_impl (nano::make_store (logger, application_path_a, network_params.ledger, flags.read_only, true, config_a, config_a.diagnostics_config.txn_tracking, config_a.block_processor_batch_max_time, config_a.lmdb_config, config_a.backup_before_upgrade)),
+	store_impl (nano::make_store (logger, application_path_a, network_params.ledger, flags.read_only, true, config_a)),
 	store (*store_impl),
 	unchecked{ config.max_unchecked_blocks, stats, flags.disable_block_processor_unchecked_deletion },
 	wallets_store_impl (std::make_unique<nano::mdb_wallets_store> (application_path_a / "wallets.ldb", config_a.lmdb_config)),

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -83,7 +83,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	flags (flags_a),
 	work (work_a),
 	distributed_work (*this),
-	store_impl (nano::make_store (logger, application_path_a, network_params.ledger, flags.read_only, true, config_a.rocksdb_config, config_a.diagnostics_config.txn_tracking, config_a.block_processor_batch_max_time, config_a.lmdb_config, config_a.backup_before_upgrade)),
+	store_impl (nano::make_store (logger, application_path_a, network_params.ledger, flags.read_only, true, config_a.rocksdb_config, config_a, config_a.diagnostics_config.txn_tracking, config_a.block_processor_batch_max_time, config_a.lmdb_config, config_a.backup_before_upgrade)),
 	store (*store_impl),
 	unchecked{ config.max_unchecked_blocks, stats, flags.disable_block_processor_unchecked_deletion },
 	wallets_store_impl (std::make_unique<nano::mdb_wallets_store> (application_path_a / "wallets.ldb", config_a.lmdb_config)),

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -83,7 +83,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	flags (flags_a),
 	work (work_a),
 	distributed_work (*this),
-	store_impl (nano::make_store (logger, application_path_a, network_params.ledger, flags.read_only, true, config_a.rocksdb_config, config_a, config_a.diagnostics_config.txn_tracking, config_a.block_processor_batch_max_time, config_a.lmdb_config, config_a.backup_before_upgrade)),
+	store_impl (nano::make_store (logger, application_path_a, network_params.ledger, flags.read_only, true, config_a, config_a.diagnostics_config.txn_tracking, config_a.block_processor_batch_max_time, config_a.lmdb_config, config_a.backup_before_upgrade)),
 	store (*store_impl),
 	unchecked{ config.max_unchecked_blocks, stats, flags.disable_block_processor_unchecked_deletion },
 	wallets_store_impl (std::make_unique<nano::mdb_wallets_store> (application_path_a / "wallets.ldb", config_a.lmdb_config)),

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -140,7 +140,7 @@ public:
 	uint64_t max_pruning_depth{ 0 };
 	nano::rocksdb_config rocksdb_config;
 	nano::lmdb_config lmdb_config;
-	nano::database_backend database_backend{ nano::database_backend::automatic };
+	nano::database_backend database_backend{ nano::rocksdb_config::using_rocksdb_in_tests () ? nano::database_backend::rocksdb : nano::database_backend::automatic };
 	bool enable_upnp{ true };
 	nano::vote_cache_config vote_cache;
 	nano::rep_crawler_config rep_crawler;

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -140,7 +140,8 @@ public:
 	uint64_t max_pruning_depth{ 0 };
 	nano::rocksdb_config rocksdb_config;
 	nano::lmdb_config lmdb_config;
-	nano::database_backend database_backend{ nano::rocksdb_config::using_rocksdb_in_tests () ? nano::database_backend::rocksdb : nano::database_backend::automatic };
+	nano::database_backend database_backend{ std::string (std::getenv ("BACKEND") ? std::getenv ("BACKEND") : "") == "rocksdb" ? nano::database_backend::rocksdb : std::string (std::getenv ("BACKEND") ? std::getenv ("BACKEND") : "") == "lmdb" ? nano::database_backend::lmdb
+																																																												  : nano::database_backend::automatic };
 	bool enable_upnp{ true };
 	nano::vote_cache_config vote_cache;
 	nano::rep_crawler_config rep_crawler;

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -41,6 +41,13 @@ namespace nano
 {
 class tomlconfig;
 
+enum class database_backend : uint8_t
+{
+	automatic, // backend is determined based on existing ledger files found
+	rocksdb,
+	lmdb
+};
+
 /**
  * Node configuration
  */
@@ -133,6 +140,7 @@ public:
 	uint64_t max_pruning_depth{ 0 };
 	nano::rocksdb_config rocksdb_config;
 	nano::lmdb_config lmdb_config;
+	nano::database_backend database_backend{ nano::database_backend::automatic };
 	bool enable_upnp{ true };
 	nano::vote_cache_config vote_cache;
 	nano::rep_crawler_config rep_crawler;
@@ -152,6 +160,8 @@ public:
 public:
 	/** Entry is ignored if it cannot be parsed as a valid address:port */
 	void deserialize_address (std::string const &, std::vector<std::pair<std::string, uint16_t>> &) const;
+	std::string serialize_database_backend (nano::database_backend) const;
+	nano::database_backend deserialize_database_backend (std::string const & string_a);
 
 private:
 	static std::optional<unsigned> env_io_threads ();

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1282,8 +1282,9 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 
 	// Open rocksdb database
 	nano::rocksdb_config rocksdb_config;
-	rocksdb_config.enable = true;
-	auto rocksdb_store = nano::make_store (logger, data_path_a, nano::dev::constants, false, true, rocksdb_config);
+	nano::node_config node_config;
+	node_config.database_backend = database_backend::rocksdb;
+	auto rocksdb_store = nano::make_store (logger, data_path_a, nano::dev::constants, false, true, node_config);
 
 	if (!rocksdb_store->init_error ())
 	{


### PR DESCRIPTION
Switching database backend between LMDB and RocksDb is currently done by setting `RocksDb.enabled` to true or false in the config.

This PR removes that setting and adds a new `Database_backend` config setting.
`Database_backend` can be set to one of the following:
* lmdb
* rocksdb
* auto

The first two will force the use of the specific backend.
When using auto mode the node will look for an existing ledger and use this. If no ledger is found it will initialize a new ~~RocksDb~~ LMDB ledger. If multiple ledgers are found it will display a warning message and use the RocksDb ledger.
The main purpose is to make new node operators use RocksDb but without forcing existing LMDB users to make changes.
In future node versions (V29?) we can show messages to LMDB users that encourage them to update to RocksDb and instructions on how to do this.
Even later versions (V30?) could halt the node initialization if LMDB is used and display instructions on updating. If they insist on using LMDB they can set `Database_backend` to lmdb 