### PR TITLE
Reduce likelyhood of race in node.fork_publish

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -522,13 +522,13 @@ TEST (node, fork_publish)
 				 .build ();
 	node1.work_generate_blocking (*send2);
 	node1.process_active (send1);
+	node1.process_active (send2);
 	ASSERT_TIMELY_EQ (5s, 1, node1.active.size ());
+	ASSERT_TIMELY (5s, node1.active.active (*send2));
 	auto election (node1.active.election (send1->qualified_root ()));
 	ASSERT_NE (nullptr, election);
 	// Wait until the genesis rep activated & makes vote
 	ASSERT_TIMELY_EQ (1s, election->votes ().size (), 2);
-	node1.process_active (send2);
-	ASSERT_TIMELY (5s, node1.active.active (*send2));
 	auto votes1 (election->votes ());
 	auto existing1 (votes1.find (nano::dev::genesis_key.pub));
 	ASSERT_NE (votes1.end (), existing1);

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -49,10 +49,10 @@ namespace test
 		/** Generate work with difficulty between \p min_difficulty_a (inclusive) and \p max_difficulty_a (exclusive) */
 		uint64_t work_generate_limited (nano::block_hash const & root_a, uint64_t min_difficulty_a, uint64_t max_difficulty_a);
 		/**
-		 * Polls, sleep if there's no work to be done (default 50ms), then check the deadline
+		 * Polls, sleep if there's no work to be done (default 10ms), then check the deadline
 		 * @returns 0 or nano::deadline_expired
 		 */
-		std::error_code poll (std::chrono::nanoseconds const & sleep_time = std::chrono::milliseconds (50));
+		std::error_code poll (std::chrono::nanoseconds const & sleep_time = std::chrono::milliseconds (10));
 		std::error_code poll_until_true (std::chrono::nanoseconds deadline, std::function<bool ()>);
 		void delay_ms (std::chrono::milliseconds const & delay);
 		void deadline_set (std::chrono::duration<double, std::nano> const & delta);


### PR DESCRIPTION
This testcase fails a lot on windows github runners and in **~3%** locally.

1. Reorder block processing in direct succession to increase likelihood of fork handling before election confirmation. (With this change alone the testcase fails in ~**0.2%**)

2. Reduce default poll interval from 50ms to 10ms to reduce internal node operations between 2 polls. (With this change alone the testcase fails in ~**0.2%**)

Both changes are needed - Reordering alone or poll interval changes alone were insufficient. With both changes applied, test passes reliably (10000/10000).