### PR TITLE
Decay bootstrap blocking set

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -178,6 +178,83 @@ TEST (account_sets, saturate_priority)
 	ASSERT_EQ (sets.priority (account), nano::bootstrap::account_sets::priority_max);
 }
 
+TEST (account_sets, decay_blocking)
+{
+	using namespace std::chrono_literals;
+
+	nano::test::system system;
+	nano::account_sets_config config;
+	config.blocking_decay = 1s;
+	nano::bootstrap::account_sets sets{ config, system.stats };
+
+	// Test empty set
+	ASSERT_EQ (0, sets.decay_blocking ());
+
+	// Create test accounts and timestamps
+	nano::account account1{ 1 };
+	nano::account account2{ 2 };
+	nano::account account3{ 3 };
+
+	auto now = std::chrono::steady_clock::now ();
+
+	// Add first account
+	sets.priority_up (account1);
+	sets.block (account1, random_hash (), now);
+	ASSERT_TRUE (sets.blocked (account1));
+	ASSERT_EQ (1, sets.blocked_size ());
+
+	// Decay before timeout should not remove entry
+	ASSERT_EQ (0, sets.decay_blocking (now));
+	ASSERT_TRUE (sets.blocked (account1));
+	ASSERT_EQ (1, sets.blocked_size ());
+
+	// Add second account after 500ms
+	now += 500ms;
+	sets.priority_up (account2);
+	sets.block (account2, random_hash (), now);
+	ASSERT_TRUE (sets.blocked (account2));
+	ASSERT_EQ (2, sets.blocked_size ());
+
+	// Add third account after another 500ms
+	now += 500ms;
+	sets.priority_up (account3);
+	sets.block (account3, random_hash (), now);
+	ASSERT_TRUE (sets.blocked (account3));
+	ASSERT_EQ (3, sets.blocked_size ());
+
+	// Decay at 1.5s - should remove first two accounts
+	now += 500ms;
+	ASSERT_EQ (2, sets.decay_blocking (now));
+	ASSERT_FALSE (sets.blocked (account1));
+	ASSERT_FALSE (sets.blocked (account2));
+	ASSERT_TRUE (sets.blocked (account3));
+	ASSERT_EQ (1, sets.blocked_size ());
+
+	// Reinsert second account
+	auto hash2 = random_hash ();
+	sets.priority_up (account2);
+	sets.block (account2, hash2, now);
+	ASSERT_TRUE (sets.blocked (account2));
+	ASSERT_EQ (2, sets.blocked_size ());
+
+	// Immediate decay should not affect reinserted account
+	ASSERT_EQ (0, sets.decay_blocking (now));
+	ASSERT_TRUE (sets.blocked (account2));
+
+	// Decay at 2s - should remove account3 but keep reinserted account2
+	now += 500ms;
+	ASSERT_EQ (1, sets.decay_blocking (now));
+	ASSERT_FALSE (sets.blocked (account3));
+	ASSERT_TRUE (sets.blocked (account2));
+	ASSERT_EQ (1, sets.blocked_size ());
+
+	// Final decay after another second - should remove remaining account
+	now += 1s;
+	ASSERT_EQ (1, sets.decay_blocking (now));
+	ASSERT_FALSE (sets.blocked (account2));
+	ASSERT_EQ (0, sets.blocked_size ());
+}
+
 /*
  * bootstrap
  */

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -546,6 +546,8 @@ enum class detail
 	deprioritize,
 	deprioritize_failed,
 	sync_dependencies,
+	decay_blocking,
+	blocking_decayed,
 	dependency_synced,
 
 	request_blocks,

--- a/nano/node/bootstrap/account_sets.cpp
+++ b/nano/node/bootstrap/account_sets.cpp
@@ -117,7 +117,7 @@ void nano::bootstrap::account_sets::priority_erase (nano::account const & accoun
 	}
 }
 
-void nano::bootstrap::account_sets::block (nano::account const & account, nano::block_hash const & dependency)
+void nano::bootstrap::account_sets::block (nano::account const & account, nano::block_hash const & dependency, std::chrono::steady_clock::time_point now)
 {
 	debug_assert (!account.is_zero ());
 
@@ -128,7 +128,7 @@ void nano::bootstrap::account_sets::block (nano::account const & account, nano::
 		stats.inc (nano::stat::type::bootstrap_account_sets, nano::stat::detail::block);
 
 		debug_assert (blocking.get<tag_account> ().count (account) == 0);
-		blocking.get<tag_account> ().insert ({ account, dependency });
+		blocking.get<tag_account> ().insert ({ account, dependency, now });
 		trim_overflow ();
 	}
 	else
@@ -309,6 +309,32 @@ void nano::bootstrap::account_sets::sync_dependencies ()
 	}
 
 	trim_overflow ();
+}
+
+size_t nano::bootstrap::account_sets::decay_blocking (std::chrono::steady_clock::time_point now)
+{
+	stats.inc (nano::stat::type::bootstrap_account_sets, nano::stat::detail::decay_blocking);
+
+	auto const cutoff = now - config.blocking_decay;
+
+	// Erase all entries that are older than the cutoff
+	size_t result = 0;
+	for (auto it = blocking.get<tag_timestamp> ().begin (); it != blocking.get<tag_timestamp> ().end ();)
+	{
+		if (it->timestamp <= cutoff)
+		{
+			it = blocking.get<tag_timestamp> ().erase (it);
+			++result;
+		}
+		else
+		{
+			break; // Entries are sorted by timestamp, no need to continue
+		}
+	}
+
+	stats.add (nano::stat::type::bootstrap_account_sets, nano::stat::detail::blocking_decayed, result);
+
+	return result;
 }
 
 bool nano::bootstrap::account_sets::blocked (nano::account const & account) const

--- a/nano/node/bootstrap/bootstrap_config.cpp
+++ b/nano/node/bootstrap/bootstrap_config.cpp
@@ -11,6 +11,7 @@ nano::error nano::account_sets_config::deserialize (nano::tomlconfig & toml)
 	toml.get ("priorities_max", priorities_max);
 	toml.get ("blocking_max", blocking_max);
 	toml.get_duration ("cooldown", cooldown);
+	toml.get_duration ("blocking_decay", blocking_decay);
 
 	return toml.get_error ();
 }
@@ -21,6 +22,7 @@ nano::error nano::account_sets_config::serialize (nano::tomlconfig & toml) const
 	toml.put ("priorities_max", priorities_max, "Cutoff size limit for the priority list.\ntype:uint64");
 	toml.put ("blocking_max", blocking_max, "Cutoff size limit for the blocked accounts from the priority list.\ntype:uint64");
 	toml.put ("cooldown", cooldown.count (), "Waiting time for an account to become available.\ntype:milliseconds");
+	toml.put ("blocking_decay", blocking_decay.count (), "Time to wait before removing an account from the blocked list.\ntype:seconds");
 
 	return toml.get_error ();
 }

--- a/nano/node/bootstrap/bootstrap_config.hpp
+++ b/nano/node/bootstrap/bootstrap_config.hpp
@@ -4,6 +4,8 @@
 #include <nano/lib/timer.hpp>
 #include <nano/node/bootstrap/bootstrap_server.hpp>
 
+using namespace std::chrono_literals;
+
 namespace nano
 {
 class tomlconfig;
@@ -19,6 +21,7 @@ public:
 	std::size_t priorities_max{ 256 * 1024 };
 	std::size_t blocking_max{ 256 * 1024 };
 	std::chrono::milliseconds cooldown{ 1000 * 3 };
+	std::chrono::seconds blocking_decay{ 15min };
 };
 
 class frontier_scan_config final

--- a/nano/node/bootstrap/bootstrap_service.cpp
+++ b/nano/node/bootstrap/bootstrap_service.cpp
@@ -757,11 +757,14 @@ void nano::bootstrap_service::cleanup_and_sync ()
 
 	throttle.resize (compute_throttle_size ());
 
+	accounts.decay_blocking ();
+
 	auto const now = std::chrono::steady_clock::now ();
 	auto should_timeout = [&] (async_tag const & tag) {
 		return tag.cutoff < now;
 	};
 
+	// Erase timed out requests
 	auto & tags_by_order = tags.get<tag_sequenced> ();
 	while (!tags_by_order.empty () && should_timeout (tags_by_order.front ()))
 	{
@@ -771,7 +774,8 @@ void nano::bootstrap_service::cleanup_and_sync ()
 		tags_by_order.pop_front ();
 	}
 
-	if (sync_dependencies_interval.elapse (60s))
+	// Reinsert known dependencies into the priority set
+	if (sync_dependencies_interval.elapse (nano::is_dev_run () ? 1s : 60s))
 	{
 		stats.inc (nano::stat::type::bootstrap, nano::stat::detail::sync_dependencies);
 		accounts.sync_dependencies ();


### PR DESCRIPTION
This adds a mechanism by which entries in bootstrap blocking set can be cleaned up after a period of time. This is to make the bootstrap process more robust. By default the decay period is set to 15 minutes, which might require tweaking, and is configurable via `[node.bootstrap.account_sets] blocking_decay` configuration variable.