### PR TITLE
Exit migration if existing rocksdb ledger found

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5484,6 +5484,10 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	ASSERT_EQ (confirmation_height_info.frontier, send->hash ());
 	ASSERT_EQ (rocksdb_store.final_vote.get (rocksdb_transaction, nano::root (send->previous ())).size (), 1);
 	ASSERT_EQ (rocksdb_store.final_vote.get (rocksdb_transaction, nano::root (send->previous ()))[0], nano::block_hash (2));
+
+	// Retry migration while rocksdb folder is still present
+	auto error_on_retry = ledger.migrate_lmdb_to_rocksdb (path);
+	ASSERT_EQ (error_on_retry, true);
 }
 
 TEST (ledger, is_send_genesis)

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1280,7 +1280,12 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 	boost::system::error_code error_chmod;
 	nano::set_secure_perm_directory (data_path_a, error_chmod);
 	auto rockdb_data_path = data_path_a / "rocksdb";
-	std::filesystem::remove_all (rockdb_data_path);
+
+	if (std::filesystem::exists (rockdb_data_path))
+	{
+		logger.error (nano::log::type::ledger, "Existing RocksDb folder found in '{}'. Please remove it and try again.", rockdb_data_path.string ());
+		return true;
+	}
 
 	auto error (false);
 


### PR DESCRIPTION
Halt migration if rocksdb folder already exists instead of deleting it.