### PR TITLE
Include status code in assertions

### DIFF
--- a/nano/lib/logging.cpp
+++ b/nano/lib/logging.cpp
@@ -215,7 +215,10 @@ void nano::logger::flush ()
 nano::logger::logger (std::string identifier) :
 	identifier{ std::move (identifier) }
 {
-	release_assert (global_initialized, "logging should be initialized before creating a logger");
+	if (!global_initialized)
+	{
+		throw std::runtime_error{ "logging should be initialized before creating a logger" };
+	}
 }
 
 nano::logger::~logger ()

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -24,6 +24,7 @@ enum class type
 	all = 0, // reserved
 
 	generic,
+	assert,
 	test,
 	system,
 	init,

--- a/nano/store/component.hpp
+++ b/nano/store/component.hpp
@@ -49,7 +49,6 @@ namespace store
 		virtual int drop (write_transaction const & transaction_a, tables table_a) = 0;
 		virtual bool not_found (int status) const = 0;
 		virtual bool success (int status) const = 0;
-		virtual int status_code_not_found () const = 0;
 		virtual std::string error_string (int status) const = 0;
 
 		store::block & block;

--- a/nano/store/lmdb/account.cpp
+++ b/nano/store/lmdb/account.cpp
@@ -16,7 +16,7 @@ bool nano::store::lmdb::account::get (store::transaction const & transaction, na
 {
 	nano::store::lmdb::db_val value;
 	auto status1 (store.get (transaction, tables::accounts, account, value));
-	release_assert (store.success (status1) || store.not_found (status1));
+	release_assert (store.success (status1) || store.not_found (status1), store.error_string (status1));
 	bool result (true);
 	if (store.success (status1))
 	{

--- a/nano/store/lmdb/block.cpp
+++ b/nano/store/lmdb/block.cpp
@@ -150,7 +150,7 @@ void nano::store::lmdb::block::for_each_par (std::function<void (store::read_tra
 void nano::store::lmdb::block::block_raw_get (store::transaction const & transaction, nano::block_hash const & hash, nano::store::lmdb::db_val & value) const
 {
 	auto status = store.get (transaction, tables::blocks, hash, value);
-	release_assert (store.success (status) || store.not_found (status));
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 }
 
 size_t nano::store::lmdb::block::block_successor_offset (store::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const

--- a/nano/store/lmdb/confirmation_height.cpp
+++ b/nano/store/lmdb/confirmation_height.cpp
@@ -17,7 +17,7 @@ bool nano::store::lmdb::confirmation_height::get (store::transaction const & tra
 {
 	nano::store::lmdb::db_val value;
 	auto status = store.get (transaction, tables::confirmation_height, account, value);
-	release_assert (store.success (status) || store.not_found (status));
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 	bool result (true);
 	if (store.success (status))
 	{

--- a/nano/store/lmdb/final_vote.cpp
+++ b/nano/store/lmdb/final_vote.cpp
@@ -9,7 +9,7 @@ bool nano::store::lmdb::final_vote::put (store::write_transaction const & transa
 {
 	nano::store::lmdb::db_val value;
 	auto status = store.get (transaction, tables::final_votes, root, value);
-	release_assert (store.success (status) || store.not_found (status));
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 	bool result (true);
 	if (store.success (status))
 	{

--- a/nano/store/lmdb/lmdb.hpp
+++ b/nano/store/lmdb/lmdb.hpp
@@ -98,6 +98,7 @@ public:
 	bool init_error () const override;
 
 	uint64_t count (store::transaction const &, MDB_dbi) const;
+
 	std::string error_string (int status) const override;
 
 private:
@@ -115,12 +116,8 @@ private:
 	bool success (int status) const override;
 	void release_assert_success (int const status) const
 	{
-		if (!success (status))
-		{
-			release_assert (false, error_string (status));
-		}
+		release_assert (success (status), error_string (status));
 	}
-	int status_code_not_found () const override;
 
 	MDB_dbi table_to_dbi (tables table_a) const;
 
@@ -148,4 +145,8 @@ private:
 	friend class mdb_block_store_upgrade_v21_v22_Test;
 	friend class block_store_DISABLED_change_dupsort_Test;
 };
-} // namespace nano::store::lmdb
+
+bool success (int status);
+bool not_found (int status);
+std::string error_string (int status);
+}

--- a/nano/store/lmdb/lmdb_env.hpp
+++ b/nano/store/lmdb/lmdb_env.hpp
@@ -66,4 +66,4 @@ public:
 	nano::id_t const store_id{ nano::next_id () };
 	std::filesystem::path const database_path;
 };
-} // namespace nano::store::lmdb
+}

--- a/nano/store/lmdb/peer.cpp
+++ b/nano/store/lmdb/peer.cpp
@@ -15,7 +15,7 @@ nano::millis_t nano::store::lmdb::peer::get (store::transaction const & transact
 	nano::millis_t result{ 0 };
 	db_val value;
 	auto status = store.get (transaction, tables::peers, endpoint, value);
-	release_assert (store.success (status) || store.not_found (status));
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 	if (store.success (status) && value.size () > 0)
 	{
 		result = static_cast<nano::millis_t> (value);

--- a/nano/store/lmdb/pending.cpp
+++ b/nano/store/lmdb/pending.cpp
@@ -21,7 +21,7 @@ std::optional<nano::pending_info> nano::store::lmdb::pending::get (store::transa
 {
 	nano::store::lmdb::db_val value;
 	auto status1 = store.get (transaction, tables::pending, key, value);
-	release_assert (store.success (status1) || store.not_found (status1));
+	release_assert (store.success (status1) || store.not_found (status1), store.error_string (status1));
 	std::optional<nano::pending_info> result;
 	if (store.success (status1))
 	{

--- a/nano/store/lmdb/rep_weight.cpp
+++ b/nano/store/lmdb/rep_weight.cpp
@@ -20,7 +20,7 @@ nano::uint128_t nano::store::lmdb::rep_weight::get (store::transaction const & t
 {
 	nano::store::lmdb::db_val value;
 	auto status = store.get (txn_a, tables::rep_weights, representative_a, value);
-	release_assert (store.success (status) || store.not_found (status));
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 	nano::uint128_t weight{ 0 };
 	if (store.success (status))
 	{

--- a/nano/store/rocksdb/account.cpp
+++ b/nano/store/rocksdb/account.cpp
@@ -15,10 +15,10 @@ void nano::store::rocksdb::account::put (store::write_transaction const & transa
 bool nano::store::rocksdb::account::get (store::transaction const & transaction, nano::account const & account, nano::account_info & info)
 {
 	nano::store::rocksdb::db_val value;
-	auto status1 (store.get (transaction, tables::accounts, account, value));
-	release_assert (store.success (status1) || store.not_found (status1));
+	auto status = store.get (transaction, tables::accounts, account, value);
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 	bool result (true);
-	if (store.success (status1))
+	if (store.success (status))
 	{
 		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()), value.size ());
 		result = info.deserialize (stream);

--- a/nano/store/rocksdb/block.cpp
+++ b/nano/store/rocksdb/block.cpp
@@ -151,7 +151,7 @@ void nano::store::rocksdb::block::for_each_par (std::function<void (store::read_
 void nano::store::rocksdb::block::block_raw_get (store::transaction const & transaction, nano::block_hash const & hash, nano::store::rocksdb::db_val & value) const
 {
 	auto status = store.get (transaction, tables::blocks, hash, value);
-	release_assert (store.success (status) || store.not_found (status));
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 }
 
 size_t nano::store::rocksdb::block::block_successor_offset (store::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const

--- a/nano/store/rocksdb/confirmation_height.cpp
+++ b/nano/store/rocksdb/confirmation_height.cpp
@@ -18,7 +18,7 @@ bool nano::store::rocksdb::confirmation_height::get (store::transaction const & 
 {
 	nano::store::rocksdb::db_val value;
 	auto status = store.get (transaction, tables::confirmation_height, account, value);
-	release_assert (store.success (status) || store.not_found (status));
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 	bool result (true);
 	if (store.success (status))
 	{

--- a/nano/store/rocksdb/final_vote.cpp
+++ b/nano/store/rocksdb/final_vote.cpp
@@ -10,7 +10,7 @@ bool nano::store::rocksdb::final_vote::put (store::write_transaction const & tra
 {
 	nano::store::rocksdb::db_val value;
 	auto status = store.get (transaction, tables::final_votes, root, value);
-	release_assert (store.success (status) || store.not_found (status));
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 	bool result (true);
 	if (store.success (status))
 	{

--- a/nano/store/rocksdb/peer.cpp
+++ b/nano/store/rocksdb/peer.cpp
@@ -16,7 +16,7 @@ nano::millis_t nano::store::rocksdb::peer::get (store::transaction const & trans
 	nano::millis_t result{ 0 };
 	db_val value;
 	auto status = store.get (transaction, tables::peers, endpoint, value);
-	release_assert (store.success (status) || store.not_found (status));
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 	if (store.success (status) && value.size () > 0)
 	{
 		result = static_cast<nano::millis_t> (value);

--- a/nano/store/rocksdb/pending.cpp
+++ b/nano/store/rocksdb/pending.cpp
@@ -21,10 +21,10 @@ void nano::store::rocksdb::pending::del (store::write_transaction const & transa
 std::optional<nano::pending_info> nano::store::rocksdb::pending::get (store::transaction const & transaction, nano::pending_key const & key)
 {
 	nano::store::rocksdb::db_val value;
-	auto status1 = store.get (transaction, tables::pending, key, value);
-	release_assert (store.success (status1) || store.not_found (status1));
+	auto status = store.get (transaction, tables::pending, key, value);
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 	std::optional<nano::pending_info> result;
-	if (store.success (status1))
+	if (store.success (status))
 	{
 		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()), value.size ());
 		result = nano::pending_info{};

--- a/nano/store/rocksdb/rep_weight.cpp
+++ b/nano/store/rocksdb/rep_weight.cpp
@@ -20,7 +20,7 @@ nano::uint128_t nano::store::rocksdb::rep_weight::get (store::transaction const 
 {
 	db_val value;
 	auto status = store.get (txn_a, tables::rep_weights, representative_a, value);
-	release_assert (store.success (status) || store.not_found (status));
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 	nano::uint128_t weight{ 0 };
 	if (store.success (status))
 	{

--- a/nano/store/rocksdb/rocksdb.hpp
+++ b/nano/store/rocksdb/rocksdb.hpp
@@ -118,12 +118,9 @@ private:
 	bool success (int status) const override;
 	void release_assert_success (int const status) const
 	{
-		if (!success (status))
-		{
-			release_assert (false, error_string (status));
-		}
+		release_assert (success (status), error_string (status));
 	}
-	int status_code_not_found () const override;
+
 	int drop (store::write_transaction const &, tables) override;
 
 	std::vector<::rocksdb::ColumnFamilyDescriptor> get_single_column_family (std::string cf_name) const;
@@ -155,4 +152,8 @@ private:
 	friend class nano::rocksdb_block_store_tombstone_count_Test;
 	friend class rocksdb_block_store_upgrade_v21_v22_Test;
 };
-} // namespace nano::store::rocksdb
+
+bool success (int status);
+bool not_found (int status);
+std::string error_string (int status);
+}


### PR DESCRIPTION
This includes info about error codes in assert statements for store operations. Additionally this ensures that asserts are also logged to standard output and persisted in log directory.


```
[2025-03-21 18:17:02.107] [assert] [critical] Assertion (false) failed: test assertion hit
/Users/xxx/nano-node/nano/nano_node/entry.cpp:2053 [int main(int, char *const *)]'
 0# nano::generate_stacktrace() in /Users/xxx/nano-node/cmake-build-debug/nano_node
 1# assert_internal(char const*, char const*, char const*, unsigned int, bool, std::__1::basic_string_view<char, std::__1::char_traits<char>>) in /Users/xxx/nano-node/cmake-build-debug/nano_node
 2# main in /Users/xxx/nano-node/cmake-build-debug/nano_node
```