### PR TITLE
Use unique_ptr with LMDB resources to prevent leaks

### DIFF
--- a/nano/store/lmdb/iterator.hpp
+++ b/nano/store/lmdb/iterator.hpp
@@ -22,7 +22,7 @@ namespace nano::store::lmdb
  */
 class iterator
 {
-	MDB_cursor * cursor{ nullptr };
+	std::unique_ptr<MDB_cursor, decltype (&mdb_cursor_close)> cursor{ nullptr, mdb_cursor_close };
 	std::variant<std::monostate, std::pair<MDB_val, MDB_val>> current;
 	void update (int status);
 	iterator (MDB_txn * tx, MDB_dbi dbi) noexcept;
@@ -38,8 +38,6 @@ public:
 	static auto begin (MDB_txn * tx, MDB_dbi dbi) -> iterator;
 	static auto end (MDB_txn * tx, MDB_dbi dbi) -> iterator;
 	static auto lower_bound (MDB_txn * tx, MDB_dbi dbi, MDB_val const & lower_bound) -> iterator;
-
-	~iterator ();
 
 	iterator (iterator const &) = delete;
 	auto operator= (iterator const &) -> iterator & = delete;

--- a/nano/store/lmdb/lmdb.cpp
+++ b/nano/store/lmdb/lmdb.cpp
@@ -121,9 +121,7 @@ bool nano::store::lmdb::component::vacuum_after_upgrade (std::filesystem::path c
 	if (vacuum_success)
 	{
 		// Need to close the database to release the file handle
-		mdb_env_sync (env.environment, true);
-		mdb_env_close (env.environment);
-		env.environment = nullptr;
+		mdb_env_sync (env, true);
 
 		// Replace the ledger file with the vacuumed one
 		std::filesystem::rename (vacuum_path, path_a);
@@ -155,7 +153,7 @@ void nano::store::lmdb::component::serialize_mdb_tracker (boost::property_tree::
 void nano::store::lmdb::component::serialize_memory_stats (boost::property_tree::ptree & json)
 {
 	MDB_stat stats;
-	auto status (mdb_env_stat (env.environment, &stats));
+	auto status (mdb_env_stat (env, &stats));
 	release_assert (status == 0);
 	json.put ("branch_pages", stats.ms_branch_pages);
 	json.put ("depth", stats.ms_depth);
@@ -448,7 +446,7 @@ std::string nano::store::lmdb::component::error_string (int status) const
 
 bool nano::store::lmdb::component::copy_db (std::filesystem::path const & destination_file)
 {
-	return !mdb_env_copy2 (env.environment, destination_file.string ().c_str (), MDB_CP_COMPACT);
+	return !mdb_env_copy2 (env, destination_file.string ().c_str (), MDB_CP_COMPACT);
 }
 
 void nano::store::lmdb::component::rebuild_db (store::write_transaction const & transaction_a)

--- a/nano/store/lmdb/lmdb_env.hpp
+++ b/nano/store/lmdb/lmdb_env.hpp
@@ -62,7 +62,7 @@ public:
 	store::read_transaction tx_begin_read (txn_callbacks callbacks = txn_callbacks{}) const;
 	store::write_transaction tx_begin_write (txn_callbacks callbacks = txn_callbacks{}) const;
 	MDB_txn * tx (store::transaction const & transaction_a) const;
-	MDB_env * environment;
+	std::unique_ptr<MDB_env, decltype (&mdb_env_close)> environment{ nullptr, mdb_env_close };
 	nano::id_t const store_id{ nano::next_id () };
 };
 } // namespace nano::store::lmdb


### PR DESCRIPTION
Fixes cursor and environment leaks.