### PR TITLE
Improve handling of rep weights snapshots

### DIFF
--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -355,18 +355,16 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 		{
 			auto const bootstrap_weights = get_bootstrap_weights ();
 			ledger.bootstrap_weight_max_blocks = bootstrap_weights.first;
+			ledger.bootstrap_weights = bootstrap_weights.second;
 
 			logger.info (nano::log::type::node, "Initial bootstrap height: {}", ledger.bootstrap_weight_max_blocks);
 			logger.info (nano::log::type::node, "Current ledger height:    {}", ledger.block_count ());
 
 			// Use bootstrap weights if initial bootstrap is not completed
-			const bool use_bootstrap_weight = ledger.block_count () < bootstrap_weights.first;
+			const bool use_bootstrap_weight = !ledger.bootstrap_height_reached ();
 			if (use_bootstrap_weight)
 			{
 				logger.info (nano::log::type::node, "Using predefined representative weights, since block count is less than bootstrap threshold");
-
-				ledger.bootstrap_weights = bootstrap_weights.second;
-
 				logger.info (nano::log::type::node, "******************************************** Bootstrap weights ********************************************");
 
 				// Sort the weights

--- a/nano/node/rep_tiers.cpp
+++ b/nano/node/rep_tiers.cpp
@@ -86,7 +86,7 @@ void nano::rep_tiers::run ()
 void nano::rep_tiers::calculate_tiers ()
 {
 	auto stake = online_reps.trended ();
-	auto rep_amounts = ledger.cache.rep_weights.get_rep_amounts ();
+	auto rep_amounts = ledger.rep_weights_snapshot ();
 
 	decltype (representatives_1) representatives_1_l;
 	decltype (representatives_2) representatives_2_l;

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -76,7 +76,8 @@ public:
 	nano::account const & epoch_signer (nano::link const &) const;
 	nano::link const & epoch_link (nano::epoch) const;
 	bool migrate_lmdb_to_rocksdb (std::filesystem::path const &) const;
-	bool bootstrap_weight_reached () const;
+	bool bootstrap_height_reached () const;
+	std::unordered_map<nano::account, nano::uint128_t> rep_weights_snapshot () const;
 
 	static nano::epoch version (nano::block const & block);
 	nano::epoch version (secure::transaction const &, nano::block_hash const & hash) const;
@@ -104,7 +105,6 @@ public:
 
 	std::unordered_map<nano::account, nano::uint128_t> bootstrap_weights;
 	uint64_t bootstrap_weight_max_blocks{ 1 };
-	mutable std::atomic<bool> check_bootstrap_weights;
 
 	bool pruning{ false };
 


### PR DESCRIPTION
Calling `ledger.cache.rep_weights.get_rep_amounts ();` to capture rep weights snapshots always used on disk ledger weights. This PR makes the behavior consistent with `ledger.weight ()` function which uses bootstrap weights if the node isn't fully bootstrapped yet. We use these weights for vote processing prioritization.