### PR TITLE
Fix `tcp_socket::type()` race

### DIFF
--- a/nano/node/transport/tcp_socket.cpp
+++ b/nano/node/transport/tcp_socket.cpp
@@ -412,7 +412,7 @@ void nano::transport::tcp_socket::operator() (nano::object_stream & obs) const
 {
 	obs.write ("remote_endpoint", remote_endpoint ());
 	obs.write ("local_endpoint", local_endpoint ());
-	obs.write ("type", type_m);
+	obs.write ("type", type_m.load ());
 	obs.write ("endpoint_type", endpoint_type_m);
 }
 

--- a/nano/node/transport/tcp_socket.hpp
+++ b/nano/node/transport/tcp_socket.hpp
@@ -115,9 +115,9 @@ public:
 	{
 		return type_m;
 	};
-	void type_set (nano::transport::socket_type type_a)
+	void type_set (nano::transport::socket_type type)
 	{
-		type_m = type_a;
+		type_m = type;
 	}
 	nano::transport::socket_endpoint endpoint_type () const
 	{
@@ -195,8 +195,8 @@ protected:
 	void read_impl (std::shared_ptr<std::vector<uint8_t>> const & data_a, std::size_t size_a, std::function<void (boost::system::error_code const &, std::size_t)> callback_a);
 
 private:
-	nano::transport::socket_type type_m{ socket_type::undefined };
-	nano::transport::socket_endpoint endpoint_type_m;
+	socket_endpoint const endpoint_type_m;
+	std::atomic<socket_type> type_m{ socket_type::undefined };
 
 public:
 	std::size_t const max_queue_size;


### PR DESCRIPTION
```
 WARNING: ThreadSanitizer: data race (pid=23151)
    Read of size 4 at 0x00011479510c by thread T122075 (mutexes: write M0):
      #0 nano::transport::tcp_socket::type() const tcp_socket.hpp:116 (core_test:arm64+0x10163c70c)
      #1 nano::transport::tcp_socket::is_bootstrap_connection() const tcp_socket.hpp:132 (core_test:arm64+0x10163c86c)
      #2 auto nano::transport::tcp_listener::bootstrap_count() const::$_7::operator()<nano::transport::tcp_listener::connection>(nano::transport::tcp_listener::connection const&) const tcp_listener.cpp:534 (core_test:arm64+0x10163c790)
      #3 std::__1::iterator_traits<std::__1::__list_const_iterator<nano::transport::tcp_listener::connection, void*>>::difference_type std::__1::count_if[abi:ue170006]<std::__1::__list_const_iterator<nano::transport::tcp_listener::connection, void*>, nano::transport::tcp_listener::bootstrap_count() const::$_7>(std::__1::__list_const_iterator<nano::transport::tcp_listener::connection, void*>, std::__1::__list_const_iterator<nano::transport::tcp_listener::connection, void*>, nano::transport::tcp_listener::bootstrap_count() const::$_7) count_if.h:28 (core_test:arm64+0x10163943c)
      #4 nano::transport::tcp_listener::bootstrap_count() const tcp_listener.cpp:531 (core_test:arm64+0x10163935c)
      #5 nano::transport::tcp_server::to_bootstrap_connection() tcp_server.cpp:647 (core_test:arm64+0x10167e988)
      #6 nano::transport::tcp_server::process_message(std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>) tcp_server.cpp:213 (core_test:arm64+0x10167e138)
      #7 nano::transport::tcp_server::received_message(std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>) tcp_server.cpp:113 (core_test:arm64+0x10167dad0)
      #8 nano::transport::tcp_server::receive_message()::$_1::operator()(boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>) const tcp_server.cpp:97 (core_test:arm64+0x101689658)
      #9 decltype(std::declval<nano::transport::tcp_server::receive_message()::$_1&>()(std::declval<boost::system::error_code>(), std::declval<std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>>())) std::__1::__invoke[abi:ue170006]<nano::transport::tcp_server::receive_message()::$_1&, boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>>(nano::transport::tcp_server::receive_message()::$_1&, boost::system::error_code&&, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>&&) invoke.h:340 (core_test:arm64+0x1016893f4)
      #10 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<nano::transport::tcp_server::receive_message()::$_1&, boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>>(nano::transport::tcp_server::receive_message()::$_1&, boost::system::error_code&&, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>&&) invoke.h:415 (core_test:arm64+0x10168930c)
      #11 std::__1::__function::__alloc_func<nano::transport::tcp_server::receive_message()::$_1, std::__1::allocator<nano::transport::tcp_server::receive_message()::$_1>, void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)>::operator()[abi:ue170006](boost::system::error_code&&, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>&&) function.h:193 (core_test:arm64+0x101689298)
      #12 std::__1::__function::__func<nano::transport::tcp_server::receive_message()::$_1, std::__1::allocator<nano::transport::tcp_server::receive_message()::$_1>, void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)>::operator()(boost::system::error_code&&, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>&&) function.h:364 (core_test:arm64+0x101686e40)
      #13 std::__1::__function::__value_func<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)>::operator()[abi:ue170006](boost::system::error_code&&, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>&&) const function.h:518 (core_test:arm64+0x1015f5d4c)
      #14 std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)>::operator()(boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>) const function.h:1169 (core_test:arm64+0x1015f082c)
      #15 nano::transport::message_deserializer::received_message(nano::message_header, unsigned long, std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&) message_deserializer.cpp:110 (core_test:arm64+0x1015f0a20)
      #16 nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1::operator()(boost::system::error_code const&, unsigned long) const message_deserializer.cpp:98 (core_test:arm64+0x1015fcd70)
      #17 decltype(std::declval<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1&>()(std::declval<boost::system::error_code const&>(), std::declval<unsigned long>())) std::__1::__invoke[abi:ue170006]<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1&, boost::system::error_code const&, unsigned long>(nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1&, boost::system::error_code const&, unsigned long&&) invoke.h:340 (core_test:arm64+0x1015fcbb0)
      #18 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1&, boost::system::error_code const&, unsigned long>(nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1&, boost::system::error_code const&, unsigned long&&) invoke.h:415 (core_test:arm64+0x1015fcad4)
      #19 std::__1::__function::__alloc_func<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1, std::__1::allocator<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1>, void (boost::system::error_code const&, unsigned long)>::operator()[abi:ue170006](boost::system::error_code const&, unsigned long&&) function.h:193 (core_test:arm64+0x1015fca60)
      #20 std::__1::__function::__func<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1, std::__1::allocator<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1>, void (boost::system::error_code const&, unsigned long)>::operator()(boost::system::error_code const&, unsigned long&&) function.h:364 (core_test:arm64+0x1015fa894)
      #21 std::__1::__function::__value_func<void (boost::system::error_code const&, unsigned long)>::operator()[abi:ue170006](boost::system::error_code const&, unsigned long&&) const function.h:518 (core_test:arm64+0x100678200)
      #22 std::__1::function<void (boost::system::error_code const&, unsigned long)>::operator()(boost::system::error_code const&, unsigned long) const function.h:1169 (core_test:arm64+0x1006770bc)
      #23 nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7::operator()(boost::system::error_code const&, unsigned long) const tcp_socket.cpp:343 (core_test:arm64+0x1016c0a00)
      #24 decltype(std::declval<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7&>()(std::declval<boost::system::error_code const&>(), std::declval<unsigned long>())) std::__1::__invoke[abi:ue170006]<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7&, boost::system::error_code const&, unsigned long>(nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7&, boost::system::error_code const&, unsigned long&&) invoke.h:340 (core_test:arm64+0x1016c0958)
      #25 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7&, boost::system::error_code const&, unsigned long>(nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7&, boost::system::error_code const&, unsigned long&&) invoke.h:415 (core_test:arm64+0x1016c087c)
      #26 std::__1::__function::__alloc_func<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7, std::__1::allocator<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7>, void (boost::system::error_code const&, unsigned long)>::operator()[abi:ue170006](boost::system::error_code const&, unsigned long&&) function.h:193 (core_test:arm64+0x1016c0808)
      #27 std::__1::__function::__func<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7, std::__1::allocator<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7>, void (boost::system::error_code const&, unsigned long)>::operator()(boost::system::error_code const&, unsigned long&&) function.h:364 (core_test:arm64+0x1016be660)
      #28 std::__1::__function::__value_func<void (boost::system::error_code const&, unsigned long)>::operator()[abi:ue170006](boost::system::error_code const&, unsigned long&&) const function.h:518 (core_test:arm64+0x100678200)
      #29 std::__1::function<void (boost::system::error_code const&, unsigned long)>::operator()(boost::system::error_code const&, unsigned long) const function.h:1169 (core_test:arm64+0x1006770bc)
      #30 nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long)::operator()(boost::system::error_code const&, unsigned long) const tcp_socket.cpp:127 (core_test:arm64+0x1016b09d0)
      #31 boost::asio::result_of<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long) (boost::system::error_code const&, unsigned long const&)>::type boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>::operator()<boost::system::error_code const&, unsigned long const&>(boost::system::error_code const&, unsigned long const&) bind_executor.hpp:384 (core_test:arm64+0x1016adf70)
      #32 boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>::operator()(boost::system::error_code, unsigned long, int) read.hpp:415 (core_test:arm64+0x1016ada6c)
      #33 boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>::operator()() bind_handler.hpp:181 (core_test:arm64+0x1016af73c)
      #34 boost::asio::detail::executor_op<boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>, std::__1::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) executor_op.hpp:70 (core_test:arm64+0x1016b010c)
      #35 boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) scheduler_operation.hpp:40 (core_test:arm64+0x1000aae80)
      #36 boost::asio::detail::strand_executor_service::run_ready_handlers(std::__1::shared_ptr<boost::asio::detail::strand_executor_service::strand_impl>&) strand_executor_service.ipp:150 (core_test:arm64+0x1000d6dfc)
      #37 boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, void>::operator()() strand_executor_service.hpp:121 (core_test:arm64+0x1000ddcc4)
      #38 boost::asio::detail::executor_op<boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, void>, boost::asio::detail::recycling_allocator<void, boost::asio::detail::thread_info_base::default_tag>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) executor_op.hpp:70 (core_test:arm64+0x1000de65c)
      #39 boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) scheduler_operation.hpp:40 (core_test:arm64+0x1000aae80)
      #40 boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) scheduler.ipp:493 (core_test:arm64+0x1000aa34c)
      #41 boost::asio::detail::scheduler::run(boost::system::error_code&) scheduler.ipp:210 (core_test:arm64+0x1000a9e74)
      #42 boost::asio::io_context::run() io_context.ipp:64 (core_test:arm64+0x101bfabe0)
      #43 nano::thread_runner::run() thread_runner.cpp:87 (core_test:arm64+0x101c1c544)
      #44 nano::thread_runner::start()::$_0::operator()() const thread_runner.cpp:37 (core_test:arm64+0x101c1cfd0)
      #45 boost::detail::thread_data<nano::thread_runner::start()::$_0>::run() thread.hpp:120 (core_test:arm64+0x101c1cf04)
      #46 boost::(anonymous namespace)::thread_proxy(void*) thread.cpp:177 (core_test:arm64+0x1021402cc)
  
    Previous write of size 4 at 0x00011479510c by thread T122074:
      #0 nano::transport::tcp_socket::type_set(nano::transport::socket_type) tcp_socket.hpp:120 (core_test:arm64+0x1016817e4)
      #1 nano::transport::tcp_server::to_realtime_connection(nano::public_key const&) tcp_server.cpp:686 (core_test:arm64+0x10167f854)
      #2 nano::transport::tcp_server::process_handshake(nano::node_id_handshake const&) tcp_server.cpp:317 (core_test:arm64+0x10167f138)
      #3 nano::transport::tcp_server::handshake_message_visitor::node_id_handshake(nano::node_id_handshake const&) tcp_server.cpp:421 (core_test:arm64+0x10167fd94)
      #4 nano::node_id_handshake::visit(nano::message_visitor&) const messages.cpp:1367 (core_test:arm64+0x1013ab990)
      #5 nano::transport::tcp_server::process_message(std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>) tcp_server.cpp:191 (core_test:arm64+0x10167dfbc)
      #6 nano::transport::tcp_server::received_message(std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>) tcp_server.cpp:113 (core_test:arm64+0x10167dad0)
      #7 nano::transport::tcp_server::receive_message()::$_1::operator()(boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>) const tcp_server.cpp:97 (core_test:arm64+0x101689658)
      #8 decltype(std::declval<nano::transport::tcp_server::receive_message()::$_1&>()(std::declval<boost::system::error_code>(), std::declval<std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>>())) std::__1::__invoke[abi:ue170006]<nano::transport::tcp_server::receive_message()::$_1&, boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>>(nano::transport::tcp_server::receive_message()::$_1&, boost::system::error_code&&, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>&&) invoke.h:340 (core_test:arm64+0x1016893f4)
      #9 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<nano::transport::tcp_server::receive_message()::$_1&, boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>>(nano::transport::tcp_server::receive_message()::$_1&, boost::system::error_code&&, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>&&) invoke.h:415 (core_test:arm64+0x10168930c)
      #10 std::__1::__function::__alloc_func<nano::transport::tcp_server::receive_message()::$_1, std::__1::allocator<nano::transport::tcp_server::receive_message()::$_1>, void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)>::operator()[abi:ue170006](boost::system::error_code&&, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>&&) function.h:193 (core_test:arm64+0x101689298)
      #11 std::__1::__function::__func<nano::transport::tcp_server::receive_message()::$_1, std::__1::allocator<nano::transport::tcp_server::receive_message()::$_1>, void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)>::operator()(boost::system::error_code&&, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>&&) function.h:364 (core_test:arm64+0x101686e40)
      #12 std::__1::__function::__value_func<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)>::operator()[abi:ue170006](boost::system::error_code&&, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>&&) const function.h:518 (core_test:arm64+0x1015f5d4c)
      #13 std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)>::operator()(boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>) const function.h:1169 (core_test:arm64+0x1015f082c)
      #14 nano::transport::message_deserializer::received_message(nano::message_header, unsigned long, std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&) message_deserializer.cpp:110 (core_test:arm64+0x1015f0a20)
      #15 nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1::operator()(boost::system::error_code const&, unsigned long) const message_deserializer.cpp:98 (core_test:arm64+0x1015fcd70)
      #16 decltype(std::declval<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1&>()(std::declval<boost::system::error_code const&>(), std::declval<unsigned long>())) std::__1::__invoke[abi:ue170006]<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1&, boost::system::error_code const&, unsigned long>(nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1&, boost::system::error_code const&, unsigned long&&) invoke.h:340 (core_test:arm64+0x1015fcbb0)
      #17 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1&, boost::system::error_code const&, unsigned long>(nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1&, boost::system::error_code const&, unsigned long&&) invoke.h:415 (core_test:arm64+0x1015fcad4)
      #18 std::__1::__function::__alloc_func<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1, std::__1::allocator<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1>, void (boost::system::error_code const&, unsigned long)>::operator()[abi:ue170006](boost::system::error_code const&, unsigned long&&) function.h:193 (core_test:arm64+0x1015fca60)
      #19 std::__1::__function::__func<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1, std::__1::allocator<nano::transport::message_deserializer::received_header(std::__1::function<void (boost::system::error_code, std::__1::unique_ptr<nano::message, std::__1::default_delete<nano::message>>)> const&&)::$_1>, void (boost::system::error_code const&, unsigned long)>::operator()(boost::system::error_code const&, unsigned long&&) function.h:364 (core_test:arm64+0x1015fa894)
      #20 std::__1::__function::__value_func<void (boost::system::error_code const&, unsigned long)>::operator()[abi:ue170006](boost::system::error_code const&, unsigned long&&) const function.h:518 (core_test:arm64+0x100678200)
      #21 std::__1::function<void (boost::system::error_code const&, unsigned long)>::operator()(boost::system::error_code const&, unsigned long) const function.h:1169 (core_test:arm64+0x1006770bc)
      #22 nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7::operator()(boost::system::error_code const&, unsigned long) const tcp_socket.cpp:343 (core_test:arm64+0x1016c0a00)
      #23 decltype(std::declval<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7&>()(std::declval<boost::system::error_code const&>(), std::declval<unsigned long>())) std::__1::__invoke[abi:ue170006]<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7&, boost::system::error_code const&, unsigned long>(nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7&, boost::system::error_code const&, unsigned long&&) invoke.h:340 (core_test:arm64+0x1016c0958)
      #24 void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7&, boost::system::error_code const&, unsigned long>(nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7&, boost::system::error_code const&, unsigned long&&) invoke.h:415 (core_test:arm64+0x1016c087c)
      #25 std::__1::__function::__alloc_func<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7, std::__1::allocator<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7>, void (boost::system::error_code const&, unsigned long)>::operator()[abi:ue170006](boost::system::error_code const&, unsigned long&&) function.h:193 (core_test:arm64+0x1016c0808)
      #26 std::__1::__function::__func<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7, std::__1::allocator<nano::transport::tcp_socket::read_impl(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_7>, void (boost::system::error_code const&, unsigned long)>::operator()(boost::system::error_code const&, unsigned long&&) function.h:364 (core_test:arm64+0x1016be660)
      #27 std::__1::__function::__value_func<void (boost::system::error_code const&, unsigned long)>::operator()[abi:ue170006](boost::system::error_code const&, unsigned long&&) const function.h:518 (core_test:arm64+0x100678200)
      #28 std::__1::function<void (boost::system::error_code const&, unsigned long)>::operator()(boost::system::error_code const&, unsigned long) const function.h:1169 (core_test:arm64+0x1006770bc)
      #29 nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long)::operator()(boost::system::error_code const&, unsigned long) const tcp_socket.cpp:127 (core_test:arm64+0x1016b09d0)
      #30 boost::asio::result_of<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long) (boost::system::error_code const&, unsigned long const&)>::type boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>::operator()<boost::system::error_code const&, unsigned long const&>(boost::system::error_code const&, unsigned long const&) bind_executor.hpp:384 (core_test:arm64+0x1016adf70)
      #31 boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>::operator()(boost::system::error_code, unsigned long, int) read.hpp:415 (core_test:arm64+0x1016ada6c)
      #32 boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>::operator()() bind_handler.hpp:181 (core_test:arm64+0x1016af73c)
      #33 boost::asio::detail::executor_op<boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>, std::__1::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) executor_op.hpp:70 (core_test:arm64+0x1016b010c)
      #34 boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) scheduler_operation.hpp:40 (core_test:arm64+0x1000aae80)
      #35 boost::asio::detail::strand_executor_service::run_ready_handlers(std::__1::shared_ptr<boost::asio::detail::strand_executor_service::strand_impl>&) strand_executor_service.ipp:150 (core_test:arm64+0x1000d6dfc)
      #36 boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, void>::operator()() strand_executor_service.hpp:121 (core_test:arm64+0x1000ddcc4)
      #37 void boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul>::execute<boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, void>>(boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, void>&&) const io_context.hpp:283 (core_test:arm64+0x1000dd91c)
      #38 void boost::asio::detail::strand_executor_service::do_execute<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>, std::__1::allocator<void>>(std::__1::shared_ptr<boost::asio::detail::strand_executor_service::strand_impl> const&, boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const&, boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>&&, std::__1::allocator<void> const&) strand_executor_service.hpp:250 (core_test:arm64+0x1016afb68)
      #39 void boost::asio::detail::strand_executor_service::execute<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>>(std::__1::shared_ptr<boost::asio::detail::strand_executor_service::strand_impl> const&, boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const&, boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>&&, std::__1::enable_if<can_query<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, boost::asio::execution::allocator_t<void>>::value, void>::type*) strand_executor_service.hpp:201 (core_test:arm64+0x1016af960)
      #40 boost::asio::constraint<traits::execute_member<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const&, boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>>::is_valid, void>::type boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul>>::execute<boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>>(boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>&&) const strand.hpp:269 (core_test:arm64+0x1016af8ac)
      #41 void boost::asio::detail::handler_work_base<boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>, boost::asio::any_io_executor, boost::asio::io_context, boost::asio::executor, void>::dispatch<boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>, boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>>(boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>&, boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>&) handler_work.hpp:92 (core_test:arm64+0x1016af7f8)
      #42 void boost::asio::detail::handler_work<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::asio::any_io_executor, void>::complete<boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>>(boost::asio::detail::binder2<boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::system::error_code, unsigned long>&, boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>&) handler_work.hpp:437 (core_test:arm64+0x1016af3b8)
      #43 boost::asio::detail::reactive_socket_recv_op<boost::asio::mutable_buffers_1, boost::asio::detail::read_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::mutable_buffers_1, boost::asio::mutable_buffer const*, boost::asio::detail::transfer_all_t, boost::asio::executor_binder<nano::transport::tcp_socket::async_read(std::__1::shared_ptr<std::__1::vector<unsigned char, std::__1::allocator<unsigned char>>> const&, unsigned long, std::__1::function<void (boost::system::error_code const&, unsigned long)>)::$_1::operator()()::'lambda'(boost::system::error_code const&, unsigned long), boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 0ul>>>>, boost::asio::any_io_executor>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) reactive_socket_recv_op.hpp:151 (core_test:arm64+0x1016aef78)
      #44 boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) scheduler_operation.hpp:40 (core_test:arm64+0x1000aae80)
      #45 boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) scheduler.ipp:493 (core_test:arm64+0x1000aa34c)
      #46 boost::asio::detail::scheduler::run(boost::system::error_code&) scheduler.ipp:210 (core_test:arm64+0x1000a9e74)
      #47 boost::asio::io_context::run() io_context.ipp:64 (core_test:arm64+0x101bfabe0)
      #48 nano::thread_runner::run() thread_runner.cpp:87 (core_test:arm64+0x101c1c544)
      #49 nano::thread_runner::start()::$_0::operator()() const thread_runner.cpp:37 (core_test:arm64+0x101c1cfd0)
      #50 boost::detail::thread_data<nano::thread_runner::start()::$_0>::run() thread.hpp:120 (core_test:arm64+0x101c1cf04)
      #51 boost::(anonymous namespace)::thread_proxy(void*) thread.cpp:177 (core_test:arm64+0x1021402cc)
  
    Location is heap block of size 416 at 0x000114794f80 allocated by thread T122075:
      #0 operator new(unsigned long) <null>:253742724 (libclang_rt.tsan_osx_dynamic.dylib:arm64e+0x84420)
      #1 void* std::__1::__libcpp_operator_new[abi:ue170006]<unsigned long>(unsigned long) new:298 (core_test:arm64+0x100049d3c)
      #2 std::__1::__libcpp_allocate[abi:ue170006](unsigned long, unsigned long) new:324 (core_test:arm64+0x100049c60)
      #3 std::__1::allocator<std::__1::__shared_ptr_emplace<nano::transport::tcp_socket, std::__1::allocator<nano::transport::tcp_socket>>>::allocate[abi:ue170006](unsigned long) allocator.h:114 (core_test:arm64+0x10024ef64)
      #4 std::__1::allocator_traits<std::__1::allocator<std::__1::__shared_ptr_emplace<nano::transport::tcp_socket, std::__1::allocator<nano::transport::tcp_socket>>>>::allocate[abi:ue170006](std::__1::allocator<std::__1::__shared_ptr_emplace<nano::transport::tcp_socket, std::__1::allocator<nano::transport::tcp_socket>>>&, unsigned long) allocator_traits.h:268 (core_test:arm64+0x10024ee58)
      #5 std::__1::__allocation_guard<std::__1::allocator<std::__1::__shared_ptr_emplace<nano::transport::tcp_socket, std::__1::allocator<nano::transport::tcp_socket>>>>::__allocation_guard[abi:ue170006]<std::__1::allocator<nano::transport::tcp_socket>>(std::__1::allocator<nano::transport::tcp_socket>, unsigned long) allocation_guard.h:57 (core_test:arm64+0x10024ed80)
      #6 std::__1::__allocation_guard<std::__1::allocator<std::__1::__shared_ptr_emplace<nano::transport::tcp_socket, std::__1::allocator<nano::transport::tcp_socket>>>>::__allocation_guard[abi:ue170006]<std::__1::allocator<nano::transport::tcp_socket>>(std::__1::allocator<nano::transport::tcp_socket>, unsigned long) allocation_guard.h:58 (core_test:arm64+0x10024e9e0)
      #7 std::__1::shared_ptr<nano::transport::tcp_socket> std::__1::allocate_shared[abi:ue170006]<nano::transport::tcp_socket, std::__1::allocator<nano::transport::tcp_socket>, nano::node&, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> const&, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> const&, nano::transport::socket_endpoint, void>(std::__1::allocator<nano::transport::tcp_socket> const&, nano::node&, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>&&, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> const&, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> const&, nano::transport::socket_endpoint&&) shared_ptr.h:1022 (core_test:arm64+0x101664efc)
      #8 std::__1::shared_ptr<nano::transport::tcp_socket> std::__1::make_shared[abi:ue170006]<nano::transport::tcp_socket, nano::node&, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> const&, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> const&, nano::transport::socket_endpoint, void>(nano::node&, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>&&, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> const&, boost::asio::ip::basic_endpoint<boost::asio::ip::tcp> const&, nano::transport::socket_endpoint&&) shared_ptr.h:1032 (core_test:arm64+0x1016387b4)
      #9 nano::transport::tcp_listener::accept_one(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>, nano::transport::tcp_listener::connection_type) tcp_listener.cpp:408 (core_test:arm64+0x1016356a0)
      #10 nano::transport::tcp_listener::run() (.resume) tcp_listener.cpp:317 (core_test:arm64+0x10166e154)
      #11 std::__1::coroutine_handle<void>::resume[abi:ue170006]() const coroutine_handle.h:78 (core_test:arm64+0x1000bf7f0)
      #12 boost::asio::detail::awaitable_frame_base<boost::asio::any_io_executor>::resume() awaitable.hpp:501 (core_test:arm64+0x1000bf638)
      #13 boost::asio::detail::awaitable_thread<boost::asio::any_io_executor>::pump() awaitable.hpp:770 (core_test:arm64+0x1000bf31c)
      #14 void boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>::operator()<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>(boost::system::error_code const&, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>&&) use_awaitable.hpp:152 (core_test:arm64+0x10165be68)
      #15 boost::asio::detail::move_binder2<boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>::operator()() bind_handler.hpp:522 (core_test:arm64+0x10165bd20)
      #16 void boost::asio::detail::executor_function::complete<boost::asio::detail::move_binder2<boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, std::__1::allocator<void>>(boost::asio::detail::executor_function::impl_base*, bool) executor_function.hpp:113 (core_test:arm64+0x10165caa4)
      #17 boost::asio::detail::executor_function::operator()() executor_function.hpp:61 (core_test:arm64+0x1000d5a40)
      #18 boost::asio::detail::executor_op<boost::asio::detail::executor_function, std::__1::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) executor_op.hpp:70 (core_test:arm64+0x1000d6668)
      #19 boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) scheduler_operation.hpp:40 (core_test:arm64+0x1000aae80)
      #20 boost::asio::detail::strand_executor_service::run_ready_handlers(std::__1::shared_ptr<boost::asio::detail::strand_executor_service::strand_impl>&) strand_executor_service.ipp:150 (core_test:arm64+0x1000d6dfc)
      #21 boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, void>::operator()() strand_executor_service.hpp:121 (core_test:arm64+0x1000ddcc4)
      #22 void boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul>::execute<boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, void>>(boost::asio::detail::strand_executor_service::invoker<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, void>&&) const io_context.hpp:283 (core_test:arm64+0x1000dd91c)
      #23 void boost::asio::detail::strand_executor_service::do_execute<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, boost::asio::detail::executor_function, std::__1::allocator<void>>(std::__1::shared_ptr<boost::asio::detail::strand_executor_service::strand_impl> const&, boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const&, boost::asio::detail::executor_function&&, std::__1::allocator<void> const&) strand_executor_service.hpp:250 (core_test:arm64+0x1000dd704)
      #24 void boost::asio::detail::strand_executor_service::execute<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, boost::asio::detail::executor_function>(std::__1::shared_ptr<boost::asio::detail::strand_executor_service::strand_impl> const&, boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const&, boost::asio::detail::executor_function&&, std::__1::enable_if<can_query<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const, boost::asio::execution::allocator_t<void>>::value, void>::type*) strand_executor_service.hpp:201 (core_test:arm64+0x1000dd510)
      #25 boost::asio::constraint<traits::execute_member<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul> const&, boost::asio::detail::executor_function>::is_valid, void>::type boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul>>::execute<boost::asio::detail::executor_function>(boost::asio::detail::executor_function&&) const strand.hpp:269 (core_test:arm64+0x1000dd45c)
      #26 void boost::asio::execution::detail::any_executor_base::execute_ex<boost::asio::strand<boost::asio::io_context::basic_executor_type<std::__1::allocator<void>, 4ul>>>(boost::asio::execution::detail::any_executor_base const&, boost::asio::detail::executor_function&&) any_executor.hpp:900 (core_test:arm64+0x1000dd20c)
      #27 void boost::asio::execution::detail::any_executor_base::execute<boost::asio::detail::move_binder2<boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>>(boost::asio::detail::move_binder2<boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>&&) const any_executor.hpp:681 (core_test:arm64+0x10165c1f8)
      #28 void boost::asio::detail::handler_work_base<boost::asio::any_io_executor, boost::asio::any_io_executor, boost::asio::io_context, boost::asio::executor, void>::dispatch<boost::asio::detail::move_binder2<boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>>(boost::asio::detail::move_binder2<boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>&, boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>&) handler_work.hpp:399 (core_test:arm64+0x10165bd90)
      #29 void boost::asio::detail::handler_work<boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, boost::asio::any_io_executor, void>::complete<boost::asio::detail::move_binder2<boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>>(boost::asio::detail::move_binder2<boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>&, boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>&) handler_work.hpp:437 (core_test:arm64+0x10165b9e4)
      #30 boost::asio::detail::reactive_socket_move_accept_op<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::asio::detail::awaitable_handler<boost::asio::any_io_executor, boost::system::error_code, boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::any_io_executor>>, boost::asio::any_io_executor>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) reactive_socket_accept_op.hpp:268 (core_test:arm64+0x10165b5b8)
      #31 boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) scheduler_operation.hpp:40 (core_test:arm64+0x1000aae80)
      #32 boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) scheduler.ipp:493 (core_test:arm64+0x1000aa34c)
      #33 boost::asio::detail::scheduler::run(boost::system::error_code&) scheduler.ipp:210 (core_test:arm64+0x1000a9e74)
      #34 boost::asio::io_context::run() io_context.ipp:64 (core_test:arm64+0x101bfabe0)
      #35 nano::thread_runner::run() thread_runner.cpp:87 (core_test:arm64+0x101c1c544)
      #36 nano::thread_runner::start()::$_0::operator()() const thread_runner.cpp:37 (core_test:arm64+0x101c1cfd0)
      #37 boost::detail::thread_data<nano::thread_runner::start()::$_0>::run() thread.hpp:120 (core_test:arm64+0x101c1cf04)
      #38 boost::(anonymous namespace)::thread_proxy(void*) thread.cpp:177 (core_test:arm64+0x1021402cc)
```