### PR TITLE
Cleanup `tcp_config` class

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -118,7 +118,7 @@ TEST (network, last_contacted)
 	ASSERT_EQ (0, node0->network.size ());
 
 	nano::node_config node1_config = system.default_config ();
-	node1_config.tcp_incoming_connections_max = 0; // Prevent ephemeral node1->node0 channel repacement with incoming connection
+	node1_config.tcp.max_inbound_connections = 0; // Prevent ephemeral node1->node0 channel repacement with incoming connection
 	auto node1 (std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), node1_config, system.work));
 	node1->start ();
 	system.nodes.push_back (node1);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2603,7 +2603,7 @@ TEST (node, bidirectional_tcp)
 	node_config.backlog_scan.enable = false;
 	auto node1 = system.add_node (node_config, node_flags);
 	node_config.peering_port = system.get_available_port ();
-	node_config.tcp_incoming_connections_max = 0; // Disable incoming TCP connections for node 2
+	node_config.tcp.max_inbound_connections = 0; // Disable incoming TCP connections for node 2
 	auto node2 = system.add_node (node_config, node_flags);
 	// Check network connections
 	ASSERT_EQ (1, node1->network.size ());

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -305,7 +305,6 @@ TEST (toml_config, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.preconfigured_representatives, defaults.node.preconfigured_representatives);
 	ASSERT_EQ (conf.node.receive_minimum, defaults.node.receive_minimum);
 	ASSERT_EQ (conf.node.signature_checker_threads, defaults.node.signature_checker_threads);
-	ASSERT_EQ (conf.node.tcp_incoming_connections_max, defaults.node.tcp_incoming_connections_max);
 	ASSERT_EQ (conf.node.tcp_io_timeout, defaults.node.tcp_io_timeout);
 	ASSERT_EQ (conf.node.unchecked_cutoff_time, defaults.node.unchecked_cutoff_time);
 	ASSERT_EQ (conf.node.use_memory_pools, defaults.node.use_memory_pools);
@@ -458,7 +457,6 @@ TEST (toml_config, daemon_config_deserialize_no_defaults)
 	preconfigured_representatives = ["nano_3arg3asgtigae3xckabaaewkx3bzsh7nwz7jkmjos79ihyaxwphhm6qgjps4"]
 	receive_minimum = "999"
 	signature_checker_threads = 999
-	tcp_incoming_connections_max = 999
 	tcp_io_timeout = 999
 	unchecked_cutoff_time = 999
 	use_memory_pools = false
@@ -710,7 +708,6 @@ TEST (toml_config, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.preconfigured_representatives, defaults.node.preconfigured_representatives);
 	ASSERT_NE (conf.node.receive_minimum, defaults.node.receive_minimum);
 	ASSERT_NE (conf.node.signature_checker_threads, defaults.node.signature_checker_threads);
-	ASSERT_NE (conf.node.tcp_incoming_connections_max, defaults.node.tcp_incoming_connections_max);
 	ASSERT_NE (conf.node.tcp_io_timeout, defaults.node.tcp_io_timeout);
 	ASSERT_NE (conf.node.unchecked_cutoff_time, defaults.node.unchecked_cutoff_time);
 	ASSERT_NE (conf.node.use_memory_pools, defaults.node.use_memory_pools);

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -250,6 +250,7 @@ TEST (toml_config, daemon_config_deserialize_defaults)
 	[node.websocket]
 	[node.lmdb]
 	[node.rocksdb]
+	[node.tcp]
 	[opencl]
 	[rpc]
 	[rpc.child_process]
@@ -417,6 +418,14 @@ TEST (toml_config, daemon_config_deserialize_defaults)
 
 	ASSERT_EQ (conf.node.message_processor.threads, defaults.node.message_processor.threads);
 	ASSERT_EQ (conf.node.message_processor.max_queue, defaults.node.message_processor.max_queue);
+
+	ASSERT_EQ (conf.node.tcp.max_inbound_connections, defaults.node.tcp.max_inbound_connections);
+	ASSERT_EQ (conf.node.tcp.max_outbound_connections, defaults.node.tcp.max_outbound_connections);
+	ASSERT_EQ (conf.node.tcp.max_attempts, defaults.node.tcp.max_attempts);
+	ASSERT_EQ (conf.node.tcp.max_attempts_per_ip, defaults.node.tcp.max_attempts_per_ip);
+	ASSERT_EQ (conf.node.tcp.connect_timeout, defaults.node.tcp.connect_timeout);
+	ASSERT_EQ (conf.node.tcp.handshake_timeout, defaults.node.tcp.handshake_timeout);
+	ASSERT_EQ (conf.node.tcp.io_timeout, defaults.node.tcp.io_timeout);
 }
 
 /** Deserialize a node config with non-default values */
@@ -639,6 +648,15 @@ TEST (toml_config, daemon_config_deserialize_no_defaults)
 	threads = 999
 	max_queue = 999
 
+	[node.tcp]
+	max_inbound_connections = 999
+	max_outbound_connections = 999
+	max_attempts = 999
+	max_attempts_per_ip = 999
+	connect_timeout = 999
+	handshake_timeout = 999
+	io_timeout = 999
+
 	[opencl]
 	device = 999
 	enable = true
@@ -820,6 +838,14 @@ TEST (toml_config, daemon_config_deserialize_no_defaults)
 
 	ASSERT_NE (conf.node.message_processor.threads, defaults.node.message_processor.threads);
 	ASSERT_NE (conf.node.message_processor.max_queue, defaults.node.message_processor.max_queue);
+
+	ASSERT_NE (conf.node.tcp.max_inbound_connections, defaults.node.tcp.max_inbound_connections);
+	ASSERT_NE (conf.node.tcp.max_outbound_connections, defaults.node.tcp.max_outbound_connections);
+	ASSERT_NE (conf.node.tcp.max_attempts, defaults.node.tcp.max_attempts);
+	ASSERT_NE (conf.node.tcp.max_attempts_per_ip, defaults.node.tcp.max_attempts_per_ip);
+	ASSERT_NE (conf.node.tcp.connect_timeout, defaults.node.tcp.connect_timeout);
+	ASSERT_NE (conf.node.tcp.handshake_timeout, defaults.node.tcp.handshake_timeout);
+	ASSERT_NE (conf.node.tcp.io_timeout, defaults.node.tcp.io_timeout);
 }
 
 /** There should be no required values **/

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -164,6 +164,8 @@ add_library(
   transport/message_deserializer.cpp
   transport/tcp_channels.hpp
   transport/tcp_channels.cpp
+  transport/tcp_config.hpp
+  transport/tcp_config.cpp
   transport/tcp_listener.hpp
   transport/tcp_listener.cpp
   transport/tcp_server.hpp

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -607,7 +607,7 @@ void nano::node::start ()
 	}
 
 	bool tcp_enabled = false;
-	if (config.tcp_incoming_connections_max > 0 && !(flags.disable_bootstrap_listener && flags.disable_tcp_realtime))
+	if (!(flags.disable_bootstrap_listener && flags.disable_tcp_realtime))
 	{
 		tcp_listener.start ();
 		tcp_enabled = true;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -246,6 +246,10 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	peer_history.serialize (peer_history_l);
 	toml.put_child ("peer_history", peer_history_l);
 
+	nano::tomlconfig tcp_l;
+	tcp.serialize (tcp_l);
+	toml.put_child ("tcp", tcp_l);
+
 	nano::tomlconfig request_aggregator_l;
 	request_aggregator.serialize (request_aggregator_l);
 	toml.put_child ("request_aggregator", request_aggregator_l);
@@ -379,6 +383,12 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			auto config_l = toml.get_required_child ("peer_history");
 			peer_history.deserialize (config_l);
+		}
+
+		if (toml.has_key ("tcp"))
+		{
+			auto config_l = toml.get_required_child ("tcp");
+			tcp.deserialize (config_l);
 		}
 
 		if (toml.has_key ("request_aggregator"))

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -125,7 +125,6 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("pow_sleep_interval", pow_sleep_interval.count (), "Time to sleep between batch work generation attempts. Reduces max CPU usage at the expense of a longer generation time.\ntype:nanoseconds");
 	toml.put ("external_address", external_address, "The external address of this node (NAT). If not set, the node will request this information via UPnP.\ntype:string,ip");
 	toml.put ("external_port", external_port, "The external port number of this node (NAT). Only used if external_address is set.\ntype:uint16");
-	toml.put ("tcp_incoming_connections_max", tcp_incoming_connections_max, "Maximum number of incoming TCP connections.\ntype:uint64");
 	toml.put ("use_memory_pools", use_memory_pools, "If true, allocate memory from memory pools. Enabling this may improve performance. Memory is never released to the OS.\ntype:bool");
 
 	toml.put ("bandwidth_limit", bandwidth_limit, "Outbound traffic limit in bytes/sec after which messages will be dropped.\nNote: changing to unlimited bandwidth (0) is not recommended for limited connections.\ntype:uint64");
@@ -538,7 +537,6 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		toml.get<boost::asio::ip::address_v6> ("external_address", external_address_l);
 		external_address = external_address_l.to_string ();
 		toml.get<uint16_t> ("external_port", external_port);
-		toml.get<unsigned> ("tcp_incoming_connections_max", tcp_incoming_connections_max);
 
 		auto pow_sleep_interval_l (pow_sleep_interval.count ());
 		toml.get (pow_sleep_interval_key, pow_sleep_interval_l);

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -27,6 +27,7 @@
 #include <nano/node/scheduler/hinted.hpp>
 #include <nano/node/scheduler/optimistic.hpp>
 #include <nano/node/scheduler/priority.hpp>
+#include <nano/node/transport/tcp_config.hpp>
 #include <nano/node/transport/tcp_listener.hpp>
 #include <nano/node/vote_cache.hpp>
 #include <nano/node/vote_processor.hpp>
@@ -109,8 +110,6 @@ public:
 	std::chrono::seconds tcp_io_timeout{ (network_params.network.is_dev_network () && !is_sanitizer_build ()) ? std::chrono::seconds (5) : std::chrono::seconds (15) };
 	std::chrono::nanoseconds pow_sleep_interval{ 0 };
 
-	/** Default maximum incoming TCP connections, including realtime network & bootstrap */
-	unsigned tcp_incoming_connections_max{ 2048 };
 	bool use_memory_pools{ true };
 	static std::chrono::minutes constexpr wallet_backup_interval = std::chrono::minutes (5);
 	/** Default outbound traffic shaping is 10MB/s */

--- a/nano/node/transport/tcp_config.cpp
+++ b/nano/node/transport/tcp_config.cpp
@@ -1,0 +1,1 @@
+#include <nano/node/transport/tcp_config.hpp>

--- a/nano/node/transport/tcp_config.cpp
+++ b/nano/node/transport/tcp_config.cpp
@@ -1,1 +1,29 @@
 #include <nano/node/transport/tcp_config.hpp>
+
+nano::error nano::transport::tcp_config::serialize (nano::tomlconfig & toml) const
+{
+	toml.put ("max_inbound_connections", max_inbound_connections, "Maximum number of incoming TCP connections. \ntype:uint64");
+	toml.put ("max_outbound_connections", max_outbound_connections, "Maximum number of outgoing TCP connections. \ntype:uint64");
+	toml.put ("max_attempts", max_attempts, "Maximum connection attempts. \ntype:uint64");
+	toml.put ("max_attempts_per_ip", max_attempts_per_ip, "Maximum connection attempts per IP. \ntype:uint64");
+
+	toml.put ("connect_timeout", connect_timeout.count (), "Timeout for establishing TCP connection in seconds. \ntype:uint64");
+	toml.put ("handshake_timeout", handshake_timeout.count (), "Timeout for completing handshake in seconds. \ntype:uint64");
+	toml.put ("io_timeout", io_timeout.count (), "Timeout for TCP I/O operations in seconds. \ntype:uint64");
+
+	return toml.get_error ();
+}
+
+nano::error nano::transport::tcp_config::deserialize (nano::tomlconfig & toml)
+{
+	toml.get ("max_inbound_connections", max_inbound_connections);
+	toml.get ("max_outbound_connections", max_outbound_connections);
+	toml.get ("max_attempts", max_attempts);
+	toml.get ("max_attempts_per_ip", max_attempts_per_ip);
+
+	toml.get_duration ("connect_timeout", connect_timeout);
+	toml.get_duration ("handshake_timeout", handshake_timeout);
+	toml.get_duration ("io_timeout", io_timeout);
+
+	return toml.get_error ();
+}

--- a/nano/node/transport/tcp_config.hpp
+++ b/nano/node/transport/tcp_config.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <nano/lib/config.hpp>
+
+#include <chrono>
+
+namespace nano::transport
+{
+class tcp_config
+{
+public:
+	explicit tcp_config (nano::network_constants const & network)
+	{
+		if (network.is_dev_network ())
+		{
+			max_inbound_connections = 128;
+			max_outbound_connections = 128;
+			max_attempts = 128;
+			max_attempts_per_ip = 128;
+			connect_timeout = std::chrono::seconds{ 5 };
+		}
+	}
+
+public:
+	size_t max_inbound_connections{ 2048 };
+	size_t max_outbound_connections{ 2048 };
+	size_t max_attempts{ 60 };
+	size_t max_attempts_per_ip{ 1 };
+	std::chrono::seconds connect_timeout{ 60 };
+	std::chrono::seconds handshake_timeout{ 30 };
+	std::chrono::seconds io_timeout{ 30 };
+};
+}

--- a/nano/node/transport/tcp_config.hpp
+++ b/nano/node/transport/tcp_config.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/config.hpp>
+#include <nano/lib/constants.hpp>
 
 #include <chrono>
 
@@ -20,6 +21,9 @@ public:
 			connect_timeout = std::chrono::seconds{ 5 };
 		}
 	}
+
+public:
+	// TODO: Serialize/deserialize
 
 public:
 	size_t max_inbound_connections{ 2048 };

--- a/nano/node/transport/tcp_config.hpp
+++ b/nano/node/transport/tcp_config.hpp
@@ -23,7 +23,8 @@ public:
 	}
 
 public:
-	// TODO: Serialize/deserialize
+	nano::error deserialize (nano::tomlconfig &);
+	nano::error serialize (nano::tomlconfig &) const;
 
 public:
 	size_t max_inbound_connections{ 2048 };

--- a/nano/node/transport/tcp_listener.hpp
+++ b/nano/node/transport/tcp_listener.hpp
@@ -6,6 +6,7 @@
 #include <nano/node/endpoint.hpp>
 #include <nano/node/fwd.hpp>
 #include <nano/node/transport/common.hpp>
+#include <nano/node/transport/tcp_config.hpp>
 
 #include <boost/asio.hpp>
 #include <boost/multi_index/hashed_index.hpp>
@@ -24,29 +25,6 @@ namespace asio = boost::asio;
 
 namespace nano::transport
 {
-class tcp_config
-{
-public:
-	explicit tcp_config (nano::network_constants const & network)
-	{
-		if (network.is_dev_network ())
-		{
-			max_inbound_connections = 128;
-			max_outbound_connections = 128;
-			max_attempts = 128;
-			max_attempts_per_ip = 128;
-			connect_timeout = std::chrono::seconds{ 5 };
-		}
-	}
-
-public:
-	size_t max_inbound_connections{ 2048 };
-	size_t max_outbound_connections{ 2048 };
-	size_t max_attempts{ 60 };
-	size_t max_attempts_per_ip{ 1 };
-	std::chrono::seconds connect_timeout{ 60 };
-};
-
 /**
  * Server side portion of tcp sessions. Listens for new socket connections and spawns tcp_server objects when connected.
  */


### PR DESCRIPTION
This moves `tcp_config` class to a dedicated file, implements serialize & deserialize functions and adds necessary tests.