### PR TITLE
Rework random block sampling for rep crawler

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -904,21 +904,6 @@ TEST (block_store, cemented_count_cache)
 	ASSERT_EQ (1, ledger.cemented_count ());
 }
 
-TEST (block_store, block_random)
-{
-	nano::logger logger;
-	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
-	{
-		nano::ledger_cache ledger_cache{ store->rep_weight };
-		auto transaction (store->tx_begin_write ());
-		store->initialize (transaction, ledger_cache, nano::dev::constants);
-	}
-	auto transaction (store->tx_begin_read ());
-	auto block (store->block.random (transaction));
-	ASSERT_NE (nullptr, block);
-	ASSERT_EQ (*block, *nano::dev::genesis);
-}
-
 TEST (block_store, pruned_random)
 {
 	nano::logger logger;

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -107,7 +107,7 @@ private:
 
 	/** Returns a list of endpoints to crawl. The total weight is passed in to avoid computing it twice. */
 	std::vector<std::shared_ptr<nano::transport::channel>> prepare_crawl_targets (bool sufficient_weight) const;
-	std::optional<hash_root_t> prepare_query_target ();
+	std::optional<hash_root_t> prepare_query_target () const;
 	bool track_rep_request (hash_root_t hash_root, std::shared_ptr<nano::transport::channel> const & channel);
 
 private:

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -936,7 +936,7 @@ std::string nano::ledger::block_text (nano::block_hash const & hash_a)
 	return result;
 }
 
-std::pair<nano::block_hash, nano::block_hash> nano::ledger::hash_root_random (secure::transaction const & transaction_a) const
+std::pair<nano::block_hash, nano::root> nano::ledger::hash_root_random (secure::transaction const & transaction_a) const
 {
 	nano::block_hash hash (0);
 	nano::root root (0);
@@ -962,7 +962,7 @@ std::pair<nano::block_hash, nano::block_hash> nano::ledger::hash_root_random (se
 			root = block->root ();
 		}
 	}
-	return std::make_pair (hash, root.as_block_hash ());
+	return std::make_pair (hash, root);
 }
 
 // Vote weight of an account

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1276,7 +1276,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 
 	if (std::filesystem::exists (rockdb_data_path))
 	{
-		logger.error (nano::log::type::ledger, "Existing RocksDb folder found in '{}'. Please remove it and try again.", rockdb_data_path.string ());
+		logger.error (nano::log::type::ledger, "Existing RocksDB folder found in '{}'. Please remove it and try again.", rockdb_data_path.string ());
 		return true;
 	}
 
@@ -1423,7 +1423,8 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		logger.info (nano::log::type::ledger, "{} entries converted ({}%)", count.load (), table_size > 0 ? count.load () * 100 / table_size : 100);
 
 		logger.info (nano::log::type::ledger, "Finalizing migration...");
-		auto lmdb_transaction (store.tx_begin_read ());
+
+		auto lmdb_transaction (tx_begin_read ());
 		auto version = store.version.get (lmdb_transaction);
 		auto rocksdb_transaction (rocksdb_store->tx_begin_write ());
 		rocksdb_store->version.put (rocksdb_transaction, version);
@@ -1447,21 +1448,26 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 		error |= store.version.get (lmdb_transaction) != rocksdb_store->version.get (rocksdb_transaction);
 
 		// For large tables a random key is used instead and makes sure it exists
-		auto random_block (store.block.random (lmdb_transaction));
-		error |= rocksdb_store->block.get (rocksdb_transaction, random_block->hash ()) == nullptr;
-
-		auto account = random_block->account ();
-		nano::account_info account_info;
-		error |= rocksdb_store->account.get (rocksdb_transaction, account, account_info);
-
-		// If confirmation height exists in the lmdb ledger for this account it should exist in the rocksdb ledger
-		nano::confirmation_height_info confirmation_height_info{};
-		if (!store.confirmation_height.get (lmdb_transaction, account, confirmation_height_info))
+		auto blocks = random_blocks (lmdb_transaction, 42);
+		release_assert (!blocks.empty ());
+		for (auto const & block : blocks)
 		{
-			error |= rocksdb_store->confirmation_height.get (rocksdb_transaction, account, confirmation_height_info);
+			auto const account = block->account ();
+
+			error |= rocksdb_store->block.get (rocksdb_transaction, block->hash ()) == nullptr;
+
+			nano::account_info account_info;
+			error |= rocksdb_store->account.get (rocksdb_transaction, account, account_info);
+
+			// If confirmation height exists in the lmdb ledger for this account it should exist in the rocksdb ledger
+			nano::confirmation_height_info confirmation_height_info{};
+			if (!store.confirmation_height.get (lmdb_transaction, account, confirmation_height_info))
+			{
+				error |= rocksdb_store->confirmation_height.get (rocksdb_transaction, account, confirmation_height_info);
+			}
 		}
 
-		logger.info (nano::log::type::ledger, "Migration completed. Make sure to enable RocksDb in the config file under [node.rocksdb]");
+		logger.info (nano::log::type::ledger, "Migration completed. Make sure to enable RocksDB in the config file under [node.rocksdb]");
 		logger.info (nano::log::type::ledger, "After confirming correct node operation, the data.ldb file can be deleted if no longer required");
 	}
 	else

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -58,7 +58,7 @@ public:
 	nano::block_hash representative_calculated (secure::transaction const &, nano::block_hash const &);
 	std::string block_text (char const *);
 	std::string block_text (nano::block_hash const &);
-	std::pair<nano::block_hash, nano::block_hash> hash_root_random (secure::transaction const &) const;
+	std::pair<nano::block_hash, nano::root> hash_root_random (secure::transaction const &) const;
 	std::optional<nano::pending_info> pending_info (secure::transaction const &, nano::pending_key const & key) const;
 	std::deque<std::shared_ptr<nano::block>> confirm (secure::write_transaction &, nano::block_hash const & hash, size_t max_blocks = 1024 * 128);
 	nano::block_status process (secure::write_transaction const &, std::shared_ptr<nano::block> block);

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -58,7 +58,7 @@ public:
 	nano::block_hash representative_calculated (secure::transaction const &, nano::block_hash const &);
 	std::string block_text (char const *);
 	std::string block_text (nano::block_hash const &);
-	std::pair<nano::block_hash, nano::root> hash_root_random (secure::transaction const &) const;
+	std::deque<std::shared_ptr<nano::block>> random_blocks (secure::transaction const &, size_t count) const;
 	std::optional<nano::pending_info> pending_info (secure::transaction const &, nano::pending_key const & key) const;
 	std::deque<std::shared_ptr<nano::block>> confirm (secure::write_transaction &, nano::block_hash const & hash, size_t max_blocks = 1024 * 128);
 	nano::block_status process (secure::write_transaction const &, std::shared_ptr<nano::block> block);

--- a/nano/store/block.hpp
+++ b/nano/store/block.hpp
@@ -30,7 +30,6 @@ public:
 	virtual std::optional<nano::block_hash> successor (transaction const & tx, nano::block_hash const &) const = 0;
 	virtual void successor_clear (write_transaction const & tx, nano::block_hash const &) = 0;
 	virtual std::shared_ptr<nano::block> get (transaction const & tx, nano::block_hash const &) const = 0;
-	virtual std::shared_ptr<nano::block> random (transaction const & tx) = 0;
 	virtual void del (write_transaction const & tx, nano::block_hash const &) = 0;
 	virtual bool exists (transaction const & tx, nano::block_hash const &) = 0;
 	virtual uint64_t count (transaction const & tx) = 0;

--- a/nano/store/lmdb/block.cpp
+++ b/nano/store/lmdb/block.cpp
@@ -106,19 +106,6 @@ std::shared_ptr<nano::block> nano::store::lmdb::block::get (store::transaction c
 	return result;
 }
 
-std::shared_ptr<nano::block> nano::store::lmdb::block::random (store::transaction const & transaction)
-{
-	nano::block_hash hash;
-	nano::random_pool::generate_block (hash.bytes.data (), hash.bytes.size ());
-	auto existing = begin (transaction, hash);
-	if (existing == end (transaction))
-	{
-		existing = begin (transaction);
-	}
-	debug_assert (existing != end (transaction));
-	return existing->second.block;
-}
-
 void nano::store::lmdb::block::del (store::write_transaction const & transaction_a, nano::block_hash const & hash_a)
 {
 	auto status = store.del (transaction_a, tables::blocks, hash_a);

--- a/nano/store/lmdb/block.hpp
+++ b/nano/store/lmdb/block.hpp
@@ -27,7 +27,6 @@ public:
 	std::optional<nano::block_hash> successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 	void successor_clear (store::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 	std::shared_ptr<nano::block> get (store::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	std::shared_ptr<nano::block> random (store::transaction const & transaction_a) override;
 	void del (store::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 	bool exists (store::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 	uint64_t count (store::transaction const & transaction_a) override;

--- a/nano/store/rocksdb/block.cpp
+++ b/nano/store/rocksdb/block.cpp
@@ -106,18 +106,6 @@ std::shared_ptr<nano::block> nano::store::rocksdb::block::get (store::transactio
 	}
 	return result;
 }
-std::shared_ptr<nano::block> nano::store::rocksdb::block::random (store::transaction const & transaction)
-{
-	nano::block_hash hash;
-	nano::random_pool::generate_block (hash.bytes.data (), hash.bytes.size ());
-	auto existing = begin (transaction, hash);
-	if (existing == end (transaction))
-	{
-		existing = begin (transaction);
-	}
-	debug_assert (existing != end (transaction));
-	return existing->second.block;
-}
 
 void nano::store::rocksdb::block::del (store::write_transaction const & transaction_a, nano::block_hash const & hash_a)
 {

--- a/nano/store/rocksdb/block.hpp
+++ b/nano/store/rocksdb/block.hpp
@@ -25,7 +25,6 @@ public:
 	std::optional<nano::block_hash> successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
 	void successor_clear (store::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 	std::shared_ptr<nano::block> get (store::transaction const & transaction_a, nano::block_hash const & hash_a) const override;
-	std::shared_ptr<nano::block> random (store::transaction const & transaction_a) override;
 	void del (store::write_transaction const & transaction_a, nano::block_hash const & hash_a) override;
 	bool exists (store::transaction const & transaction_a, nano::block_hash const & hash_a) override;
 	uint64_t count (store::transaction const & transaction_a) override;


### PR DESCRIPTION
This improves how random blocks are sampled for rep crawler. The issue with previous way was that it sometimes caused tests to fail, simply because block hashes were too close together and it was improbable for some to be chosen. 

This was never a problem for live network where there are many more blocks, but randomly failing tests are annoying nevertheless. The new way avoids some code repetition so that's a plus.