### PR TITLE
Enable debug logging for core tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -35,6 +35,9 @@ jobs:
         if: steps.build.outcome == 'success' && (success() || failure())
         run: ../ci/tests/run-core-tests.sh
         working-directory: build
+        env:
+          NANO_LOG_STATS: 1
+          NANO_LOG: debug
 
       - name: RPC Tests
         if: steps.build.outcome == 'success' && (success() || failure())
@@ -81,6 +84,9 @@ jobs:
         if: steps.build.outcome == 'success' && (success() || failure())
         run: ../ci/tests/run-core-tests.sh
         working-directory: build
+        env:
+          NANO_LOG_STATS: 1
+          NANO_LOG: debug
 
       - name: RPC Tests
         if: steps.build.outcome == 'success' && (success() || failure())
@@ -132,6 +138,9 @@ jobs:
         run: ../ci/tests/run-core-tests.sh
         working-directory: build
         shell: bash
+        env:
+          NANO_LOG_STATS: 1
+          NANO_LOG: debug
 
       - name: RPC Tests
         if: steps.build.outcome == 'success' && (success() || failure())

--- a/ci/tests/run-gtest-parallel.sh
+++ b/ci/tests/run-gtest-parallel.sh
@@ -11,11 +11,14 @@ fi
 
 executable=./${target}$(get_exec_extension)
 
-# Check if gtest-parallel is available
-if command -v gtest-parallel >/dev/null 2>&1; then
+# Get the project root directory (2 levels up from ci/tests)
+PROJECT_ROOT="$(cd "$(dirname "$BASH_SOURCE")/../.." && pwd)"
+GTEST_PARALLEL="${PROJECT_ROOT}/submodules/gtest-parallel/gtest-parallel"
+
+if [ -f "${GTEST_PARALLEL}" ]; then
     echo "Running tests with gtest-parallel for target: ${target}"
-    gtest-parallel "${executable}" --worker=1
+    "${GTEST_PARALLEL}" "${executable}" --worker=1
 else
-    echo "gtest-parallel not found, running tests directly for target: ${target}"
+    echo "gtest-parallel not found at ${GTEST_PARALLEL}, running tests directly for target: ${target}"
     "${executable}"
 fi 

--- a/ci/tests/run-gtest-parallel.sh
+++ b/ci/tests/run-gtest-parallel.sh
@@ -3,23 +3,27 @@ set -euo pipefail
 
 source "$(dirname "$BASH_SOURCE")/common.sh"
 
-target=$1
-if [ -z "${target-}" ]; then
-    echo "Target not specified"
+executable=$1
+if [ -z "${executable-}" ]; then
+    echo "Executable not specified"
     exit 1
 fi
 
 shift
-executable=./${target}$(get_exec_extension)
 
 # Get the project root directory (2 levels up from ci/tests)
 PROJECT_ROOT="$(cd "$(dirname "$BASH_SOURCE")/../.." && pwd)"
 GTEST_PARALLEL="${PROJECT_ROOT}/submodules/gtest-parallel/gtest-parallel"
 
 if [ -f "${GTEST_PARALLEL}" ]; then
-    echo "Running tests with gtest-parallel for target: ${target}"
+    echo "Running tests with gtest-parallel for executable: ${executable}"
     "${GTEST_PARALLEL}" "${executable}" --worker=1 "$@"
+    test_status=$?
 else
-    echo "gtest-parallel not found at ${GTEST_PARALLEL}, running tests directly for target: ${target}"
+    echo "gtest-parallel not found at ${GTEST_PARALLEL}, running tests directly for executable: ${executable}"
     "${executable}" "$@"
-fi 
+    test_status=$?
+fi
+
+# Return the original test exit status
+exit $test_status

--- a/ci/tests/run-gtest-parallel.sh
+++ b/ci/tests/run-gtest-parallel.sh
@@ -9,6 +9,7 @@ if [ -z "${target-}" ]; then
     exit 1
 fi
 
+shift
 executable=./${target}$(get_exec_extension)
 
 # Get the project root directory (2 levels up from ci/tests)
@@ -17,8 +18,8 @@ GTEST_PARALLEL="${PROJECT_ROOT}/submodules/gtest-parallel/gtest-parallel"
 
 if [ -f "${GTEST_PARALLEL}" ]; then
     echo "Running tests with gtest-parallel for target: ${target}"
-    "${GTEST_PARALLEL}" "${executable}" --worker=1
+    "${GTEST_PARALLEL}" "${executable}" --worker=1 "$@"
 else
     echo "gtest-parallel not found at ${GTEST_PARALLEL}, running tests directly for target: ${target}"
-    "${executable}"
+    "${executable}" "$@"
 fi 

--- a/ci/tests/run-gtest-parallel.sh
+++ b/ci/tests/run-gtest-parallel.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euo pipefail
+
+source "$(dirname "$BASH_SOURCE")/common.sh"
+
+target=$1
+if [ -z "${target-}" ]; then
+    echo "Target not specified"
+    exit 1
+fi
+
+executable=./${target}$(get_exec_extension)
+
+# Check if gtest-parallel is available
+if command -v gtest-parallel >/dev/null 2>&1; then
+    echo "Running tests with gtest-parallel for target: ${target}"
+    gtest-parallel "${executable}" --worker=1
+else
+    echo "gtest-parallel not found, running tests directly for target: ${target}"
+    "${executable}"
+fi 

--- a/ci/tests/run-tests.sh
+++ b/ci/tests/run-tests.sh
@@ -46,10 +46,10 @@ case "$(uname -s)" in
         ;;
 esac
 
-# Run the test
+# Run the test using gtest-parallel helper
 shift
 executable=./${target}$(get_exec_extension)
-"${executable}" "$@"
+"$(dirname "$BASH_SOURCE")/run-gtest-parallel.sh" "${target}" "$@"
 status=$?
 
 if [ $status -ne 0 ]; then

--- a/ci/tests/run-tests.sh
+++ b/ci/tests/run-tests.sh
@@ -46,10 +46,11 @@ case "$(uname -s)" in
         ;;
 esac
 
-# Run the test using gtest-parallel helper
 shift
 executable=./${target}$(get_exec_extension)
-"$(dirname "$BASH_SOURCE")/run-gtest-parallel.sh" "${target}" "$@"
+
+# Run the test using gtest-parallel helper
+"$(dirname "$BASH_SOURCE")/run-gtest-parallel.sh" "${executable}" "$@"
 status=$?
 
 if [ $status -ne 0 ]; then


### PR DESCRIPTION
Failures on GitHub runners are sometimes hard to reproduce locally. Adding detailed logging helps analyze test failures directly from CI logs.

- Enables NANO_LOG_STATS and debug level logging for core tests across all CI platforms
- Helps diagnose intermittent test failures by providing more detailed execution traces