### PR TITLE
Make election behavior mutable to support dynamic behaviour transition

### DIFF
--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -193,20 +193,19 @@ TEST (election_scheduler, transition_optimistic_to_priority)
 	ASSERT_TIMELY (5s, node.vote_router.active (block->hash ()));
 	auto election = node.active.election (block->qualified_root ());
 	ASSERT_EQ (election->behavior (), nano::election_behavior::optimistic);
+	ASSERT_TIMELY_EQ (1s, 1, election->current_status ().status.vote_broadcast_count);
 
 	// Confirm first block to allow upgrading second block's election
 	nano::test::confirm (node.ledger, blocks.at (howmany_blocks - 1));
 
 	// Attempt to start priority election for second block
-	node.stats.clear ();
-	ASSERT_EQ (0, node.stats.count (nano::stat::type::election, nano::stat::detail::broadcast_vote));
 	node.active.insert (block, nano::election_behavior::priority);
 
 	// Verify priority transition
 	ASSERT_EQ (election->behavior (), nano::election_behavior::priority);
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::transition_priority));
 	// Verify vote broadcast after transitioning
-	ASSERT_TIMELY_EQ (1s, 1, node.stats.count (nano::stat::type::election, nano::stat::detail::broadcast_vote));
+	ASSERT_TIMELY_EQ (1s, 2, election->current_status ().status.vote_broadcast_count);
 	ASSERT_TRUE (node.active.active (*block));
 }
 

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -426,6 +426,8 @@ enum class detail
 	// active
 	insert,
 	insert_failed,
+	transition_priority,
+	transition_priority_failed,
 	election_cleanup,
 
 	// active_elections

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -183,6 +183,25 @@ void nano::election::transition_active ()
 	state_change (nano::election_state::passive, nano::election_state::active);
 }
 
+bool nano::election::transition_priority ()
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+
+	if (behavior_m == nano::election_behavior::priority || behavior_m == nano::election_behavior::manual)
+	{
+		return false;
+	}
+
+	behavior_m = nano::election_behavior::priority;
+	last_vote = std::chrono::steady_clock::time_point{}; // allow new outgoing votes immediately
+
+	node.logger.debug (nano::log::type::election, "Transitioned election behavior to priority from {} for root: {}",
+	to_string (behavior_m),
+	qualified_root.to_string ());
+
+	return true;
+}
+
 void nano::election::cancel ()
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -152,7 +152,7 @@ bool nano::election::state_change (nano::election_state expected_a, nano::electi
 
 std::chrono::milliseconds nano::election::confirm_req_time () const
 {
-	switch (behavior ())
+	switch (behavior_m)
 	{
 		case election_behavior::manual:
 		case election_behavior::priority:
@@ -314,7 +314,7 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 
 std::chrono::milliseconds nano::election::time_to_live () const
 {
-	switch (behavior ())
+	switch (behavior_m)
 	{
 		case election_behavior::manual:
 		case election_behavior::priority:
@@ -771,6 +771,7 @@ std::vector<nano::vote_with_weight_info> nano::election::votes_with_weight () co
 
 nano::election_behavior nano::election::behavior () const
 {
+	nano::lock_guard<nano::mutex> guard{ mutex };
 	return behavior_m;
 }
 

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -27,7 +27,7 @@ nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> cons
 	live_vote_action (live_vote_action_a),
 	node (node_a),
 	behavior_m (election_behavior_a),
-	status ({ block_a, 0, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 0, 1, 0, nano::election_status_type::ongoing }),
+	status (block_a),
 	height (block_a->sideband ().height),
 	root (block_a->root ()),
 	qualified_root (block_a->qualified_root ())

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -97,6 +97,7 @@ public: // Status
 	std::shared_ptr<nano::block> winner () const;
 	std::chrono::milliseconds duration () const;
 	std::atomic<unsigned> confirmation_request_count{ 0 };
+	std::atomic<unsigned> vote_broadcast_count{ 0 };
 
 	nano::tally_t tally () const;
 	bool have_quorum (nano::tally_t const &) const;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -180,7 +180,7 @@ private:
 	mutable nano::uint128_t final_weight{ 0 };
 	mutable std::unordered_map<nano::block_hash, nano::uint128_t> last_tally;
 
-	nano::election_behavior const behavior_m;
+	nano::election_behavior behavior_m;
 	std::chrono::steady_clock::time_point const election_start{ std::chrono::steady_clock::now () };
 
 	mutable nano::mutex mutex;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -87,6 +87,7 @@ private: // State management
 public: // State transitions
 	bool transition_time (nano::confirmation_solicitor &);
 	void transition_active ();
+	bool transition_priority ();
 	void cancel ();
 
 public: // Status

--- a/nano/node/election_status.hpp
+++ b/nano/node/election_status.hpp
@@ -39,5 +39,14 @@ public:
 	unsigned block_count{ 0 };
 	unsigned voter_count{ 0 };
 	election_status_type type{ nano::election_status_type::inactive_confirmation_height };
+
+	election_status () = default;
+
+	election_status (std::shared_ptr<nano::block> block_a, election_status_type type_a = nano::election_status_type::ongoing) :
+		winner (block_a),
+		type (type_a)
+	{
+		block_count = 1;
+	}
 };
 }

--- a/nano/node/election_status.hpp
+++ b/nano/node/election_status.hpp
@@ -35,6 +35,7 @@ public:
 	std::chrono::milliseconds election_end{ std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()) };
 	std::chrono::milliseconds election_duration{ std::chrono::duration_values<std::chrono::milliseconds>::zero () };
 	unsigned confirmation_request_count{ 0 };
+	unsigned vote_broadcast_count{ 0 };
 	unsigned block_count{ 0 };
 	unsigned voter_count{ 0 };
 	election_status_type type{ nano::election_status_type::inactive_confirmation_height };

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1196,7 +1196,7 @@ void nano::json_handler::block_confirm ()
 			else
 			{
 				// Add record in confirmation history for confirmed block
-				nano::election_status status{ block_l, 0, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 1, 0, nano::election_status_type::active_confirmation_height };
+				nano::election_status status{ block_l, 0, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 0, 1, 0, nano::election_status_type::active_confirmation_height };
 				node.active.recently_cemented.put (status);
 				// Trigger callback for confirmed block
 				auto account = block_l->account ();

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1196,7 +1196,7 @@ void nano::json_handler::block_confirm ()
 			else
 			{
 				// Add record in confirmation history for confirmed block
-				nano::election_status status{ block_l, 0, 0, std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()), std::chrono::duration_values<std::chrono::milliseconds>::zero (), 0, 0, 1, 0, nano::election_status_type::active_confirmation_height };
+				nano::election_status status{ block_l, nano::election_status_type::active_confirmation_height };
 				node.active.recently_cemented.put (status);
 				// Trigger callback for confirmed block
 				auto account = block_l->account ();


### PR DESCRIPTION
Problem:
- Elections are currently immutable and can't be transitioned to priority status
- Causing delays for optimistic elections rescheduled by priority scheduler as the next Vote broadcast is fixed to 15-second intervals. (by `network.vote_broadcast_interval`)

Changes:
- Modifies election behavior to be mutable, allowing elections (optimistic/hinted/...) to be transitioned to priority status
- Added ability to trigger immediate vote broadcasts on transition without waiting for the next 15-second round

Benefits:
- It would allow for more aggressive use of optimistic elections (to narrow the gap between checked and cemented during bootstrapping) 
  - currently configured to accounts with gap_threshold of 32 could be reduced to 4
- Maintain quick response times for live traffic by allowing election behavior changes.