### PR TITLE
Online weight tracking improvements

### DIFF
--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -198,8 +198,6 @@ TEST (election, quorum_minimum_confirm_fail)
 	ASSERT_FALSE (election->confirmed ());
 }
 
-namespace nano
-{
 // FIXME: this test fails on rare occasions. It needs a review.
 TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 {
@@ -266,7 +264,6 @@ TEST (election, quorum_minimum_update_weight_before_quorum_checks)
 	ASSERT_EQ (nano::vote_code::vote, node1.vote_router.vote (vote2).at (send1->hash ()));
 	ASSERT_TIMELY (5s, election->confirmed ());
 	ASSERT_NE (nullptr, node1.block (send1->hash ()));
-}
 }
 
 TEST (election, continuous_voting)

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2783,9 +2783,8 @@ TEST (node, rollback_vote_self)
 		system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 
 		// Without the rollback being finished, the aggregator should not reply with any vote
-		auto channel = std::make_shared<nano::transport::fake::channel> (node);
-		node.aggregator.request ({ { send2->hash (), send2->root () } }, channel);
-		ASSERT_ALWAYS_EQ (1s, node.stats.count (nano::stat::type::request_aggregator_replies), 0);
+		node.aggregator.request ({ { send2->hash (), send2->root () } }, node.loopback_channel);
+		ASSERT_ALWAYS (1s, !election->votes ().contains (nano::dev::genesis_key.pub));
 
 		// Going out of the scope allows the rollback to complete
 	}

--- a/nano/core_test/online_reps.cpp
+++ b/nano/core_test/online_reps.cpp
@@ -1,3 +1,5 @@
+#include "nano/node/election.hpp"
+
 #include <nano/node/online_reps.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/secure/vote.hpp>
@@ -8,8 +10,8 @@
 
 TEST (online_reps, basic)
 {
-	nano::test::system system (1);
-	auto & node1 (*system.nodes[0]);
+	nano::test::system system;
+	auto & node1 = *system.add_node ();
 	// 1 sample of minimum weight
 	ASSERT_EQ (node1.config.online_weight_minimum, node1.online_reps.trended ());
 	auto vote (std::make_shared<nano::vote> ());
@@ -69,4 +71,204 @@ TEST (online_reps, election)
 	ASSERT_EQ (0, node1.online_reps.online ());
 	node1.vote_processor.vote_blocking (vote, std::make_shared<nano::transport::fake::channel> (node1));
 	ASSERT_EQ (nano::dev::constants.genesis_amount - nano::Knano_ratio, node1.online_reps.online ());
+}
+
+// Online reps should be able to observe remote representative
+TEST (online_reps, observe)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+	ASSERT_EQ (0, node.online_reps.online ());
+
+	// Addd genesis representative
+	auto & node_rep = *system.add_node ();
+	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
+
+	// The node should see that weight as online
+	ASSERT_TIMELY_EQ (10s, node.online_reps.online (), nano::dev::constants.genesis_amount);
+	ASSERT_ALWAYS_EQ (1s, node.online_reps.online (), nano::dev::constants.genesis_amount);
+}
+
+TEST (online_reps, observe_multiple)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+	ASSERT_EQ (0, node.online_reps.online ());
+
+	auto & node_rep1 = *system.add_node (); // key1
+	auto & node_rep2 = *system.add_node (); // key2 & key3
+
+	auto const weight_1 = nano::nano_ratio * 1000;
+	auto const weight_2 = nano::nano_ratio * 1000000;
+	auto const weight_3 = nano::nano_ratio * 10000000;
+
+	nano::keypair key1, key2, key3;
+
+	// Distribute genesis voting weight
+	{
+		nano::block_builder builder;
+		auto send1 = builder.state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (nano::dev::genesis->hash ())
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - weight_1)
+					 .link (key1.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (nano::dev::genesis->hash ()))
+					 .build ();
+		auto send2 = builder.state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (send1->hash ())
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - weight_1 - weight_2)
+					 .link (key2.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send1->hash ()))
+					 .build ();
+		auto send3 = builder.state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (send2->hash ())
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - weight_1 - weight_2 - weight_3)
+					 .link (key3.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*system.work.generate (send2->hash ()))
+					 .build ();
+		auto open1 = builder.state ()
+					 .account (key1.pub)
+					 .previous (0)
+					 .representative (key1.pub)
+					 .balance (weight_1)
+					 .link (send1->hash ())
+					 .sign (key1.prv, key1.pub)
+					 .work (*system.work.generate (key1.pub))
+					 .build ();
+		auto open2 = builder.state ()
+					 .account (key2.pub)
+					 .previous (0)
+					 .representative (key2.pub)
+					 .balance (weight_2)
+					 .link (send2->hash ())
+					 .sign (key2.prv, key2.pub)
+					 .work (*system.work.generate (key2.pub))
+					 .build ();
+		auto open3 = builder.state ()
+					 .account (key3.pub)
+					 .previous (0)
+					 .representative (key3.pub)
+					 .balance (weight_3)
+					 .link (send3->hash ())
+					 .sign (key3.prv, key3.pub)
+					 .work (*system.work.generate (key3.pub))
+					 .build ();
+		ASSERT_TRUE (nano::test::process (node_rep1, { send1, send2, send3, open1, open2, open3 }));
+		ASSERT_TRUE (nano::test::process (node_rep2, { send1, send2, send3, open1, open2, open3 }));
+	}
+
+	// Add rep keys to nodes
+	system.wallet (1)->insert_adhoc (key1.prv);
+	system.wallet (2)->insert_adhoc (key2.prv);
+	system.wallet (2)->insert_adhoc (key3.prv);
+
+	ASSERT_TIMELY_EQ (10s, node.online_reps.online (), weight_1 + weight_2 + weight_3);
+	ASSERT_ALWAYS_EQ (1s, node.online_reps.online (), weight_1 + weight_2 + weight_3);
+}
+
+// Online weight calculation should include local representative
+TEST (online_reps, observe_local)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+	ASSERT_EQ (0, node.online_reps.online ());
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	ASSERT_TIMELY_EQ (10s, node.online_reps.online (), nano::dev::constants.genesis_amount);
+	ASSERT_ALWAYS_EQ (1s, node.online_reps.online (), nano::dev::constants.genesis_amount);
+}
+
+// Online weight calculation should include slower but active representatives
+TEST (online_reps, observe_slow)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+	ASSERT_EQ (0, node.online_reps.online ());
+
+	// Enough to reach quorum by a single vote
+	auto const weight = nano::nano_ratio * 80000000;
+
+	nano::keypair key1, key2; // Fast and slow reps
+
+	// Distribute genesis voting weight
+	nano::block_builder builder;
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - weight)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto send2 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - weight * 2)
+				 .link (key2.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (send1->hash ()))
+				 .build ();
+	auto open1 = builder.state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (key1.pub)
+				 .balance (weight)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*system.work.generate (key1.pub))
+				 .build ();
+	auto open2 = builder.state ()
+				 .account (key2.pub)
+				 .previous (0)
+				 .representative (key2.pub)
+				 .balance (weight)
+				 .link (send2->hash ())
+				 .sign (key2.prv, key2.pub)
+				 .work (*system.work.generate (key2.pub))
+				 .build ();
+	ASSERT_TRUE (nano::test::process (node, { send1, send2, open1, open2 }));
+	nano::test::confirm (node, { send1, send2, open1, open2 });
+
+	ASSERT_EQ (node.active.size (), 0);
+
+	// Add a block that we can vote on
+	auto send_dummy = builder.state ()
+					  .account (nano::dev::genesis_key.pub)
+					  .previous (send2->hash ())
+					  .representative (nano::dev::genesis_key.pub)
+					  .balance (nano::dev::constants.genesis_amount - weight * 2 - nano::nano_ratio)
+					  .link (nano::keypair{}.pub)
+					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					  .work (*system.work.generate (send2->hash ()))
+					  .build ();
+	ASSERT_TRUE (nano::test::process (node, { send_dummy }));
+
+	// Wait for election for the block to be activated
+	std::shared_ptr<nano::election> election;
+	ASSERT_TIMELY (5s, election = node.active.election (send_dummy->qualified_root ()));
+	ASSERT_TRUE (election->contains (send_dummy->hash ()));
+
+	// Issue vote from a fast rep
+	auto vote_fast = nano::test::make_final_vote (key1, { send_dummy });
+	node.vote_processor.vote_blocking (vote_fast, nano::test::fake_channel (node));
+
+	ASSERT_TIMELY (5s, election->confirmed ());
+	ASSERT_TIMELY (5s, !node.active.active (send_dummy->qualified_root ())); // No longer present in AEC
+	ASSERT_TIMELY_EQ (5s, node.online_reps.online (), weight);
+
+	// Issue vote from a slow rep
+	auto vote_slow = nano::test::make_final_vote (key2, { send_dummy });
+	node.vote_processor.vote_blocking (vote_slow, nano::test::fake_channel (node));
+
+	// The slow rep weight should still be counted as online, even though it arrived slightly after the election already reached quorum
+	ASSERT_TIMELY_EQ (5s, node.online_reps.online (), weight * 2);
 }

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -28,7 +28,9 @@ TEST (request_aggregator, one)
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
 	node_config.backlog_scan.enable = false;
-	auto & node (*system.add_node (node_config));
+	nano::node_flags node_flags;
+	node_flags.disable_rep_crawler = true;
+	auto & node (*system.add_node (node_config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::block_builder builder;
 	auto send1 = builder
@@ -77,7 +79,9 @@ TEST (request_aggregator, one_update)
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
 	node_config.backlog_scan.enable = false;
-	auto & node (*system.add_node (node_config));
+	nano::node_flags node_flags;
+	node_flags.disable_rep_crawler = true;
+	auto & node (*system.add_node (node_config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key1;
 	auto send1 = nano::state_block_builder ()
@@ -143,7 +147,9 @@ TEST (request_aggregator, two)
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
 	node_config.backlog_scan.enable = false;
-	auto & node (*system.add_node (node_config));
+	nano::node_flags node_flags;
+	node_flags.disable_rep_crawler = true;
+	auto & node (*system.add_node (node_config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key1;
 	nano::state_block_builder builder;
@@ -273,7 +279,9 @@ TEST (request_aggregator, split)
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
 	node_config.backlog_scan.enable = false;
-	auto & node (*system.add_node (node_config));
+	nano::node_flags node_flags;
+	node_flags.disable_rep_crawler = true;
+	auto & node (*system.add_node (node_config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	std::vector<std::shared_ptr<nano::block>> blocks;
@@ -328,7 +336,9 @@ TEST (request_aggregator, channel_max_queue)
 	nano::node_config node_config = system.default_config ();
 	node_config.backlog_scan.enable = false;
 	node_config.request_aggregator.max_queue = 0;
-	auto & node (*system.add_node (node_config));
+	nano::node_flags node_flags;
+	node_flags.disable_rep_crawler = true;
+	auto & node (*system.add_node (node_config, node_flags));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::block_builder builder;
 	auto send1 = builder
@@ -390,6 +400,7 @@ TEST (request_aggregator, cannot_vote)
 	nano::test::system system;
 	nano::node_flags flags;
 	flags.disable_request_loop = true;
+	flags.disable_rep_crawler = true;
 	auto & node (*system.add_node (flags));
 	nano::state_block_builder builder;
 	auto send1 = builder.make_block ()
@@ -548,7 +559,12 @@ TEST (request_aggregator, forked_open)
 TEST (request_aggregator, epoch_conflict)
 {
 	nano::test::system system;
-	auto & node = *system.add_node ();
+
+	nano::node_flags node_flags;
+	// Workaround for vote spacing dropping requests with the same root
+	// FIXME: Vote spacing should use full qualified root
+	node_flags.disable_rep_crawler = true;
+	auto & node = *system.add_node (node_flags);
 
 	// Voting needs a rep key set up on the node
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -114,7 +114,7 @@ TEST (vote_processor, weights)
 	auto & node (*system.nodes[0]);
 
 	// Create representatives of different weight levels
-	auto const stake = node.config.online_weight_minimum.number ();
+	auto const stake = nano::dev::genesis->balance ().number ();
 	auto const level0 = stake / 5000; // 0.02%
 	auto const level1 = stake / 500; // 0.2%
 	auto const level2 = stake / 50; // 2%

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -637,6 +637,7 @@ enum class detail
 	sample,
 	rep_new,
 	rep_update,
+	rep_trim,
 	update_online,
 
 	// error codes

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -15,6 +15,7 @@ enum class type
 	test,
 	error,
 	message,
+	message_loopback,
 	block,
 	ledger,
 	ledger_notifications,

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -167,6 +167,8 @@ add_library(
   transport/fwd.hpp
   transport/inproc.hpp
   transport/inproc.cpp
+  transport/loopback.cpp
+  transport/loopback.hpp
   transport/message_deserializer.hpp
   transport/message_deserializer.cpp
   transport/tcp_channels.hpp

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -64,8 +64,10 @@ class election final : public std::enable_shared_from_this<election>
 private:
 	// Minimum time between broadcasts of the current winner of an election, as a backup to requesting confirmations
 	std::chrono::milliseconds base_latency () const;
+
+	// Callbacks
 	std::function<void (std::shared_ptr<nano::block> const &)> confirmation_action;
-	std::function<void (nano::account const &)> live_vote_action;
+	std::function<void (nano::account const &)> vote_action;
 
 private: // State management
 	static unsigned constexpr passive_duration_factor = 5;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -39,6 +39,7 @@
 #include <nano/node/scheduler/optimistic.hpp>
 #include <nano/node/scheduler/priority.hpp>
 #include <nano/node/telemetry.hpp>
+#include <nano/node/transport/loopback.hpp>
 #include <nano/node/transport/tcp_listener.hpp>
 #include <nano/node/vote_generator.hpp>
 #include <nano/node/vote_processor.hpp>
@@ -130,6 +131,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	//
 	network_impl{ std::make_unique<nano::network> (*this, config.peering_port.has_value () ? *config.peering_port : 0) },
 	network{ *network_impl },
+	loopback_channel{ std::make_shared<nano::transport::loopback_channel> (*this) },
 	telemetry_impl{ std::make_unique<nano::telemetry> (flags, *this, network, observers, network_params, stats) },
 	telemetry{ *telemetry_impl },
 	// BEWARE: `bootstrap` takes `network.port` instead of `config.peering_port` because when the user doesn't specify
@@ -171,9 +173,9 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	vote_processor{ *vote_processor_impl },
 	vote_cache_processor_impl{ std::make_unique<nano::vote_cache_processor> (config.vote_processor, vote_router, vote_cache, stats, logger) },
 	vote_cache_processor{ *vote_cache_processor_impl },
-	generator_impl{ std::make_unique<nano::vote_generator> (config, *this, ledger, wallets, vote_processor, history, network, stats, logger, /* non-final */ false) },
+	generator_impl{ std::make_unique<nano::vote_generator> (config, *this, ledger, wallets, vote_processor, history, network, stats, logger, /* non-final */ false, loopback_channel) },
 	generator{ *generator_impl },
-	final_generator_impl{ std::make_unique<nano::vote_generator> (config, *this, ledger, wallets, vote_processor, history, network, stats, logger, /* final */ true) },
+	final_generator_impl{ std::make_unique<nano::vote_generator> (config, *this, ledger, wallets, vote_processor, history, network, stats, logger, /* final */ true, loopback_channel) },
 	final_generator{ *final_generator_impl },
 	scheduler_impl{ std::make_unique<nano::scheduler::component> (config, *this, ledger, ledger_notifications, bucketing, active, online_reps, vote_cache, confirming_set, stats, logger) },
 	scheduler{ *scheduler_impl },

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -136,6 +136,7 @@ public:
 	nano::message_processor & message_processor;
 	std::unique_ptr<nano::network> network_impl;
 	nano::network & network;
+	std::shared_ptr<nano::transport::channel> loopback_channel;
 	std::unique_ptr<nano::telemetry> telemetry_impl;
 	nano::telemetry & telemetry;
 	std::unique_ptr<nano::transport::tcp_listener> tcp_listener_impl;

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -66,26 +66,40 @@ void nano::online_reps::observe (nano::account const & rep)
 
 		stats.inc (nano::stat::type::online_reps, new_insert ? nano::stat::detail::rep_new : nano::stat::detail::rep_update);
 
-		bool trimmed = trim ();
-
 		// Update current online weight if anything changed
-		if (new_insert || trimmed)
+		if (new_insert)
 		{
 			stats.inc (nano::stat::type::online_reps, nano::stat::detail::update_online);
+			logger.debug (nano::log::type::online_reps, "Observed new representative: {}", rep.to_account ());
 			cached_online = calculate_online ();
 		}
 	}
 }
 
-bool nano::online_reps::trim ()
+void nano::online_reps::trim ()
 {
 	debug_assert (!mutex.try_lock ());
 
-	auto now = std::chrono::steady_clock::now ();
-	auto cutoff = reps.get<tag_time> ().lower_bound (now - config.network_params.node.weight_interval);
-	auto trimmed = reps.get<tag_time> ().begin () != cutoff;
-	reps.get<tag_time> ().erase (reps.get<tag_time> ().begin (), cutoff);
-	return trimmed;
+	auto const now = std::chrono::steady_clock::now ();
+	auto const cutoff = now - config.network_params.node.weight_interval;
+
+	while (reps.get<tag_time> ().begin () != reps.get<tag_time> ().end ())
+	{
+		auto oldest = reps.get<tag_time> ().begin ();
+		if (oldest->time < cutoff)
+		{
+			stats.inc (nano::stat::type::online_reps, nano::stat::detail::rep_trim);
+			logger.debug (nano::log::type::online_reps, "Removing representative: {}, last observed: {}s ago",
+			oldest->account.to_account (),
+			nano::log::seconds_delta (oldest->time, now));
+
+			reps.get<tag_time> ().erase (oldest);
+		}
+		else
+		{
+			break; // Entries are ordered by timestamp, break early
+		}
+	}
 }
 
 void nano::online_reps::run ()
@@ -100,6 +114,7 @@ void nano::online_reps::run ()
 		});
 		if (!stopped)
 		{
+			trim ();
 			lock.unlock ();
 			sample ();
 			lock.lock ();
@@ -125,6 +140,7 @@ void nano::online_reps::sample ()
 		nano::lock_guard<nano::mutex> lock{ mutex };
 		cached_trended = trended_l;
 	}
+
 	logger.info (nano::log::type::online_reps, "Updated trended weight: {}", trended_l);
 }
 
@@ -281,12 +297,14 @@ void nano::online_reps::force_online_weight (nano::uint128_t const & online_weig
 	release_assert (nano::is_dev_run ());
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	cached_online = online_weight;
+	logger.debug (nano::log::type::online_reps, "Forced online weight: {}", online_weight);
 }
 
 void nano::online_reps::force_sample ()
 {
 	release_assert (nano::is_dev_run ());
 	sample ();
+	logger.debug (nano::log::type::online_reps, "Forced sample call");
 }
 
 nano::container_info nano::online_reps::container_info () const

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -81,7 +81,7 @@ void nano::online_reps::trim ()
 	debug_assert (!mutex.try_lock ());
 
 	auto const now = std::chrono::steady_clock::now ();
-	auto const cutoff = now - config.network_params.node.weight_interval;
+	auto const cutoff = now - config.network_params.node.weight_interval * 2;
 
 	while (reps.get<tag_time> ().begin () != reps.get<tag_time> ().end ())
 	{

--- a/nano/node/online_reps.hpp
+++ b/nano/node/online_reps.hpp
@@ -40,7 +40,9 @@ public:
 	nano::uint128_t delta () const;
 	/** List of online representatives, both the currently sampling ones and the ones observed in the previous sampling period */
 	std::vector<nano::account> list ();
+
 	void clear ();
+
 	nano::container_info container_info () const;
 
 public:
@@ -57,7 +59,7 @@ private:
 	void run ();
 	/** Called periodically to sample online weight */
 	void sample ();
-	bool trim ();
+	void trim ();
 	/** Remove old records from the database */
 	void trim_trended (nano::store::write_transaction const &);
 	/** Iterate over all database samples and remove invalid records. This is meant to clean potential leftovers from previous versions. */

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -209,6 +209,13 @@ void nano::rep_crawler::run ()
 			lock.lock ();
 		}
 
+		// Query local representative
+		{
+			lock.unlock ();
+			query (node.loopback_channel);
+			lock.lock ();
+		}
+
 		debug_assert (lock.owns_lock ());
 	}
 }

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -38,6 +38,11 @@ void nano::rep_crawler::start ()
 {
 	debug_assert (!thread.joinable ());
 
+	if (node.flags.disable_rep_crawler)
+	{
+		return;
+	}
+
 	thread = std::thread{ [this] () {
 		nano::thread_role::set (nano::thread_role::name::rep_crawler);
 		run ();
@@ -130,11 +135,16 @@ void nano::rep_crawler::validate_and_process (nano::unique_lock<nano::mutex> & l
 
 		if (inserted)
 		{
-			logger.info (nano::log::type::rep_crawler, "Found representative: {} at: {}", vote->account.to_account (), channel->to_string ());
+			logger.info (nano::log::type::rep_crawler, "Found representative: {} at: {}",
+			vote->account.to_account (),
+			channel->to_string ());
 		}
 		if (updated)
 		{
-			logger.warn (nano::log::type::rep_crawler, "Updated representative: {} at: {} (was at: {})", vote->account.to_account (), channel->to_string (), prev_channel->to_string ());
+			logger.warn (nano::log::type::rep_crawler, "Updated representative: {} at: {} (was at: {})",
+			vote->account.to_account (),
+			channel->to_string (),
+			prev_channel->to_string ());
 		}
 	}
 }

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -140,6 +140,11 @@ private:
 		std::shared_ptr<nano::transport::channel> channel;
 		std::chrono::steady_clock::time_point time{ std::chrono::steady_clock::now () };
 		unsigned int replies{ 0 }; // number of replies to the query
+
+		std::pair<std::shared_ptr<nano::transport::channel>, nano::block_hash> unique_key () const
+		{
+			return std::make_pair (channel, hash);
+		}
 	};
 
 	// clang-format off
@@ -147,6 +152,7 @@ private:
 	class tag_account {};
 	class tag_channel {};
 	class tag_sequenced {};
+	class tag_unique {};
 
 	using ordered_reps = boost::multi_index_container<rep_entry,
 	mi::indexed_by<
@@ -163,7 +169,9 @@ private:
 			mi::member<query_entry, std::shared_ptr<nano::transport::channel>, &query_entry::channel>>,
 		mi::sequenced<mi::tag<tag_sequenced>>,
 		mi::hashed_non_unique<mi::tag<tag_hash>,
-			mi::member<query_entry, nano::block_hash, &query_entry::hash>>
+			mi::member<query_entry, nano::block_hash, &query_entry::hash>>,
+		mi::hashed_unique<mi::tag<tag_unique>,
+			mi::const_mem_fun<query_entry, std::pair<std::shared_ptr<nano::transport::channel>, nano::block_hash>, &query_entry::unique_key>>
 	>>;
 	// clang-format on
 

--- a/nano/node/transport/fwd.hpp
+++ b/nano/node/transport/fwd.hpp
@@ -3,12 +3,19 @@
 namespace nano::transport
 {
 class channel;
+class loopback_channel;
 class tcp_channel;
 class tcp_channels;
 class tcp_server;
 class tcp_socket;
 }
+
 namespace nano::transport::fake
+{
+class channel;
+}
+
+namespace nano::transport::inproc
 {
 class channel;
 }

--- a/nano/node/transport/loopback.cpp
+++ b/nano/node/transport/loopback.cpp
@@ -1,0 +1,35 @@
+#include <nano/node/network.hpp>
+#include <nano/node/node.hpp>
+#include <nano/node/transport/loopback.hpp>
+#include <nano/node/transport/message_deserializer.hpp>
+
+#include <boost/format.hpp>
+
+nano::transport::loopback_channel::loopback_channel (nano::node & node) :
+	transport::channel{ node },
+	endpoint{ node.network.endpoint () }
+{
+	set_node_id (node.node_id.pub);
+	set_network_version (node.network_params.network.protocol_version);
+}
+
+bool nano::transport::loopback_channel::send_impl (nano::message const & message, nano::transport::traffic_type traffic_type, nano::transport::channel::callback_t callback)
+{
+	node.stats.inc (nano::stat::type::message_loopback, to_stat_detail (message.type ()), nano::stat::dir::in);
+
+	node.inbound (message, shared_from_this ());
+
+	if (callback)
+	{
+		node.io_ctx.post ([callback_l = std::move (callback)] () {
+			callback_l (boost::system::errc::make_error_code (boost::system::errc::success), 0);
+		});
+	}
+
+	return true;
+}
+
+std::string nano::transport::loopback_channel::to_string () const
+{
+	return boost::str (boost::format ("%1%") % endpoint);
+}

--- a/nano/node/transport/loopback.hpp
+++ b/nano/node/transport/loopback.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <nano/node/transport/channel.hpp>
+#include <nano/node/transport/transport.hpp>
+
+namespace nano::transport
+{
+class loopback_channel final : public nano::transport::channel, public std::enable_shared_from_this<loopback_channel>
+{
+public:
+	explicit loopback_channel (nano::node & node);
+
+	std::string to_string () const override;
+
+	nano::endpoint get_remote_endpoint () const override
+	{
+		return endpoint;
+	}
+
+	nano::endpoint get_local_endpoint () const override
+	{
+		return endpoint;
+	}
+
+	nano::transport::transport_type get_type () const override
+	{
+		return nano::transport::transport_type::loopback;
+	}
+
+	void close () override
+	{
+		// Can't be closed
+	}
+
+protected:
+	bool send_impl (nano::message const &, nano::transport::traffic_type, nano::transport::channel::callback_t) override;
+
+private:
+	nano::endpoint const endpoint;
+};
+}

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -16,7 +16,7 @@
 
 #include <chrono>
 
-nano::vote_generator::vote_generator (nano::node_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_processor & vote_processor_a, nano::local_vote_history & history_a, nano::network & network_a, nano::stats & stats_a, nano::logger & logger_a, bool is_final_a) :
+nano::vote_generator::vote_generator (nano::node_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_processor & vote_processor_a, nano::local_vote_history & history_a, nano::network & network_a, nano::stats & stats_a, nano::logger & logger_a, bool is_final_a, std::shared_ptr<nano::transport::channel> inproc_channel_a) :
 	config (config_a),
 	node (node_a),
 	ledger (ledger_a),
@@ -29,7 +29,7 @@ nano::vote_generator::vote_generator (nano::node_config const & config_a, nano::
 	stats (stats_a),
 	logger (logger_a),
 	is_final (is_final_a),
-	inproc_channel{ std::make_shared<nano::transport::inproc::channel> (node, node) },
+	inproc_channel{ inproc_channel_a },
 	vote_generation_queue{ stats, nano::stat::type::vote_generator, is_final ? nano::thread_role::name::voting_final : nano::thread_role::name::voting, /* single threaded */ 1, /* max queue size */ 1024 * 32, /* max batch size */ 256 }
 {
 	vote_generation_queue.process_batch = [this] (auto & batch) {

--- a/nano/node/vote_generator.hpp
+++ b/nano/node/vote_generator.hpp
@@ -33,7 +33,7 @@ private:
 	std::chrono::steady_clock::time_point next_broadcast = { std::chrono::steady_clock::now () };
 
 public:
-	vote_generator (nano::node_config const &, nano::node &, nano::ledger &, nano::wallets &, nano::vote_processor &, nano::local_vote_history &, nano::network &, nano::stats &, nano::logger &, bool is_final);
+	vote_generator (nano::node_config const &, nano::node &, nano::ledger &, nano::wallets &, nano::vote_processor &, nano::local_vote_history &, nano::network &, nano::stats &, nano::logger &, bool is_final, std::shared_ptr<nano::transport::channel> inproc_channel);
 	~vote_generator ();
 
 	/** Queue items for vote generation, or broadcast votes already in cache */


### PR DESCRIPTION
This fixes an edge case where online weight tracking would underreport the current online weight. The problem was that votes from slow representatives wouldn't be reliably counted toward online voting weight. By slow representative I mean a node that votes on elections after they already reach quorum and are evicted from active election container. We still want to count such votes as online weight if they arrive within a reasonable timeframe.