### PR TITLE
Filter channels with spare capacity when broadcasting

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -971,7 +971,7 @@ TEST (active_elections, fork_replacement_tally)
 	node_config.peering_port = system.get_available_port ();
 	auto & node2 (*system.add_node (node_config));
 	node1.network.filter.clear ();
-	node2.network.flood_block (send_last, nano::transport::traffic_type::test);
+	ASSERT_TRUE (node2.network.flood_block (send_last, nano::transport::traffic_type::test));
 	ASSERT_TIMELY (3s, node1.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) > 0);
 
 	// Correct block without votes is ignored
@@ -985,7 +985,7 @@ TEST (active_elections, fork_replacement_tally)
 	// ensure vote arrives before the block
 	ASSERT_TIMELY_EQ (5s, 1, node1.vote_cache.find (send_last->hash ()).size ());
 	node1.network.filter.clear ();
-	node2.network.flood_block (send_last, nano::transport::traffic_type::test);
+	ASSERT_TRUE (node2.network.flood_block (send_last, nano::transport::traffic_type::test));
 	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) > 1);
 
 	// the send_last block should replace one of the existing block of the election because it has higher vote weight

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2238,11 +2238,11 @@ TEST (node, DISABLED_fork_invalid_block_signature)
 	node1.process_active (send1);
 	ASSERT_TIMELY (5s, node1.block (send1->hash ()));
 	// Send the vote with the corrupt block signature
-	node2.network.flood_vote (vote_corrupt, 1.0f);
+	ASSERT_TRUE (node2.network.flood_vote_rebroadcasted (vote_corrupt, 1.0f));
 	// Wait for the rollback
 	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::rollback));
 	// Send the vote with the correct block
-	node2.network.flood_vote (vote, 1.0f);
+	ASSERT_TRUE (node2.network.flood_vote_rebroadcasted (vote, 1.0f));
 	ASSERT_TIMELY (10s, !node1.block (send1->hash ()));
 	ASSERT_TIMELY (10s, node1.block (send2->hash ()));
 	ASSERT_EQ (node1.block (send2->hash ())->block_signature (), send2->block_signature ());

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -174,6 +174,7 @@ enum class detail
 	error,
 	failed,
 	refresh,
+	sent,
 
 	// processing queue
 	queue,
@@ -432,11 +433,13 @@ enum class detail
 	cleanup_outdated,
 	erase_stale,
 
-	// vote generator
+	// vote_generator
 	generator_broadcasts,
 	generator_replies,
 	generator_replies_discarded,
 	generator_spacing,
+	sent_pr,
+	sent_non_pr,
 
 	// hinting
 	missing_block,

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -299,11 +299,11 @@ size_t nano::network::flood_block_initial (std::shared_ptr<nano::block> const & 
 	return result;
 }
 
-size_t nano::network::flood_vote (std::shared_ptr<nano::vote> const & vote, float scale, bool rebroadcasted) const
+size_t nano::network::flood_vote_rebroadcasted (std::shared_ptr<nano::vote> const & vote, float scale) const
 {
-	nano::confirm_ack message{ node.network_params.network, vote, rebroadcasted };
+	nano::confirm_ack message{ node.network_params.network, vote, /* rebroadcasted */ true };
 
-	auto const type = rebroadcasted ? nano::transport::traffic_type::vote_rebroadcast : nano::transport::traffic_type::vote;
+	auto const type = nano::transport::traffic_type::vote_rebroadcast;
 
 	auto channels = list (fanout (scale), [type] (auto const & channel) {
 		return !channel->max (type); // Only use channels that are not full for this traffic type
@@ -318,11 +318,11 @@ size_t nano::network::flood_vote (std::shared_ptr<nano::vote> const & vote, floa
 	return result;
 }
 
-size_t nano::network::flood_vote_non_pr (std::shared_ptr<nano::vote> const & vote, float scale, bool rebroadcasted) const
+size_t nano::network::flood_vote_non_pr (std::shared_ptr<nano::vote> const & vote, float scale) const
 {
-	nano::confirm_ack message{ node.network_params.network, vote, rebroadcasted };
+	nano::confirm_ack message{ node.network_params.network, vote };
 
-	auto const type = rebroadcasted ? nano::transport::traffic_type::vote_rebroadcast : nano::transport::traffic_type::vote;
+	auto const type = transport::traffic_type::vote;
 
 	auto channels = list_non_pr (fanout (scale), [type] (auto const & channel) {
 		return !channel->max (type); // Only use channels that are not full for this traffic type
@@ -337,11 +337,11 @@ size_t nano::network::flood_vote_non_pr (std::shared_ptr<nano::vote> const & vot
 	return result;
 }
 
-size_t nano::network::flood_vote_pr (std::shared_ptr<nano::vote> const & vote, bool rebroadcasted) const
+size_t nano::network::flood_vote_pr (std::shared_ptr<nano::vote> const & vote) const
 {
-	nano::confirm_ack message{ node.network_params.network, vote, rebroadcasted };
+	nano::confirm_ack message{ node.network_params.network, vote };
 
-	auto const type = rebroadcasted ? nano::transport::traffic_type::vote_rebroadcast : nano::transport::traffic_type::vote;
+	auto const type = nano::transport::traffic_type::vote;
 
 	size_t result = 0;
 	for (auto const & channel : node.rep_crawler.principal_representatives ())

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -95,16 +95,16 @@ public:
 
 	nano::endpoint endpoint () const;
 
-	void flood_message (nano::message const &, nano::transport::traffic_type, float scale = 1.0f) const;
-	void flood_keepalive (float scale = 1.0f) const;
-	void flood_keepalive_self (float scale = 0.5f) const;
-	void flood_vote (std::shared_ptr<nano::vote> const &, float scale, bool rebroadcasted = false) const;
-	void flood_vote_pr (std::shared_ptr<nano::vote> const &, bool rebroadcasted = false) const;
-	void flood_vote_non_pr (std::shared_ptr<nano::vote> const &, float scale, bool rebroadcasted = false) const;
+	size_t flood_message (nano::message const &, nano::transport::traffic_type, float scale = 1.0f) const;
+	size_t flood_keepalive (float scale = 1.0f) const;
+	size_t flood_keepalive_self (float scale = 0.5f) const;
+	size_t flood_vote (std::shared_ptr<nano::vote> const &, float scale, bool rebroadcasted = false) const;
+	size_t flood_vote_pr (std::shared_ptr<nano::vote> const &, bool rebroadcasted = false) const;
+	size_t flood_vote_non_pr (std::shared_ptr<nano::vote> const &, float scale, bool rebroadcasted = false) const;
 	// Flood block to all PRs and a random selection of non-PRs
-	void flood_block_initial (std::shared_ptr<nano::block> const &) const;
+	size_t flood_block_initial (std::shared_ptr<nano::block> const &) const;
 	// Flood block to a random selection of peers
-	void flood_block (std::shared_ptr<nano::block> const &, nano::transport::traffic_type) const;
+	size_t flood_block (std::shared_ptr<nano::block> const &, nano::transport::traffic_type) const;
 	void flood_block_many (std::deque<std::shared_ptr<nano::block>>, nano::transport::traffic_type, std::chrono::milliseconds delay = 10ms, std::function<void ()> callback = nullptr) const;
 
 	void send_keepalive (std::shared_ptr<nano::transport::channel> const &) const;

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -121,8 +121,13 @@ public:
 	// Should we reach out to this endpoint with a keepalive message? If yes, register a new reachout attempt
 	bool track_reachout (nano::endpoint const &);
 
-	std::deque<std::shared_ptr<nano::transport::channel>> list (std::size_t max_count = 0, uint8_t minimum_version = 0) const;
-	std::deque<std::shared_ptr<nano::transport::channel>> list_non_pr (std::size_t max_count, uint8_t minimum_version = 0) const;
+	using channel_filter = std::function<bool (std::shared_ptr<nano::transport::channel> const &)>;
+
+	std::deque<std::shared_ptr<nano::transport::channel>> list (std::size_t max_count = 0, channel_filter = nullptr) const;
+	std::deque<std::shared_ptr<nano::transport::channel>> list_non_pr (std::size_t max_count = 0, channel_filter = nullptr) const;
+
+	std::deque<std::shared_ptr<nano::transport::channel>> list (std::size_t max_count, uint8_t minimum_version) const;
+	std::deque<std::shared_ptr<nano::transport::channel>> list_non_pr (std::size_t max_count, uint8_t minimum_version) const;
 
 	// Desired fanout for a given scale
 	std::size_t fanout (float scale = 1.0f) const;

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -98,9 +98,9 @@ public:
 	size_t flood_message (nano::message const &, nano::transport::traffic_type, float scale = 1.0f) const;
 	size_t flood_keepalive (float scale = 1.0f) const;
 	size_t flood_keepalive_self (float scale = 0.5f) const;
-	size_t flood_vote (std::shared_ptr<nano::vote> const &, float scale, bool rebroadcasted = false) const;
-	size_t flood_vote_pr (std::shared_ptr<nano::vote> const &, bool rebroadcasted = false) const;
-	size_t flood_vote_non_pr (std::shared_ptr<nano::vote> const &, float scale, bool rebroadcasted = false) const;
+	size_t flood_vote_pr (std::shared_ptr<nano::vote> const &) const;
+	size_t flood_vote_non_pr (std::shared_ptr<nano::vote> const &, float scale) const;
+	size_t flood_vote_rebroadcasted (std::shared_ptr<nano::vote> const &, float scale) const;
 	// Flood block to all PRs and a random selection of non-PRs
 	size_t flood_block_initial (std::shared_ptr<nano::block> const &) const;
 	// Flood block to a random selection of peers

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -417,6 +417,21 @@ std::deque<std::shared_ptr<nano::transport::channel>> nano::transport::tcp_chann
 	return result;
 }
 
+std::deque<std::shared_ptr<nano::transport::channel>> nano::transport::tcp_channels::list (channel_filter filter) const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+
+	std::deque<std::shared_ptr<nano::transport::channel>> result;
+	for (auto const & entry : channels)
+	{
+		if (filter == nullptr || filter (entry.channel))
+		{
+			result.push_back (entry.channel);
+		}
+	}
+	return result;
+}
+
 bool nano::transport::tcp_channels::start_tcp (nano::endpoint const & endpoint)
 {
 	return node.tcp_listener.connect (endpoint.address (), endpoint.port ());

--- a/nano/node/transport/tcp_channels.hpp
+++ b/nano/node/transport/tcp_channels.hpp
@@ -50,8 +50,12 @@ public:
 	// Should we reach out to this endpoint with a keepalive message? If yes, register a new reachout attempt
 	bool track_reachout (nano::endpoint const &);
 	void purge (std::chrono::steady_clock::time_point cutoff_deadline);
+
+	using channel_filter = std::function<bool (std::shared_ptr<nano::transport::channel> const &)>;
+	std::deque<std::shared_ptr<nano::transport::channel>> list (channel_filter) const;
 	std::deque<std::shared_ptr<nano::transport::channel>> list (uint8_t minimum_version = 0) const;
 	std::unordered_set<std::shared_ptr<nano::transport::channel>> random_set (std::size_t max_count, uint8_t minimum_version = 0) const;
+
 	void keepalive ();
 	std::optional<nano::keepalive> sample_keepalive ();
 

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -278,9 +278,13 @@ void nano::vote_generator::vote (std::vector<nano::block_hash> const & hashes_a,
 
 void nano::vote_generator::broadcast_action (std::shared_ptr<nano::vote> const & vote_a) const
 {
-	network.flood_vote_pr (vote_a);
-	network.flood_vote_non_pr (vote_a, 2.0f);
 	vote_processor.vote (vote_a, inproc_channel);
+
+	auto sent_pr = network.flood_vote_pr (vote_a);
+	auto sent_non_pr = network.flood_vote_non_pr (vote_a, 2.0f);
+
+	stats.add (nano::stat::type::vote_generator, nano::stat::detail::sent_pr, sent_pr);
+	stats.add (nano::stat::type::vote_generator, nano::stat::detail::sent_non_pr, sent_non_pr);
 }
 
 void nano::vote_generator::run ()

--- a/nano/node/vote_rebroadcaster.cpp
+++ b/nano/node/vote_rebroadcaster.cpp
@@ -114,7 +114,7 @@ void nano::vote_rebroadcaster::run ()
 			stats.inc (nano::stat::type::vote_rebroadcaster, nano::stat::detail::rebroadcast);
 			stats.add (nano::stat::type::vote_rebroadcaster, nano::stat::detail::rebroadcast_hashes, vote->hashes.size ());
 
-			auto sent = network.flood_vote (vote, 0.5f, /* rebroadcasted */ true);
+			auto sent = network.flood_vote_rebroadcasted (vote, 0.5f);
 			stats.add (nano::stat::type::vote_rebroadcaster, nano::stat::detail::sent, sent);
 
 			lock.lock ();

--- a/nano/node/vote_rebroadcaster.cpp
+++ b/nano/node/vote_rebroadcaster.cpp
@@ -113,7 +113,9 @@ void nano::vote_rebroadcaster::run ()
 
 			stats.inc (nano::stat::type::vote_rebroadcaster, nano::stat::detail::rebroadcast);
 			stats.add (nano::stat::type::vote_rebroadcaster, nano::stat::detail::rebroadcast_hashes, vote->hashes.size ());
-			network.flood_vote (vote, 0.5f, /* rebroadcasted */ true); // TODO: Track number of peers that we sent the vote to
+
+			auto sent = network.flood_vote (vote, 0.5f, /* rebroadcasted */ true);
+			stats.add (nano::stat::type::vote_rebroadcaster, nano::stat::detail::sent, sent);
 
 			lock.lock ();
 		}


### PR DESCRIPTION
This PR modifies the `network.flood_message / vote / block / keepalive` functions so that they only broadcast the messages on channels with spare capacity. This also adds additional tracking of messages sent by the `flood_*` functions to better assess how much traffic is generated.