### PR TITLE
Improve logging for failures in the store backend

### DIFF
--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -18,7 +18,7 @@ unsigned constexpr nano::wallet_store::version_current;
 TEST (wallet, no_special_keys_accounts)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -39,7 +39,7 @@ TEST (wallet, no_special_keys_accounts)
 TEST (wallet, no_key)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -54,7 +54,7 @@ TEST (wallet, no_key)
 TEST (wallet, fetch_locked)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -76,7 +76,7 @@ TEST (wallet, fetch_locked)
 TEST (wallet, retrieval)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -98,7 +98,7 @@ TEST (wallet, retrieval)
 TEST (wallet, empty_iteration)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -112,7 +112,7 @@ TEST (wallet, empty_iteration)
 TEST (wallet, one_item_iteration)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -134,7 +134,7 @@ TEST (wallet, one_item_iteration)
 TEST (wallet, two_item_iteration)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	nano::keypair key1;
 	nano::keypair key2;
@@ -260,7 +260,7 @@ TEST (wallet, spend_no_previous)
 TEST (wallet, find_none)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -273,7 +273,7 @@ TEST (wallet, find_none)
 TEST (wallet, find_existing)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -292,7 +292,7 @@ TEST (wallet, find_existing)
 TEST (wallet, rekey)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -322,7 +322,7 @@ TEST (wallet, rekey)
 TEST (wallet, hash_password)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -371,7 +371,7 @@ TEST (fan, change)
 TEST (wallet, reopen_default_password)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	ASSERT_FALSE (init);
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -407,7 +407,7 @@ TEST (wallet, reopen_default_password)
 TEST (wallet, representative)
 {
 	auto error (false);
-	nano::store::lmdb::env env (error, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (error, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (error);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -428,7 +428,7 @@ TEST (wallet, representative)
 TEST (wallet, serialize_json_empty)
 {
 	auto error (false);
-	nano::store::lmdb::env env (error, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (error, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (error);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -453,7 +453,7 @@ TEST (wallet, serialize_json_empty)
 TEST (wallet, serialize_json_one)
 {
 	auto error (false);
-	nano::store::lmdb::env env (error, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (error, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (error);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -482,7 +482,7 @@ TEST (wallet, serialize_json_one)
 TEST (wallet, serialize_json_password)
 {
 	auto error (false);
-	nano::store::lmdb::env env (error, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (error, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (error);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -515,7 +515,7 @@ TEST (wallet, serialize_json_password)
 TEST (wallet_store, move)
 {
 	auto error (false);
-	nano::store::lmdb::env env (error, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (error, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (error);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -672,7 +672,7 @@ TEST (wallet, insert_locked)
 TEST (wallet, deterministic_keys)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
@@ -715,7 +715,7 @@ TEST (wallet, deterministic_keys)
 TEST (wallet, reseed)
 {
 	bool init;
-	nano::store::lmdb::env env (init, nano::unique_path () / "wallet.ldb");
+	nano::store::lmdb::env env (init, nano::default_logger (), nano::unique_path () / "wallet.ldb");
 	ASSERT_FALSE (init);
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -22,7 +22,6 @@ class election_status;
 class ledger_notifications;
 class local_block_broadcaster;
 class local_vote_history;
-class logger;
 class network;
 class network_params;
 class node;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -114,7 +114,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	store{ *store_impl },
 	unchecked_impl{ std::make_unique<nano::unchecked_map> (config.max_unchecked_blocks, stats, flags.disable_block_processor_unchecked_deletion) },
 	unchecked{ *unchecked_impl },
-	wallets_store_impl{ std::make_unique<nano::mdb_wallets_store> (application_path_a / "wallets.ldb", config_a.lmdb_config) },
+	wallets_store_impl{ std::make_unique<nano::mdb_wallets_store> (logger, application_path_a / "wallets.ldb", config_a.lmdb_config) },
 	wallets_store{ *wallets_store_impl },
 	wallets_impl{ std::make_unique<nano::wallets> (wallets_store.init_error (), *this) },
 	wallets{ *wallets_impl },

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1883,8 +1883,8 @@ auto nano::wallet_store::end (store::transaction const & transaction_a) -> itera
 	return iterator{ store::iterator{ store::lmdb::iterator::end (env.tx (transaction_a), handle) } };
 }
 
-nano::mdb_wallets_store::mdb_wallets_store (std::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a) :
-	environment (error, path_a, nano::store::lmdb::env::options::make ().set_config (lmdb_config_a).override_config_sync (nano::lmdb_config::sync_strategy::always).override_config_map_size (1ULL * 1024 * 1024 * 1024))
+nano::mdb_wallets_store::mdb_wallets_store (nano::logger & logger, std::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a) :
+	environment (error, logger, path_a, nano::store::lmdb::env::options::make ().set_config (lmdb_config_a).override_config_sync (nano::lmdb_config::sync_strategy::always).override_config_map_size (1ULL * 1024 * 1024 * 1024))
 {
 }
 

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/fwd.hpp>
 #include <nano/lib/id_dispenser.hpp>
 #include <nano/lib/lmdbconfig.hpp>
 #include <nano/lib/locks.hpp>
@@ -270,7 +271,7 @@ public:
 class mdb_wallets_store final : public wallets_store
 {
 public:
-	mdb_wallets_store (std::filesystem::path const &, nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{});
+	mdb_wallets_store (nano::logger & logger, std::filesystem::path const &, nano::lmdb_config const & lmdb_config_a = nano::lmdb_config{});
 	nano::store::lmdb::env environment;
 	bool init_error () const override;
 	bool error{ false };

--- a/nano/store/lmdb/lmdb.cpp
+++ b/nano/store/lmdb/lmdb.cpp
@@ -44,7 +44,7 @@ nano::store::lmdb::component::component (nano::logger & logger_a, std::filesyste
 	rep_weight_store{ *this },
 	database_path{ path_a },
 	logger{ logger_a },
-	env (error, path_a, nano::store::lmdb::env::options::make ().set_config (lmdb_config_a).set_use_no_mem_init (true)),
+	env (error, logger, path_a, nano::store::lmdb::env::options::make ().set_config (lmdb_config_a).set_use_no_mem_init (true)),
 	mdb_txn_tracker (logger_a, txn_tracking_config_a, block_processor_batch_max_time_a),
 	txn_tracking_enabled (txn_tracking_config_a.enable)
 {

--- a/nano/store/lmdb/lmdb_env.cpp
+++ b/nano/store/lmdb/lmdb_env.cpp
@@ -4,7 +4,8 @@
 
 #include <boost/system/error_code.hpp>
 
-nano::store::lmdb::env::env (bool & error_a, std::filesystem::path const & path_a, nano::store::lmdb::env::options options_a) :
+nano::store::lmdb::env::env (bool & error_a, nano::logger & logger, std::filesystem::path const & path_a, nano::store::lmdb::env::options options_a) :
+	logger{ logger },
 	database_path{ path_a }
 {
 	init (error_a, path_a, options_a);
@@ -22,11 +23,19 @@ void nano::store::lmdb::env::init (bool & error_a, std::filesystem::path const &
 		if (!error_mkdir)
 		{
 			MDB_env * environment;
-			auto status1 (mdb_env_create (&environment));
-			release_assert (status1 == 0);
+			auto status1 = mdb_env_create (&environment);
+			if (status1 != MDB_SUCCESS)
+			{
+				logger.critical (nano::log::type::lmdb, "Unable to create lmdb environment {}", status1);
+				release_assert (false);
+			}
 			this->environment.reset (environment);
-			auto status2 (mdb_env_set_maxdbs (environment, options_a.config.max_databases));
-			release_assert (status2 == 0);
+			auto status2 = mdb_env_set_maxdbs (environment, options_a.config.max_databases);
+			if (status2 != MDB_SUCCESS)
+			{
+				logger.critical (nano::log::type::lmdb, "Unable to set maximum dbs to: {} {}", options_a.config.max_databases, status2);
+				release_assert (false);
+			}
 			auto map_size = options_a.config.map_size;
 			auto max_instrumented_map_size = 16 * 1024 * 1024;
 			if (memory_intensive_instrumentation () && map_size > max_instrumented_map_size)
@@ -34,8 +43,12 @@ void nano::store::lmdb::env::init (bool & error_a, std::filesystem::path const &
 				// In order to run LMDB with some types of memory instrumentation, the maximum map size must be smaller than what is normally used when non-instrumented
 				map_size = max_instrumented_map_size;
 			}
-			auto status3 (mdb_env_set_mapsize (environment, map_size));
-			release_assert (status3 == 0);
+			auto status3 = mdb_env_set_mapsize (environment, map_size);
+			if (status3 != MDB_SUCCESS)
+			{
+				logger.critical (nano::log::type::lmdb, "Unable to set enviroment map size to: {} {}", map_size, status3);
+				release_assert (false);
+			}
 			// It seems if there's ever more threads than mdb_env_set_maxreaders has read slots available, we get failures on transaction creation unless MDB_NOTLS is specified
 			// This can happen if something like 256 io_threads are specified in the node config
 			// MDB_NORDAHEAD will allow platforms that support it to load the DB in memory as needed.
@@ -58,13 +71,12 @@ void nano::store::lmdb::env::init (bool & error_a, std::filesystem::path const &
 			{
 				environment_flags |= MDB_NOMEMINIT;
 			}
-			auto status4 (mdb_env_open (environment, path_a.string ().c_str (), environment_flags, 00600));
-			if (status4 != 0)
+			auto status4 = mdb_env_open (environment, path_a.string ().c_str (), environment_flags, 00600);
+			if (status4 != MDB_SUCCESS)
 			{
-				std::string message = "Could not open lmdb environment(" + std::to_string (status4) + "): " + mdb_strerror (status4);
-				throw std::runtime_error (message);
+				logger.critical (nano::log::type::lmdb, "Could not open lmdb environment at: {} {}", path_a.string (), status4);
+				release_assert (false);
 			}
-			release_assert (status4 == 0);
 			error_a = status4 != 0;
 		}
 		else

--- a/nano/store/lmdb/lmdb_env.hpp
+++ b/nano/store/lmdb/lmdb_env.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/fwd.hpp>
 #include <nano/lib/id_dispenser.hpp>
 #include <nano/lib/lmdbconfig.hpp>
 #include <nano/store/component.hpp>
@@ -55,13 +56,14 @@ public:
 		nano::lmdb_config config;
 	};
 
-	env (bool &, std::filesystem::path const &, env::options options_a = env::options::make ());
+	env (bool &, nano::logger & logger, std::filesystem::path const &, env::options options_a = env::options::make ());
 	void init (bool &, std::filesystem::path const &, env::options options_a = env::options::make ());
 	~env ();
 	operator MDB_env * () const;
 	store::read_transaction tx_begin_read (txn_callbacks callbacks = txn_callbacks{}) const;
 	store::write_transaction tx_begin_write (txn_callbacks callbacks = txn_callbacks{}) const;
 	MDB_txn * tx (store::transaction const & transaction_a) const;
+	nano::logger & logger;
 	std::unique_ptr<MDB_env, decltype (&mdb_env_close)> environment{ nullptr, mdb_env_close };
 	nano::id_t const store_id{ nano::next_id () };
 	std::filesystem::path const database_path;

--- a/nano/store/lmdb/transaction.cpp
+++ b/nano/store/lmdb/transaction.cpp
@@ -36,19 +36,27 @@ private:
 }
 
 nano::store::lmdb::read_transaction_impl::read_transaction_impl (nano::store::lmdb::env const & environment_a, nano::store::lmdb::txn_callbacks txn_callbacks_a) :
-	store::read_transaction_impl (environment_a.store_id),
+	store::read_transaction_impl (environment_a.logger, environment_a.store_id),
 	txn_callbacks (txn_callbacks_a)
 {
-	auto status (mdb_txn_begin (environment_a, nullptr, MDB_RDONLY, &handle));
-	release_assert (status == 0);
+	auto status = mdb_txn_begin (environment_a, nullptr, MDB_RDONLY, &handle);
+	if (status != MDB_SUCCESS)
+	{
+		logger.critical (nano::log::type::lmdb, "Unable to open read transaction {}", status);
+		release_assert (false);
+	}
 	txn_callbacks.txn_start (this);
 }
 
 nano::store::lmdb::read_transaction_impl::~read_transaction_impl ()
 {
 	// This uses commit rather than abort, as it is needed when opening databases with a read only transaction
-	auto status (mdb_txn_commit (handle));
-	release_assert (status == MDB_SUCCESS);
+	auto status = mdb_txn_commit (handle);
+	if (status != MDB_SUCCESS)
+	{
+		logger.critical (nano::log::type::lmdb, "Unable to commit read transaction {}", status);
+		release_assert (false);
+	}
 	txn_callbacks.txn_end (this);
 }
 
@@ -60,8 +68,12 @@ void nano::store::lmdb::read_transaction_impl::reset ()
 
 void nano::store::lmdb::read_transaction_impl::renew ()
 {
-	auto status (mdb_txn_renew (handle));
-	release_assert (status == 0);
+	auto status = mdb_txn_renew (handle);
+	if (status != MDB_SUCCESS)
+	{
+		logger.critical (nano::log::type::lmdb, "Unable to renew read transaction {}", status);
+		release_assert (false);
+	}
 	txn_callbacks.txn_start (this);
 }
 
@@ -71,7 +83,7 @@ void * nano::store::lmdb::read_transaction_impl::get_handle () const
 }
 
 nano::store::lmdb::write_transaction_impl::write_transaction_impl (nano::store::lmdb::env const & environment_a, nano::store::lmdb::txn_callbacks txn_callbacks_a) :
-	store::write_transaction_impl (environment_a.store_id),
+	store::write_transaction_impl (env.logger, environment_a.store_id),
 	env (environment_a),
 	txn_callbacks (txn_callbacks_a)
 {
@@ -90,7 +102,8 @@ void nano::store::lmdb::write_transaction_impl::commit ()
 		auto status = mdb_txn_commit (handle);
 		if (status != MDB_SUCCESS)
 		{
-			release_assert (false && "Unable to write to the LMDB database", mdb_strerror (status));
+			logger.critical (nano::log::type::lmdb, "Unable to commit write transaction {}", status);
+			release_assert (false);
 		}
 		txn_callbacks.txn_end (this);
 		active = false;
@@ -100,7 +113,11 @@ void nano::store::lmdb::write_transaction_impl::commit ()
 void nano::store::lmdb::write_transaction_impl::renew ()
 {
 	auto status (mdb_txn_begin (env, nullptr, 0, &handle));
-	release_assert (status == MDB_SUCCESS, mdb_strerror (status));
+	if (status != MDB_SUCCESS)
+	{
+		logger.critical (nano::log::type::lmdb, "Unable to renew write transaction {}", status);
+		release_assert (false);
+	}
 	txn_callbacks.txn_start (this);
 	active = true;
 }

--- a/nano/store/rocksdb/rocksdb.cpp
+++ b/nano/store/rocksdb/rocksdb.cpp
@@ -412,12 +412,12 @@ std::vector<rocksdb::ColumnFamilyDescriptor> nano::store::rocksdb::component::cr
 nano::store::write_transaction nano::store::rocksdb::component::tx_begin_write ()
 {
 	release_assert (transaction_db != nullptr);
-	return store::write_transaction{ std::make_unique<nano::store::rocksdb::write_transaction_impl> (transaction_db) };
+	return store::write_transaction{ std::make_unique<nano::store::rocksdb::write_transaction_impl> (logger, transaction_db) };
 }
 
 nano::store::read_transaction nano::store::rocksdb::component::tx_begin_read () const
 {
-	return store::read_transaction{ std::make_unique<nano::store::rocksdb::read_transaction_impl> (db.get ()) };
+	return store::read_transaction{ std::make_unique<nano::store::rocksdb::read_transaction_impl> (logger, db.get ()) };
 }
 
 std::string nano::store::rocksdb::component::vendor_get () const

--- a/nano/store/rocksdb/transaction.cpp
+++ b/nano/store/rocksdb/transaction.cpp
@@ -1,7 +1,9 @@
+#include <nano/lib/logging.hpp>
 #include <nano/store/rocksdb/transaction_impl.hpp>
 
-nano::store::rocksdb::read_transaction_impl::read_transaction_impl (::rocksdb::DB * db_a) :
-	db (db_a)
+nano::store::rocksdb::read_transaction_impl::read_transaction_impl (nano::logger & logger, ::rocksdb::DB * db_a) :
+	store::read_transaction_impl{ logger },
+	db{ db_a }
 {
 	if (db_a)
 	{
@@ -32,8 +34,9 @@ void * nano::store::rocksdb::read_transaction_impl::get_handle () const
 	return (void *)&options;
 }
 
-nano::store::rocksdb::write_transaction_impl::write_transaction_impl (::rocksdb::TransactionDB * db_a) :
-	db (db_a)
+nano::store::rocksdb::write_transaction_impl::write_transaction_impl (nano::logger & logger, ::rocksdb::TransactionDB * db_a) :
+	store::write_transaction_impl{ logger },
+	db{ db_a }
 {
 	debug_assert (check_no_write_tx ());
 	::rocksdb::TransactionOptions txn_options;
@@ -52,7 +55,11 @@ void nano::store::rocksdb::write_transaction_impl::commit ()
 	if (active)
 	{
 		auto status = txn->Commit ();
-		release_assert (status.ok () && "Unable to write to the RocksDB database", status.ToString ());
+		if (!status.ok ())
+		{
+			logger.critical (nano::log::type::rocksdb, "Unable to commit write transaction {}", status.ToString ());
+			release_assert (false);
+		}
 		active = false;
 	}
 }

--- a/nano/store/rocksdb/transaction_impl.hpp
+++ b/nano/store/rocksdb/transaction_impl.hpp
@@ -12,7 +12,7 @@ namespace nano::store::rocksdb
 class read_transaction_impl final : public store::read_transaction_impl
 {
 public:
-	read_transaction_impl (::rocksdb::DB * db);
+	read_transaction_impl (nano::logger & logger, ::rocksdb::DB * db);
 	~read_transaction_impl ();
 	void reset () override;
 	void renew () override;
@@ -26,7 +26,7 @@ private:
 class write_transaction_impl final : public store::write_transaction_impl
 {
 public:
-	write_transaction_impl (::rocksdb::TransactionDB * db_a);
+	write_transaction_impl (nano::logger & logger, ::rocksdb::TransactionDB * db_a);
 	~write_transaction_impl ();
 	void commit () override;
 	void renew () override;

--- a/nano/store/transaction.cpp
+++ b/nano/store/transaction.cpp
@@ -6,7 +6,8 @@
  * transaction_impl
  */
 
-nano::store::transaction_impl::transaction_impl (nano::id_dispenser::id_t const store_id_a) :
+nano::store::transaction_impl::transaction_impl (nano::logger & logger, nano::id_dispenser::id_t const store_id_a) :
+	logger{ logger },
 	store_id{ store_id_a }
 {
 	debug_assert (!nano::thread_role::is_network_io (), "database operations are not allowed to run on network IO threads");
@@ -16,8 +17,8 @@ nano::store::transaction_impl::transaction_impl (nano::id_dispenser::id_t const 
  * read_transaction_impl
  */
 
-nano::store::read_transaction_impl::read_transaction_impl (nano::id_dispenser::id_t const store_id_a) :
-	transaction_impl (store_id_a)
+nano::store::read_transaction_impl::read_transaction_impl (nano::logger & logger, nano::id_dispenser::id_t const store_id_a) :
+	transaction_impl (logger, store_id_a)
 {
 }
 
@@ -25,8 +26,8 @@ nano::store::read_transaction_impl::read_transaction_impl (nano::id_dispenser::i
  * write_transaction_impl
  */
 
-nano::store::write_transaction_impl::write_transaction_impl (nano::id_dispenser::id_t const store_id_a) :
-	transaction_impl (store_id_a)
+nano::store::write_transaction_impl::write_transaction_impl (nano::logger & logger, nano::id_dispenser::id_t const store_id_a) :
+	transaction_impl (logger, store_id_a)
 {
 }
 

--- a/nano/store/transaction.hpp
+++ b/nano/store/transaction.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/fwd.hpp>
 #include <nano/lib/id_dispenser.hpp>
 #include <nano/store/tables.hpp>
 
@@ -10,17 +11,18 @@ namespace nano::store
 class transaction_impl
 {
 public:
-	transaction_impl (nano::id_dispenser::id_t const store_id);
+	transaction_impl (nano::logger & logger, nano::id_dispenser::id_t const store_id);
 	virtual ~transaction_impl () = default;
 	virtual void * get_handle () const = 0;
 
+	nano::logger & logger;
 	nano::id_dispenser::id_t const store_id;
 };
 
 class read_transaction_impl : public transaction_impl
 {
 public:
-	explicit read_transaction_impl (nano::id_dispenser::id_t const store_id = 0);
+	explicit read_transaction_impl (nano::logger & logger, nano::id_dispenser::id_t const store_id = 0);
 	virtual void reset () = 0;
 	virtual void renew () = 0;
 };
@@ -28,7 +30,7 @@ public:
 class write_transaction_impl : public transaction_impl
 {
 public:
-	explicit write_transaction_impl (nano::id_dispenser::id_t const store_id = 0);
+	explicit write_transaction_impl (nano::logger & logger, nano::id_dispenser::id_t const store_id = 0);
 	virtual void commit () = 0;
 	virtual void renew () = 0;
 	virtual bool contains (nano::tables table_a) const = 0;


### PR DESCRIPTION
release_assert checks are replaced with both a critical log with the status code and also will call release_assert to give a stack trace.