### PR TITLE
Optimize vote distribution between PRs and non-PRs

### DIFF
--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -386,11 +386,13 @@ std::deque<std::shared_ptr<nano::transport::channel>> nano::network::list_non_pr
 {
 	std::deque<std::shared_ptr<nano::transport::channel>> result;
 	tcp_channels.list (result);
+
+	auto partition_point = std::partition (result.begin (), result.end (),
+	[this] (std::shared_ptr<nano::transport::channel> const & channel) {
+		return !node.rep_crawler.is_pr (channel);
+	});
+	result.resize (std::distance (result.begin (), partition_point));
 	nano::random_pool_shuffle (result.begin (), result.end ());
-	result.erase (std::remove_if (result.begin (), result.end (), [this] (std::shared_ptr<nano::transport::channel> const & channel) {
-		return node.rep_crawler.is_pr (channel);
-	}),
-	result.end ());
 	if (result.size () > count_a)
 	{
 		result.resize (count_a, nullptr);

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -281,6 +281,15 @@ void nano::network::flood_vote (std::shared_ptr<nano::vote> const & vote, float 
 	}
 }
 
+void nano::network::flood_vote_non_pr (std::shared_ptr<nano::vote> const & vote, float scale, bool rebroadcasted)
+{
+	nano::confirm_ack message{ node.network_params.network, vote, rebroadcasted };
+	for (auto & i : list_non_pr (fanout (scale)))
+	{
+		i->send (message, nullptr);
+	}
+}
+
 void nano::network::flood_vote_pr (std::shared_ptr<nano::vote> const & vote, bool rebroadcasted)
 {
 	nano::confirm_ack message{ node.network_params.network, vote, rebroadcasted };

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -95,6 +95,7 @@ public:
 	void flood_keepalive_self (float const scale_a = 0.5f);
 	void flood_vote (std::shared_ptr<nano::vote> const &, float scale, bool rebroadcasted = false);
 	void flood_vote_pr (std::shared_ptr<nano::vote> const &, bool rebroadcasted = false);
+	void flood_vote_non_pr (std::shared_ptr<nano::vote> const &, float scale, bool rebroadcasted = false);
 	// Flood block to all PRs and a random selection of non-PRs
 	void flood_block_initial (std::shared_ptr<nano::block> const &);
 	// Flood block to a random selection of peers

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -277,7 +277,7 @@ void nano::vote_generator::vote (std::vector<nano::block_hash> const & hashes_a,
 void nano::vote_generator::broadcast_action (std::shared_ptr<nano::vote> const & vote_a) const
 {
 	network.flood_vote_pr (vote_a);
-	network.flood_vote (vote_a, 2.0f);
+	network.flood_vote_non_pr (vote_a, 2.0f);
 	vote_processor.vote (vote_a, inproc_channel);
 }
 


### PR DESCRIPTION
Currently, PRs receive votes both from flood_vote and flood_vote_pr, leading to duplicate voting, while fewer non-PR receive votes. This is particularly noticeable in small test networks.

This change ensures votes are distributed more efficiently:
- PRs receive votes only through flood_vote_pr
- Non-PRs receive votes through flood_vote_non_pr
- Overall outgoing vote load remains unchanged

Here is the difference seen in a local test network:

<img width="925" alt="Screenshot 2024-10-24 at 20 38 12" src="https://github.com/user-attachments/assets/e4e93558-25a4-4ad7-b052-dbaeb11d876c">


I included a small optimization to `nano::network::list_non_pr` since it's called often.

```
Test Configuration & Benchmark Results:
PR Count: 100
Non-PR Count: 200
Iterations: 10000

--------------------------------------------------
Current method   - Duration: -- 521 ms
Partition method - Duration: -- 354 ms
--------------------------------------------------

Target count per iteration: 29 [ceil( 2* sqrt(200))]
Actual Current method:      29
Actual Partition method:    29
```