### PR TITLE
Fix `epoch_conflict_confirm` test

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1630,11 +1630,8 @@ TEST (block_store, final_vote)
 		ASSERT_EQ (store->final_vote.count (transaction), 0);
 		store->final_vote.put (transaction, qualified_root, nano::block_hash (2));
 		ASSERT_EQ (store->final_vote.count (transaction), 1);
-		// Clearing with incorrect root shouldn't remove
-		store->final_vote.clear (transaction, qualified_root.previous ());
-		ASSERT_EQ (store->final_vote.count (transaction), 1);
 		// Clearing with correct root should remove
-		store->final_vote.clear (transaction, qualified_root.root ());
+		store->final_vote.del (transaction, qualified_root);
 		ASSERT_EQ (store->final_vote.count (transaction), 0);
 	}
 }

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5482,8 +5482,8 @@ TEST (ledger, migrate_lmdb_to_rocksdb)
 	ASSERT_FALSE (rocksdb_store.confirmation_height.get (rocksdb_transaction, nano::dev::genesis_key.pub, confirmation_height_info));
 	ASSERT_EQ (confirmation_height_info.height, 2);
 	ASSERT_EQ (confirmation_height_info.frontier, send->hash ());
-	ASSERT_EQ (rocksdb_store.final_vote.get (rocksdb_transaction, nano::root (send->previous ())).size (), 1);
-	ASSERT_EQ (rocksdb_store.final_vote.get (rocksdb_transaction, nano::root (send->previous ()))[0], nano::block_hash (2));
+	ASSERT_TRUE (rocksdb_store.final_vote.get (rocksdb_transaction, send->qualified_root ()).has_value ());
+	ASSERT_EQ (rocksdb_store.final_vote.get (rocksdb_transaction, send->qualified_root ()).value (), nano::block_hash (2));
 
 	// Retry migration while rocksdb folder is still present
 	auto error_on_retry = ledger.migrate_lmdb_to_rocksdb (path);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2211,12 +2211,12 @@ TEST (node, epoch_conflict_confirm)
 					  .build ();
 
 	// Process initial blocks
-	ASSERT_TRUE (nano::test::process (node0, { send, send2, open }));
-	ASSERT_TRUE (nano::test::process (node1, { send, send2, open }));
+	ASSERT_TRUE (nano::test::process (node0, nano::test::clone ({ send, send2, open })));
+	ASSERT_TRUE (nano::test::process (node1, nano::test::clone ({ send, send2, open })));
 
 	// Process conflicting blocks on nodes as blocks coming from live network
-	ASSERT_TRUE (nano::test::process_live (node0, { change, epoch_open }));
-	ASSERT_TRUE (nano::test::process_live (node1, { change, epoch_open }));
+	ASSERT_TRUE (nano::test::process_live (node0, nano::test::clone ({ change, epoch_open })));
+	ASSERT_TRUE (nano::test::process_live (node1, nano::test::clone ({ change, epoch_open })));
 
 	// Ensure blocks were propagated to both nodes
 	ASSERT_TIMELY (5s, nano::test::exists (node0, { change, epoch_open }));

--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -210,7 +210,7 @@ nano::block_hash nano::block::full_hash () const
 
 nano::block_sideband const & nano::block::sideband () const
 {
-	debug_assert (sideband_m.is_initialized ());
+	release_assert (sideband_m.is_initialized ());
 	return *sideband_m;
 }
 
@@ -569,6 +569,11 @@ nano::send_block::send_block (bool & error_a, boost::property_tree::ptree const 
 	}
 }
 
+std::shared_ptr<nano::block> nano::send_block::clone () const
+{
+	return std::make_shared<nano::send_block> (*this);
+}
+
 bool nano::send_block::operator== (nano::block const & other_a) const
 {
 	return blocks_equal (*this, other_a);
@@ -756,6 +761,11 @@ nano::open_block::open_block (bool & error_a, boost::property_tree::ptree const 
 			error_a = true;
 		}
 	}
+}
+
+std::shared_ptr<nano::block> nano::open_block::clone () const
+{
+	return std::make_shared<nano::open_block> (*this);
 }
 
 void nano::open_block::generate_hash (blake2b_state & hash_a) const
@@ -1027,6 +1037,11 @@ nano::change_block::change_block (bool & error_a, boost::property_tree::ptree co
 			error_a = true;
 		}
 	}
+}
+
+std::shared_ptr<nano::block> nano::change_block::clone () const
+{
+	return std::make_shared<nano::change_block> (*this);
 }
 
 void nano::change_block::generate_hash (blake2b_state & hash_a) const
@@ -1324,6 +1339,11 @@ nano::state_block::state_block (bool & error_a, boost::property_tree::ptree cons
 			error_a = true;
 		}
 	}
+}
+
+std::shared_ptr<nano::block> nano::state_block::clone () const
+{
+	return std::make_shared<nano::state_block> (*this);
 }
 
 void nano::state_block::generate_hash (blake2b_state & hash_a) const
@@ -1790,6 +1810,11 @@ nano::receive_block::receive_block (bool & error_a, boost::property_tree::ptree 
 			error_a = true;
 		}
 	}
+}
+
+std::shared_ptr<nano::block> nano::receive_block::clone () const
+{
+	return std::make_shared<nano::receive_block> (*this);
 }
 
 void nano::receive_block::generate_hash (blake2b_state & hash_a) const

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -23,6 +23,7 @@ namespace nano
 class block
 {
 public:
+	virtual ~block () = default;
 	// Return a digest of the hashables in this block.
 	nano::block_hash const & hash () const;
 	// Return a digest of hashables and non-hashables in this block.
@@ -46,10 +47,10 @@ public:
 	virtual nano::block_type type () const = 0;
 	virtual nano::signature const & block_signature () const = 0;
 	virtual void signature_set (nano::signature const &) = 0;
-	virtual ~block () = default;
 	virtual bool valid_predecessor (nano::block const &) const = 0;
 	static size_t size (nano::block_type);
 	virtual nano::work_version work_version () const;
+	virtual std::shared_ptr<nano::block> clone () const = 0;
 	// If there are any changes to the hashables, call this to update the cached hash
 	void refresh ();
 	bool is_send () const noexcept;
@@ -138,6 +139,7 @@ public:
 	bool operator== (nano::block const &) const override;
 	bool operator== (nano::send_block const &) const;
 	bool valid_predecessor (nano::block const &) const override;
+	std::shared_ptr<nano::block> clone () const override;
 	send_hashables hashables;
 	nano::signature signature;
 	uint64_t work;
@@ -192,6 +194,7 @@ public:
 	bool operator== (nano::block const &) const override;
 	bool operator== (nano::receive_block const &) const;
 	bool valid_predecessor (nano::block const &) const override;
+	std::shared_ptr<nano::block> clone () const override;
 	receive_hashables hashables;
 	nano::signature signature;
 	uint64_t work;
@@ -247,6 +250,7 @@ public:
 	bool operator== (nano::block const &) const override;
 	bool operator== (nano::open_block const &) const;
 	bool valid_predecessor (nano::block const &) const override;
+	std::shared_ptr<nano::block> clone () const override;
 	nano::open_hashables hashables;
 	nano::signature signature;
 	uint64_t work;
@@ -302,6 +306,7 @@ public:
 	bool operator== (nano::block const &) const override;
 	bool operator== (nano::change_block const &) const;
 	bool valid_predecessor (nano::block const &) const override;
+	std::shared_ptr<nano::block> clone () const override;
 	nano::change_hashables hashables;
 	nano::signature signature;
 	uint64_t work;
@@ -368,6 +373,7 @@ public:
 	bool operator== (nano::block const &) const override;
 	bool operator== (nano::state_block const &) const;
 	bool valid_predecessor (nano::block const &) const override;
+	std::shared_ptr<nano::block> clone () const override;
 	nano::state_hashables hashables;
 	nano::signature signature;
 	uint64_t work;

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -646,10 +646,10 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 			{
 				auto root_str = root_it->second.as<std::string> ();
 				auto transaction (node.node->store.tx_begin_write ());
-				nano::root root;
+				nano::qualified_root root;
 				if (!root.decode_hex (root_str))
 				{
-					node.node->store.final_vote.clear (transaction, root);
+					node.node->store.final_vote.del (transaction, root);
 					std::cout << "Successfully cleared final votes" << std::endl;
 				}
 				else

--- a/nano/store/final_vote.hpp
+++ b/nano/store/final_vote.hpp
@@ -22,7 +22,6 @@ public:
 
 public:
 	virtual bool put (store::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) = 0;
-	virtual std::vector<nano::block_hash> get (store::transaction const & transaction_a, nano::root const & root_a) = 0;
 	virtual std::optional<nano::block_hash> get (store::transaction const & transaction_a, nano::qualified_root const & qualified_root_a) = 0;
 	virtual void del (store::write_transaction const & transaction_a, nano::root const & root_a) = 0;
 	virtual size_t count (store::transaction const & transaction_a) const = 0;

--- a/nano/store/final_vote.hpp
+++ b/nano/store/final_vote.hpp
@@ -23,6 +23,7 @@ public:
 public:
 	virtual bool put (store::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) = 0;
 	virtual std::vector<nano::block_hash> get (store::transaction const & transaction_a, nano::root const & root_a) = 0;
+	virtual std::optional<nano::block_hash> get (store::transaction const & transaction_a, nano::qualified_root const & qualified_root_a) = 0;
 	virtual void del (store::write_transaction const & transaction_a, nano::root const & root_a) = 0;
 	virtual size_t count (store::transaction const & transaction_a) const = 0;
 	virtual void clear (store::write_transaction const &, nano::root const &) = 0;

--- a/nano/store/final_vote.hpp
+++ b/nano/store/final_vote.hpp
@@ -23,9 +23,8 @@ public:
 public:
 	virtual bool put (store::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) = 0;
 	virtual std::optional<nano::block_hash> get (store::transaction const & transaction_a, nano::qualified_root const & qualified_root_a) = 0;
-	virtual void del (store::write_transaction const & transaction_a, nano::root const & root_a) = 0;
+	virtual void del (store::write_transaction const & transaction_a, nano::qualified_root const & root_a) = 0;
 	virtual size_t count (store::transaction const & transaction_a) const = 0;
-	virtual void clear (store::write_transaction const &, nano::root const &) = 0;
 	virtual void clear (store::write_transaction const &) = 0;
 	virtual iterator begin (store::transaction const & transaction_a, nano::qualified_root const & root_a) const = 0;
 	virtual iterator begin (store::transaction const & transaction_a) const = 0;

--- a/nano/store/lmdb/final_vote.cpp
+++ b/nano/store/lmdb/final_vote.cpp
@@ -23,17 +23,6 @@ bool nano::store::lmdb::final_vote::put (store::write_transaction const & transa
 	return result;
 }
 
-std::vector<nano::block_hash> nano::store::lmdb::final_vote::get (store::transaction const & transaction, nano::root const & root_a)
-{
-	std::vector<nano::block_hash> result;
-	nano::qualified_root key_start{ root_a.raw, 0 };
-	for (auto i = begin (transaction, key_start), n = end (transaction); i != n && nano::qualified_root{ i->first }.root () == root_a; ++i)
-	{
-		result.push_back (i->second);
-	}
-	return result;
-}
-
 std::optional<nano::block_hash> nano::store::lmdb::final_vote::get (store::transaction const & transaction, nano::qualified_root const & qualified_root_a)
 {
 	nano::store::lmdb::db_val result;

--- a/nano/store/lmdb/final_vote.cpp
+++ b/nano/store/lmdb/final_vote.cpp
@@ -35,29 +35,15 @@ std::optional<nano::block_hash> nano::store::lmdb::final_vote::get (store::trans
 	return final_vote_hash;
 }
 
-void nano::store::lmdb::final_vote::del (store::write_transaction const & transaction, nano::root const & root)
+void nano::store::lmdb::final_vote::del (store::write_transaction const & transaction, nano::qualified_root const & root)
 {
-	std::vector<nano::qualified_root> final_vote_qualified_roots;
-	for (auto i = begin (transaction, nano::qualified_root{ root.raw, 0 }), n = end (transaction); i != n && nano::qualified_root{ i->first }.root () == root; ++i)
-	{
-		final_vote_qualified_roots.push_back (i->first);
-	}
-
-	for (auto & final_vote_qualified_root : final_vote_qualified_roots)
-	{
-		auto status = store.del (transaction, tables::final_votes, final_vote_qualified_root);
-		store.release_assert_success (status);
-	}
+	auto status = store.del (transaction, tables::final_votes, root);
+	store.release_assert_success (status);
 }
 
 size_t nano::store::lmdb::final_vote::count (store::transaction const & transaction_a) const
 {
 	return store.count (transaction_a, tables::final_votes);
-}
-
-void nano::store::lmdb::final_vote::clear (store::write_transaction const & transaction_a, nano::root const & root_a)
-{
-	del (transaction_a, root_a);
 }
 
 void nano::store::lmdb::final_vote::clear (store::write_transaction const & transaction_a)

--- a/nano/store/lmdb/final_vote.cpp
+++ b/nano/store/lmdb/final_vote.cpp
@@ -34,6 +34,18 @@ std::vector<nano::block_hash> nano::store::lmdb::final_vote::get (store::transac
 	return result;
 }
 
+std::optional<nano::block_hash> nano::store::lmdb::final_vote::get (store::transaction const & transaction, nano::qualified_root const & qualified_root_a)
+{
+	nano::store::lmdb::db_val result;
+	auto status = store.get (transaction, tables::final_votes, qualified_root_a, result);
+	std::optional<nano::block_hash> final_vote_hash;
+	if (store.success (status))
+	{
+		final_vote_hash = static_cast<nano::block_hash> (result);
+	}
+	return final_vote_hash;
+}
+
 void nano::store::lmdb::final_vote::del (store::write_transaction const & transaction, nano::root const & root)
 {
 	std::vector<nano::qualified_root> final_vote_qualified_roots;

--- a/nano/store/lmdb/final_vote.hpp
+++ b/nano/store/lmdb/final_vote.hpp
@@ -19,6 +19,7 @@ public:
 	explicit final_vote (nano::store::lmdb::component & store);
 	bool put (store::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override;
 	std::vector<nano::block_hash> get (store::transaction const & transaction_a, nano::root const & root_a) override;
+	std::optional<nano::block_hash> get (store::transaction const & transaction_a, nano::qualified_root const & qualified_root_a) override;
 	void del (store::write_transaction const & transaction_a, nano::root const & root_a) override;
 	size_t count (store::transaction const & transaction_a) const override;
 	void clear (store::write_transaction const & transaction_a, nano::root const & root_a) override;

--- a/nano/store/lmdb/final_vote.hpp
+++ b/nano/store/lmdb/final_vote.hpp
@@ -19,9 +19,8 @@ public:
 	explicit final_vote (nano::store::lmdb::component & store);
 	bool put (store::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override;
 	std::optional<nano::block_hash> get (store::transaction const & transaction_a, nano::qualified_root const & qualified_root_a) override;
-	void del (store::write_transaction const & transaction_a, nano::root const & root_a) override;
+	void del (store::write_transaction const & transaction_a, nano::qualified_root const & root_a) override;
 	size_t count (store::transaction const & transaction_a) const override;
-	void clear (store::write_transaction const & transaction_a, nano::root const & root_a) override;
 	void clear (store::write_transaction const & transaction_a) override;
 	iterator begin (store::transaction const & transaction_a, nano::qualified_root const & root_a) const override;
 	iterator begin (store::transaction const & transaction_a) const override;

--- a/nano/store/lmdb/final_vote.hpp
+++ b/nano/store/lmdb/final_vote.hpp
@@ -18,7 +18,6 @@ private:
 public:
 	explicit final_vote (nano::store::lmdb::component & store);
 	bool put (store::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override;
-	std::vector<nano::block_hash> get (store::transaction const & transaction_a, nano::root const & root_a) override;
 	std::optional<nano::block_hash> get (store::transaction const & transaction_a, nano::qualified_root const & qualified_root_a) override;
 	void del (store::write_transaction const & transaction_a, nano::root const & root_a) override;
 	size_t count (store::transaction const & transaction_a) const override;

--- a/nano/store/rocksdb/final_vote.cpp
+++ b/nano/store/rocksdb/final_vote.cpp
@@ -35,6 +35,18 @@ std::vector<nano::block_hash> nano::store::rocksdb::final_vote::get (store::tran
 	return result;
 }
 
+std::optional<nano::block_hash> nano::store::rocksdb::final_vote::get (store::transaction const & transaction, nano::qualified_root const & qualified_root_a)
+{
+	nano::store::rocksdb::db_val result;
+	auto status = store.get (transaction, tables::final_votes, qualified_root_a, result);
+	std::optional<nano::block_hash> final_vote_hash;
+	if (store.success (status))
+	{
+		final_vote_hash = static_cast<nano::block_hash> (result);
+	}
+	return final_vote_hash;
+}
+
 void nano::store::rocksdb::final_vote::del (store::write_transaction const & transaction, nano::root const & root)
 {
 	std::vector<nano::qualified_root> final_vote_qualified_roots;

--- a/nano/store/rocksdb/final_vote.cpp
+++ b/nano/store/rocksdb/final_vote.cpp
@@ -36,29 +36,15 @@ std::optional<nano::block_hash> nano::store::rocksdb::final_vote::get (store::tr
 	return final_vote_hash;
 }
 
-void nano::store::rocksdb::final_vote::del (store::write_transaction const & transaction, nano::root const & root)
+void nano::store::rocksdb::final_vote::del (store::write_transaction const & transaction, nano::qualified_root const & root)
 {
-	std::vector<nano::qualified_root> final_vote_qualified_roots;
-	for (auto i = begin (transaction, nano::qualified_root{ root.raw, 0 }), n = end (transaction); i != n && nano::qualified_root{ i->first }.root () == root; ++i)
-	{
-		final_vote_qualified_roots.push_back (i->first);
-	}
-
-	for (auto & final_vote_qualified_root : final_vote_qualified_roots)
-	{
-		auto status = store.del (transaction, tables::final_votes, final_vote_qualified_root);
-		store.release_assert_success (status);
-	}
+	auto status = store.del (transaction, tables::final_votes, root);
+	store.release_assert_success (status);
 }
 
 size_t nano::store::rocksdb::final_vote::count (store::transaction const & transaction_a) const
 {
 	return store.count (transaction_a, tables::final_votes);
-}
-
-void nano::store::rocksdb::final_vote::clear (store::write_transaction const & transaction_a, nano::root const & root_a)
-{
-	del (transaction_a, root_a);
 }
 
 void nano::store::rocksdb::final_vote::clear (store::write_transaction const & transaction_a)

--- a/nano/store/rocksdb/final_vote.cpp
+++ b/nano/store/rocksdb/final_vote.cpp
@@ -24,17 +24,6 @@ bool nano::store::rocksdb::final_vote::put (store::write_transaction const & tra
 	return result;
 }
 
-std::vector<nano::block_hash> nano::store::rocksdb::final_vote::get (store::transaction const & transaction, nano::root const & root_a)
-{
-	std::vector<nano::block_hash> result;
-	nano::qualified_root key_start{ root_a.raw, 0 };
-	for (auto i = begin (transaction, key_start), n = end (transaction); i != n && nano::qualified_root{ i->first }.root () == root_a; ++i)
-	{
-		result.push_back (i->second);
-	}
-	return result;
-}
-
 std::optional<nano::block_hash> nano::store::rocksdb::final_vote::get (store::transaction const & transaction, nano::qualified_root const & qualified_root_a)
 {
 	nano::store::rocksdb::db_val result;

--- a/nano/store/rocksdb/final_vote.hpp
+++ b/nano/store/rocksdb/final_vote.hpp
@@ -16,7 +16,6 @@ private:
 public:
 	explicit final_vote (nano::store::rocksdb::component & store);
 	bool put (store::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override;
-	std::vector<nano::block_hash> get (store::transaction const & transaction_a, nano::root const & root_a) override;
 	std::optional<nano::block_hash> get (store::transaction const & transaction_a, nano::qualified_root const & qualified_root_a) override;
 	void del (store::write_transaction const & transaction_a, nano::root const & root_a) override;
 	size_t count (store::transaction const & transaction_a) const override;

--- a/nano/store/rocksdb/final_vote.hpp
+++ b/nano/store/rocksdb/final_vote.hpp
@@ -17,9 +17,8 @@ public:
 	explicit final_vote (nano::store::rocksdb::component & store);
 	bool put (store::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override;
 	std::optional<nano::block_hash> get (store::transaction const & transaction_a, nano::qualified_root const & qualified_root_a) override;
-	void del (store::write_transaction const & transaction_a, nano::root const & root_a) override;
+	void del (store::write_transaction const & transaction_a, nano::qualified_root const & root_a) override;
 	size_t count (store::transaction const & transaction_a) const override;
-	void clear (store::write_transaction const & transaction_a, nano::root const & root_a) override;
 	void clear (store::write_transaction const & transaction_a) override;
 	iterator begin (store::transaction const & transaction_a, nano::qualified_root const & root_a) const override;
 	iterator begin (store::transaction const & transaction_a) const override;

--- a/nano/store/rocksdb/final_vote.hpp
+++ b/nano/store/rocksdb/final_vote.hpp
@@ -17,6 +17,7 @@ public:
 	explicit final_vote (nano::store::rocksdb::component & store);
 	bool put (store::write_transaction const & transaction_a, nano::qualified_root const & root_a, nano::block_hash const & hash_a) override;
 	std::vector<nano::block_hash> get (store::transaction const & transaction_a, nano::root const & root_a) override;
+	std::optional<nano::block_hash> get (store::transaction const & transaction_a, nano::qualified_root const & qualified_root_a) override;
 	void del (store::write_transaction const & transaction_a, nano::root const & root_a) override;
 	size_t count (store::transaction const & transaction_a) const override;
 	void clear (store::write_transaction const & transaction_a, nano::root const & root_a) override;

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -124,6 +124,11 @@ bool nano::test::exists (nano::node & node, std::vector<std::shared_ptr<nano::bl
 	return exists (node, blocks_to_hashes (blocks));
 }
 
+void nano::test::confirm (nano::node & node, std::vector<std::shared_ptr<nano::block>> const blocks)
+{
+	confirm (node.ledger, blocks);
+}
+
 void nano::test::confirm (nano::ledger & ledger, std::vector<std::shared_ptr<nano::block>> const blocks)
 {
 	for (auto const block : blocks)

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -242,6 +242,13 @@ std::vector<nano::block_hash> nano::test::blocks_to_hashes (std::vector<std::sha
 	return hashes;
 }
 
+std::vector<std::shared_ptr<nano::block>> nano::test::clone (std::vector<std::shared_ptr<nano::block>> blocks)
+{
+	std::vector<std::shared_ptr<nano::block>> clones;
+	std::transform (blocks.begin (), blocks.end (), std::back_inserter (clones), [] (auto & block) { return block->clone (); });
+	return clones;
+}
+
 std::shared_ptr<nano::transport::fake::channel> nano::test::fake_channel (nano::node & node, nano::account node_id)
 {
 	auto channel = std::make_shared<nano::transport::fake::channel> (node);

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -329,6 +329,7 @@ namespace test
 	void confirm (nano::ledger & ledger, std::vector<std::shared_ptr<nano::block>> const blocks);
 	void confirm (nano::ledger & ledger, std::shared_ptr<nano::block> const block);
 	void confirm (nano::ledger & ledger, nano::block_hash const & hash);
+	void confirm (nano::node & node, std::vector<std::shared_ptr<nano::block>> const blocks);
 	/*
 	 * Convenience function to check whether *all* of the hashes exists in node ledger or in the pruned table.
 	 * @return true if all blocks are fully processed and inserted in the ledger, false otherwise

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -391,6 +391,10 @@ namespace test
 	 */
 	std::vector<nano::block_hash> blocks_to_hashes (std::vector<std::shared_ptr<nano::block>> blocks);
 	/*
+	 * Clones list of blocks
+	 */
+	std::vector<std::shared_ptr<nano::block>> clone (std::vector<std::shared_ptr<nano::block>> blocks);
+	/*
 	 * Creates a new fake channel associated with `node`
 	 */
 	std::shared_ptr<nano::transport::fake::channel> fake_channel (nano::node & node, nano::account node_id = { 0 });


### PR DESCRIPTION
Fixing this test necessitated reworking `request_aggregator::aggregate ( .. )` and the way final votes are queried - only query final votes by full qualified root.