### PR TITLE
Only query confirmed blocks in rep crawler

### DIFF
--- a/nano/core_test/rep_crawler.cpp
+++ b/nano/core_test/rep_crawler.cpp
@@ -254,7 +254,8 @@ TEST (rep_crawler, rep_connection_close)
 // The behaviour of this test previously was the opposite, that the repcrawler eventually send out such a block and deleted the block
 // from the recently confirmed list to try to make ammends for sending it, which is bad behaviour.
 // In the long term, we should have a better way to check for reps and this test should become redundant
-TEST (rep_crawler, recently_confirmed)
+// DISABLED as behaviour changed, and we now only query confirmed blocks
+TEST (rep_crawler, DISABLED_recently_confirmed)
 {
 	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -106,7 +106,7 @@ private:
 	/** Returns a list of endpoints to crawl. The total weight is passed in to avoid computing it twice. */
 
 	std::deque<std::shared_ptr<nano::transport::channel>> prepare_crawl_targets (bool sufficient_weight) const;
-	std::optional<hash_root_t> prepare_query_target () const;
+	hash_root_t prepare_query_target () const;
 	bool track_rep_request (hash_root_t hash_root, std::shared_ptr<nano::transport::channel> const & channel);
 
 private:


### PR DESCRIPTION
At some point behavior of `request_aggregator` changed and now nodes will not respond to queries for blocks that are not confirmed. Because of this we need to adjust `rep_crawler` block selection logic.