### PR TITLE
Fix websocket confirmation options handling

### DIFF
--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -1146,3 +1146,107 @@ TEST (websocket, new_unconfirmed_block)
 	ASSERT_EQ ("state", message_contents.get<std::string> ("type"));
 	ASSERT_EQ ("send", message_contents.get<std::string> ("subtype"));
 }
+
+
+// Test verifying that multiple subscribers with different options receive messages with their correct
+// individual settings applied (specifically targeting the bug that was fixed)
+TEST (websocket, confirmation_options_independent)
+{
+	nano::test::system system;
+	nano::node_config config = system.default_config ();
+	config.websocket_config.enabled = true;
+	config.websocket_config.port = system.get_available_port ();
+	auto node1 (system.add_node (config));
+
+	// First prepare a block we'll confirm later
+	nano::keypair key;
+	nano::state_block_builder builder;
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	auto prev_balance = nano::dev::constants.genesis_amount;
+	auto send_amount = node1->online_reps.delta () + 1;
+	auto new_balance = prev_balance - send_amount;
+	nano::block_hash previous (node1->latest (nano::dev::genesis_key.pub));
+	
+	auto send = builder
+				.account (nano::dev::genesis_key.pub)
+				.previous (previous)
+				.representative (nano::dev::genesis_key.pub)
+				.balance (new_balance)
+				.link (key.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (previous))
+				.build ();
+				
+	// Set up two concurrent tasks to subscribe with different options and wait for responses
+	std::atomic<bool> client1_done{ false };
+	std::atomic<bool> client2_done{ false };
+	boost::optional<std::string> client1_response;
+	boost::optional<std::string> client2_response;
+	
+	// Client 1: Subscribe with include_block = true but no sideband
+	auto client1_task = ([&client1_done, &client1_response, &node1] () {
+		fake_websocket_client client (node1->websocket.server->listening_port ());
+		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"include_block": "true", "include_sideband_info": "false"}})json");
+		client.await_ack ();
+		auto response = client.get_response ();
+		client1_response = response;
+		client1_done = true;
+	});
+	
+	// Client 2: Subscribe with include_block = true AND include_sideband_info = true
+	auto client2_task = ([&client2_done, &client2_response, &node1] () {
+		fake_websocket_client client (node1->websocket.server->listening_port ());
+		client.send_message (R"json({"action": "subscribe", "topic": "confirmation", "ack": "true", "options": {"include_block": "true", "include_sideband_info": "true"}})json");
+		client.await_ack ();
+		auto response = client.get_response ();
+		client2_response = response;
+		client2_done = true;
+	});
+	
+	// Start both client tasks concurrently
+	auto future1 = std::async (std::launch::async, client1_task);
+	auto future2 = std::async (std::launch::async, client2_task);
+	
+	// Wait for both clients to be set up (both awaiting notifications)
+	ASSERT_TIMELY (5s, node1->websocket.server->subscriber_count (nano::websocket::topic::confirmation) == 2);
+	
+	// Now process the block to trigger notifications to both clients
+	node1->process_active (send);
+	
+	// Wait for both clients to receive their responses
+	ASSERT_TIMELY (5s, client1_done && client2_done);
+	
+	// Verify both clients got responses
+	ASSERT_TRUE (client1_response.has_value ());
+	ASSERT_TRUE (client2_response.has_value ());
+	
+	// Parse and check client1 response (should have block but no sideband)
+	boost::property_tree::ptree event1;
+	std::stringstream stream1;
+	stream1 << client1_response.get ();
+	boost::property_tree::read_json (stream1, event1);
+	ASSERT_EQ (event1.get<std::string> ("topic"), "confirmation");
+	
+	auto & message1 = event1.get_child ("message");
+	ASSERT_EQ (1, message1.count ("block"));
+	ASSERT_EQ (0, message1.count ("sideband"));
+	
+	// Parse and check client2 response (should have both block AND sideband)
+	boost::property_tree::ptree event2;
+	std::stringstream stream2;
+	stream2 << client2_response.get ();
+	boost::property_tree::read_json (stream2, event2);
+	ASSERT_EQ (event2.get<std::string> ("topic"), "confirmation");
+	
+	auto & message2 = event2.get_child ("message");
+	ASSERT_EQ (1, message2.count ("block"));
+	
+	// With the old caching code, this would fail because client2 would receive the same
+	// message as client1 (with no sideband info) despite requesting it
+	ASSERT_EQ (1, message2.count ("sideband"));
+	
+	// Verify sideband contains expected fields
+	auto & sideband = message2.get_child ("sideband");
+	ASSERT_EQ (1, sideband.count ("height"));
+	ASSERT_EQ (1, sideband.count ("local_timestamp"));
+}

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -91,13 +91,13 @@ namespace websocket
 	public:
 		message_builder (nano::ledger & ledger);
 
-		message block_confirmed (std::shared_ptr<nano::block> const & block_a, nano::account const & account_a, nano::amount const & amount_a, std::string subtype, bool include_block, nano::election_status const & election_status_a, std::vector<nano::vote_with_weight_info> const & election_votes_a, nano::websocket::confirmation_options const & options_a);
-		message started_election (nano::block_hash const & hash_a);
-		message stopped_election (nano::block_hash const & hash_a);
-		message vote_received (std::shared_ptr<nano::vote> const & vote_a, nano::vote_code code_a);
-		message work_generation (nano::work_version const version_a, nano::block_hash const & root_a, uint64_t const work_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::string const & peer_a, std::vector<std::string> const & bad_peers_a, bool const completed_a = true, bool const cancelled_a = false);
-		message work_cancelled (nano::work_version const version_a, nano::block_hash const & root_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::vector<std::string> const & bad_peers_a);
-		message work_failed (nano::work_version const version_a, nano::block_hash const & root_a, uint64_t const difficulty_a, uint64_t const publish_threshold_a, std::chrono::milliseconds const & duration_a, std::vector<std::string> const & bad_peers_a);
+		message block_confirmed (std::shared_ptr<nano::block> const & block, nano::account const & account, nano::amount const & amount, std::string subtype, nano::election_status const & election_status, std::vector<nano::vote_with_weight_info> const & election_votes, nano::websocket::confirmation_options const & options);
+		message started_election (nano::block_hash const & hash);
+		message stopped_election (nano::block_hash const & hash);
+		message vote_received (std::shared_ptr<nano::vote> const & vote, nano::vote_code code);
+		message work_generation (nano::work_version const version, nano::block_hash const & root, uint64_t work, uint64_t difficulty, uint64_t publish_threshold, std::chrono::milliseconds const & duration, std::string const & peer, std::vector<std::string> const & bad_peers, bool completed = true, bool cancelled = false);
+		message work_cancelled (nano::work_version const version, nano::block_hash const & root, uint64_t difficulty, uint64_t publish_threshold, std::chrono::milliseconds const & duration, std::vector<std::string> const & bad_peers);
+		message work_failed (nano::work_version const version, nano::block_hash const & root, uint64_t difficulty, uint64_t publish_threshold, std::chrono::milliseconds const & duration, std::vector<std::string> const & bad_peers);
 		message bootstrap_started (std::string const & id_a, std::string const & mode_a);
 		message bootstrap_exited (std::string const & id_a, std::string const & mode_a, std::chrono::steady_clock::time_point const start_time_a, uint64_t const total_blocks_a);
 		message telemetry_received (nano::telemetry_data const &, nano::endpoint const &);
@@ -325,7 +325,7 @@ namespace websocket
 		void stop ();
 
 		/** Broadcast block confirmation. The content of the message depends on subscription options (such as "include_block") */
-		void broadcast_confirmation (std::shared_ptr<nano::block> const & block_a, nano::account const & account_a, nano::amount const & amount_a, std::string const & subtype, nano::election_status const & election_status_a, std::vector<nano::vote_with_weight_info> const & election_votes_a);
+		void broadcast_confirmation (std::shared_ptr<nano::block> const & block, nano::account const & account, nano::amount const & amount, std::string const & subtype, nano::election_status const & election_status, std::vector<nano::vote_with_weight_info> const & election_votes);
 
 		/** Broadcast \p message to all session subscribing to the message topic. */
 		void broadcast (nano::websocket::message message_a);


### PR DESCRIPTION
This PR fixes an issue with the websocket confirmation message handling. Previously, the system would cache messages based solely on the `include_block` option, causing other subscriber options (like `include_linked_account` and `include_sideband_info`) to be ignored if another subscriber had already created a cached message.

Changes made:
- Removed the message caching mechanism that was causing options to be ignored
- Each subscriber now receives a message built specifically with their configuration options
- Simplified parameter naming for better readability
- Made options handling more consistent across the codebase
- Added a failing testcase that is passing by the removal of the cache

These changes ensure that all subscribers receive confirmation messages that correctly respect their individual option settings.