### PR TITLE
Fix activate immediately logic

### DIFF
--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -86,6 +86,7 @@ enum class type
 	monitor,
 	confirming_set,
 	bounded_backlog,
+	request_aggregator,
 
 	// bootstrap
 	bulk_pull_client,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -458,6 +458,7 @@ enum class detail
 	transition_priority,
 	transition_priority_failed,
 	election_cleanup,
+	activate_immediately,
 
 	// active_elections
 	started,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -284,6 +284,7 @@ enum class detail
 	broadcast_block_repeat,
 	confirm_once,
 	confirm_once_failed,
+	confirmation_request,
 
 	// election types
 	manual,

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -419,11 +419,16 @@ nano::election_insertion_result nano::active_elections::insert (std::shared_ptr<
 			count_by_behavior[result.election->behavior ()]++;
 
 			// Skip passive phase for blocks without cached votes to avoid bootstrap delays
-			bool active_immediately = false;
-			if (node.vote_cache.contains (hash))
+			bool activate_immediately = false;
+			if (!node.vote_cache.contains (hash))
 			{
+				activate_immediately = true;
+			}
+
+			if (activate_immediately)
+			{
+				node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::activate_immediately);
 				result.election->transition_active ();
-				active_immediately = true;
 			}
 
 			node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::started);
@@ -436,7 +441,7 @@ nano::election_insertion_result nano::active_elections::insert (std::shared_ptr<
 			node.logger.debug (nano::log::type::active_elections, "Started new election for block: {} (behavior: {}, active immediately: {})",
 			hash.to_string (),
 			to_string (election_behavior_a),
-			active_immediately);
+			activate_immediately);
 		}
 		else
 		{

--- a/nano/node/block_processor.cpp
+++ b/nano/node/block_processor.cpp
@@ -392,41 +392,51 @@ nano::block_status nano::block_processor::process_one (secure::write_transaction
 			stats.inc (nano::stat::type::ledger, nano::stat::detail::old);
 			break;
 		}
+		// These are unexpected and indicate erroneous/malicious behavior, log debug info to highlight the issue
 		case nano::block_status::bad_signature:
 		{
+			logger.debug (nano::log::type::block_processor, "Block signature is invalid: {}", hash);
 			break;
 		}
 		case nano::block_status::negative_spend:
 		{
+			logger.debug (nano::log::type::block_processor, "Block spends negative amount: {}", hash);
 			break;
 		}
 		case nano::block_status::unreceivable:
 		{
+			logger.debug (nano::log::type::block_processor, "Block is unreceivable: {}", hash);
 			break;
 		}
 		case nano::block_status::fork:
 		{
 			stats.inc (nano::stat::type::ledger, nano::stat::detail::fork);
+			logger.debug (nano::log::type::block_processor, "Block is a fork: {}", hash);
 			break;
 		}
 		case nano::block_status::opened_burn_account:
 		{
+			logger.debug (nano::log::type::block_processor, "Block opens burn account: {}", hash);
 			break;
 		}
 		case nano::block_status::balance_mismatch:
 		{
+			logger.debug (nano::log::type::block_processor, "Block balance mismatch: {}", hash);
 			break;
 		}
 		case nano::block_status::representative_mismatch:
 		{
+			logger.debug (nano::log::type::block_processor, "Block representative mismatch: {}", hash);
 			break;
 		}
 		case nano::block_status::block_position:
 		{
+			logger.debug (nano::log::type::block_processor, "Block is in incorrect position: {}", hash);
 			break;
 		}
 		case nano::block_status::insufficient_work:
 		{
+			logger.debug (nano::log::type::block_processor, "Block has insufficient work: {}", hash);
 			break;
 		}
 	}

--- a/nano/node/bootstrap/bootstrap_service.cpp
+++ b/nano/node/bootstrap/bootstrap_service.cpp
@@ -515,33 +515,58 @@ bool nano::bootstrap_service::request (nano::account account, size_t count, std:
 		// Check if the account picked has blocks, if it does, start the pull from the highest block
 		if (auto info = ledger.store.account.get (transaction, account))
 		{
-			tag.type = query_type::blocks_by_hash;
-
 			// Probabilistically choose between requesting blocks from account frontier or confirmed frontier
 			// Optimistic requests start from the (possibly unconfirmed) account frontier and are vulnerable to bootstrap poisoning
 			// Safe requests start from the confirmed frontier and given enough time will eventually resolve forks
 			bool optimistic_reuest = rng.random (100) < config.optimistic_request_percentage;
-			if (!optimistic_reuest)
-			{
-				if (auto conf_info = ledger.store.confirmation_height.get (transaction, account))
-				{
-					stats.inc (nano::stat::type::bootstrap_request_blocks, nano::stat::detail::safe);
-					tag.start = conf_info->frontier;
-					tag.hash = conf_info->height;
-				}
-			}
-			if (tag.start.is_zero ())
+
+			if (optimistic_reuest) // Optimistic request case
 			{
 				stats.inc (nano::stat::type::bootstrap_request_blocks, nano::stat::detail::optimistic);
+
+				tag.type = query_type::blocks_by_hash;
 				tag.start = info->head;
 				tag.hash = info->head;
+
+				logger.debug (nano::log::type::bootstrap, "Requesting blocks for {} starting from account frontier: {} (optimistic: {})",
+				account.to_account (), // TODO: Lazy eval
+				tag.start.to_string (), // TODO: Lazy eval
+				optimistic_reuest);
+			}
+			else // Pessimistic (safe) request case
+			{
+				stats.inc (nano::stat::type::bootstrap_request_blocks, nano::stat::detail::safe);
+
+				if (auto conf_info = ledger.store.confirmation_height.get (transaction, account))
+				{
+					tag.type = query_type::blocks_by_hash;
+					tag.start = conf_info->frontier;
+					tag.hash = conf_info->height;
+
+					logger.debug (nano::log::type::bootstrap, "Requesting blocks for {} starting from confirmation frontier: {} (optimistic: {})",
+					account.to_account (), // TODO: Lazy eval
+					tag.start.to_string (), // TODO: Lazy eval
+					optimistic_reuest);
+				}
+				else
+				{
+					tag.type = query_type::blocks_by_account;
+					tag.start = account;
+
+					logger.debug (nano::log::type::bootstrap, "Requesting blocks for {} starting from account root (optimistic: {})",
+					account.to_account (), // TODO: Lazy eval
+					optimistic_reuest);
+				}
 			}
 		}
 		else
 		{
 			stats.inc (nano::stat::type::bootstrap_request_blocks, nano::stat::detail::base);
+
 			tag.type = query_type::blocks_by_account;
 			tag.start = account;
+
+			logger.debug (nano::log::type::bootstrap, "Requesting blocks for {}", account.to_account ()); // TODO: Lazy eval
 		}
 	}
 

--- a/nano/node/bootstrap/bootstrap_service.cpp
+++ b/nano/node/bootstrap/bootstrap_service.cpp
@@ -1047,6 +1047,8 @@ void nano::bootstrap_service::process_frontiers (std::deque<std::pair<nano::acco
 	stats.add (nano::stat::type::bootstrap_frontiers, nano::stat::detail::outdated, outdated);
 	stats.add (nano::stat::type::bootstrap_frontiers, nano::stat::detail::pending, pending);
 
+	logger.debug (nano::log::type::bootstrap, "Processed {} frontiers of which outdated: {}, pending: {}", frontiers.size (), outdated, pending);
+
 	nano::lock_guard<nano::mutex> guard{ mutex };
 
 	for (auto const & account : result)

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -557,6 +557,14 @@ nano::vote_code nano::election::vote (nano::account const & rep, uint64_t timest
 	nano::log::arg{ "vote_source", vote_source_a },
 	nano::log::arg{ "weight", weight });
 
+	node.logger.debug (nano::log::type::election, "Vote received for: {} from: {} root: {} (final: {}, weight: {}, source: {})",
+	block_hash_a.to_string (),
+	rep.to_account (),
+	qualified_root.to_string (),
+	nano::vote::is_final_timestamp (timestamp_a),
+	weight.convert_to<std::string> (),
+	to_string (vote_source_a));
+
 	if (!confirmed_locked ())
 	{
 		confirm_if_quorum (lock);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -171,7 +171,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	final_generator{ *final_generator_impl },
 	scheduler_impl{ std::make_unique<nano::scheduler::component> (config, *this, ledger, bucketing, block_processor, active, online_reps, vote_cache, confirming_set, stats, logger) },
 	scheduler{ *scheduler_impl },
-	aggregator_impl{ std::make_unique<nano::request_aggregator> (config.request_aggregator, *this, stats, generator, final_generator, history, ledger, wallets, vote_router) },
+	aggregator_impl{ std::make_unique<nano::request_aggregator> (config.request_aggregator, *this, generator, final_generator, history, ledger, wallets, vote_router) },
 	aggregator{ *aggregator_impl },
 	backlog_scan_impl{ std::make_unique<nano::backlog_scan> (config.backlog_scan, ledger, stats) },
 	backlog_scan{ *backlog_scan_impl },

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -15,16 +15,17 @@
 #include <nano/secure/ledger_set_confirmed.hpp>
 #include <nano/store/component.hpp>
 
-nano::request_aggregator::request_aggregator (request_aggregator_config const & config_a, nano::node & node_a, nano::stats & stats_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_router & vote_router_a) :
+nano::request_aggregator::request_aggregator (request_aggregator_config const & config_a, nano::node & node_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_router & vote_router_a) :
 	config{ config_a },
 	network_constants{ node_a.network_params.network },
-	stats (stats_a),
 	local_votes (history_a),
 	ledger (ledger_a),
 	wallets (wallets_a),
 	vote_router{ vote_router_a },
 	generator (generator_a),
-	final_generator (final_generator_a)
+	final_generator (final_generator_a),
+	stats (node_a.stats),
+	logger (node_a.logger)
 {
 	queue.max_size_query = [this] (auto const & origin) {
 		return config.max_queue;
@@ -238,15 +239,28 @@ auto nano::request_aggregator::aggregate (nano::secure::transaction const & tran
 			{
 				to_generate_final.push_back (block);
 				stats.inc (nano::stat::type::requests, nano::stat::detail::requests_final);
+
+				logger.debug (nano::log::type::request_aggregator, "Replying with final vote for: {} to: {}",
+				block->hash ().to_string (), // TODO: Lazy eval
+				channel_a->to_string ()); // TODO: Lazy eval
 			}
 			else
 			{
 				stats.inc (nano::stat::type::requests, nano::stat::detail::requests_non_final);
+
+				logger.debug (nano::log::type::request_aggregator, "Skipping reply with normal vote for: {} (requested by: {})",
+				block->hash ().to_string (), // TODO: Lazy eval
+				channel_a->to_string ()); // TODO: Lazy eval
 			}
 		}
 		else
 		{
 			stats.inc (nano::stat::type::requests, nano::stat::detail::requests_unknown);
+
+			logger.debug (nano::log::type::request_aggregator, "Cannot reply, block not found: {} with root: {} (requested by: {})",
+			hash.to_string (), // TODO: Lazy eval
+			root.to_string (), // TODO: Lazy eval
+			channel_a->to_string ()); // TODO: Lazy eval
 		}
 	}
 

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -45,7 +45,7 @@ public:
 class request_aggregator final
 {
 public:
-	request_aggregator (request_aggregator_config const &, nano::node &, nano::stats &, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::vote_router &);
+	request_aggregator (request_aggregator_config const &, nano::node &, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::vote_router &);
 	~request_aggregator ();
 
 	void start ();
@@ -84,13 +84,14 @@ private:
 private: // Dependencies
 	request_aggregator_config const & config;
 	nano::network_constants const & network_constants;
-	nano::stats & stats;
 	nano::local_vote_history & local_votes;
 	nano::ledger & ledger;
 	nano::wallets & wallets;
 	nano::vote_router & vote_router;
 	nano::vote_generator & generator;
 	nano::vote_generator & final_generator;
+	nano::stats & stats;
+	nano::logger & logger;
 
 private:
 	using value_type = std::pair<request_type, std::shared_ptr<nano::transport::channel>>;

--- a/nano/node/vote_router.cpp
+++ b/nano/node/vote_router.cpp
@@ -11,16 +11,6 @@
 
 using namespace std::chrono_literals;
 
-nano::stat::detail nano::to_stat_detail (nano::vote_code code)
-{
-	return nano::enum_util::cast<nano::stat::detail> (code);
-}
-
-nano::stat::detail nano::to_stat_detail (nano::vote_source source)
-{
-	return nano::enum_util::cast<nano::stat::detail> (source);
-}
-
 nano::vote_router::vote_router (nano::vote_cache & vote_cache_a, nano::recently_confirmed_cache & recently_confirmed_a) :
 	vote_cache{ vote_cache_a },
 	recently_confirmed{ recently_confirmed_a }
@@ -200,4 +190,28 @@ nano::container_info nano::vote_router::container_info () const
 	nano::container_info info;
 	info.put ("elections", elections);
 	return info;
+}
+
+/*
+ *
+ */
+
+nano::stat::detail nano::to_stat_detail (nano::vote_code code)
+{
+	return nano::enum_util::cast<nano::stat::detail> (code);
+}
+
+std::string_view nano::to_string (nano::vote_code code)
+{
+	return nano::enum_util::name (code);
+}
+
+nano::stat::detail nano::to_stat_detail (nano::vote_source source)
+{
+	return nano::enum_util::cast<nano::stat::detail> (source);
+}
+
+std::string_view nano::to_string (nano::vote_source source)
+{
+	return nano::enum_util::name (source);
 }

--- a/nano/node/vote_router.hpp
+++ b/nano/node/vote_router.hpp
@@ -21,6 +21,7 @@ enum class vote_code
 };
 
 nano::stat::detail to_stat_detail (vote_code);
+std::string_view to_string (vote_code);
 
 enum class vote_source
 {
@@ -30,6 +31,7 @@ enum class vote_source
 };
 
 nano::stat::detail to_stat_detail (vote_source);
+std::string_view to_string (vote_source);
 
 // This class routes votes to their associated election
 // This class holds a weak_ptr as this container does not own the elections


### PR DESCRIPTION
The main intention of this PR is to fix the bug in activate immediately logic; the if statement needs to be inverted. However, fixing it made `TEST (node, bootstrap_fork_open)` testcase fail, which upon further investigation uncovered bugs in bootstrap service and request aggregator.

To debug the problems I added quite a bit of new debug logging points which I decided to keep. It might be worthwhile to profile the node to ensure none of the log statements are impacting hot path too much.