### PR TITLE
Fix timing issue in active_elections.fork_replacement_tally

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -901,6 +901,7 @@ TEST (active_elections, fork_replacement_tally)
 					 .build ();
 
 	// Forks without votes
+	std::shared_ptr<nano::election> election;
 	for (auto i (0); i < reps_count; i++)
 	{
 		auto fork = builder.make_block ()
@@ -913,10 +914,15 @@ TEST (active_elections, fork_replacement_tally)
 					.work (*system.work.generate (latest))
 					.build ();
 		node1.process_active (fork);
+
+		// Assert election exists on first iteration
+		if (i == 0)
+		{
+			ASSERT_TIMELY (5s, election = node1.active.election (fork->qualified_root ()));
+		}
 	}
 
 	// Check overflow of blocks
-	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node1.active.election (send_last->qualified_root ()));
 	ASSERT_TIMELY_EQ (5s, max_blocks, election->blocks ().size ());
 

--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -915,11 +915,8 @@ TEST (active_elections, fork_replacement_tally)
 					.build ();
 		node1.process_active (fork);
 
-		// Assert election exists on first iteration
-		if (i == 0)
-		{
-			ASSERT_TIMELY (5s, election = node1.active.election (fork->qualified_root ()));
-		}
+		// Assert election exists and is the same for each fork
+		ASSERT_TIMELY (1s, election = node1.active.election (fork->qualified_root ()));
 	}
 
 	// Check overflow of blocks


### PR DESCRIPTION
This testcase fails in ~10% of cases on my machine with
```
Expected equality of these values:
  max_blocks
    Which is: 10
  election->blocks ().size ()
    Which is: 1
```
By waiting for election insertion for the first block, before processing forks, this timing issue is eliminated.