### PR TITLE
Fix flaky inactive_votes_cache.election_start test

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -522,7 +522,8 @@ TEST (inactive_votes_cache, election_start)
 	node.vote_processor.vote (vote0, std::make_shared<nano::transport::inproc::channel> (node, node));
 	ASSERT_TIMELY_EQ (5s, 0, node.active.size ());
 	ASSERT_TIMELY_EQ (5s, 5, node.ledger.cemented_count ());
-	ASSERT_TRUE (nano::test::confirmed (node, { send1, send2, open1, open2 }));
+	// Confirmation on disk may lag behind cemented_count cache
+	ASSERT_TIMELY (5s, nano::test::confirmed (node, { send1, send2, open1, open2 }));
 
 	// A late block arrival also checks the inactive votes cache
 	ASSERT_TRUE (node.active.empty ());


### PR DESCRIPTION
This testcase fails sometimes on the github runners. And in ~1/1000 cases on my machine.

`nano::test::confirmed () ` checks for confirmation being written to disk while node.ledger.cemented_count () uses cached cemented_count.

Use ASSERT_TIMELY to give some time for disk I/O completion.