### PR TITLE
Disallow database operations on network IO threads

### DIFF
--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -206,9 +206,12 @@ std::string nano::thread_role::get_string ()
 
 void nano::thread_role::set (nano::thread_role::name role)
 {
-	auto thread_role_name_string (get_string (role));
-
-	nano::thread_role::set_os_name (thread_role_name_string);
-
+	auto thread_role_name_string = get_string (role);
+	nano::thread_role::set_os_name (thread_role_name_string); // Implementation is platform specific
 	current_thread_role = role;
+}
+
+bool nano::thread_role::is_network_io ()
+{
+	return nano::thread_role::get () == nano::thread_role::name::io;
 }

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -22,6 +22,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::io_daemon:
 			thread_role_name_string = "I/O (daemon)";
 			break;
+		case nano::thread_role::name::io_ipc:
+			thread_role_name_string = "I/O (IPC)";
+			break;
 		case nano::thread_role::name::work:
 			thread_role_name_string = "Work pool";
 			break;

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -12,6 +12,7 @@ enum class name
 	unknown,
 	io,
 	io_daemon,
+	io_ipc,
 	work,
 	message_processing,
 	vote_processing,

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -87,4 +87,9 @@ std::string get_string ();
  * Internal only, should not be called directly
  */
 void set_os_name (std::string const &);
+
+/*
+ * Check if the current thread is a network IO thread
+ */
+bool is_network_io ();
 }

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -483,7 +483,7 @@ public:
 		acceptor->set_option (option_keepalive);
 		accept ();
 
-		runner = std::make_unique<nano::thread_runner> (io_ctx, server.logger, static_cast<unsigned> (std::max (1, concurrency_a)));
+		runner = std::make_unique<nano::thread_runner> (io_ctx, server.logger, static_cast<unsigned> (std::max (1, concurrency_a)), nano::thread_role::name::io_ipc);
 	}
 
 	boost::asio::io_context & context () const

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -240,7 +240,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 				if ((status_a.type == nano::election_status_type::active_confirmed_quorum || status_a.type == nano::election_status_type::active_confirmation_height))
 				{
 					auto node_l (shared_from_this ());
-					background ([node_l, block_a, account_a, amount_a, is_state_send_a, is_state_epoch_a] () {
+					io_ctx.post ([node_l, block_a, account_a, amount_a, is_state_send_a, is_state_epoch_a] () {
 						boost::property_tree::ptree event;
 						event.add ("account", account_a.to_account ());
 						event.add ("hash", block_a->hash ().to_string ());

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -76,12 +76,6 @@ public:
 
 	std::shared_ptr<nano::node> shared ();
 
-	template <typename T>
-	void background (T action_a)
-	{
-		io_ctx.post (action_a);
-	}
-
 	bool copy_with_compaction (std::filesystem::path const &);
 	void keepalive (std::string const &, uint16_t);
 	int store_version ();

--- a/nano/node/transport/channel.cpp
+++ b/nano/node/transport/channel.cpp
@@ -36,7 +36,7 @@ void nano::transport::channel::send (nano::message & message_a, std::function<vo
 	{
 		if (callback_a)
 		{
-			node.background ([callback_a] () {
+			node.io_ctx.post ([callback_a] () {
 				callback_a (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
 			});
 		}

--- a/nano/node/transport/fake.cpp
+++ b/nano/node/transport/fake.cpp
@@ -20,7 +20,7 @@ void nano::transport::fake::channel::send_buffer (nano::shared_const_buffer cons
 	auto size = buffer_a.size ();
 	if (callback_a)
 	{
-		node.background ([callback_a, size] () {
+		node.io_ctx.post ([callback_a, size] () {
 			callback_a (boost::system::errc::make_error_code (boost::system::errc::success), size);
 		});
 	}

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -50,7 +50,7 @@ void nano::transport::inproc::channel::send_buffer (nano::shared_const_buffer co
 
 	if (callback_a)
 	{
-		node.background ([callback_l = std::move (callback_a), buffer_size = buffer_a.size ()] () {
+		node.io_ctx.post ([callback_l = std::move (callback_a), buffer_size = buffer_a.size ()] () {
 			callback_l (boost::system::errc::make_error_code (boost::system::errc::success), buffer_size);
 		});
 	}

--- a/nano/node/transport/tcp_channel.cpp
+++ b/nano/node/transport/tcp_channel.cpp
@@ -80,7 +80,7 @@ void nano::transport::tcp_channel::send_buffer (nano::shared_const_buffer const 
 	}
 	else if (callback_a)
 	{
-		node.background ([callback_a] () {
+		node.io_ctx.post ([callback_a] () {
 			callback_a (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
 		});
 	}

--- a/nano/node/transport/tcp_socket.cpp
+++ b/nano/node/transport/tcp_socket.cpp
@@ -149,7 +149,7 @@ void nano::transport::tcp_socket::async_write (nano::shared_const_buffer const &
 	{
 		if (callback_a)
 		{
-			node_l->background ([callback = std::move (callback_a)] () {
+			node_l->io_ctx.post ([callback = std::move (callback_a)] () {
 				callback (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
 			});
 		}
@@ -161,7 +161,7 @@ void nano::transport::tcp_socket::async_write (nano::shared_const_buffer const &
 	{
 		if (callback_a)
 		{
-			node_l->background ([callback = std::move (callback_a)] () {
+			node_l->io_ctx.post ([callback = std::move (callback_a)] () {
 				callback (boost::system::errc::make_error_code (boost::system::errc::not_supported), 0);
 			});
 		}

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -714,7 +714,7 @@ nano_qt::block_viewer::block_viewer (nano_qt::wallet & wallet_a) :
 			if (this->wallet.node.ledger.any.block_exists (transaction, block))
 			{
 				rebroadcast->setEnabled (false);
-				this->wallet.node.background ([this, block] () {
+				this->wallet.node.workers.post ([this, block] () {
 					rebroadcast_action (block);
 				});
 			}
@@ -1194,7 +1194,7 @@ void nano_qt::wallet::start ()
 						if (this_l->wallet_m->store.valid_password (transaction))
 						{
 							this_l->send_blocks_send->setEnabled (false);
-							this_l->node.background ([this_w, account_l, actual] () {
+							this_l->node.workers.post ([this_w, account_l, actual] () {
 								if (auto this_l = this_w.lock ())
 								{
 									this_l->wallet_m->send_async (this_l->account, account_l, actual, [this_w] (std::shared_ptr<nano::block> const & block_a) {

--- a/nano/store/transaction.cpp
+++ b/nano/store/transaction.cpp
@@ -9,6 +9,7 @@
 nano::store::transaction_impl::transaction_impl (nano::id_dispenser::id_t const store_id_a) :
 	store_id{ store_id_a }
 {
+	debug_assert (!nano::thread_role::is_network_io (), "database operations are not allowed to run on network IO threads");
 }
 
 /*


### PR DESCRIPTION
Doing synchronous disk IO on network IO threads can introduce very long delays, blocking network thread pool. This adds an assert that will detect this.

Currently this doesn't pass tests nicely because legacy bootstrap trips the assert.