### PR TITLE
Remove `election_winner_details` container

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -1398,6 +1398,8 @@ TEST (active_elections, bound_election_winners)
 	nano::node_config config = system.default_config ();
 	// Set election winner limit to a low value
 	config.active_elections.max_election_winners = 5;
+	// Large batch size would complicate this testcase
+	config.confirming_set.batch_size = 1;
 	auto & node = *system.add_node (config);
 
 	// Start elections for a couple of blocks, number of elections is larger than the election winner set limit
@@ -1411,22 +1413,12 @@ TEST (active_elections, bound_election_winners)
 		auto guard = node.ledger.tx_begin_write (nano::store::writer::testing);
 
 		// Ensure that when the number of election winners reaches the limit, AEC vacancy reflects that
+		// Confirming more elections should make the vacancy negative
 		ASSERT_TRUE (node.active.vacancy (nano::election_behavior::priority) > 0);
 
-		int index = 0;
-		for (; index < config.active_elections.max_election_winners; ++index)
+		for (auto const & block : blocks)
 		{
-			auto election = node.vote_router.election (blocks[index]->hash ());
-			ASSERT_TRUE (election);
-			election->force_confirm ();
-		}
-
-		ASSERT_TIMELY_EQ (5s, node.active.vacancy (nano::election_behavior::priority), 0);
-
-		// Confirming more elections should make the vacancy negative
-		for (; index < blocks.size (); ++index)
-		{
-			auto election = node.vote_router.election (blocks[index]->hash ());
+			auto election = node.vote_router.election (block->hash ());
 			ASSERT_TRUE (election);
 			election->force_confirm ();
 		}

--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -1224,7 +1224,7 @@ TEST (active_elections, activate_inactive)
 	ASSERT_NE (nullptr, election);
 	election->force_confirm ();
 
-	ASSERT_TIMELY (5s, !node.confirming_set.exists (send2->hash ()));
+	ASSERT_TIMELY (5s, !node.confirming_set.contains (send2->hash ()));
 	ASSERT_TIMELY (5s, node.block_confirmed (send2->hash ()));
 	ASSERT_TIMELY (5s, node.block_confirmed (send->hash ()));
 

--- a/nano/core_test/confirming_set.cpp
+++ b/nano/core_test/confirming_set.cpp
@@ -20,14 +20,14 @@ TEST (confirming_set, construction)
 {
 	auto ctx = nano::test::ledger_empty ();
 	nano::confirming_set_config config{};
-	nano::confirming_set confirming_set{ config, ctx.ledger (), ctx.stats () };
+	nano::confirming_set confirming_set{ config, ctx.ledger (), ctx.stats (), ctx.logger () };
 }
 
 TEST (confirming_set, add_exists)
 {
 	auto ctx = nano::test::ledger_send_receive ();
 	nano::confirming_set_config config{};
-	nano::confirming_set confirming_set{ config, ctx.ledger (), ctx.stats () };
+	nano::confirming_set confirming_set{ config, ctx.ledger (), ctx.stats (), ctx.logger () };
 	auto send = ctx.blocks ()[0];
 	confirming_set.add (send->hash ());
 	ASSERT_TRUE (confirming_set.contains (send->hash ()));
@@ -37,7 +37,7 @@ TEST (confirming_set, process_one)
 {
 	auto ctx = nano::test::ledger_send_receive ();
 	nano::confirming_set_config config{};
-	nano::confirming_set confirming_set{ config, ctx.ledger (), ctx.stats () };
+	nano::confirming_set confirming_set{ config, ctx.ledger (), ctx.stats (), ctx.logger () };
 	std::atomic<int> count = 0;
 	std::mutex mutex;
 	std::condition_variable condition;
@@ -54,7 +54,7 @@ TEST (confirming_set, process_multiple)
 {
 	auto ctx = nano::test::ledger_send_receive ();
 	nano::confirming_set_config config{};
-	nano::confirming_set confirming_set{ config, ctx.ledger (), ctx.stats () };
+	nano::confirming_set confirming_set{ config, ctx.ledger (), ctx.stats (), ctx.logger () };
 	std::atomic<int> count = 0;
 	std::mutex mutex;
 	std::condition_variable condition;

--- a/nano/core_test/confirming_set.cpp
+++ b/nano/core_test/confirming_set.cpp
@@ -30,7 +30,7 @@ TEST (confirming_set, add_exists)
 	nano::confirming_set confirming_set{ config, ctx.ledger (), ctx.stats () };
 	auto send = ctx.blocks ()[0];
 	confirming_set.add (send->hash ());
-	ASSERT_TRUE (confirming_set.exists (send->hash ()));
+	ASSERT_TRUE (confirming_set.contains (send->hash ()));
 }
 
 TEST (confirming_set, process_one)
@@ -242,7 +242,7 @@ TEST (confirmation_callback, dependent_election)
 	// Wait for blocks to be confirmed in ledger, callbacks will happen after
 	ASSERT_TIMELY_EQ (5s, 3, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
 	// Once the item added to the confirming set no longer exists, callbacks have completed
-	ASSERT_TIMELY (5s, !node->confirming_set.exists (send2->hash ()));
+	ASSERT_TIMELY (5s, !node->confirming_set.contains (send2->hash ()));
 
 	ASSERT_TIMELY_EQ (5s, 1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out));
 	ASSERT_TIMELY_EQ (5s, 1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_conf_height, nano::stat::dir::out));

--- a/nano/core_test/confirming_set.cpp
+++ b/nano/core_test/confirming_set.cpp
@@ -170,8 +170,7 @@ TEST (confirmation_callback, confirmed_history)
 
 	ASSERT_TIMELY (10s, !node->store.write_queue.contains (nano::store::writer::confirmation_height));
 
-	auto transaction = node->ledger.tx_begin_read ();
-	ASSERT_TRUE (node->ledger.confirmed.block_exists (transaction, send->hash ()));
+	ASSERT_TIMELY (5s, node->ledger.confirmed.block_exists (node->ledger.tx_begin_read (), send->hash ()));
 
 	ASSERT_TIMELY_EQ (10s, node->active.size (), 0);
 	ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out), 1);

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -195,7 +195,7 @@ TEST (election_scheduler, no_vacancy)
 				.work (*system.work.generate (nano::dev::genesis->hash ()))
 				.build ();
 	ASSERT_EQ (nano::block_status::progress, node.process (send));
-	node.process_confirmed (nano::election_status{ send });
+	node.process_confirmed (send->hash ());
 
 	auto receive = builder.make_block ()
 				   .account (key.pub)
@@ -207,7 +207,7 @@ TEST (election_scheduler, no_vacancy)
 				   .work (*system.work.generate (key.pub))
 				   .build ();
 	ASSERT_EQ (nano::block_status::progress, node.process (receive));
-	node.process_confirmed (nano::election_status{ receive });
+	node.process_confirmed (receive->hash ());
 
 	ASSERT_TIMELY (5s, nano::test::confirmed (node, { send, receive }));
 

--- a/nano/core_test/ledger_confirm.cpp
+++ b/nano/core_test/ledger_confirm.cpp
@@ -752,29 +752,6 @@ TEST (ledger_confirm, observers)
 	ASSERT_EQ (2, node1->ledger.cemented_count ());
 }
 
-TEST (ledger_confirm, election_winner_details_clearing_node_process_confirmed)
-{
-	// Make sure election_winner_details is also cleared if the block never enters the confirmation height processor from node::process_confirmed
-	nano::test::system system (1);
-	auto node = system.nodes.front ();
-
-	nano::block_builder builder;
-	auto send = builder
-				.send ()
-				.previous (nano::dev::genesis->hash ())
-				.destination (nano::dev::genesis_key.pub)
-				.balance (nano::dev::constants.genesis_amount - nano::Knano_ratio)
-				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*system.work.generate (nano::dev::genesis->hash ()))
-				.build ();
-	// Add to election_winner_details. Use an unrealistic iteration so that it should fall into the else case and do a cleanup
-	node->active.add_election_winner_details (send->hash (), nullptr);
-	nano::election_status election;
-	election.winner = send;
-	node->process_confirmed (election, 1000000);
-	ASSERT_EQ (0, node->active.election_winner_details_size ());
-}
-
 TEST (ledger_confirm, pruned_source)
 {
 	nano::test::system system;

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3564,9 +3564,9 @@ TEST (node, pruning_automatic)
 	ASSERT_TIMELY (5s, node1.block (send2->hash ()) != nullptr);
 
 	// Force-confirm both blocks
-	node1.process_confirmed (nano::election_status{ send1 });
+	node1.process_confirmed (send1->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send1->hash ()));
-	node1.process_confirmed (nano::election_status{ send2 });
+	node1.process_confirmed (send2->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
 
 	// Check pruning result
@@ -3615,9 +3615,9 @@ TEST (node, DISABLED_pruning_age)
 	node1.process_active (send2);
 
 	// Force-confirm both blocks
-	node1.process_confirmed (nano::election_status{ send1 });
+	node1.process_confirmed (send1->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send1->hash ()));
-	node1.process_confirmed (nano::election_status{ send2 });
+	node1.process_confirmed (send2->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
 
 	// Three blocks in total, nothing pruned yet
@@ -3676,9 +3676,9 @@ TEST (node, DISABLED_pruning_depth)
 	node1.process_active (send2);
 
 	// Force-confirm both blocks
-	node1.process_confirmed (nano::election_status{ send1 });
+	node1.process_confirmed (send1->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send1->hash ()));
-	node1.process_confirmed (nano::election_status{ send2 });
+	node1.process_confirmed (send2->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
 
 	// Three blocks in total, nothing pruned yet

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -82,6 +82,7 @@ enum class type
 	message_processor,
 	local_block_broadcaster,
 	monitor,
+	confirming_set,
 
 	// bootstrap
 	bulk_pull_client,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -505,6 +505,7 @@ enum class detail
 	already_cemented,
 	cementing,
 	cemented_hash,
+	cementing_failed,
 
 	// election_state
 	passive,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -412,6 +412,7 @@ enum class detail
 	// active_elections
 	started,
 	stopped,
+	confirm_dependent,
 
 	// unchecked
 	put,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -249,6 +249,8 @@ enum class detail
 	generate_vote_final,
 	broadcast_block_initial,
 	broadcast_block_repeat,
+	confirm_once,
+	confirm_once_failed,
 
 	// election types
 	manual,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -93,6 +93,7 @@ enum class type
 	message_processor,
 	message_processor_overfill,
 	message_processor_type,
+	process_confirmed,
 
 	_last // Must be the last enum
 };
@@ -134,6 +135,8 @@ enum class detail
 	cemented,
 	cooldown,
 	empty,
+	done,
+	retry,
 
 	// processing queue
 	queue,

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -32,7 +32,7 @@ nano::active_elections::active_elections (nano::node & node_a, nano::confirming_
 
 	confirming_set.batch_cemented.add ([this] (auto const & cemented) {
 		auto transaction = node.ledger.tx_begin_read ();
-		for (auto const & [block, confirmation_root] : cemented)
+		for (auto const & [block, confirmation_root, election] : cemented)
 		{
 			transaction.refresh_if_needed ();
 			block_cemented_callback (transaction, block, confirmation_root);

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -40,13 +40,9 @@ nano::active_elections::active_elections (nano::node & node_a, nano::confirming_
 
 	// Notify elections about alternative (forked) blocks
 	block_processor.block_processed.add ([this] (auto const & result, auto const & context) {
-		switch (result)
+		if (result == nano::block_status::fork)
 		{
-			case nano::block_status::fork:
-				publish (context.block);
-				break;
-			default:
-				break;
+			publish (context.block);
 		}
 	});
 }

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -123,10 +123,6 @@ public:
 	int64_t vacancy (nano::election_behavior behavior) const;
 	std::function<void ()> vacancy_update{ [] () {} };
 
-	std::size_t election_winner_details_size () const;
-	void add_election_winner_details (nano::block_hash const &, std::shared_ptr<nano::election> const &);
-	std::shared_ptr<nano::election> remove_election_winner_details (nano::block_hash const &);
-
 	nano::container_info container_info () const;
 
 private:
@@ -139,8 +135,7 @@ private:
 	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t) const;
 	void activate_successors (nano::secure::transaction const &, std::shared_ptr<nano::block> const & block);
 	void notify_observers (nano::secure::transaction const &, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes) const;
-	void block_cemented_callback (nano::secure::transaction const &, std::shared_ptr<nano::block> const & block, nano::block_hash const & confirmation_root);
-	void block_already_cemented_callback (nano::block_hash const & hash);
+	void block_cemented (nano::secure::transaction const &, std::shared_ptr<nano::block> const & block, nano::block_hash const & confirmation_root, std::shared_ptr<nano::election> const & source_election);
 
 private: // Dependencies
 	active_elections_config const & config;
@@ -157,12 +152,6 @@ public:
 	mutable nano::mutex mutex{ mutex_identifier (mutexes::active) };
 
 private:
-	mutable nano::mutex election_winner_details_mutex{ mutex_identifier (mutexes::election_winner_details) };
-	std::unordered_map<nano::block_hash, std::shared_ptr<nano::election>> election_winner_details;
-
-	// Maximum time an election can be kept active if it is extending the container
-	std::chrono::seconds const election_time_to_live;
-
 	/** Keeps track of number of elections by election behavior (normal, hinted, optimistic) */
 	nano::enum_array<nano::election_behavior, int64_t> count_by_behavior{};
 

--- a/nano/node/confirming_set.cpp
+++ b/nano/node/confirming_set.cpp
@@ -48,6 +48,11 @@ void nano::confirming_set::start ()
 {
 	debug_assert (!thread.joinable ());
 
+	if (!config.enable)
+	{
+		return;
+	}
+
 	thread = std::thread{ [this] () {
 		nano::thread_role::set (nano::thread_role::name::confirmation_height);
 		run ();
@@ -123,7 +128,7 @@ void nano::confirming_set::run_batch (std::unique_lock<std::mutex> & lock)
 	std::deque<context> cemented;
 	std::deque<nano::block_hash> already;
 
-	auto batch = next_batch (batch_size);
+	auto batch = next_batch (config.batch_size);
 
 	lock.unlock ();
 

--- a/nano/node/confirming_set.cpp
+++ b/nano/node/confirming_set.cpp
@@ -68,7 +68,7 @@ void nano::confirming_set::stop ()
 	notification_workers.stop ();
 }
 
-bool nano::confirming_set::exists (nano::block_hash const & hash) const
+bool nano::confirming_set::contains (nano::block_hash const & hash) const
 {
 	std::lock_guard lock{ mutex };
 	return set.get<tag_hash> ().contains (hash);

--- a/nano/node/confirming_set.hpp
+++ b/nano/node/confirming_set.hpp
@@ -102,6 +102,7 @@ private:
 	// clang-format on
 
 	ordered_entries set;
+	std::unordered_set<nano::block_hash> current;
 
 	nano::thread_pool notification_workers;
 

--- a/nano/node/confirming_set.hpp
+++ b/nano/node/confirming_set.hpp
@@ -48,16 +48,10 @@ public:
 	nano::container_info container_info () const;
 
 public: // Events
-	// Observers will be called once ledger has blocks marked as confirmed
 	using cemented_t = std::pair<std::shared_ptr<nano::block>, nano::block_hash>; // <block, confirmation root>
+	nano::observer_set<std::deque<cemented_t> const &> batch_cemented;
+	nano::observer_set<std::deque<nano::block_hash> const &> already_cemented;
 
-	struct cemented_notification
-	{
-		std::deque<cemented_t> cemented;
-		std::deque<nano::block_hash> already_cemented;
-	};
-
-	nano::observer_set<cemented_notification const &> batch_cemented;
 	nano::observer_set<std::shared_ptr<nano::block>> cemented_observers;
 
 private: // Dependencies
@@ -79,5 +73,7 @@ private:
 	mutable std::mutex mutex;
 	std::condition_variable condition;
 	std::thread thread;
+
+	static size_t constexpr batch_size = 256;
 };
 }

--- a/nano/node/confirming_set.hpp
+++ b/nano/node/confirming_set.hpp
@@ -28,6 +28,9 @@ public:
 	// TODO: Serialization & deserialization
 
 public:
+	bool enable{ true };
+	size_t batch_size{ 256 };
+
 	/** Maximum number of dependent blocks to be stored in memory during processing */
 	size_t max_blocks{ 128 * 1024 };
 	size_t max_queued_notifications{ 8 };
@@ -106,7 +109,5 @@ private:
 	mutable std::mutex mutex;
 	std::condition_variable condition;
 	std::thread thread;
-
-	static size_t constexpr batch_size = 256;
 };
 }

--- a/nano/node/confirming_set.hpp
+++ b/nano/node/confirming_set.hpp
@@ -45,7 +45,7 @@ class confirming_set final
 	friend class confirmation_height_pruned_source_Test;
 
 public:
-	confirming_set (confirming_set_config const &, nano::ledger &, nano::stats &);
+	confirming_set (confirming_set_config const &, nano::ledger &, nano::stats &, nano::logger &);
 	~confirming_set ();
 
 	void start ();
@@ -76,6 +76,7 @@ private: // Dependencies
 	confirming_set_config const & config;
 	nano::ledger & ledger;
 	nano::stats & stats;
+	nano::logger & logger;
 
 private:
 	struct entry

--- a/nano/node/confirming_set.hpp
+++ b/nano/node/confirming_set.hpp
@@ -51,7 +51,7 @@ public:
 	// Adds a block to the set of blocks to be confirmed
 	void add (nano::block_hash const & hash, std::shared_ptr<nano::election> const & election = nullptr);
 	// Added blocks will remain in this set until after ledger has them marked as confirmed.
-	bool exists (nano::block_hash const & hash) const;
+	bool contains (nano::block_hash const & hash) const;
 	std::size_t size () const;
 
 	nano::container_info container_info () const;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -56,6 +56,7 @@ void nano::election::confirm_once (nano::unique_lock<nano::mutex> & lock_a)
 
 		node.active.recently_confirmed.put (qualified_root, status_l.winner->hash ());
 
+		node.stats.inc (nano::stat::type::election, nano::stat::detail::confirm_once);
 		node.logger.trace (nano::log::type::election, nano::log::detail::election_confirmed,
 		nano::log::arg{ "id", id },
 		nano::log::arg{ "qualified_root", qualified_root },
@@ -74,6 +75,7 @@ void nano::election::confirm_once (nano::unique_lock<nano::mutex> & lock_a)
 	}
 	else
 	{
+		node.stats.inc (nano::stat::type::election, nano::stat::detail::confirm_once_failed);
 		lock_a.unlock ();
 	}
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1187,7 +1187,7 @@ void nano::json_handler::block_confirm ()
 			if (!node.ledger.confirmed.block_exists_or_pruned (transaction, hash))
 			{
 				// Start new confirmation for unconfirmed (or not being confirmed) block
-				if (!node.confirming_set.exists (hash))
+				if (!node.confirming_set.contains (hash))
 				{
 					node.start_election (std::move (block_l));
 				}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1143,6 +1143,8 @@ void nano::node::ongoing_online_weight_calculation ()
 
 void nano::node::process_confirmed (nano::election_status const & status_a, uint64_t iteration_a)
 {
+	stats.inc (nano::stat::type::process_confirmed, nano::stat::detail::initiate);
+
 	auto hash (status_a.winner->hash ());
 	decltype (iteration_a) const num_iters = (config.block_processor_batch_max_time / network_params.node.process_confirmed_interval) * 4;
 	if (auto block_l = ledger.any.block_get (ledger.tx_begin_read (), hash))

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1104,14 +1104,14 @@ void nano::node::start_election (std::shared_ptr<nano::block> const & block)
 	scheduler.manual.push (block);
 }
 
-bool nano::node::block_confirmed (nano::block_hash const & hash_a)
+bool nano::node::block_confirmed (nano::block_hash const & hash)
 {
-	return ledger.confirmed.block_exists_or_pruned (ledger.tx_begin_read (), hash_a);
+	return ledger.confirmed.block_exists_or_pruned (ledger.tx_begin_read (), hash);
 }
 
-bool nano::node::block_confirmed_or_being_confirmed (nano::secure::transaction const & transaction, nano::block_hash const & hash_a)
+bool nano::node::block_confirmed_or_being_confirmed (nano::secure::transaction const & transaction, nano::block_hash const & hash)
 {
-	return confirming_set.exists (hash_a) || ledger.confirmed.block_exists_or_pruned (transaction, hash_a);
+	return confirming_set.contains (hash) || ledger.confirmed.block_exists_or_pruned (transaction, hash);
 }
 
 bool nano::node::block_confirmed_or_being_confirmed (nano::block_hash const & hash_a)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -115,7 +115,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	port_mapping_impl{ std::make_unique<nano::port_mapping> (*this) },
 	port_mapping{ *port_mapping_impl },
 	block_processor (*this),
-	confirming_set_impl{ std::make_unique<nano::confirming_set> (config.confirming_set, ledger, stats) },
+	confirming_set_impl{ std::make_unique<nano::confirming_set> (config.confirming_set, ledger, stats, logger) },
 	confirming_set{ *confirming_set_impl },
 	active_impl{ std::make_unique<nano::active_elections> (*this, confirming_set, block_processor) },
 	active{ *active_impl },

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1172,7 +1172,6 @@ void nano::node::process_confirmed (nano::election_status const & status_a, uint
 		stats.inc (nano::stat::type::process_confirmed, nano::stat::detail::timeout);
 
 		// Do some cleanup due to this block never being processed by confirmation height processor
-		active.remove_election_winner_details (hash);
 	}
 }
 

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -94,7 +94,7 @@ public:
 	bool copy_with_compaction (std::filesystem::path const &);
 	void keepalive (std::string const &, uint16_t);
 	int store_version ();
-	void process_confirmed (nano::election_status const &, uint64_t = 0);
+	void process_confirmed (nano::block_hash, std::shared_ptr<nano::election> = nullptr, uint64_t iteration = 0);
 	void process_active (std::shared_ptr<nano::block> const &);
 	std::optional<nano::block_status> process_local (std::shared_ptr<nano::block> const &);
 	void process_local_async (std::shared_ptr<nano::block> const &);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1201,7 +1201,7 @@ bool nano::wallet::search_receivable (store::transaction const & wallet_transact
 							// Receive confirmed block
 							receive_async (hash, representative, amount, account, [] (std::shared_ptr<nano::block> const &) {});
 						}
-						else if (!wallets.node.confirming_set.exists (hash))
+						else if (!wallets.node.confirming_set.contains (hash))
 						{
 							auto block = wallets.node.ledger.any.block_get (block_transaction, hash);
 							if (block)

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -865,7 +865,10 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_tr
 		bool refreshed = transaction.refresh_if_needed ();
 		if (refreshed)
 		{
-			release_assert (any.block_exists (transaction, target_hash), "block was rolled back during cementing");
+			if (!any.block_exists (transaction, target_hash))
+			{
+				break; // Block was rolled back during cementing
+			}
 		}
 
 		// Early return might leave parts of the dependency tree unconfirmed

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -717,7 +717,6 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), 0);
 
 	ASSERT_TIMELY_EQ (40s, (node->ledger.cemented_count () - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::dir::out));
-	ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 }
 
 TEST (confirmation_height, many_accounts_many_confirmations)
@@ -792,8 +791,6 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	ASSERT_EQ (cemented_count, node->ledger.cemented_count ());
 
 	ASSERT_TIMELY_EQ (20s, (node->ledger.cemented_count () - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::dir::out));
-
-	ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 }
 
 TEST (confirmation_height, long_chains)
@@ -939,7 +936,6 @@ TEST (confirmation_height, long_chains)
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), 0);
 
 	ASSERT_TIMELY_EQ (40s, (node->ledger.cemented_count () - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::dir::out));
-	ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 }
 
 TEST (confirmation_height, dynamic_algorithm)
@@ -987,7 +983,6 @@ TEST (confirmation_height, dynamic_algorithm)
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_blocks);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in), 1);
 	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), num_blocks - 1);
-	ASSERT_TIMELY_EQ (10s, node->active.election_winner_details_size (), 0);
 }
 
 TEST (confirmation_height, many_accounts_send_receive_self)
@@ -1118,10 +1113,6 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 	}
 
 	system.deadline_set (60s);
-	while (node->active.election_winner_details_size () > 0)
-	{
-		ASSERT_NO_ERROR (system.poll ());
-	}
 }
 
 // Same as the many_accounts_send_receive_self test, except works on the confirmation height processor directly

--- a/nano/test_common/ledger_context.cpp
+++ b/nano/test_common/ledger_context.cpp
@@ -4,8 +4,8 @@
 #include <nano/test_common/ledger_context.hpp>
 
 nano::test::ledger_context::ledger_context (std::deque<std::shared_ptr<nano::block>> && blocks) :
-	store_m{ nano::make_store (logger, nano::unique_path (), nano::dev::constants) },
-	stats_m{ logger },
+	store_m{ nano::make_store (logger_m, nano::unique_path (), nano::dev::constants) },
+	stats_m{ logger_m },
 	ledger_m{ *store_m, stats_m, nano::dev::constants },
 	blocks_m{ blocks },
 	pool_m{ nano::dev::network_params.network, 1 }
@@ -33,6 +33,11 @@ nano::store::component & nano::test::ledger_context::store ()
 nano::stats & nano::test::ledger_context::stats ()
 {
 	return stats_m;
+}
+
+nano::logger & nano::test::ledger_context::logger ()
+{
+	return logger_m;
 }
 
 std::deque<std::shared_ptr<nano::block>> const & nano::test::ledger_context::blocks () const

--- a/nano/test_common/ledger_context.hpp
+++ b/nano/test_common/ledger_context.hpp
@@ -16,12 +16,13 @@ public:
 	ledger_context (std::deque<std::shared_ptr<nano::block>> && blocks = std::deque<std::shared_ptr<nano::block>>{});
 	nano::ledger & ledger ();
 	nano::store::component & store ();
-	nano::stats & stats ();
 	std::deque<std::shared_ptr<nano::block>> const & blocks () const;
 	nano::work_pool & pool ();
+	nano::stats & stats ();
+	nano::logger & logger ();
 
 private:
-	nano::logger logger;
+	nano::logger logger_m;
 	std::unique_ptr<nano::store::component> store_m;
 	nano::stats stats_m;
 	nano::ledger ledger_m;


### PR DESCRIPTION
This removes `election_winner_details` container which proved to be difficult to keep in sync and was leaking entires when rollbacks were performed (as part of bounded backlog work). The election that triggered the cementing is now passed as part of context, ie. the flow of cementing is: `election::confirm_once (...) > confirming_set::add (...) > confirming_set::batch_cemented event > active_elections::block_cemented callback (...)` where election is passed through the pipeline.