### PR TITLE
Database backend configuration

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -12,7 +12,7 @@ jobs:
         RELEASE:
           - ${{ startsWith(github.ref, 'refs/tags/') }}
     env:
-      BACKEND: ${{ matrix.BACKEND }}
+      NANO_BACKEND: ${{ matrix.BACKEND }}
       BUILD_TYPE: ${{ matrix.RELEASE && 'RelWithDebInfo' || 'Debug' }}
       TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}
       DEADLINE_SCALE_FACTOR: ${{ matrix.BACKEND == 'rocksdb' && '2' || '1' }}

--- a/nano/lib/rocksdbconfig.cpp
+++ b/nano/lib/rocksdbconfig.cpp
@@ -4,7 +4,6 @@
 
 nano::error nano::rocksdb_config::serialize_toml (nano::tomlconfig & toml) const
 {
-	toml.put ("enable", enable, "Whether to use the RocksDB backend for the ledger database.\ntype:bool");
 	toml.put ("io_threads", io_threads, "Number of threads to use with the background compaction and flushing.\ntype:uint32");
 	toml.put ("read_cache", read_cache, "Amount of megabytes per table allocated to read cache. Valid range is 1 - 1024. Default is 32.\nCarefully monitor memory usage if non-default values are used\ntype:long");
 	toml.put ("write_cache", write_cache, "Total amount of megabytes allocated to write cache. Valid range is 1 - 256. Default is 64.\nCarefully monitor memory usage if non-default values are used\ntype:long");
@@ -14,7 +13,7 @@ nano::error nano::rocksdb_config::serialize_toml (nano::tomlconfig & toml) const
 
 nano::error nano::rocksdb_config::deserialize_toml (nano::tomlconfig & toml)
 {
-	toml.get_optional<bool> ("enable", enable);
+	toml.get_optional<bool> ("enable", enable); // TODO: This setting can be removed in future versions
 	toml.get_optional<unsigned> ("io_threads", io_threads);
 	toml.get_optional<long> ("read_cache", read_cache);
 	toml.get_optional<long> ("write_cache", write_cache);

--- a/nano/node/make_store.cpp
+++ b/nano/node/make_store.cpp
@@ -6,9 +6,16 @@
 
 std::unique_ptr<nano::store::component> nano::make_store (nano::logger & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::node_config const & node_config)
 {
-	if (node_config.rocksdb_config.enable)
+	if (node_config.database_backend == nano::database_backend::rocksdb)
 	{
 		return std::make_unique<nano::store::rocksdb::component> (logger, add_db_postfix ? path / "rocksdb" : path, constants, node_config.rocksdb_config, read_only);
+	}
+	if (node_config.rocksdb_config.enable && node_config.database_backend == nano::database_backend::lmdb)
+	{
+		// rocksdb.enable is true in config, but database_backend is set to LMDB in config
+		logger.critical (nano::log::type::config, "Legacy RocksDb setting detected in config file.");
+		logger.info (nano::log::type::config, "Edit node_config.toml and use 'database_backend' in the node section to re-enable RocksDb");
+		std::exit (EXIT_FAILURE);
 	}
 
 	return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, node_config.diagnostics_config.txn_tracking, node_config.block_processor_batch_max_time, node_config.lmdb_config, node_config.backup_before_upgrade);

--- a/nano/node/make_store.cpp
+++ b/nano/node/make_store.cpp
@@ -4,7 +4,7 @@
 #include <nano/store/lmdb/lmdb.hpp>
 #include <nano/store/rocksdb/rocksdb.hpp>
 
-std::unique_ptr<nano::store::component> nano::make_store (nano::logger & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::node_config const & node_config)
+std::unique_ptr<nano::store::component> nano::make_store (nano::logger & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::node_config node_config)
 {
 	if (node_config.database_backend == nano::database_backend::rocksdb)
 	{
@@ -13,9 +13,9 @@ std::unique_ptr<nano::store::component> nano::make_store (nano::logger & logger,
 	if (node_config.rocksdb_config.enable && node_config.database_backend == nano::database_backend::lmdb)
 	{
 		// rocksdb.enable is true in config, but database_backend is set to LMDB in config
-		logger.critical (nano::log::type::config, "Legacy RocksDb setting detected in config file.");
-		logger.info (nano::log::type::config, "Edit node_config.toml and use 'database_backend' in the node section to re-enable RocksDb");
-		std::exit (EXIT_FAILURE);
+		logger.warn (nano::log::type::config, "Use of deprecated RocksDb setting detected in config file.\nPlease edit node_config.toml and use the new 'database_backend' to enable RocksDb");
+		node_config.database_backend = nano::database_backend::rocksdb;
+		return std::make_unique<nano::store::rocksdb::component> (logger, add_db_postfix ? path / "rocksdb" : path, constants, node_config.rocksdb_config, read_only);
 	}
 
 	return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, node_config.diagnostics_config.txn_tracking, node_config.block_processor_batch_max_time, node_config.lmdb_config, node_config.backup_before_upgrade);

--- a/nano/node/make_store.cpp
+++ b/nano/node/make_store.cpp
@@ -6,17 +6,27 @@
 
 std::unique_ptr<nano::store::component> nano::make_store (nano::logger & logger, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only, bool add_db_postfix, nano::node_config node_config)
 {
-	if (node_config.database_backend == nano::database_backend::rocksdb)
+	auto decide_backend = [&] () -> nano::database_backend {
+		if (node_config.rocksdb_config.enable && node_config.database_backend == nano::database_backend::lmdb)
+		{
+			logger.warn (nano::log::type::config, "Use of deprecated `[node.rocksdb].enable` setting detected in config file, defaulting to RocksDB backend.\nPlease edit config-node.toml and use the new '[node].database_backend' for future compatibility.");
+			return nano::database_backend::rocksdb;
+		}
+		return node_config.database_backend;
+	};
+
+	auto backend = decide_backend ();
+	switch (backend)
 	{
-		return std::make_unique<nano::store::rocksdb::component> (logger, add_db_postfix ? path / "rocksdb" : path, constants, node_config.rocksdb_config, read_only);
-	}
-	if (node_config.rocksdb_config.enable && node_config.database_backend == nano::database_backend::lmdb)
-	{
-		// rocksdb.enable is true in config, but database_backend is set to LMDB in config
-		logger.warn (nano::log::type::config, "Use of deprecated RocksDb setting detected in config file.\nPlease edit node_config.toml and use the new 'database_backend' to enable RocksDb");
-		node_config.database_backend = nano::database_backend::rocksdb;
-		return std::make_unique<nano::store::rocksdb::component> (logger, add_db_postfix ? path / "rocksdb" : path, constants, node_config.rocksdb_config, read_only);
+		case nano::database_backend::lmdb:
+		{
+			return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, node_config.diagnostics_config.txn_tracking, node_config.block_processor_batch_max_time, node_config.lmdb_config, node_config.backup_before_upgrade);
+		}
+		case nano::database_backend::rocksdb:
+		{
+			return std::make_unique<nano::store::rocksdb::component> (logger, add_db_postfix ? path / "rocksdb" : path, constants, node_config.rocksdb_config, read_only);
+		}
 	}
 
-	return std::make_unique<nano::store::lmdb::component> (logger, add_db_postfix ? path / "data.ldb" : path, constants, node_config.diagnostics_config.txn_tracking, node_config.block_processor_batch_max_time, node_config.lmdb_config, node_config.backup_before_upgrade);
+	release_assert (false); // Must be handled above
 }

--- a/nano/node/make_store.hpp
+++ b/nano/node/make_store.hpp
@@ -23,5 +23,5 @@ class component;
 
 namespace nano
 {
-std::unique_ptr<nano::store::component> make_store (nano::logger &, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only = false, bool add_db_postfix = true, nano::node_config const & node_config = nano::node_config{});
+std::unique_ptr<nano::store::component> make_store (nano::logger &, std::filesystem::path const & path, nano::ledger_constants & constants, bool read_only = false, bool add_db_postfix = true, nano::node_config node_config = nano::node_config{});
 }

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -701,18 +701,18 @@ nano::database_backend nano::node_config::get_config_backend (nano::tomlconfig &
 
 nano::database_backend nano::node_config::get_default_backend ()
 {
-	auto backend_str = nano::env::get<std::string> ("BACKEND");
+	auto backend_str = nano::env::get<std::string> ("NANO_BACKEND");
 
 	if (backend_str.has_value ())
 	{
 		auto backend = deserialize_database_backend (backend_str.value ());
 		if (backend.has_value ())
 		{
-			std::cerr << "Database backend overridden by BACKEND environment variable: " << *backend_str << std::endl;
+			std::cerr << "Database backend overridden by NANO_BACKEND environment variable: " << *backend_str << std::endl;
 			return backend.value ();
 		}
 
-		std::cerr << "Unknown database backend in BACKEND environment variable: " << *backend_str << std::endl;
+		std::cerr << "Unknown database backend in NANO_BACKEND environment variable: " << *backend_str << std::endl;
 	}
 	return database_backend::lmdb;
 }

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -139,7 +139,7 @@ public:
 	uint64_t max_pruning_depth{ 0 };
 	nano::rocksdb_config rocksdb_config;
 	nano::lmdb_config lmdb_config;
-	nano::database_backend database_backend{ std::string (std::getenv ("BACKEND") ? std::getenv ("BACKEND") : "") == "rocksdb" ? nano::database_backend::rocksdb : nano::database_backend::lmdb };
+	nano::database_backend database_backend{ get_default_backend () };
 	bool enable_upnp{ true };
 	std::size_t max_ledger_notifications{ 8 };
 
@@ -164,7 +164,9 @@ public:
 	/** Entry is ignored if it cannot be parsed as a valid address:port */
 	void deserialize_address (std::string const &, std::vector<std::pair<std::string, uint16_t>> &) const;
 	std::string serialize_database_backend (nano::database_backend) const;
-	nano::database_backend get_database_backend (nano::tomlconfig & toml);
+	std::optional<nano::database_backend> deserialize_database_backend (std::string backend_str) const;
+	nano::database_backend get_config_backend (nano::tomlconfig & toml);
+	nano::database_backend get_default_backend ();
 
 private:
 	static std::optional<unsigned> env_io_threads ();

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -49,6 +49,9 @@ enum class database_backend
 	rocksdb
 };
 
+std::string to_string (database_backend);
+std::optional<database_backend> parse_database_backend (std::string const &);
+
 /**
  * Node configuration
  */
@@ -139,7 +142,7 @@ public:
 	uint64_t max_pruning_depth{ 0 };
 	nano::rocksdb_config rocksdb_config;
 	nano::lmdb_config lmdb_config;
-	nano::database_backend database_backend{ get_default_backend () };
+	nano::database_backend database_backend{ env_database_backend ().value_or (nano::database_backend::lmdb) };
 	bool enable_upnp{ true };
 	std::size_t max_ledger_notifications{ 8 };
 
@@ -163,12 +166,9 @@ public:
 public:
 	/** Entry is ignored if it cannot be parsed as a valid address:port */
 	void deserialize_address (std::string const &, std::vector<std::pair<std::string, uint16_t>> &) const;
-	std::string serialize_database_backend (nano::database_backend) const;
-	std::optional<nano::database_backend> deserialize_database_backend (std::string backend_str) const;
-	nano::database_backend get_config_backend (nano::tomlconfig & toml);
-	nano::database_backend get_default_backend ();
 
-private:
+public:
+	static std::optional<nano::database_backend> env_database_backend ();
 	static std::optional<unsigned> env_io_threads ();
 };
 

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -43,6 +43,12 @@ namespace nano
 {
 class tomlconfig;
 
+enum class database_backend
+{
+	lmdb,
+	rocksdb
+};
+
 /**
  * Node configuration
  */
@@ -133,6 +139,7 @@ public:
 	uint64_t max_pruning_depth{ 0 };
 	nano::rocksdb_config rocksdb_config;
 	nano::lmdb_config lmdb_config;
+	nano::database_backend database_backend{ std::string (std::getenv ("BACKEND") ? std::getenv ("BACKEND") : "") == "rocksdb" ? nano::database_backend::rocksdb : nano::database_backend::lmdb };
 	bool enable_upnp{ true };
 	std::size_t max_ledger_notifications{ 8 };
 
@@ -156,6 +163,8 @@ public:
 public:
 	/** Entry is ignored if it cannot be parsed as a valid address:port */
 	void deserialize_address (std::string const &, std::vector<std::pair<std::string, uint16_t>> &) const;
+	std::string serialize_database_backend (nano::database_backend) const;
+	nano::database_backend get_database_backend (nano::tomlconfig & toml);
 
 private:
 	static std::optional<unsigned> env_io_threads ();

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1487,7 +1487,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			}
 		}
 
-		logger.info (nano::log::type::ledger, "Migration completed. Make sure to enable RocksDB in the config file under [node.rocksdb]");
+		logger.info (nano::log::type::ledger, "Migration completed. Make sure to update [node.database_backend] to 'rocksdb' in config.toml");
 		logger.info (nano::log::type::ledger, "After confirming correct node operation, the data.ldb file can be deleted if no longer required");
 	}
 	else

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1487,7 +1487,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 			}
 		}
 
-		logger.info (nano::log::type::ledger, "Migration completed. Make sure to update [node.database_backend] to 'rocksdb' in config.toml");
+		logger.info (nano::log::type::ledger, "Migration completed. Make sure to set `database_backend` under [node] to 'rocksdb' in config-node.toml");
 		logger.info (nano::log::type::ledger, "After confirming correct node operation, the data.ldb file can be deleted if no longer required");
 	}
 	else

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1304,7 +1304,7 @@ bool nano::ledger::migrate_lmdb_to_rocksdb (std::filesystem::path const & data_p
 
 	// Open rocksdb database
 	nano::node_config node_config;
-	node_config.rocksdb_config.enable = true;
+	node_config.database_backend = database_backend::rocksdb;
 	auto rocksdb_store = nano::make_store (logger, data_path_a, nano::dev::constants, false, true, node_config);
 
 	if (!rocksdb_store->init_error ())


### PR DESCRIPTION
In the current implementation, the database backend is determined by the setting of `RocksDb.Enable` config setting which is not very intuitive.
This PR replaces that setting with a new `database_backend` setting. It can be set to either `lmdb` or `rocksdb`. If not set, it defaults to `lmdb`.
To make it easier for node operators that are currently using RocksDb, the node will notify the operator with an error message if the config file has the old `RocksDb.Enable` set to true and `database_backend` set to lmdb (for example when using an old config file that does not have the new database_backend property). The error message can be removed in future versions when operators have migrated to use the new `database_backend` type
This PR also makes it easier to add more backends in the future.