### PR TITLE
Move http callbacks logic out of node class

### DIFF
--- a/nano/lib/interval.hpp
+++ b/nano/lib/interval.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <chrono>
+#include <mutex>
 
 namespace nano
 {
 class interval
 {
 public:
-	bool elapsed (auto target)
+	bool elapse (auto target)
 	{
 		auto const now = std::chrono::steady_clock::now ();
 		if (now - last >= target)
@@ -19,6 +20,26 @@ public:
 	}
 
 private:
+	std::chrono::steady_clock::time_point last{ std::chrono::steady_clock::now () };
+};
+
+class interval_mt
+{
+public:
+	bool elapse (auto target)
+	{
+		std::lock_guard guard{ mutex };
+		auto const now = std::chrono::steady_clock::now ();
+		if (now - last >= target)
+		{
+			last = now;
+			return true;
+		}
+		return false;
+	}
+
+private:
+	std::mutex mutex;
 	std::chrono::steady_clock::time_point last{ std::chrono::steady_clock::now () };
 };
 }

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -39,7 +39,7 @@ enum class type
 	qt,
 	rpc,
 	rpc_connection,
-	rpc_callbacks,
+	http_callbacks,
 	rpc_request,
 	ipc,
 	ipc_server,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -638,6 +638,7 @@ enum class detail
 
 	// http_callbacks
 	block_confirmed,
+	large_backlog,
 
 	_last // Must be the last enum
 };

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -26,7 +26,9 @@ enum class type
 	election,
 	election_cleanup,
 	election_vote,
-	http_callback,
+	http_callbacks,
+	http_callbacks_notified,
+	http_callbacks_ec,
 	ipc,
 	tcp,
 	tcp_server,
@@ -166,6 +168,8 @@ enum class detail
 	other,
 	drop,
 	queued,
+	error,
+	failed,
 
 	// processing queue
 	queue,
@@ -624,6 +628,16 @@ enum class detail
 	timed_out,
 	host_unreachable,
 	not_supported,
+
+	// http
+	error_resolving,
+	error_connecting,
+	error_sending,
+	error_completing,
+	bad_status,
+
+	// http_callbacks
+	block_confirmed,
 
 	_last // Must be the last enum
 };

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -190,6 +190,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::monitor:
 			thread_role_name_string = "Monitor";
 			break;
+		case nano::thread_role::name::http_callbacks:
+			thread_role_name_string = "HTTP callbacks";
+			break;
 		default:
 			debug_assert (false && "nano::thread_role::get_string unhandled thread role");
 	}

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -68,6 +68,7 @@ enum class name
 	vote_router,
 	online_reps,
 	monitor,
+	http_callbacks,
 };
 
 std::string_view to_string (name);

--- a/nano/lib/uniquer.hpp
+++ b/nano/lib/uniquer.hpp
@@ -27,7 +27,7 @@ public:
 
 		nano::lock_guard<nano::mutex> guard{ mutex };
 
-		if (cleanup_interval.elapsed (cleanup_cutoff))
+		if (cleanup_interval.elapse (cleanup_cutoff))
 		{
 			cleanup ();
 		}

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -135,6 +135,8 @@ add_library(
   rep_tiers.cpp
   request_aggregator.hpp
   request_aggregator.cpp
+  rpc_callbacks.hpp
+  rpc_callbacks.cpp
   scheduler/bucket.cpp
   scheduler/bucket.hpp
   scheduler/component.hpp

--- a/nano/node/block_processor.cpp
+++ b/nano/node/block_processor.cpp
@@ -223,7 +223,7 @@ void nano::block_processor::run ()
 				}
 			}
 
-			if (log_interval.elapsed (15s))
+			if (log_interval.elapse (15s))
 			{
 				logger.info (nano::log::type::block_processor, "{} blocks (+ {} forced) in processing queue",
 				queue.size (),

--- a/nano/node/bootstrap/bootstrap_service.cpp
+++ b/nano/node/bootstrap/bootstrap_service.cpp
@@ -727,7 +727,7 @@ void nano::bootstrap_service::cleanup_and_sync ()
 		tags_by_order.pop_front ();
 	}
 
-	if (sync_dependencies_interval.elapsed (60s))
+	if (sync_dependencies_interval.elapse (60s))
 	{
 		stats.inc (nano::stat::type::bootstrap, nano::stat::detail::sync_dependencies);
 		accounts.sync_dependencies ();

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -33,7 +33,7 @@ class recently_cemented_cache;
 class recently_confirmed_cache;
 class rep_crawler;
 class rep_tiers;
-class rpc_callbacks;
+class http_callbacks;
 class telemetry;
 class unchecked_map;
 class stats;

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -33,6 +33,7 @@ class recently_cemented_cache;
 class recently_confirmed_cache;
 class rep_crawler;
 class rep_tiers;
+class rpc_callbacks;
 class telemetry;
 class unchecked_map;
 class stats;

--- a/nano/node/local_block_broadcaster.cpp
+++ b/nano/node/local_block_broadcaster.cpp
@@ -127,7 +127,7 @@ void nano::local_block_broadcaster::run ()
 		{
 			stats.inc (nano::stat::type::local_block_broadcaster, nano::stat::detail::loop);
 
-			if (cleanup_interval.elapsed (config.cleanup_interval))
+			if (cleanup_interval.elapse (config.cleanup_interval))
 			{
 				cleanup (lock);
 				debug_assert (lock.owns_lock ());

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -194,8 +194,8 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	peer_history{ *peer_history_impl },
 	monitor_impl{ std::make_unique<nano::monitor> (config.monitor, *this) },
 	monitor{ *monitor_impl },
-	rpc_callbacks_impl{ std::make_unique<nano::rpc_callbacks> (*this) },
-	rpc_callbacks{ *rpc_callbacks_impl },
+	http_callbacks_impl{ std::make_unique<nano::http_callbacks> (*this) },
+	http_callbacks{ *http_callbacks_impl },
 	startup_time{ std::chrono::steady_clock::now () },
 	node_seq{ seq }
 {

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -558,6 +558,7 @@ void nano::node::start ()
 	vote_router.start ();
 	online_reps.start ();
 	monitor.start ();
+	http_callbacks.start ();
 
 	add_initial_peers ();
 }
@@ -605,6 +606,7 @@ void nano::node::stop ()
 	message_processor.stop ();
 	network.stop ();
 	monitor.stop ();
+	http_callbacks.stop ();
 
 	bootstrap_workers.stop ();
 	wallet_workers.stop ();
@@ -1075,6 +1077,7 @@ nano::container_info nano::node::container_info () const
 	info.add ("bandwidth", outbound_limiter.container_info ());
 	info.add ("backlog_scan", backlog_scan.container_info ());
 	info.add ("bounded_backlog", backlog.container_info ());
+	info.add ("http_callbacks", http_callbacks.container_info ());
 	return info;
 }
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -30,6 +30,7 @@
 #include <nano/node/peer_history.hpp>
 #include <nano/node/portmapping.hpp>
 #include <nano/node/request_aggregator.hpp>
+#include <nano/node/rpc_callbacks.hpp>
 #include <nano/node/scheduler/component.hpp>
 #include <nano/node/scheduler/hinted.hpp>
 #include <nano/node/scheduler/manual.hpp>
@@ -193,6 +194,8 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	peer_history{ *peer_history_impl },
 	monitor_impl{ std::make_unique<nano::monitor> (config.monitor, *this) },
 	monitor{ *monitor_impl },
+	rpc_callbacks_impl{ std::make_unique<nano::rpc_callbacks> (*this) },
+	rpc_callbacks{ *rpc_callbacks_impl },
 	startup_time{ std::chrono::steady_clock::now () },
 	node_seq{ seq }
 {
@@ -250,66 +253,6 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 		network.disconnect_observer = [this] () {
 			observers.disconnect.notify ();
 		};
-		if (!config.callback_address.empty ())
-		{
-			observers.blocks.add ([this] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const & votes_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a, bool is_state_epoch_a) {
-				auto block_a (status_a.winner);
-				if ((status_a.type == nano::election_status_type::active_confirmed_quorum || status_a.type == nano::election_status_type::active_confirmation_height))
-				{
-					auto node_l (shared_from_this ());
-					io_ctx.post ([node_l, block_a, account_a, amount_a, is_state_send_a, is_state_epoch_a] () {
-						boost::property_tree::ptree event;
-						event.add ("account", account_a.to_account ());
-						event.add ("hash", block_a->hash ().to_string ());
-						std::string block_text;
-						block_a->serialize_json (block_text);
-						event.add ("block", block_text);
-						event.add ("amount", amount_a.to_string_dec ());
-						if (is_state_send_a)
-						{
-							event.add ("is_send", is_state_send_a);
-							event.add ("subtype", "send");
-						}
-						// Subtype field
-						else if (block_a->type () == nano::block_type::state)
-						{
-							if (block_a->is_change ())
-							{
-								event.add ("subtype", "change");
-							}
-							else if (is_state_epoch_a)
-							{
-								debug_assert (amount_a == 0 && node_l->ledger.is_epoch_link (block_a->link_field ().value ()));
-								event.add ("subtype", "epoch");
-							}
-							else
-							{
-								event.add ("subtype", "receive");
-							}
-						}
-						std::stringstream ostream;
-						boost::property_tree::write_json (ostream, event);
-						ostream.flush ();
-						auto body (std::make_shared<std::string> (ostream.str ()));
-						auto address (node_l->config.callback_address);
-						auto port (node_l->config.callback_port);
-						auto target (std::make_shared<std::string> (node_l->config.callback_target));
-						auto resolver (std::make_shared<boost::asio::ip::tcp::resolver> (node_l->io_ctx));
-						resolver->async_resolve (boost::asio::ip::tcp::resolver::query (address, std::to_string (port)), [node_l, address, port, target, body, resolver] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator i_a) {
-							if (!ec)
-							{
-								node_l->do_rpc_callback (i_a, address, port, target, body, resolver);
-							}
-							else
-							{
-								node_l->logger.error (nano::log::type::rpc_callbacks, "Error resolving callback: {}:{} ({})", address, port, ec.message ());
-								node_l->stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
-							}
-						});
-					});
-				}
-			});
-		}
 
 		observers.channel_connected.add ([this] (std::shared_ptr<nano::transport::channel> const & channel) {
 			network.send_keepalive_self (channel);
@@ -470,68 +413,6 @@ nano::node::~node ()
 {
 	logger.debug (nano::log::type::node, "Destructing node...");
 	stop ();
-}
-
-// TODO: Move to a separate class
-void nano::node::do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const & address, uint16_t port, std::shared_ptr<std::string> const & target, std::shared_ptr<std::string> const & body, std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
-{
-	if (i_a != boost::asio::ip::tcp::resolver::iterator{})
-	{
-		auto node_l (shared_from_this ());
-		auto sock (std::make_shared<boost::asio::ip::tcp::socket> (node_l->io_ctx));
-		sock->async_connect (i_a->endpoint (), [node_l, target, body, sock, address, port, i_a, resolver] (boost::system::error_code const & ec) mutable {
-			if (!ec)
-			{
-				auto req (std::make_shared<boost::beast::http::request<boost::beast::http::string_body>> ());
-				req->method (boost::beast::http::verb::post);
-				req->target (*target);
-				req->version (11);
-				req->insert (boost::beast::http::field::host, address);
-				req->insert (boost::beast::http::field::content_type, "application/json");
-				req->body () = *body;
-				req->prepare_payload ();
-				boost::beast::http::async_write (*sock, *req, [node_l, sock, address, port, req, i_a, target, body, resolver] (boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
-					if (!ec)
-					{
-						auto sb (std::make_shared<boost::beast::flat_buffer> ());
-						auto resp (std::make_shared<boost::beast::http::response<boost::beast::http::string_body>> ());
-						boost::beast::http::async_read (*sock, *sb, *resp, [node_l, sb, resp, sock, address, port, i_a, target, body, resolver] (boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
-							if (!ec)
-							{
-								if (boost::beast::http::to_status_class (resp->result ()) == boost::beast::http::status_class::successful)
-								{
-									node_l->stats.inc (nano::stat::type::http_callback, nano::stat::detail::initiate, nano::stat::dir::out);
-								}
-								else
-								{
-									node_l->logger.error (nano::log::type::rpc_callbacks, "Callback to {}:{} failed [status: {}]", address, port, nano::util::to_str (resp->result ()));
-									node_l->stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
-								}
-							}
-							else
-							{
-								node_l->logger.error (nano::log::type::rpc_callbacks, "Unable to complete callback: {}:{} ({})", address, port, ec.message ());
-								node_l->stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
-							};
-						});
-					}
-					else
-					{
-						node_l->logger.error (nano::log::type::rpc_callbacks, "Unable to send callback: {}:{} ({})", address, port, ec.message ());
-						node_l->stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
-					}
-				});
-			}
-			else
-			{
-				node_l->logger.error (nano::log::type::rpc_callbacks, "Unable to connect to callback address({}): {}:{} ({})", address, i_a->endpoint ().address ().to_string (), port, ec.message ());
-				node_l->stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
-				++i_a;
-
-				node_l->do_rpc_callback (i_a, address, port, target, body, resolver);
-			}
-		});
-	}
 }
 
 bool nano::node::copy_with_compaction (std::filesystem::path const & destination)

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -82,7 +82,6 @@ public:
 	bool block_confirmed_or_being_confirmed (nano::secure::transaction const &, nano::block_hash const &);
 	bool block_confirmed_or_being_confirmed (nano::block_hash const &);
 
-	void do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);
 	bool online () const;
 	bool init_error () const;
 	std::pair<uint64_t, std::unordered_map<nano::account, nano::uint128_t>> get_bootstrap_weights () const;
@@ -201,6 +200,8 @@ public:
 	nano::peer_history & peer_history;
 	std::unique_ptr<nano::monitor> monitor_impl;
 	nano::monitor & monitor;
+	std::unique_ptr<nano::rpc_callbacks> rpc_callbacks_impl;
+	nano::rpc_callbacks & rpc_callbacks;
 
 public:
 	std::chrono::steady_clock::time_point const startup_time;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -200,8 +200,8 @@ public:
 	nano::peer_history & peer_history;
 	std::unique_ptr<nano::monitor> monitor_impl;
 	nano::monitor & monitor;
-	std::unique_ptr<nano::rpc_callbacks> rpc_callbacks_impl;
-	nano::rpc_callbacks & rpc_callbacks;
+	std::unique_ptr<nano::http_callbacks> http_callbacks_impl;
+	nano::http_callbacks & http_callbacks;
 
 public:
 	std::chrono::steady_clock::time_point const startup_time;

--- a/nano/node/rpc_callbacks.cpp
+++ b/nano/node/rpc_callbacks.cpp
@@ -3,7 +3,7 @@
 #include <nano/node/rpc_callbacks.hpp>
 #include <nano/secure/ledger.hpp>
 
-nano::rpc_callbacks::rpc_callbacks (nano::node & node_a) :
+nano::http_callbacks::http_callbacks (nano::node & node_a) :
 	node{ node_a },
 	config{ node_a.config },
 	observers{ node_a.observers },
@@ -14,12 +14,12 @@ nano::rpc_callbacks::rpc_callbacks (nano::node & node_a) :
 	// Only set up callbacks if a callback address is configured
 	if (!config.callback_address.empty ())
 	{
-		logger.info (nano::log::type::rpc_callbacks, "RPC callbacks enabled on {}:{}", config.callback_address, config.callback_port);
+		logger.info (nano::log::type::http_callbacks, "Callbacks enabled on {}:{}", config.callback_address, config.callback_port);
 		setup_callbacks ();
 	}
 }
 
-void nano::rpc_callbacks::setup_callbacks ()
+void nano::http_callbacks::setup_callbacks ()
 {
 	// Add observer for block confirmations
 	observers.blocks.add ([this] (nano::election_status const & status_a,
@@ -93,7 +93,7 @@ void nano::rpc_callbacks::setup_callbacks ()
 					}
 					else
 					{
-						logger.error (nano::log::type::rpc_callbacks, "Error resolving callback: {}:{} ({})", address, port, ec.message ());
+						logger.error (nano::log::type::http_callbacks, "Error resolving callback: {}:{} ({})", address, port, ec.message ());
 						stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
 					}
 				});
@@ -107,7 +107,7 @@ void nano::rpc_callbacks::setup_callbacks ()
  * Handles connection establishment, request sending, and response processing
  * Includes retry logic for failed connection attempts
  */
-void nano::rpc_callbacks::do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a,
+void nano::http_callbacks::do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a,
 std::string const & address,
 uint16_t port,
 std::shared_ptr<std::string> const & target,
@@ -156,14 +156,14 @@ std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 								}
 								else
 								{
-									logger.error (nano::log::type::rpc_callbacks, "Callback to {}:{} failed [status: {}]",
+									logger.error (nano::log::type::http_callbacks, "Callback to {}:{} failed [status: {}]",
 									address, port, nano::util::to_str (resp->result ()));
 									stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
 								}
 							}
 							else
 							{
-								logger.error (nano::log::type::rpc_callbacks, "Unable to complete callback: {}:{} ({})",
+								logger.error (nano::log::type::http_callbacks, "Unable to complete callback: {}:{} ({})",
 								address, port, ec.message ());
 								stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
 							}
@@ -171,7 +171,7 @@ std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 					}
 					else
 					{
-						logger.error (nano::log::type::rpc_callbacks, "Unable to send callback: {}:{} ({})", address, port, ec.message ());
+						logger.error (nano::log::type::http_callbacks, "Unable to send callback: {}:{} ({})", address, port, ec.message ());
 						stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
 					}
 				});
@@ -179,7 +179,7 @@ std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 			else
 			{
 				// Connection failed, try next endpoint if available
-				logger.error (nano::log::type::rpc_callbacks, "Unable to connect to callback address({}): {}:{} ({})",
+				logger.error (nano::log::type::http_callbacks, "Unable to connect to callback address({}): {}:{} ({})",
 				address, i_a->endpoint ().address ().to_string (), port, ec.message ());
 				stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
 

--- a/nano/node/rpc_callbacks.cpp
+++ b/nano/node/rpc_callbacks.cpp
@@ -1,0 +1,139 @@
+#include <nano/lib/block_type.hpp>
+#include <nano/node/node.hpp>
+#include <nano/node/rpc_callbacks.hpp>
+#include <nano/secure/ledger.hpp>
+
+nano::rpc_callbacks::rpc_callbacks (nano::node & node_a) :
+	node{ node_a },
+	config{ node_a.config },
+	observers{ node_a.observers },
+	ledger{ node_a.ledger },
+	logger{ node_a.logger },
+	stats{ node_a.stats }
+{
+	if (!config.callback_address.empty ())
+	{
+		logger.info (nano::log::type::rpc_callbacks, "RPC callbacks enabled on {}:{}", config.callback_address, config.callback_port);
+		setup_callbacks ();
+	}
+}
+
+void nano::rpc_callbacks::setup_callbacks ()
+{
+	observers.blocks.add ([this] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const & votes_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a, bool is_state_epoch_a) {
+		auto block_a (status_a.winner);
+		if ((status_a.type == nano::election_status_type::active_confirmed_quorum || status_a.type == nano::election_status_type::active_confirmation_height))
+		{
+			node.workers.post ([this, block_a, account_a, amount_a, is_state_send_a, is_state_epoch_a] () {
+				boost::property_tree::ptree event;
+				event.add ("account", account_a.to_account ());
+				event.add ("hash", block_a->hash ().to_string ());
+				std::string block_text;
+				block_a->serialize_json (block_text);
+				event.add ("block", block_text);
+				event.add ("amount", amount_a.to_string_dec ());
+				if (is_state_send_a)
+				{
+					event.add ("is_send", is_state_send_a);
+					event.add ("subtype", "send");
+				}
+				// Subtype field
+				else if (block_a->type () == nano::block_type::state)
+				{
+					if (block_a->is_change ())
+					{
+						event.add ("subtype", "change");
+					}
+					else if (is_state_epoch_a)
+					{
+						debug_assert (amount_a == 0 && ledger.is_epoch_link (block_a->link_field ().value ()));
+						event.add ("subtype", "epoch");
+					}
+					else
+					{
+						event.add ("subtype", "receive");
+					}
+				}
+				std::stringstream ostream;
+				boost::property_tree::write_json (ostream, event);
+				ostream.flush ();
+				auto body (std::make_shared<std::string> (ostream.str ()));
+				auto address (config.callback_address);
+				auto port (config.callback_port);
+				auto target (std::make_shared<std::string> (config.callback_target));
+				auto resolver (std::make_shared<boost::asio::ip::tcp::resolver> (node.io_ctx));
+				resolver->async_resolve (boost::asio::ip::tcp::resolver::query (address, std::to_string (port)), [this, address, port, target, body, resolver] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator i_a) {
+					if (!ec)
+					{
+						do_rpc_callback (i_a, address, port, target, body, resolver);
+					}
+					else
+					{
+						logger.error (nano::log::type::rpc_callbacks, "Error resolving callback: {}:{} ({})", address, port, ec.message ());
+						stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
+					}
+				});
+			});
+		}
+	});
+}
+
+void nano::rpc_callbacks::do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const & address, uint16_t port, std::shared_ptr<std::string> const & target, std::shared_ptr<std::string> const & body, std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
+{
+	if (i_a != boost::asio::ip::tcp::resolver::iterator{})
+	{
+		auto sock (std::make_shared<boost::asio::ip::tcp::socket> (node.io_ctx));
+		sock->async_connect (i_a->endpoint (), [this, target, body, sock, address, port, i_a, resolver] (boost::system::error_code const & ec) mutable {
+			if (!ec)
+			{
+				auto req (std::make_shared<boost::beast::http::request<boost::beast::http::string_body>> ());
+				req->method (boost::beast::http::verb::post);
+				req->target (*target);
+				req->version (11);
+				req->insert (boost::beast::http::field::host, address);
+				req->insert (boost::beast::http::field::content_type, "application/json");
+				req->body () = *body;
+				req->prepare_payload ();
+				boost::beast::http::async_write (*sock, *req, [this, sock, address, port, req, i_a, target, body, resolver] (boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
+					if (!ec)
+					{
+						auto sb (std::make_shared<boost::beast::flat_buffer> ());
+						auto resp (std::make_shared<boost::beast::http::response<boost::beast::http::string_body>> ());
+						boost::beast::http::async_read (*sock, *sb, *resp, [this, sb, resp, sock, address, port, i_a, target, body, resolver] (boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
+							if (!ec)
+							{
+								if (boost::beast::http::to_status_class (resp->result ()) == boost::beast::http::status_class::successful)
+								{
+									stats.inc (nano::stat::type::http_callback, nano::stat::detail::initiate, nano::stat::dir::out);
+								}
+								else
+								{
+									logger.error (nano::log::type::rpc_callbacks, "Callback to {}:{} failed [status: {}]", address, port, nano::util::to_str (resp->result ()));
+									stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
+								}
+							}
+							else
+							{
+								logger.error (nano::log::type::rpc_callbacks, "Unable to complete callback: {}:{} ({})", address, port, ec.message ());
+								stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
+							};
+						});
+					}
+					else
+					{
+						logger.error (nano::log::type::rpc_callbacks, "Unable to send callback: {}:{} ({})", address, port, ec.message ());
+						stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
+					}
+				});
+			}
+			else
+			{
+				logger.error (nano::log::type::rpc_callbacks, "Unable to connect to callback address({}): {}:{} ({})", address, i_a->endpoint ().address ().to_string (), port, ec.message ());
+				stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
+				++i_a;
+
+				do_rpc_callback (i_a, address, port, target, body, resolver);
+			}
+		});
+	}
+}

--- a/nano/node/rpc_callbacks.cpp
+++ b/nano/node/rpc_callbacks.cpp
@@ -11,6 +11,7 @@ nano::rpc_callbacks::rpc_callbacks (nano::node & node_a) :
 	logger{ node_a.logger },
 	stats{ node_a.stats }
 {
+	// Only set up callbacks if a callback address is configured
 	if (!config.callback_address.empty ())
 	{
 		logger.info (nano::log::type::rpc_callbacks, "RPC callbacks enabled on {}:{}", config.callback_address, config.callback_port);
@@ -20,12 +21,22 @@ nano::rpc_callbacks::rpc_callbacks (nano::node & node_a) :
 
 void nano::rpc_callbacks::setup_callbacks ()
 {
-	observers.blocks.add ([this] (nano::election_status const & status_a, std::vector<nano::vote_with_weight_info> const & votes_a, nano::account const & account_a, nano::amount const & amount_a, bool is_state_send_a, bool is_state_epoch_a) {
+	// Add observer for block confirmations
+	observers.blocks.add ([this] (nano::election_status const & status_a,
+						  std::vector<nano::vote_with_weight_info> const & votes_a,
+						  nano::account const & account_a,
+						  nano::amount const & amount_a,
+						  bool is_state_send_a,
+						  bool is_state_epoch_a) {
 		auto block_a = status_a.winner;
+
+		// Only process blocks that have achieved quorum or confirmation height
 		if ((status_a.type == nano::election_status_type::active_confirmed_quorum || status_a.type == nano::election_status_type::active_confirmation_height))
 		{
-			// It's OK to capture this by reference since workers are stopped before node destruction
+			// Post callback processing to worker thread
+			// Safe to capture 'this' by reference as workers are stopped before node destruction
 			node.workers.post ([this, block_a, account_a, amount_a, is_state_send_a, is_state_epoch_a] () {
+				// Construct the callback payload as a property tree
 				boost::property_tree::ptree event;
 				event.add ("account", account_a.to_account ());
 				event.add ("hash", block_a->hash ().to_string ());
@@ -33,12 +44,15 @@ void nano::rpc_callbacks::setup_callbacks ()
 				block_a->serialize_json (block_text);
 				event.add ("block", block_text);
 				event.add ("amount", amount_a.to_string_dec ());
+
+				// Add transaction type information
 				if (is_state_send_a)
 				{
 					event.add ("is_send", is_state_send_a);
 					event.add ("subtype", "send");
 				}
-				// Subtype field
+
+				// Handle different state block subtypes
 				else if (block_a->type () == nano::block_type::state)
 				{
 					if (block_a->is_change ())
@@ -55,18 +69,24 @@ void nano::rpc_callbacks::setup_callbacks ()
 						event.add ("subtype", "receive");
 					}
 				}
+
+				// Serialize the event to JSON
 				std::stringstream ostream;
 				boost::property_tree::write_json (ostream, event);
 				ostream.flush ();
+
+				// Prepare callback request parameters
 				auto body = std::make_shared<std::string> (ostream.str ());
 				auto address = config.callback_address;
 				auto port = config.callback_port;
 				auto target = std::make_shared<std::string> (config.callback_target);
 				auto resolver = std::make_shared<boost::asio::ip::tcp::resolver> (node.io_ctx);
 
-				// It's OK to capture this by reference since io_context is stopped before node destruction
+				// Resolve the callback address
+				// Safe to capture 'this' as io_context is stopped before node destruction
 				resolver->async_resolve (boost::asio::ip::tcp::resolver::query{ address, std::to_string (port) },
-				[this, address, port, target, body, resolver] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator i_a) {
+				[this, address, port, target, body, resolver] (boost::system::error_code const & ec,
+				boost::asio::ip::tcp::resolver::iterator i_a) {
 					if (!ec)
 					{
 						do_rpc_callback (i_a, address, port, target, body, resolver);
@@ -82,15 +102,28 @@ void nano::rpc_callbacks::setup_callbacks ()
 	});
 }
 
-void nano::rpc_callbacks::do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const & address, uint16_t port,
-std::shared_ptr<std::string> const & target, std::shared_ptr<std::string> const & body, std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
+/**
+ * Performs the actual RPC callback HTTP request
+ * Handles connection establishment, request sending, and response processing
+ * Includes retry logic for failed connection attempts
+ */
+void nano::rpc_callbacks::do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a,
+std::string const & address,
+uint16_t port,
+std::shared_ptr<std::string> const & target,
+std::shared_ptr<std::string> const & body,
+std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 {
+	// Check if we have more endpoints to try
 	if (i_a != boost::asio::ip::tcp::resolver::iterator{})
 	{
+		// Create socket and attempt connection
 		auto sock = std::make_shared<boost::asio::ip::tcp::socket> (node.io_ctx);
-		sock->async_connect (i_a->endpoint (), [this, target, body, sock, address, port, i_a, resolver] (boost::system::error_code const & ec) mutable {
+		sock->async_connect (i_a->endpoint (),
+		[this, target, body, sock, address, port, i_a, resolver] (boost::system::error_code const & ec) mutable {
 			if (!ec)
 			{
+				// Connection successful, prepare and send HTTP request
 				auto req = std::make_shared<boost::beast::http::request<boost::beast::http::string_body>> ();
 				req->method (boost::beast::http::verb::post);
 				req->target (*target);
@@ -99,16 +132,24 @@ std::shared_ptr<std::string> const & target, std::shared_ptr<std::string> const 
 				req->insert (boost::beast::http::field::content_type, "application/json");
 				req->body () = *body;
 				req->prepare_payload ();
+
+				// Send the HTTP request
 				boost::beast::http::async_write (*sock, *req,
-				[this, sock, address, port, req, i_a, target, body, resolver] (boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
+				[this, sock, address, port, req, i_a, target, body, resolver] (
+				boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
 					if (!ec)
 					{
+						// Request sent successfully, prepare to receive response
 						auto sb = std::make_shared<boost::beast::flat_buffer> ();
 						auto resp = std::make_shared<boost::beast::http::response<boost::beast::http::string_body>> ();
+
+						// Read the HTTP response
 						boost::beast::http::async_read (*sock, *sb, *resp,
-						[this, sb, resp, sock, address, port, i_a, target, body, resolver] (boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
+						[this, sb, resp, sock, address, port, i_a, target, body, resolver] (
+						boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
 							if (!ec)
 							{
+								// Check response status
 								if (boost::beast::http::to_status_class (resp->result ()) == boost::beast::http::status_class::successful)
 								{
 									stats.inc (nano::stat::type::http_callback, nano::stat::detail::initiate, nano::stat::dir::out);
@@ -137,11 +178,12 @@ std::shared_ptr<std::string> const & target, std::shared_ptr<std::string> const 
 			}
 			else
 			{
+				// Connection failed, try next endpoint if available
 				logger.error (nano::log::type::rpc_callbacks, "Unable to connect to callback address({}): {}:{} ({})",
 				address, i_a->endpoint ().address ().to_string (), port, ec.message ());
 				stats.inc (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out);
-				++i_a;
 
+				++i_a;
 				do_rpc_callback (i_a, address, port, target, body, resolver);
 			}
 		});

--- a/nano/node/rpc_callbacks.cpp
+++ b/nano/node/rpc_callbacks.cpp
@@ -53,9 +53,8 @@ void nano::http_callbacks::setup_callbacks ()
 			stats.inc (nano::stat::type::http_callbacks_notified, nano::stat::detail::block_confirmed);
 
 			constexpr size_t warning_threshold = 10000;
-			static nano::interval warning_interval;
 
-			if (workers.queued_tasks () > warning_threshold && warning_interval.elapsed (15s))
+			if (workers.queued_tasks () > warning_threshold && warning_interval.elapse (15s))
 			{
 				stats.inc (nano::stat::type::http_callbacks, nano::stat::detail::large_backlog);
 				logger.warn (nano::log::type::http_callbacks, "Backlog of {} http callback notifications to process", workers.queued_tasks ());

--- a/nano/node/rpc_callbacks.cpp
+++ b/nano/node/rpc_callbacks.cpp
@@ -24,6 +24,7 @@ void nano::rpc_callbacks::setup_callbacks ()
 		auto block_a (status_a.winner);
 		if ((status_a.type == nano::election_status_type::active_confirmed_quorum || status_a.type == nano::election_status_type::active_confirmation_height))
 		{
+			// It's OK to capture this by reference since workers are stopped before node destruction
 			node.workers.post ([this, block_a, account_a, amount_a, is_state_send_a, is_state_epoch_a] () {
 				boost::property_tree::ptree event;
 				event.add ("account", account_a.to_account ());
@@ -62,6 +63,8 @@ void nano::rpc_callbacks::setup_callbacks ()
 				auto port (config.callback_port);
 				auto target (std::make_shared<std::string> (config.callback_target));
 				auto resolver (std::make_shared<boost::asio::ip::tcp::resolver> (node.io_ctx));
+
+				// It's OK to capture this by reference since io_context is stopped before node destruction
 				resolver->async_resolve (boost::asio::ip::tcp::resolver::query (address, std::to_string (port)), [this, address, port, target, body, resolver] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator i_a) {
 					if (!ec)
 					{

--- a/nano/node/rpc_callbacks.hpp
+++ b/nano/node/rpc_callbacks.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/thread_pool.hpp>
 #include <nano/node/fwd.hpp>
 
 namespace nano
@@ -8,6 +9,11 @@ class http_callbacks
 {
 public:
 	explicit http_callbacks (nano::node &);
+
+	void start ();
+	void stop ();
+
+	nano::container_info container_info () const;
 
 private: // Dependencies
 	nano::node_config const & config;
@@ -20,5 +26,7 @@ private: // Dependencies
 private:
 	void setup_callbacks ();
 	void do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);
+
+	nano::thread_pool workers;
 };
 }

--- a/nano/node/rpc_callbacks.hpp
+++ b/nano/node/rpc_callbacks.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <nano/node/fwd.hpp>
+
+namespace nano
+{
+class rpc_callbacks
+{
+public:
+	explicit rpc_callbacks (nano::node &);
+
+private: // Dependencies
+	nano::node_config const & config;
+	nano::node & node;
+	nano::node_observers & observers;
+	nano::ledger & ledger;
+	nano::logger & logger;
+	nano::stats & stats;
+
+private:
+	void setup_callbacks ();
+	void do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);
+};
+}

--- a/nano/node/rpc_callbacks.hpp
+++ b/nano/node/rpc_callbacks.hpp
@@ -4,10 +4,10 @@
 
 namespace nano
 {
-class rpc_callbacks
+class http_callbacks
 {
 public:
-	explicit rpc_callbacks (nano::node &);
+	explicit http_callbacks (nano::node &);
 
 private: // Dependencies
 	nano::node_config const & config;

--- a/nano/node/rpc_callbacks.hpp
+++ b/nano/node/rpc_callbacks.hpp
@@ -28,5 +28,6 @@ private:
 	void do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);
 
 	nano::thread_pool workers;
+	nano::interval_mt warning_interval;
 };
 }

--- a/nano/node/transport/tcp_listener.cpp
+++ b/nano/node/transport/tcp_listener.cpp
@@ -362,7 +362,7 @@ asio::awaitable<void> nano::transport::tcp_listener::wait_available_slots () con
 	nano::interval log_interval;
 	while (connection_count () >= config.max_inbound_connections && !stopped)
 	{
-		if (log_interval.elapsed (node.network_params.network.is_dev_network () ? 1s : 15s))
+		if (log_interval.elapse (node.network_params.network.is_dev_network () ? 1s : 15s))
 		{
 			logger.warn (nano::log::type::tcp_listener, "Waiting for available slots to accept new connections (current: {} / max: {})",
 			connection_count (), config.max_inbound_connections);

--- a/nano/node/vote_cache.cpp
+++ b/nano/node/vote_cache.cpp
@@ -238,7 +238,7 @@ std::deque<nano::vote_cache::top_entry> nano::vote_cache::top (const nano::uint1
 	{
 		nano::lock_guard<nano::mutex> lock{ mutex };
 
-		if (cleanup_interval.elapsed (config.age_cutoff / 2))
+		if (cleanup_interval.elapse (config.age_cutoff / 2))
 		{
 			cleanup ();
 		}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5252,7 +5252,7 @@ TEST (rpc, block_confirm_confirmed)
 		auto transaction = node->ledger.tx_begin_read ();
 		ASSERT_TRUE (node->ledger.confirmed.block_exists_or_pruned (transaction, nano::dev::genesis->hash ()));
 	}
-	ASSERT_EQ (0, node->stats.count (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out));
+	ASSERT_EQ (0, node->stats.count (nano::stat::type::http_callbacks_ec));
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "block_confirm");
@@ -5266,7 +5266,7 @@ TEST (rpc, block_confirm_confirmed)
 	// Check callback
 	// Callback result is error because callback target port isn't listening
 	// Check for error count greater than zero as the address goes through DNS resolution and may make multiple attempts for multiple IPs per DNS
-	ASSERT_TIMELY (5s, node->stats.count (nano::stat::type::error, nano::stat::detail::http_callback, nano::stat::dir::out) != 0);
+	ASSERT_TIMELY (5s, node->stats.count (nano::stat::type::http_callbacks_ec) != 0);
 }
 
 TEST (rpc, node_id)


### PR DESCRIPTION
This moves http callback handling logic out of node class, makes it run on a separate thread pool and adds more stats and logging.