### PR TITLE
Offload block processor notifications

### DIFF
--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -37,6 +37,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::block_processing:
 			thread_role_name_string = "Blck processing";
 			break;
+		case nano::thread_role::name::block_processing_notifications:
+			thread_role_name_string = "Blck proc notif";
+			break;
 		case nano::thread_role::name::request_loop:
 			thread_role_name_string = "Request loop";
 			break;

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -17,6 +17,7 @@ enum class name
 	vote_processing,
 	vote_cache_processing,
 	block_processing,
+	block_processing_notifications,
 	request_loop,
 	wallet_actions,
 	bootstrap_initiator,

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -13,28 +13,6 @@
 #include <utility>
 
 /*
- * block_processor::context
- */
-
-nano::block_processor::context::context (std::shared_ptr<nano::block> block, nano::block_source source_a, callback_t callback_a) :
-	block{ std::move (block) },
-	source{ source_a },
-	callback{ std::move (callback_a) }
-{
-	debug_assert (source != nano::block_source::unknown);
-}
-
-auto nano::block_processor::context::get_future () -> std::future<result_t>
-{
-	return promise.get_future ();
-}
-
-void nano::block_processor::context::set_result (result_t const & result)
-{
-	promise.set_value (result);
-}
-
-/*
  * block_processor
  */
 
@@ -473,6 +451,28 @@ nano::container_info nano::block_processor::container_info () const
 	info.add ("queue", queue.container_info ());
 	info.add ("workers", workers.container_info ());
 	return info;
+}
+
+/*
+ * block_processor::context
+ */
+
+nano::block_processor::context::context (std::shared_ptr<nano::block> block, nano::block_source source_a, callback_t callback_a) :
+	block{ std::move (block) },
+	source{ source_a },
+	callback{ std::move (callback_a) }
+{
+	debug_assert (source != nano::block_source::unknown);
+}
+
+auto nano::block_processor::context::get_future () -> std::future<result_t>
+{
+	return promise.get_future ();
+}
+
+void nano::block_processor::context::set_result (result_t const & result)
+{
+	promise.set_value (result);
 }
 
 /*

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -41,7 +41,8 @@ void nano::block_processor::context::set_result (result_t const & result)
 nano::block_processor::block_processor (nano::node & node_a) :
 	config{ node_a.config.block_processor },
 	node (node_a),
-	next_log (std::chrono::steady_clock::now ())
+	next_log (std::chrono::steady_clock::now ()),
+	workers{ 1, nano::thread_role::name::block_processing_notifications }
 {
 	batch_processed.add ([this] (auto const & items) {
 		// For every batch item: notify the 'processed' observer.
@@ -84,11 +85,14 @@ nano::block_processor::~block_processor ()
 {
 	// Thread must be stopped before destruction
 	debug_assert (!thread.joinable ());
+	debug_assert (!workers.alive ());
 }
 
 void nano::block_processor::start ()
 {
 	debug_assert (!thread.joinable ());
+
+	workers.start ();
 
 	thread = std::thread ([this] () {
 		nano::thread_role::set (nano::thread_role::name::block_processing);
@@ -107,6 +111,7 @@ void nano::block_processor::stop ()
 	{
 		thread.join ();
 	}
+	workers.stop ();
 }
 
 // TODO: Remove and replace all checks with calls to size (block_source)
@@ -234,6 +239,17 @@ void nano::block_processor::run ()
 	{
 		if (!queue.empty ())
 		{
+			// It's possible that ledger processing happens faster than the notifications can be processed by other components, cooldown here
+			while (workers.queued_tasks () >= config.max_queued_notifications)
+			{
+				node.stats.inc (nano::stat::type::blockprocessor, nano::stat::detail::cooldown);
+				condition.wait_for (lock, 100ms, [this] { return stopped; });
+				if (stopped)
+				{
+					return;
+				}
+			}
+
 			// TODO: Cleaner periodical logging
 			if (should_log ())
 			{
@@ -244,20 +260,22 @@ void nano::block_processor::run ()
 
 			auto processed = process_batch (lock);
 			debug_assert (!lock.owns_lock ());
-
-			// Set results for futures when not holding the lock
-			for (auto & [result, context] : processed)
-			{
-				if (context.callback)
-				{
-					context.callback (result);
-				}
-				context.set_result (result);
-			}
-
-			batch_processed.notify (processed);
-
 			lock.lock ();
+
+			// Queue notifications to be dispatched in the background
+			workers.post ([this, processed = std::move (processed)] () mutable {
+				node.stats.inc (nano::stat::type::blockprocessor, nano::stat::detail::notify);
+				// Set results for futures when not holding the lock
+				for (auto & [result, context] : processed)
+				{
+					if (context.callback)
+					{
+						context.callback (result);
+					}
+					context.set_result (result);
+				}
+				batch_processed.notify (processed);
+			});
 		}
 		else
 		{
@@ -315,7 +333,7 @@ auto nano::block_processor::process_batch (nano::unique_lock<nano::mutex> & lock
 	debug_assert (!mutex.try_lock ());
 	debug_assert (!queue.empty ());
 
-	auto batch = next_batch (256);
+	auto batch = next_batch (config.batch_size);
 
 	lock.unlock ();
 
@@ -466,6 +484,7 @@ nano::container_info nano::block_processor::container_info () const
 	info.put ("blocks", queue.size ());
 	info.put ("forced", queue.size ({ nano::block_source::forced }));
 	info.add ("queue", queue.container_info ());
+	info.add ("workers", workers.container_info ());
 	return info;
 }
 

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -256,8 +256,9 @@ void nano::block_processor::run ()
 		}
 		else
 		{
-			condition.notify_one ();
-			condition.wait (lock);
+			condition.wait (lock, [this] {
+				return stopped || !queue.empty ();
+			});
 		}
 	}
 }

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/logging.hpp>
+#include <nano/lib/thread_pool.hpp>
 #include <nano/node/fair_queue.hpp>
 #include <nano/node/fwd.hpp>
 #include <nano/secure/common.hpp>
@@ -46,6 +47,9 @@ public:
 	size_t priority_live{ 1 };
 	size_t priority_bootstrap{ 8 };
 	size_t priority_local{ 16 };
+
+	size_t batch_size{ 256 };
+	size_t max_queued_notifications{ 8 };
 };
 
 /**
@@ -128,5 +132,7 @@ private:
 	nano::condition_variable condition;
 	mutable nano::mutex mutex{ mutex_identifier (mutexes::block_processor) };
 	std::thread thread;
+
+	nano::thread_pool workers;
 };
 }

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -93,7 +93,6 @@ public:
 	bool add (std::shared_ptr<nano::block> const &, nano::block_source = nano::block_source::live, std::shared_ptr<nano::transport::channel> const & channel = nullptr, std::function<void (nano::block_status)> callback = {});
 	std::optional<nano::block_status> add_blocking (std::shared_ptr<nano::block> const & block, nano::block_source);
 	void force (std::shared_ptr<nano::block> const &);
-	bool should_log ();
 
 	nano::container_info container_info () const;
 
@@ -125,8 +124,6 @@ private: // Dependencies
 
 private:
 	nano::fair_queue<context, nano::block_source> queue;
-
-	std::chrono::steady_clock::time_point next_log;
 
 	bool stopped{ false };
 	nano::condition_variable condition;

--- a/nano/node/bootstrap_ascending/service.cpp
+++ b/nano/node/bootstrap_ascending/service.cpp
@@ -33,7 +33,6 @@ nano::bootstrap_ascending::service::service (nano::node_config const & node_conf
 	scoring{ config, node_config_a.network_params.network },
 	database_limiter{ config.database_rate_limit, 1.0 }
 {
-	// TODO: This is called from a very congested blockprocessor thread. Offload this work to a dedicated processing thread
 	block_processor.batch_processed.add ([this] (auto const & batch) {
 		{
 			nano::lock_guard<nano::mutex> lock{ mutex };
@@ -217,11 +216,14 @@ void nano::bootstrap_ascending::service::inspect (secure::transaction const & tx
 		{
 			if (source == nano::block_source::bootstrap)
 			{
-				const auto account = block.previous ().is_zero () ? block.account_field ().value () : ledger.any.block_account (tx, block.previous ()).value ();
+				const auto account = block.previous ().is_zero () ? block.account_field ().value () : ledger.any.block_account (tx, block.previous ()).value_or (0);
 				const auto source_hash = block.source_field ().value_or (block.link_field ().value_or (0).as_block_hash ());
 
-				// Mark account as blocked because it is missing the source block
-				accounts.block (account, source_hash);
+				if (!account.is_zero () && !source_hash.is_zero ())
+				{
+					// Mark account as blocked because it is missing the source block
+					accounts.block (account, source_hash);
+				}
 			}
 		}
 		break;

--- a/nano/node/confirming_set.hpp
+++ b/nano/node/confirming_set.hpp
@@ -105,11 +105,11 @@ private:
 	ordered_entries set;
 	std::unordered_set<nano::block_hash> current;
 
-	nano::thread_pool notification_workers;
-
 	std::atomic<bool> stopped{ false };
 	mutable std::mutex mutex;
 	std::condition_variable condition;
 	std::thread thread;
+
+	nano::thread_pool workers;
 };
 }


### PR DESCRIPTION
This offloads block processors notifications to be processed on a background thread, so that block processor can continue checking new blocks without waiting for other components to do their work. Checking new blocks requires a write-transaction, while handling `batch_processed` event is done with read-only transaction, both can happen in parallel.

The changes here are based on top of https://github.com/nanocurrency/nano-node/pull/4762 which is a necessary prerequisite.