### PR TITLE
Ledger: Use representative for change blocks and epoch signer for epoch blocks in linked_account

### DIFF
--- a/nano/lib/blocks.cpp
+++ b/nano/lib/blocks.cpp
@@ -293,6 +293,19 @@ nano::account nano::block::destination () const noexcept
 	}
 }
 
+nano::account nano::block::representative () const noexcept
+{
+	switch (type ())
+	{
+		case nano::block_type::open:
+		case nano::block_type::change:
+		case nano::block_type::state:
+			return representative_field ().value ();
+		default:
+			release_assert (false);
+	}
+}
+
 nano::block_hash nano::block::source () const noexcept
 {
 	release_assert (has_sideband ());
@@ -304,6 +317,17 @@ nano::block_hash nano::block::source () const noexcept
 		case nano::block_type::state:
 			release_assert (sideband ().details.is_receive);
 			return link_field ().value ().as_block_hash ();
+		default:
+			release_assert (false);
+	}
+}
+
+nano::link nano::block::link () const noexcept
+{
+	switch (type ())
+	{
+		case nano::block_type::state:
+			return link_field ().value ();
 		default:
 			release_assert (false);
 	}

--- a/nano/lib/blocks.hpp
+++ b/nano/lib/blocks.hpp
@@ -71,13 +71,17 @@ public: // Direct access to the block fields or nullopt if the block type does n
 	nano::account destination () const noexcept;
 	// Destination account for send blocks
 	virtual std::optional<nano::account> destination_field () const;
+	// Returns the link hash or account for state blocks
+	nano::link link () const noexcept;
 	// Link field for state blocks
 	virtual std::optional<nano::link> link_field () const;
 	// Previous block if field exists or 0
 	nano::block_hash previous () const noexcept;
 	// Previous block in chain if the field exists
 	virtual std::optional<nano::block_hash> previous_field () const = 0;
-	// Representative field for open/change blocks
+	// Returns the representative account for open/change/state blocks
+	nano::account representative () const noexcept;
+	// Representative field for open/change/state blocks
 	virtual std::optional<nano::account> representative_field () const;
 	// Returns the source block hash for open/receive/state blocks that are receives
 	nano::block_hash source () const noexcept;

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -41,7 +41,7 @@ nano::distributed_work::~distributed_work ()
 	{
 		if (!node_l->stopped && node_l->websocket.server && node_l->websocket.server->any_subscriber (nano::websocket::topic::work))
 		{
-			nano::websocket::message_builder builder;
+			nano::websocket::message_builder builder{ node_l->ledger };
 			if (status == work_generation_status::success)
 			{
 				node_l->websocket.server->broadcast (builder.work_generation (request.version, request.root.as_block_hash (), work_result, request.difficulty, node_l->default_difficulty (request.version), elapsed.value (), winner, bad_peers));

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -187,7 +187,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	bootstrap_server{ *bootstrap_server_impl },
 	bootstrap_impl{ std::make_unique<nano::bootstrap_service> (config, ledger, ledger_notifications, block_processor, network, stats, logger) },
 	bootstrap{ *bootstrap_impl },
-	websocket_impl{ std::make_unique<nano::websocket_server> (config.websocket_config, observers, wallets, ledger, io_ctx, logger) },
+	websocket_impl{ std::make_unique<nano::websocket_server> (config.websocket_config, *this, observers, wallets, ledger, io_ctx, logger) },
 	websocket{ *websocket_impl },
 	epoch_upgrader_impl{ std::make_unique<nano::epoch_upgrader> (*this, ledger, store, network_params, logger) },
 	epoch_upgrader{ *epoch_upgrader_impl },
@@ -236,7 +236,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 			{
 				if (websocket.server && websocket.server->any_subscriber (nano::websocket::topic::new_unconfirmed_block))
 				{
-					websocket.server->broadcast (nano::websocket::message_builder ().new_block_arrived (*context.block));
+					websocket.server->broadcast (nano::websocket::message_builder (ledger).new_block_arrived (*context.block));
 				}
 			}
 		}

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -24,6 +24,7 @@ class election_status;
 enum class election_status_type : uint8_t;
 class ledger;
 class logger;
+class node;
 class node_observers;
 class telemetry_data;
 class vote;
@@ -88,6 +89,8 @@ namespace websocket
 	class message_builder final
 	{
 	public:
+		message_builder (nano::ledger & ledger);
+
 		message block_confirmed (std::shared_ptr<nano::block> const & block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype, bool include_block, nano::election_status const & election_status_a, std::vector<nano::vote_with_weight_info> const & election_votes_a, nano::websocket::confirmation_options const & options_a);
 		message started_election (nano::block_hash const & hash_a);
 		message stopped_election (nano::block_hash const & hash_a);
@@ -103,6 +106,8 @@ namespace websocket
 	private:
 		/** Set the common fields for messages: timestamp and topic. */
 		void set_common_fields (message & message_a);
+
+		nano::ledger & ledger;
 	};
 
 	/** Options for subscriptions */
@@ -183,6 +188,12 @@ namespace websocket
 			return include_election_info_with_votes;
 		}
 
+		/** Returns whether or not to include linked accounts */
+		bool get_include_linked_account () const
+		{
+			return include_linked_account;
+		}
+
 		/** Returns whether or not to include sideband info */
 		bool get_include_sideband_info () const
 		{
@@ -203,6 +214,7 @@ namespace websocket
 
 		bool include_election_info{ false };
 		bool include_election_info_with_votes{ false };
+		bool include_linked_account{ false };
 		bool include_sideband_info{ false };
 		bool include_block{ true };
 		bool has_account_filtering_options{ false };
@@ -302,7 +314,7 @@ namespace websocket
 	class listener final : public std::enable_shared_from_this<listener>
 	{
 	public:
-		listener (nano::logger &, nano::wallets & wallets_a, boost::asio::io_context & io_ctx_a, boost::asio::ip::tcp::endpoint endpoint_a);
+		listener (nano::logger &, nano::node &, nano::wallets & wallets_a, boost::asio::io_context & io_ctx_a, boost::asio::ip::tcp::endpoint endpoint_a);
 
 		/** Start accepting connections */
 		void run ();
@@ -352,6 +364,7 @@ namespace websocket
 		void decrease_subscriber_count (nano::websocket::topic const & topic_a);
 
 		nano::logger & logger;
+		nano::node & node;
 		nano::wallets & wallets;
 		boost::asio::ip::tcp::acceptor acceptor;
 		socket_type socket;
@@ -368,7 +381,7 @@ namespace websocket
 class websocket_server
 {
 public:
-	websocket_server (nano::websocket::config &, nano::node_observers &, nano::wallets &, nano::ledger &, boost::asio::io_context &, nano::logger &);
+	websocket_server (nano::websocket::config &, nano::node &, nano::node_observers &, nano::wallets &, nano::ledger &, boost::asio::io_context &, nano::logger &);
 
 	void start ();
 	void stop ();

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1170,6 +1170,22 @@ std::shared_ptr<nano::block> nano::ledger::find_receive_block_by_send_hash (secu
 	return result;
 }
 
+std::optional<nano::account> nano::ledger::linked_account (secure::transaction const & transaction, nano::block const & block)
+{
+	debug_assert (block.has_sideband ());
+
+	if (block.sideband ().details.is_send)
+	{
+		return block.destination ();
+	}
+	else if (block.sideband ().details.is_receive)
+	{
+		return any.block_account (transaction, block.source ());
+	}
+
+	return std::nullopt;
+}
+
 nano::account const & nano::ledger::epoch_signer (nano::link const & link_a) const
 {
 	return constants.epochs.signer (constants.epochs.epoch (link_a));

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1172,13 +1172,11 @@ std::shared_ptr<nano::block> nano::ledger::find_receive_block_by_send_hash (secu
 
 std::optional<nano::account> nano::ledger::linked_account (secure::transaction const & transaction, nano::block const & block)
 {
-	debug_assert (block.has_sideband ());
-
-	if (block.sideband ().details.is_send)
+	if (block.is_send ())
 	{
 		return block.destination ();
 	}
-	else if (block.sideband ().details.is_receive)
+	else if (block.is_receive ())
 	{
 		return any.block_account (transaction, block.source ());
 	}

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1180,6 +1180,14 @@ std::optional<nano::account> nano::ledger::linked_account (secure::transaction c
 	{
 		return any.block_account (transaction, block.source ());
 	}
+	else if (block.is_change ())
+	{
+		return block.representative ();
+	}
+	else if (block.is_epoch ())
+	{
+		return epoch_signer (block.link ());
+	}
 
 	return std::nullopt;
 }

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -72,6 +72,7 @@ public:
 	bool is_epoch_link (nano::link const &) const;
 	std::array<nano::block_hash, 2> dependent_blocks (secure::transaction const &, nano::block const &) const;
 	std::shared_ptr<nano::block> find_receive_block_by_send_hash (secure::transaction const &, nano::account const & destination, nano::block_hash const & send_block_hash);
+	std::optional<nano::account> linked_account (secure::transaction const &, nano::block const &);
 	nano::account const & epoch_signer (nano::link const &) const;
 	nano::link const & epoch_link (nano::epoch) const;
 	bool migrate_lmdb_to_rocksdb (std::filesystem::path const &) const;


### PR DESCRIPTION
- For change blocks, `ledger::linked_account` now returns the block's representative
- For epoch blocks, it returns the corresponding epoch signer

**Issues resolved**
This PR is an extension to PR #4841

This PR simplifies the detection of related accounts for block explorer applications. As a result, the following logic can be completely removed, reducing complexity:

```
switch (historyEntry.type) {
  case "change":
	relatedAccount = historyEntry.representative;
	break;
  case "open":
  case "receive":
	relatedAccount = historyEntry.account;
	break;
  case "send":
	relatedAccount = historyEntry.destination;
	break;
  case "state":
	switch (historyEntry.subtype) {
	  case "change":
		relatedAccount = historyEntry.representative;
		break;
	  case "epoch": // ToDo: Find epoch signer
		relatedAccount = historyEntry.account;
		break;
	  case "receive":
	  case "send":
		relatedAccount = historyEntry.account;
		break;
	}
	break;
}
```