### PR TITLE
Upgrade to C++23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,7 +364,7 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 # set(CMAKE_C_EXTENSIONS OFF)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -536,6 +536,13 @@ else()
       CACHE BOOL "" FORCE)
 endif()
 add_subdirectory(submodules/rocksdb EXCLUDE_FROM_ALL)
+
+# RocksDB does not support C++23 at this time
+set_target_properties(
+  rocksdb
+  PROPERTIES CXX_STANDARD 20
+             CXX_STANDARD_REQUIRED ON
+             CXX_EXTENSIONS OFF)
 
 # cpptoml
 include_directories(submodules/cpptoml/include)


### PR DESCRIPTION
Compiler support for C++23 features is still a bit patchy, but since it's almost 2025 I think we should keep the pace with cpp releases.