### PR TITLE
Offload rollback notifications to background thread

### DIFF
--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -65,10 +65,13 @@ nano::active_elections::active_elections (nano::node & node_a, nano::confirming_
 	});
 
 	// Stop all rolled back active transactions except initial
-	block_processor.rolled_back.add ([this] (auto const & block, auto const & rollback_root) {
-		if (block->qualified_root () != rollback_root)
+	block_processor.rolled_back.add ([this] (auto const & blocks, auto const & rollback_root) {
+		for (auto const & block : blocks)
 		{
-			erase (block->qualified_root ());
+			if (block->qualified_root () != rollback_root)
+			{
+				erase (block->qualified_root ());
+			}
 		}
 	});
 }

--- a/nano/node/blockprocessor.cpp
+++ b/nano/node/blockprocessor.cpp
@@ -197,8 +197,10 @@ void nano::block_processor::rollback_competitor (secure::write_transaction const
 			logger.debug (nano::log::type::blockprocessor, "Blocks rolled back: {}", rollback_list.size ());
 		}
 
-		// Notify observers of the rolled back blocks
-		rolled_back.notify (rollback_list, fork_block.qualified_root ());
+		// Notify observers of the rolled back blocks on a background thread while not holding the ledger write lock
+		workers.post ([this, rollback_list = std::move (rollback_list), root = fork_block.qualified_root ()] () {
+			rolled_back.notify (rollback_list, root);
+		});
 	}
 }
 

--- a/nano/node/blockprocessor.hpp
+++ b/nano/node/blockprocessor.hpp
@@ -99,15 +99,14 @@ public:
 	std::atomic<bool> flushing{ false };
 
 public: // Events
-	using processed_t = std::tuple<nano::block_status, context>;
-	using processed_batch_t = std::deque<processed_t>;
+	// All processed blocks including forks, rejected etc
+	using processed_batch_t = std::deque<std::pair<nano::block_status, context>>;
+	using processed_batch_event_t = nano::observer_set<processed_batch_t>;
+	processed_batch_event_t batch_processed;
 
-	// The batch observer feeds the processed observer
-	nano::observer_set<nano::block_status const &, context const &> block_processed;
-	nano::observer_set<processed_batch_t const &> batch_processed;
-
-	// Rolled back blocks <rolled back block, root of rollback>
-	nano::observer_set<std::shared_ptr<nano::block> const &, nano::qualified_root const &> rolled_back;
+	// Rolled back blocks <rolled back blocks, root of rollback>
+	using rolled_back_event_t = nano::observer_set<std::deque<std::shared_ptr<nano::block>>, nano::qualified_root>;
+	rolled_back_event_t rolled_back;
 
 private: // Dependencies
 	block_processor_config const & config;

--- a/nano/node/local_block_broadcaster.cpp
+++ b/nano/node/local_block_broadcaster.cpp
@@ -56,10 +56,13 @@ nano::local_block_broadcaster::local_block_broadcaster (local_block_broadcaster_
 		}
 	});
 
-	block_processor.rolled_back.add ([this] (auto const & block, auto const & rollback_root) {
+	block_processor.rolled_back.add ([this] (auto const & blocks, auto const & rollback_root) {
 		nano::lock_guard<nano::mutex> guard{ mutex };
-		auto erased = local_blocks.get<tag_hash> ().erase (block->hash ());
-		stats.add (nano::stat::type::local_block_broadcaster, nano::stat::detail::rollback, erased);
+		for (auto const & block : blocks)
+		{
+			auto erased = local_blocks.get<tag_hash> ().erase (block->hash ());
+			stats.add (nano::stat::type::local_block_broadcaster, nano::stat::detail::rollback, erased);
+		}
 	});
 
 	confirming_set.cemented_observers.add ([this] (auto const & block) {

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -201,8 +201,11 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	});
 
 	// Do some cleanup of rolled back blocks
-	block_processor.rolled_back.add ([this] (auto const & block, auto const & rollback_root) {
-		history.erase (block->root ());
+	block_processor.rolled_back.add ([this] (auto const & blocks, auto const & rollback_root) {
+		for (auto const & block : blocks)
+		{
+			history.erase (block->root ());
+		}
 	});
 
 	if (!init_error ())

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -36,7 +36,7 @@ namespace
 class rollback_visitor : public nano::block_visitor
 {
 public:
-	rollback_visitor (nano::secure::write_transaction const & transaction_a, nano::ledger & ledger_a, std::vector<std::shared_ptr<nano::block>> & list_a) :
+	rollback_visitor (nano::secure::write_transaction const & transaction_a, nano::ledger & ledger_a, std::deque<std::shared_ptr<nano::block>> & list_a) :
 		transaction (transaction_a),
 		ledger (ledger_a),
 		list (list_a)
@@ -179,7 +179,7 @@ public:
 	}
 	nano::secure::write_transaction const & transaction;
 	nano::ledger & ledger;
-	std::vector<std::shared_ptr<nano::block>> & list;
+	std::deque<std::shared_ptr<nano::block>> & list;
 	bool error{ false };
 };
 
@@ -992,7 +992,7 @@ nano::uint128_t nano::ledger::weight_exact (secure::transaction const & txn_a, n
 }
 
 // Rollback blocks until `block_a' doesn't exist or it tries to penetrate the confirmation height
-bool nano::ledger::rollback (secure::write_transaction const & transaction_a, nano::block_hash const & block_a, std::vector<std::shared_ptr<nano::block>> & list_a)
+bool nano::ledger::rollback (secure::write_transaction const & transaction_a, nano::block_hash const & block_a, std::deque<std::shared_ptr<nano::block>> & list_a)
 {
 	debug_assert (any.block_exists (transaction_a, block_a));
 	auto account_l = any.block_account (transaction_a, block_a).value ();
@@ -1026,7 +1026,7 @@ bool nano::ledger::rollback (secure::write_transaction const & transaction_a, na
 
 bool nano::ledger::rollback (secure::write_transaction const & transaction_a, nano::block_hash const & block_a)
 {
-	std::vector<std::shared_ptr<nano::block>> rollback_list;
+	std::deque<std::shared_ptr<nano::block>> rollback_list;
 	return rollback (transaction_a, block_a, rollback_list);
 }
 

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -62,7 +62,7 @@ public:
 	std::optional<nano::pending_info> pending_info (secure::transaction const &, nano::pending_key const & key) const;
 	std::deque<std::shared_ptr<nano::block>> confirm (secure::write_transaction &, nano::block_hash const & hash, size_t max_blocks = 1024 * 128);
 	nano::block_status process (secure::write_transaction const &, std::shared_ptr<nano::block> block);
-	bool rollback (secure::write_transaction const &, nano::block_hash const &, std::vector<std::shared_ptr<nano::block>> &);
+	bool rollback (secure::write_transaction const &, nano::block_hash const &, std::deque<std::shared_ptr<nano::block>> & rollback_list);
 	bool rollback (secure::write_transaction const &, nano::block_hash const &);
 	void update_account (secure::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);
 	uint64_t pruning_action (secure::write_transaction &, nano::block_hash const &, uint64_t const);

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -448,7 +448,7 @@ void nano::test::system::generate_rollback (nano::node & node_a, std::vector<nan
 		{
 			accounts_a[index] = accounts_a[accounts_a.size () - 1];
 			accounts_a.pop_back ();
-			std::vector<std::shared_ptr<nano::block>> rollback_list;
+			std::deque<std::shared_ptr<nano::block>> rollback_list;
 			auto error = node_a.ledger.rollback (transaction, hash, rollback_list);
 			(void)error;
 			debug_assert (!error);


### PR DESCRIPTION
This avoids holding the database write lock when issuing block rollback notifications.