### PR TITLE
Bootstrap stale elections

### DIFF
--- a/nano/lib/constants.hpp
+++ b/nano/lib/constants.hpp
@@ -84,7 +84,7 @@ public:
 		default_rpc_port (45000),
 		default_ipc_port (46000),
 		default_websocket_port (47000),
-		aec_loop_interval_ms (300), // Update AEC ~3 times per second
+		aec_loop_interval (300ms), // Update AEC ~3 times per second
 		cleanup_period (default_cleanup_period),
 		merge_period (std::chrono::milliseconds (250)),
 		keepalive_period (std::chrono::seconds (15)),
@@ -120,7 +120,7 @@ public:
 		}
 		else if (is_dev_network ())
 		{
-			aec_loop_interval_ms = 20;
+			aec_loop_interval = 20ms;
 			cleanup_period = std::chrono::seconds (1);
 			merge_period = std::chrono::milliseconds (10);
 			keepalive_period = std::chrono::seconds (1);
@@ -147,7 +147,7 @@ public:
 	uint16_t default_rpc_port;
 	uint16_t default_ipc_port;
 	uint16_t default_websocket_port;
-	unsigned aec_loop_interval_ms;
+	std::chrono::milliseconds aec_loop_interval;
 
 	std::chrono::seconds cleanup_period;
 	std::chrono::milliseconds cleanup_period_half () const

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -490,6 +490,7 @@ enum class detail
 	stopped,
 	confirm_dependent,
 	forks_cached,
+	bootstrap_stale,
 
 	// unchecked
 	put,

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -46,8 +46,8 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::ledger_notifications:
 			thread_role_name_string = "Ledger notif";
 			break;
-		case nano::thread_role::name::request_loop:
-			thread_role_name_string = "Request loop";
+		case nano::thread_role::name::aec_loop:
+			thread_role_name_string = "AEC";
 			break;
 		case nano::thread_role::name::wallet_actions:
 			thread_role_name_string = "Wallet actions";

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -20,7 +20,7 @@ enum class name
 	vote_rebroadcasting,
 	block_processing,
 	ledger_notifications,
-	request_loop,
+	aec_loop,
 	wallet_actions,
 	bootstrap_initiator,
 	bootstrap_connections,

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -129,8 +129,9 @@ public: // Events
 	nano::observer_set<> vacancy_updated;
 
 private:
-	void request_loop ();
-	void request_confirm (nano::unique_lock<nano::mutex> &);
+	void run ();
+	void tick_elections (nano::unique_lock<nano::mutex> &);
+
 	// Erase all blocks from active and, if not confirmed, clear digests from network filters
 	void cleanup_election (nano::unique_lock<nano::mutex> & lock_a, std::shared_ptr<nano::election>);
 
@@ -139,7 +140,7 @@ private:
 	void notify_observers (nano::secure::transaction const &, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes) const;
 
 	std::shared_ptr<nano::election> election_impl (nano::qualified_root const &) const;
-	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t max_count) const;
+	std::vector<std::shared_ptr<nano::election>> list_active_impl (std::size_t max_count = std::numeric_limits<std::size_t>::max ()) const;
 
 private: // Dependencies
 	active_elections_config const & config;

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/enum_util.hpp>
+#include <nano/lib/interval.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/observer_set.hpp>
 #include <nano/node/election_behavior.hpp>
@@ -50,6 +51,8 @@ public:
 	std::size_t confirmation_cache{ 65536 };
 	// Maximum size of election winner details set
 	std::size_t max_election_winners{ 1024 * 16 };
+
+	std::chrono::seconds bootstrap_stale_threshold{ 60s };
 };
 
 /**
@@ -163,6 +166,8 @@ private:
 	nano::condition_variable condition;
 	bool stopped{ false };
 	std::thread thread;
+
+	nano::interval bootstrap_stale_interval;
 
 	friend class election;
 

--- a/nano/node/bootstrap/bootstrap_service.cpp
+++ b/nano/node/bootstrap/bootstrap_service.cpp
@@ -163,6 +163,12 @@ void nano::bootstrap_service::reset ()
 	throttle.reset ();
 }
 
+void nano::bootstrap_service::prioritize (nano::account const & account)
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	accounts.priority_set (account);
+}
+
 bool nano::bootstrap_service::send (std::shared_ptr<nano::transport::channel> const & channel, async_tag tag)
 {
 	debug_assert (tag.type != query_type::invalid);

--- a/nano/node/bootstrap/bootstrap_service.hpp
+++ b/nano/node/bootstrap/bootstrap_service.hpp
@@ -46,6 +46,11 @@ public:
 	 */
 	void reset ();
 
+	/**
+	 * Adds an account to the priority set
+	 */
+	void prioritize (nano::account const & account);
+
 	std::size_t blocked_size () const;
 	std::size_t priority_size () const;
 	std::size_t score_size () const;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -805,6 +805,12 @@ void nano::election::force_confirm ()
 	confirm_once (lock);
 }
 
+nano::account nano::election::account () const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return status.winner->account ();
+}
+
 std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> nano::election::blocks () const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -142,6 +142,7 @@ public: // Information
 	nano::root const root;
 	nano::qualified_root const qualified_root;
 
+	nano::account account () const;
 	std::vector<nano::vote_with_weight_info> votes_with_weight () const;
 	nano::election_behavior behavior () const;
 	nano::election_state state () const;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1776,7 +1776,7 @@ TEST (node, mass_block_new)
 	nano::node_config node_config = system.default_config ();
 	node_config.backlog_scan.enable = false;
 	auto & node = *system.add_node (node_config);
-	node.network_params.network.aec_loop_interval_ms = 500;
+	node.network_params.network.aec_loop_interval = 500ms;
 
 #ifndef NDEBUG
 	auto const num_blocks = 5000;


### PR DESCRIPTION
This adds a mechanism by which additional bootstrap attempts are made to find missing blocks for stale forked elections.