### PR TITLE
Remove unnecessary com file for Win

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -844,18 +844,6 @@ if(NANO_GUI OR RAIBLOCKS_GUI)
 
   target_link_libraries(nano_wallet Boost::process rpc node qt)
 
-  if(WIN32)
-    target_link_libraries(nano_wallet Qt5::WinExtras)
-    # nano_wallet.com executable for Windows console
-    add_executable(nano_wallet_com nano/nano_wallet/entry_com.cpp)
-    target_link_libraries(nano_wallet_com node)
-    set_target_properties(
-      nano_wallet_com
-      PROPERTIES COMPILE_FLAGS "-DBOOST_ASIO_HAS_STD_ARRAY=1"
-                 OUTPUT_NAME "nano_wallet"
-                 SUFFIX ".com")
-  endif()
-
   set_target_properties(
     qt nano_wallet PROPERTIES COMPILE_FLAGS
                               "-DQT_NO_KEYWORDS -DBOOST_ASIO_HAS_STD_ARRAY=1")
@@ -933,7 +921,6 @@ if(NANO_GUI OR RAIBLOCKS_GUI)
                         LOCATION)
     get_filename_component(Qt5_bin_DIR ${Qt5_DIR}/../../../bin ABSOLUTE)
     install(TARGETS nano_wallet DESTINATION .)
-    install(TARGETS nano_wallet_com DESTINATION .)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${WIN_REDIST} DESTINATION .)
     install(FILES ${Qt5_bin_DIR}/libGLESv2.dll DESTINATION .)
     install(FILES ${Qt5_bin_DIR}/Qt5Core.dll DESTINATION .)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -844,6 +844,10 @@ if(NANO_GUI OR RAIBLOCKS_GUI)
 
   target_link_libraries(nano_wallet Boost::process rpc node qt)
 
+  if(WIN32)
+    target_link_libraries(nano_wallet Qt5::WinExtras)
+  endif()
+
   set_target_properties(
     qt nano_wallet PROPERTIES COMPILE_FLAGS
                               "-DQT_NO_KEYWORDS -DBOOST_ASIO_HAS_STD_ARRAY=1")


### PR DESCRIPTION
The build process is creating both nano_wallet.exe and nano_wallet.com for the Windows build. The dot com file is not needed. 
Running the gui wallet from the console doesn't make much sense. If you want to use the console you should be using nano_node.exe
It is also possible to add arguments to nano_wallet.exe if you launch it from a console.