### PR TITLE
Link boost stacktrace appropriately for line information.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,18 +122,6 @@ set(NANO_ROCKSDB_TOOLS
     OFF
     CACHE BOOL "")
 
-option(NANO_STACKTRACE_BACKTRACE
-       "Use BOOST_STACKTRACE_USE_BACKTRACE in stacktraces, for POSIX" OFF)
-
-if(NANO_STACKTRACE_BACKTRACE)
-  add_definitions(-DNANO_STACKTRACE_BACKTRACE)
-  add_definitions(-DBOOST_STACKTRACE_USE_BACKTRACE)
-  if(NANO_BACKTRACE_INCLUDE)
-    add_definitions(
-      -DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE=${NANO_BACKTRACE_INCLUDE})
-  endif()
-endif()
-
 # Enable NANO_TRACING by default in Debug builds
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   option(NANO_TRACING "Enable trace logging" ON)
@@ -497,6 +485,17 @@ endforeach()
 include_directories(${BOOST_LIBRARY_INCLUDES})
 add_library(Boost::stacktrace ALIAS boost_stacktrace_basic)
 add_definitions(-DBOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED)
+
+if(WIN32)
+  # Windows-specific configuration
+  target_link_libraries(boost_stacktrace_basic PRIVATE dbghelp)
+else()
+  # Unix-like systems (Linux, macOS)
+  target_link_libraries(boost_stacktrace_basic PRIVATE dl)
+
+  # Add -rdynamic linker flag for better symbol resolution
+  target_link_options(boost_stacktrace_basic PRIVATE -rdynamic)
+endif()
 
 # Workaround for missing reference errata in the boost property_tree module
 target_link_libraries(boost_property_tree INTERFACE Boost::any)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,19 +390,17 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
 # Find libbacktrace first (Unix/Linux only)
 if(NOT WIN32)
-    find_path(BACKTRACE_INCLUDE_DIR
-        NAMES backtrace.h
-        PATHS
-            /usr/local/include
-            /usr/include
-    )
-    
-    if(BACKTRACE_INCLUDE_DIR)
-        set(BACKTRACE_FOUND TRUE)
-        # Most systems just need -lbacktrace
-        set(BACKTRACE_LIBRARIES backtrace)
-        message(STATUS "Found backtrace.h at ${BACKTRACE_INCLUDE_DIR}")
-    endif()
+  find_path(
+    BACKTRACE_INCLUDE_DIR
+    NAMES backtrace.h
+    PATHS /usr/local/include /usr/include)
+
+  if(BACKTRACE_INCLUDE_DIR)
+    set(BACKTRACE_FOUND TRUE)
+    # Most systems just need -lbacktrace
+    set(BACKTRACE_LIBRARIES backtrace)
+    message(STATUS "Found backtrace.h at ${BACKTRACE_INCLUDE_DIR}")
+  endif()
 endif()
 
 # Then set up boost modules
@@ -504,19 +502,21 @@ include_directories(${BOOST_LIBRARY_INCLUDES})
 
 # Configure stacktrace with appropriate backend
 if(WIN32)
-    message(STATUS "Windows platform - Using WinDbg stacktrace")
-    add_definitions(-DBOOST_STACKTRACE_USE_WINDBG)
-    add_library(Boost::stacktrace ALIAS boost_stacktrace_windbg)
-    target_link_libraries(boost_stacktrace_windbg PRIVATE dbghelp)
-elseif(BACKTRACE_FOUND)
-    message(STATUS "Found libbacktrace - enabling Boost stacktrace backtrace support")
-    add_definitions(-DBOOST_STACKTRACE_USE_BACKTRACE)
-    add_library(Boost::stacktrace ALIAS boost_stacktrace_backtrace)
-    target_link_libraries(boost_stacktrace_backtrace PRIVATE ${BACKTRACE_LIBRARIES})
+  message(STATUS "Windows platform - Using WinDbg stacktrace")
+  add_definitions(-DBOOST_STACKTRACE_USE_WINDBG)
+  add_library(Boost::stacktrace ALIAS boost_stacktrace_windbg)
+  target_link_libraries(boost_stacktrace_windbg PRIVATE dbghelp)
+elseif(BOOST_STACKTRACE_HAS_BACKTRACE)
+  message(
+    STATUS "Found libbacktrace - enabling Boost stacktrace backtrace support")
+  add_definitions(-DBOOST_STACKTRACE_USE_BACKTRACE)
+  add_library(Boost::stacktrace ALIAS boost_stacktrace_backtrace)
+  target_link_libraries(boost_stacktrace_backtrace
+                        PRIVATE ${BACKTRACE_LIBRARIES})
 else()
-    message(STATUS "Unix platform without libbacktrace - Using basic backtrace")
-    add_definitions(-DBOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED)
-    add_library(Boost::stacktrace ALIAS boost_stacktrace_basic)
+  message(STATUS "Using basic stacktrace backend")
+  add_definitions(-DBOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED)
+  add_library(Boost::stacktrace ALIAS boost_stacktrace_basic)
 endif()
 
 # Workaround for missing reference errata in the boost property_tree module

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,24 @@ endif()
 include_directories(${CMAKE_SOURCE_DIR})
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
+# Find libbacktrace first (Unix/Linux only)
+if(NOT WIN32)
+    find_path(BACKTRACE_INCLUDE_DIR
+        NAMES backtrace.h
+        PATHS
+            /usr/local/include
+            /usr/include
+    )
+    
+    if(BACKTRACE_INCLUDE_DIR)
+        set(BACKTRACE_FOUND TRUE)
+        # Most systems just need -lbacktrace
+        set(BACKTRACE_LIBRARIES backtrace)
+        message(STATUS "Found backtrace.h at ${BACKTRACE_INCLUDE_DIR}")
+    endif()
+endif()
+
+# Then set up boost modules
 set(Boost_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/submodules/boost/libs/config/include)
 set(BOOST_MODULE_LIBS
     algorithm
@@ -483,18 +501,22 @@ foreach(lib IN LISTS BOOST_MODULE_LIBS)
   add_subdirectory(submodules/boost/libs/${lib} EXCLUDE_FROM_ALL)
 endforeach()
 include_directories(${BOOST_LIBRARY_INCLUDES})
-add_library(Boost::stacktrace ALIAS boost_stacktrace_basic)
-add_definitions(-DBOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED)
 
+# Configure stacktrace with appropriate backend
 if(WIN32)
-  # Windows-specific configuration
-  target_link_libraries(boost_stacktrace_basic PRIVATE dbghelp)
+    message(STATUS "Windows platform - Using WinDbg stacktrace")
+    add_definitions(-DBOOST_STACKTRACE_USE_WINDBG)
+    add_library(Boost::stacktrace ALIAS boost_stacktrace_windbg)
+    target_link_libraries(boost_stacktrace_windbg PRIVATE dbghelp)
+elseif(BACKTRACE_FOUND)
+    message(STATUS "Found libbacktrace - enabling Boost stacktrace backtrace support")
+    add_definitions(-DBOOST_STACKTRACE_USE_BACKTRACE)
+    add_library(Boost::stacktrace ALIAS boost_stacktrace_backtrace)
+    target_link_libraries(boost_stacktrace_backtrace PRIVATE ${BACKTRACE_LIBRARIES})
 else()
-  # Unix-like systems (Linux, macOS)
-  target_link_libraries(boost_stacktrace_basic PRIVATE dl)
-
-  # Add -rdynamic linker flag for better symbol resolution
-  target_link_options(boost_stacktrace_basic PRIVATE -rdynamic)
+    message(STATUS "Unix platform without libbacktrace - Using basic backtrace")
+    add_definitions(-DBOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED)
+    add_library(Boost::stacktrace ALIAS boost_stacktrace_basic)
 endif()
 
 # Workaround for missing reference errata in the boost property_tree module

--- a/ci/build-ci.sh
+++ b/ci/build-ci.sh
@@ -28,17 +28,6 @@ fi
 
 ulimit -S -n 8192
 
-if [[ "$OS" == 'Linux' ]]; then
-    if clang --version && [ ${LCOV:-0} == 0 ]; then
-        BACKTRACE="-DNANO_STACKTRACE_BACKTRACE=ON \
-        -DNANO_BACKTRACE_INCLUDE=</tmp/backtrace.h>"
-    else
-        BACKTRACE="-DNANO_STACKTRACE_BACKTRACE=ON"
-    fi
-else
-    BACKTRACE=""
-fi
-
 cmake \
 -G'Unix Makefiles' \
 -DACTIVE_NETWORK=nano_dev_network \

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -10,15 +10,6 @@ fi
 SRC=${SRC:-${PWD}}
 OS=$(uname)
 
-CMAKE_BACKTRACE=""
-if [[ ${OS} == 'Linux' ]]; then
-    CMAKE_BACKTRACE="-DNANO_STACKTRACE_BACKTRACE=ON"
-
-    if [[ ${COMPILER:-} == 'clang' ]]; then
-        CMAKE_BACKTRACE="${CMAKE_BACKTRACE} -DNANO_BACKTRACE_INCLUDE=</tmp/backtrace.h>"
-    fi
-fi
-
 CMAKE_QT_DIR=""
 if [[ ${QT_DIR:-} ]]; then
     CMAKE_QT_DIR="-DQt5_DIR=${QT_DIR}"

--- a/ci/prepare/linux/prepare-clang.sh
+++ b/ci/prepare/linux/prepare-clang.sh
@@ -12,3 +12,7 @@ curl -O https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh $CLANG_VER
 update-alternatives --install /usr/bin/cc cc /usr/bin/clang-$CLANG_VERSION 100
 update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-$CLANG_VERSION 100
 update-alternatives --install /usr/bin/lldb lldb /usr/bin/lldb-$CLANG_VERSION 100
+
+# Workaround to get a path that can be easily passed into cmake for BOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE
+# See https://www.boost.org/doc/libs/1_70_0/doc/html/stacktrace/configuration_and_build.html#stacktrace.configuration_and_build.f3
+backtrace_file=$(find /usr/lib/gcc/ -name 'backtrace.h' | head -n 1) && test -f $backtrace_file && ln -s $backtrace_file /usr/local/include/backtrace.h

--- a/ci/prepare/linux/prepare-clang.sh
+++ b/ci/prepare/linux/prepare-clang.sh
@@ -12,7 +12,3 @@ curl -O https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh $CLANG_VER
 update-alternatives --install /usr/bin/cc cc /usr/bin/clang-$CLANG_VERSION 100
 update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-$CLANG_VERSION 100
 update-alternatives --install /usr/bin/lldb lldb /usr/bin/lldb-$CLANG_VERSION 100
-
-# Workaround to get a path that can be easily passed into cmake for BOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE
-# See https://www.boost.org/doc/libs/1_70_0/doc/html/stacktrace/configuration_and_build.html#stacktrace.configuration_and_build.f3
-backtrace_file=$(find /usr/lib/gcc/ -name 'backtrace.h' | head -n 1) && test -f $backtrace_file && ln -s $backtrace_file /tmp/backtrace.h

--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(
   request_aggregator.cpp
   signal_manager.cpp
   socket.cpp
+  stacktrace.cpp
   system.cpp
   tcp_listener.cpp
   telemetry.cpp

--- a/nano/core_test/stacktrace.cpp
+++ b/nano/core_test/stacktrace.cpp
@@ -1,0 +1,13 @@
+#include <nano/lib/stacktrace.hpp>
+
+#include <gtest/gtest.h>
+
+// Check that the stacktrace contains the current function name
+// This depends on the way testcase names are compiled by gtest
+// Current name: "stacktrace_human_readable_Test::TestBody()"
+TEST (stacktrace, human_readable)
+{
+	auto stacktrace = nano::generate_stacktrace ();
+	ASSERT_FALSE (stacktrace.empty ());
+	ASSERT_TRUE (stacktrace.find ("stacktrace_human_readable_Test") != std::string::npos);
+}

--- a/nano/core_test/stacktrace.cpp
+++ b/nano/core_test/stacktrace.cpp
@@ -8,6 +8,7 @@
 TEST (stacktrace, human_readable)
 {
 	auto stacktrace = nano::generate_stacktrace ();
+	std::cout << stacktrace << std::endl;
 	ASSERT_FALSE (stacktrace.empty ());
 	ASSERT_TRUE (stacktrace.find ("stacktrace_human_readable_Test") != std::string::npos);
 }

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -148,10 +148,6 @@ target_link_libraries(
   Boost::property_tree
   Boost::stacktrace)
 
-if(NANO_STACKTRACE_BACKTRACE)
-  target_link_libraries(nano_lib backtrace)
-endif()
-
 target_compile_definitions(
   nano_lib
   PRIVATE -DMAJOR_VERSION_STRING=${CPACK_PACKAGE_VERSION_MAJOR}


### PR DESCRIPTION
The previous code was overcomplicating a relatively straightforward requirement to link against librt and libdynamic to get symbolic stacktraces.