### PR TITLE
Handle `gap_epoch_open_pending` block status when bootstrapping

### DIFF
--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -528,6 +528,7 @@ enum class detail
 	blocking_overflow,
 	priority_insert,
 	priority_set,
+	priority_erase,
 	priority_unblocked,
 	erase_by_threshold,
 	erase_by_blocking,

--- a/nano/node/bootstrap/account_sets.cpp
+++ b/nano/node/bootstrap/account_sets.cpp
@@ -104,6 +104,19 @@ void nano::bootstrap::account_sets::priority_set (nano::account const & account,
 	}
 }
 
+void nano::bootstrap::account_sets::priority_erase (nano::account const & account)
+{
+	if (account.is_zero ())
+	{
+		return;
+	}
+
+	if (priorities.get<tag_account> ().erase (account) > 0)
+	{
+		stats.inc (nano::stat::type::bootstrap_account_sets, nano::stat::detail::priority_erase);
+	}
+}
+
 void nano::bootstrap::account_sets::block (nano::account const & account, nano::block_hash const & dependency)
 {
 	debug_assert (!account.is_zero ());

--- a/nano/node/bootstrap/account_sets.hpp
+++ b/nano/node/bootstrap/account_sets.hpp
@@ -33,18 +33,10 @@ public: // Constants
 public:
 	account_sets (account_sets_config const &, nano::stats &);
 
-	/**
-	 * If an account is not blocked, increase its priority.
-	 * If the account does not exist in priority set and is not blocked, inserts a new entry.
-	 * Current implementation increases priority by 1.0f each increment
-	 */
 	void priority_up (nano::account const & account);
-	/**
-	 * Decreases account priority
-	 * Current implementation divides priority by 2.0f and saturates down to 1.0f.
-	 */
 	void priority_down (nano::account const & account);
 	void priority_set (nano::account const & account, double priority = priority_initial);
+	void priority_erase (nano::account const & account);
 
 	void block (nano::account const & account, nano::block_hash const & dependency);
 	void unblock (nano::account const & account, std::optional<nano::block_hash> const & hash = std::nullopt);

--- a/nano/node/bootstrap/bootstrap_service.cpp
+++ b/nano/node/bootstrap/bootstrap_service.cpp
@@ -326,7 +326,16 @@ void nano::bootstrap_service::inspect (secure::transaction const & tx, nano::blo
 			}
 		}
 		break;
+		case nano::block_status::gap_epoch_open_pending:
+		{
+			// Epoch open blocks for accounts that don't have any pending blocks yet
+			debug_assert (block.type () == block_type::state); // Only state blocks can have epoch open pending status
+			const auto account = block.account_field ().value_or (0);
+			accounts.priority_erase (account);
+		}
+		break;
 		default: // No need to handle other cases
+			// TODO: If we receive blocks that are invalid (bad signature, fork, etc.), we should penalize the peer that sent them
 			break;
 	}
 }


### PR DESCRIPTION
We can't process blocks that have `gap_epoch_open_pending` status immediately, but instead need to wait until at least one pending send is available for their account chain. Epoch blocks do not link to the associated send block, so we have no way of pulling the dependency other than randomly sampling the rest of the ledger. Given this the proper behavior when encountering this status is to evict the priority account associated with the epoch open block.