### PR TITLE
Unlimited bootstrap request rate

### DIFF
--- a/nano/node/bootstrap/bootstrap_config.hpp
+++ b/nano/node/bootstrap/bootstrap_config.hpp
@@ -48,7 +48,7 @@ public:
 
 	// Maximum number of un-responded requests per channel, should be lower or equal to bootstrap server max queue size
 	std::size_t channel_limit{ 16 };
-	std::size_t rate_limit{ 500 };
+	std::size_t rate_limit{ 0 };
 	std::size_t database_rate_limit{ 250 };
 	std::size_t frontier_rate_limit{ 8 };
 	std::size_t database_warmup_ratio{ 10 };


### PR DESCRIPTION
This changes the default bootstrap client request rate limit to unlimited. The rate is still limited indirectly by the ability of peers to process them in a timely manner, we use peer scoring to limit number of outstanding requests per peer to 16 by default.