### PR TITLE
Optimize Vote Request Behavior During Bootstrapping

### DIFF
--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -416,6 +416,14 @@ nano::election_insertion_result nano::active_elections::insert (std::shared_ptr<
 			debug_assert (count_by_behavior[result.election->behavior ()] >= 0);
 			count_by_behavior[result.election->behavior ()]++;
 
+			// Skip passive phase for blocks without cached votes to avoid bootstrap delays
+			bool active_immediately = false;
+			if (node.vote_cache.contains (hash))
+			{
+				result.election->transition_active ();
+				active_immediately = true;
+			}
+
 			node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::started);
 			node.stats.inc (nano::stat::type::active_elections_started, to_stat_detail (election_behavior_a));
 
@@ -423,9 +431,10 @@ nano::election_insertion_result nano::active_elections::insert (std::shared_ptr<
 			nano::log::arg{ "behavior", election_behavior_a },
 			nano::log::arg{ "election", result.election });
 
-			node.logger.debug (nano::log::type::active_elections, "Started new election for block: {} (behavior: {})",
+			node.logger.debug (nano::log::type::active_elections, "Started new election for block: {} (behavior: {}, active immediately: {})",
 			hash.to_string (),
-			to_string (election_behavior_a));
+			to_string (election_behavior_a),
+			active_immediately);
 		}
 		else
 		{


### PR DESCRIPTION
With bounded backlog there's a need to minimize the gap between checked and cemented blocks especially during bootstrapping phase. Currently, elections stay passive for 5 seconds by default, during which we don't request votes. However, during bootstrapping, we need to request votes to confirm blocks.

This PR implements a heuristic to identify if a block is actively being voted on. If there are no recent votes in the vote cache for a block, it likely indicates we're in bootstrapping phase, and we should request votes immediately rather than waiting for the default 5-second passive period.

The election will transition to active state immediately if the block's hash is not found in the vote cache. 
