### PR TITLE
Disable `peer_container.list_fanout` test

### DIFF
--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -169,7 +169,7 @@ TEST (channels, fill_random_part)
 }
 
 // TODO: remove node instantiation requirement for testing with bigger network size
-TEST (peer_container, list_fanout)
+TEST (peer_container, DISABLED_list_fanout)
 {
 	nano::test::system system{ 1 };
 	auto node = system.nodes[0];


### PR DESCRIPTION
Originally this test was fine because it was using channels, but in #3923 channels were replaced with full nodes. Running so many (10+) full nodes on github runners is unstable.