### PR TITLE
Rename `confirming_set` to `cementing_set`

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(
   bucketing.cpp
   cli.cpp
   confirmation_solicitor.cpp
-  confirming_set.cpp
+  cementing_set.cpp
   conflicts.cpp
   difficulty.cpp
   distributed_work.cpp

--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/active_elections.hpp>
-#include <nano/node/confirming_set.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/online_reps.hpp>
 #include <nano/node/scheduler/component.hpp>
@@ -1232,7 +1232,7 @@ TEST (active_elections, activate_inactive)
 	ASSERT_NE (nullptr, election);
 	election->force_confirm ();
 
-	ASSERT_TIMELY (5s, !node.confirming_set.contains (send2->hash ()));
+	ASSERT_TIMELY (5s, !node.cementing_set.contains (send2->hash ()));
 	ASSERT_TIMELY (5s, node.block_confirmed (send2->hash ()));
 	ASSERT_TIMELY (5s, node.block_confirmed (send->hash ()));
 
@@ -1409,7 +1409,7 @@ TEST (active_elections, bound_election_winners)
 	// Set election winner limit to a low value
 	config.active_elections.max_election_winners = 5;
 	// Large batch size would complicate this testcase
-	config.confirming_set.batch_size = 1;
+	config.cementing_set.batch_size = 1;
 	auto & node = *system.add_node (config);
 
 	// Start elections for a couple of blocks, number of elections is larger than the election winner set limit

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -247,7 +247,7 @@ TEST (election_scheduler, no_vacancy)
 				.work (*system.work.generate (nano::dev::genesis->hash ()))
 				.build ();
 	ASSERT_EQ (nano::block_status::progress, node.process (send));
-	node.confirming_set.add (send->hash ());
+	node.cementing_set.add (send->hash ());
 
 	auto receive = builder.make_block ()
 				   .account (key.pub)
@@ -259,7 +259,7 @@ TEST (election_scheduler, no_vacancy)
 				   .work (*system.work.generate (key.pub))
 				   .build ();
 	ASSERT_EQ (nano::block_status::progress, node.process (receive));
-	node.confirming_set.add (receive->hash ());
+	node.cementing_set.add (receive->hash ());
 
 	ASSERT_TIMELY (5s, nano::test::confirmed (node, { send, receive }));
 

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3,7 +3,7 @@
 #include <nano/lib/logging.hpp>
 #include <nano/lib/work_version.hpp>
 #include <nano/node/active_elections.hpp>
-#include <nano/node/confirming_set.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/inactive_node.hpp>
 #include <nano/node/local_vote_history.hpp>
@@ -1433,7 +1433,7 @@ TEST (node, bootstrap_fork_open)
 
 	// They disagree about open0/open1
 	ASSERT_EQ (nano::block_status::progress, node0->process (open0));
-	node0->confirming_set.add (open0->hash ());
+	node0->cementing_set.add (open0->hash ());
 	ASSERT_TIMELY (5s, node0->block_confirmed (open0->hash ()));
 
 	ASSERT_EQ (nano::block_status::progress, node1->process (open1));
@@ -1747,7 +1747,7 @@ TEST (node, DISABLED_local_votes_cache_batch)
 				 .work (*node.work_generate_blocking (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
-	node.confirming_set.add (send1->hash ());
+	node.cementing_set.add (send1->hash ());
 	ASSERT_TIMELY (5s, node.ledger.confirmed.block_exists_or_pruned (node.ledger.tx_begin_read (), send1->hash ()));
 	auto send2 = nano::state_block_builder ()
 				 .account (nano::dev::genesis_key.pub)
@@ -3394,9 +3394,9 @@ TEST (node, pruning_automatic)
 	ASSERT_TIMELY (5s, node1.block (send2->hash ()) != nullptr);
 
 	// Force-confirm both blocks
-	node1.confirming_set.add (send1->hash ());
+	node1.cementing_set.add (send1->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send1->hash ()));
-	node1.confirming_set.add (send2->hash ());
+	node1.cementing_set.add (send2->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
 
 	// Check pruning result
@@ -3445,9 +3445,9 @@ TEST (node, DISABLED_pruning_age)
 	node1.process_active (send2);
 
 	// Force-confirm both blocks
-	node1.confirming_set.add (send1->hash ());
+	node1.cementing_set.add (send1->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send1->hash ()));
-	node1.confirming_set.add (send2->hash ());
+	node1.cementing_set.add (send2->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
 
 	// Three blocks in total, nothing pruned yet
@@ -3506,9 +3506,9 @@ TEST (node, DISABLED_pruning_depth)
 	node1.process_active (send2);
 
 	// Force-confirm both blocks
-	node1.confirming_set.add (send1->hash ());
+	node1.cementing_set.add (send1->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send1->hash ()));
-	node1.confirming_set.add (send2->hash ());
+	node1.cementing_set.add (send2->hash ());
 	ASSERT_TIMELY (5s, node1.block_confirmed (send2->hash ()));
 
 	// Three blocks in total, nothing pruned yet

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -2,7 +2,7 @@
 #include <nano/lib/function.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/node/active_elections.hpp>
-#include <nano/node/confirming_set.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/local_vote_history.hpp>
 #include <nano/node/request_aggregator.hpp>

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -288,7 +288,7 @@ TEST (toml_config, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.bootstrap_serving_threads, defaults.node.bootstrap_serving_threads);
 	ASSERT_EQ (conf.node.bootstrap_frontier_request_count, defaults.node.bootstrap_frontier_request_count);
 	ASSERT_EQ (conf.node.bootstrap_fraction_numerator, defaults.node.bootstrap_fraction_numerator);
-	ASSERT_EQ (conf.node.confirming_set_batch_time, defaults.node.confirming_set_batch_time);
+	ASSERT_EQ (conf.node.cementing_set_batch_time, defaults.node.cementing_set_batch_time);
 	ASSERT_EQ (conf.node.enable_voting, defaults.node.enable_voting);
 	ASSERT_EQ (conf.node.external_address, defaults.node.external_address);
 	ASSERT_EQ (conf.node.external_port, defaults.node.external_port);
@@ -456,7 +456,7 @@ TEST (toml_config, daemon_config_deserialize_no_defaults)
 	bootstrap_serving_threads = 999
 	bootstrap_frontier_request_count = 9999
 	bootstrap_fraction_numerator = 999
-	confirming_set_batch_time = 999
+	cementing_set_batch_time = 999
 	enable_voting = false
 	external_address = "0:0:0:0:0:ffff:7f01:101"
 	external_port = 999
@@ -720,7 +720,7 @@ TEST (toml_config, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.bootstrap_serving_threads, defaults.node.bootstrap_serving_threads);
 	ASSERT_NE (conf.node.bootstrap_frontier_request_count, defaults.node.bootstrap_frontier_request_count);
 	ASSERT_NE (conf.node.bootstrap_fraction_numerator, defaults.node.bootstrap_fraction_numerator);
-	ASSERT_NE (conf.node.confirming_set_batch_time, defaults.node.confirming_set_batch_time);
+	ASSERT_NE (conf.node.cementing_set_batch_time, defaults.node.cementing_set_batch_time);
 	ASSERT_NE (conf.node.enable_voting, defaults.node.enable_voting);
 	ASSERT_NE (conf.node.external_address, defaults.node.external_address);
 	ASSERT_NE (conf.node.external_port, defaults.node.external_port);

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -85,7 +85,7 @@ enum class type
 	online_reps,
 	local_block_broadcaster,
 	monitor,
-	confirming_set,
+	cementing_set,
 	bounded_backlog,
 	request_aggregator,
 

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -53,7 +53,7 @@ enum class type
 	socket,
 	confirmation_height,
 	confirmation_observer,
-	confirming_set,
+	cementing_set,
 	drop, // TODO: Rename to message_drop
 	aggregator,
 	requests,
@@ -605,7 +605,7 @@ enum class detail
 	notify_processed,
 	notify_rolled_back,
 
-	// confirming_set
+	// cementing_set
 	notify_cemented,
 	notify_already_cemented,
 	notify_intermediate,

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -8,8 +8,8 @@
 #include <nano/lib/work_version.hpp>
 #include <nano/nano_node/daemon.hpp>
 #include <nano/node/active_elections.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/cli.hpp>
-#include <nano/node/confirming_set.hpp>
 #include <nano/node/daemonconfig.hpp>
 #include <nano/node/inactive_node.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
@@ -1261,7 +1261,7 @@ int main (int argc, char * const * argv)
 			// Confirm blocks for node1
 			for (auto & block : blocks)
 			{
-				node1->confirming_set.add (block->hash ());
+				node1->cementing_set.add (block->hash ());
 			}
 			while (node1->ledger.cemented_count () != node1->ledger.block_count ())
 			{

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -50,8 +50,8 @@ add_library(
   bootstrap/peer_scoring.cpp
   cli.hpp
   cli.cpp
-  confirming_set.hpp
-  confirming_set.cpp
+  cementing_set.hpp
+  cementing_set.cpp
   confirmation_solicitor.hpp
   confirmation_solicitor.cpp
   daemonconfig.hpp

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -93,7 +93,7 @@ private: // Elections
 	ordered_roots roots;
 
 public:
-	active_elections (nano::node &, nano::ledger_notifications &, nano::confirming_set &);
+	active_elections (nano::node &, nano::ledger_notifications &, nano::cementing_set &);
 	~active_elections ();
 
 	void start ();
@@ -149,7 +149,7 @@ private: // Dependencies
 	active_elections_config const & config;
 	nano::node & node;
 	nano::ledger_notifications & ledger_notifications;
-	nano::confirming_set & confirming_set;
+	nano::cementing_set & cementing_set;
 
 public:
 	nano::recently_confirmed_cache recently_confirmed;

--- a/nano/node/bounded_backlog.cpp
+++ b/nano/node/bounded_backlog.cpp
@@ -3,7 +3,7 @@
 #include <nano/node/backlog_scan.hpp>
 #include <nano/node/block_processor.hpp>
 #include <nano/node/bounded_backlog.hpp>
-#include <nano/node/confirming_set.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/ledger_notifications.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/scheduler/component.hpp>
@@ -13,14 +13,14 @@
 #include <nano/secure/ledger_set_confirmed.hpp>
 #include <nano/secure/transaction.hpp>
 
-nano::bounded_backlog::bounded_backlog (nano::node_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::ledger_notifications & ledger_notifications_a, nano::bucketing & bucketing_a, nano::backlog_scan & backlog_scan_a, nano::block_processor & block_processor_a, nano::confirming_set & confirming_set_a, nano::stats & stats_a, nano::logger & logger_a) :
+nano::bounded_backlog::bounded_backlog (nano::node_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::ledger_notifications & ledger_notifications_a, nano::bucketing & bucketing_a, nano::backlog_scan & backlog_scan_a, nano::block_processor & block_processor_a, nano::cementing_set & cementing_set_a, nano::stats & stats_a, nano::logger & logger_a) :
 	config{ config_a },
 	node{ node_a },
 	ledger{ ledger_a },
 	ledger_notifications{ ledger_notifications_a },
 	bucketing{ bucketing_a },
 	backlog_scan{ backlog_scan_a },
-	confirming_set{ confirming_set_a },
+	cementing_set{ cementing_set_a },
 	stats{ stats_a },
 	logger{ logger_a },
 	scan_limiter{ config.bounded_backlog.scan_rate }
@@ -69,7 +69,7 @@ nano::bounded_backlog::bounded_backlog (nano::node_config const & config_a, nano
 	});
 
 	// Remove cemented blocks from the backlog
-	confirming_set.batch_cemented.add ([this] (auto const & batch) {
+	cementing_set.batch_cemented.add ([this] (auto const & batch) {
 		nano::lock_guard<nano::mutex> guard{ mutex };
 		for (auto const & context : batch)
 		{
@@ -262,7 +262,7 @@ bool nano::bounded_backlog::should_rollback (nano::block_hash const & hash) cons
 	{
 		return false;
 	}
-	if (node.confirming_set.contains (hash))
+	if (node.cementing_set.contains (hash))
 	{
 		return false;
 	}

--- a/nano/node/bounded_backlog.hpp
+++ b/nano/node/bounded_backlog.hpp
@@ -107,7 +107,7 @@ public:
 class bounded_backlog
 {
 public:
-	bounded_backlog (nano::node_config const &, nano::node &, nano::ledger &, nano::ledger_notifications &, nano::bucketing &, nano::backlog_scan &, nano::block_processor &, nano::confirming_set &, nano::stats &, nano::logger &);
+	bounded_backlog (nano::node_config const &, nano::node &, nano::ledger &, nano::ledger_notifications &, nano::bucketing &, nano::backlog_scan &, nano::block_processor &, nano::cementing_set &, nano::stats &, nano::logger &);
 	~bounded_backlog ();
 
 	void start ();
@@ -126,7 +126,7 @@ private: // Dependencies
 	nano::ledger_notifications & ledger_notifications;
 	nano::bucketing & bucketing;
 	nano::backlog_scan & backlog_scan;
-	nano::confirming_set & confirming_set;
+	nano::cementing_set & cementing_set;
 	nano::stats & stats;
 	nano::logger & logger;
 

--- a/nano/node/cementing_set.cpp
+++ b/nano/node/cementing_set.cpp
@@ -3,7 +3,7 @@
 #include <nano/lib/stats.hpp>
 #include <nano/lib/thread_roles.hpp>
 #include <nano/node/block_processor.hpp>
-#include <nano/node/confirming_set.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/ledger_notifications.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
@@ -11,7 +11,7 @@
 #include <nano/store/component.hpp>
 #include <nano/store/write_queue.hpp>
 
-nano::confirming_set::confirming_set (confirming_set_config const & config_a, nano::ledger & ledger_a, nano::ledger_notifications & ledger_notifications_a, nano::stats & stats_a, nano::logger & logger_a) :
+nano::cementing_set::cementing_set (cementing_set_config const & config_a, nano::ledger & ledger_a, nano::ledger_notifications & ledger_notifications_a, nano::stats & stats_a, nano::logger & logger_a) :
 	config{ config_a },
 	ledger{ ledger_a },
 	ledger_notifications{ ledger_notifications_a },
@@ -35,7 +35,7 @@ nano::confirming_set::confirming_set (confirming_set_config const & config_a, na
 			{
 				if (auto it = deferred.get<tag_hash> ().find (context.block->hash ()); it != deferred.get<tag_hash> ().end ())
 				{
-					stats.inc (nano::stat::type::confirming_set, nano::stat::detail::requeued);
+					stats.inc (nano::stat::type::cementing_set, nano::stat::detail::requeued);
 					set.push_back (*it);
 					deferred.get<tag_hash> ().erase (it);
 					should_notify = true;
@@ -49,12 +49,12 @@ nano::confirming_set::confirming_set (confirming_set_config const & config_a, na
 	});
 }
 
-nano::confirming_set::~confirming_set ()
+nano::cementing_set::~cementing_set ()
 {
 	debug_assert (!thread.joinable ());
 }
 
-void nano::confirming_set::add (nano::block_hash const & hash, std::shared_ptr<nano::election> const & election)
+void nano::cementing_set::add (nano::block_hash const & hash, std::shared_ptr<nano::election> const & election)
 {
 	bool added = false;
 	{
@@ -65,15 +65,15 @@ void nano::confirming_set::add (nano::block_hash const & hash, std::shared_ptr<n
 	if (added)
 	{
 		condition.notify_all ();
-		stats.inc (nano::stat::type::confirming_set, nano::stat::detail::insert);
+		stats.inc (nano::stat::type::cementing_set, nano::stat::detail::insert);
 	}
 	else
 	{
-		stats.inc (nano::stat::type::confirming_set, nano::stat::detail::duplicate);
+		stats.inc (nano::stat::type::cementing_set, nano::stat::detail::duplicate);
 	}
 }
 
-void nano::confirming_set::start ()
+void nano::cementing_set::start ()
 {
 	debug_assert (!thread.joinable ());
 
@@ -90,7 +90,7 @@ void nano::confirming_set::start ()
 	} };
 }
 
-void nano::confirming_set::stop ()
+void nano::cementing_set::stop ()
 {
 	{
 		std::lock_guard lock{ mutex };
@@ -104,25 +104,25 @@ void nano::confirming_set::stop ()
 	workers.stop ();
 }
 
-bool nano::confirming_set::contains (nano::block_hash const & hash) const
+bool nano::cementing_set::contains (nano::block_hash const & hash) const
 {
 	std::lock_guard lock{ mutex };
 	return set.get<tag_hash> ().contains (hash) || deferred.get<tag_hash> ().contains (hash) || current.contains (hash);
 }
 
-std::size_t nano::confirming_set::size () const
+std::size_t nano::cementing_set::size () const
 {
 	// Do not report deferred blocks, as they are not currently being processed (and might never be requeued)
 	std::lock_guard lock{ mutex };
 	return set.size () + current.size ();
 }
 
-void nano::confirming_set::run ()
+void nano::cementing_set::run ()
 {
 	std::unique_lock lock{ mutex };
 	while (!stopped)
 	{
-		stats.inc (nano::stat::type::confirming_set, nano::stat::detail::loop);
+		stats.inc (nano::stat::type::cementing_set, nano::stat::detail::loop);
 
 		cleanup (lock);
 		debug_assert (lock.owns_lock ());
@@ -140,7 +140,7 @@ void nano::confirming_set::run ()
 	}
 }
 
-auto nano::confirming_set::next_batch (size_t max_count) -> std::deque<entry>
+auto nano::cementing_set::next_batch (size_t max_count) -> std::deque<entry>
 {
 	debug_assert (!mutex.try_lock ());
 	debug_assert (!set.empty ());
@@ -154,7 +154,7 @@ auto nano::confirming_set::next_batch (size_t max_count) -> std::deque<entry>
 	return results;
 }
 
-void nano::confirming_set::run_batch (std::unique_lock<std::mutex> & lock)
+void nano::cementing_set::run_batch (std::unique_lock<std::mutex> & lock)
 {
 	debug_assert (lock.owns_lock ());
 	debug_assert (!mutex.try_lock ());
@@ -183,7 +183,7 @@ void nano::confirming_set::run_batch (std::unique_lock<std::mutex> & lock)
 		// It's possible that ledger cementing happens faster than the notifications can be processed by other components, cooldown here
 		while (workers.queued_tasks () >= config.max_queued_notifications)
 		{
-			stats.inc (nano::stat::type::confirming_set, nano::stat::detail::cooldown);
+			stats.inc (nano::stat::type::cementing_set, nano::stat::detail::cooldown);
 			condition.wait_for (lock, 100ms, [this] { return stopped.load (); });
 			if (stopped)
 			{
@@ -192,7 +192,7 @@ void nano::confirming_set::run_batch (std::unique_lock<std::mutex> & lock)
 		}
 
 		workers.post ([this, batch = std::move (batch)] () {
-			stats.inc (nano::stat::type::confirming_set, nano::stat::detail::notify);
+			stats.inc (nano::stat::type::cementing_set, nano::stat::detail::notify);
 			batch_cemented.notify (batch);
 		});
 	};
@@ -201,7 +201,7 @@ void nano::confirming_set::run_batch (std::unique_lock<std::mutex> & lock)
 	auto notify_maybe = [this, &cemented, &already, &notify] (auto & transaction) {
 		if (cemented.size () >= config.max_blocks)
 		{
-			stats.inc (nano::stat::type::confirming_set, nano::stat::detail::notify_intermediate);
+			stats.inc (nano::stat::type::cementing_set, nano::stat::detail::notify_intermediate);
 			transaction.commit ();
 			notify ();
 			transaction.renew ();
@@ -230,12 +230,12 @@ void nano::confirming_set::run_batch (std::unique_lock<std::mutex> & lock)
 				// Issue notifications here, so that `cemented` set is not too large before we add more blocks
 				notify_maybe (transaction);
 
-				stats.inc (nano::stat::type::confirming_set, nano::stat::detail::cementing);
+				stats.inc (nano::stat::type::cementing_set, nano::stat::detail::cementing);
 
 				// The block might be rolled back before it's fully cemented
 				if (!ledger.any.block_exists (transaction, hash))
 				{
-					stats.inc (nano::stat::type::confirming_set, nano::stat::detail::missing_block);
+					stats.inc (nano::stat::type::cementing_set, nano::stat::detail::missing_block);
 					break;
 				}
 
@@ -243,7 +243,7 @@ void nano::confirming_set::run_batch (std::unique_lock<std::mutex> & lock)
 				if (!added.empty ())
 				{
 					// Confirming this block may implicitly confirm more
-					stats.add (nano::stat::type::confirming_set, nano::stat::detail::cemented, added.size ());
+					stats.add (nano::stat::type::cementing_set, nano::stat::detail::cemented, added.size ());
 					for (auto & block : added)
 					{
 						cemented.push_back ({ block, hash, election });
@@ -252,7 +252,7 @@ void nano::confirming_set::run_batch (std::unique_lock<std::mutex> & lock)
 				}
 				else
 				{
-					stats.inc (nano::stat::type::confirming_set, nano::stat::detail::already_cemented);
+					stats.inc (nano::stat::type::cementing_set, nano::stat::detail::already_cemented);
 					already.push_back (hash);
 					debug_assert (ledger.confirmed.block_exists (transaction, hash));
 				}
@@ -262,13 +262,13 @@ void nano::confirming_set::run_batch (std::unique_lock<std::mutex> & lock)
 
 			if (success)
 			{
-				stats.inc (nano::stat::type::confirming_set, nano::stat::detail::cemented_hash);
-				logger.debug (nano::log::type::confirming_set, "Cemented block: {} (total cemented: {})", hash, cemented_count);
+				stats.inc (nano::stat::type::cementing_set, nano::stat::detail::cemented_hash);
+				logger.debug (nano::log::type::cementing_set, "Cemented block: {} (total cemented: {})", hash, cemented_count);
 			}
 			else
 			{
-				stats.inc (nano::stat::type::confirming_set, nano::stat::detail::cementing_failed);
-				logger.debug (nano::log::type::confirming_set, "Failed to cement block: {}", hash);
+				stats.inc (nano::stat::type::cementing_set, nano::stat::detail::cementing_failed);
+				logger.debug (nano::log::type::cementing_set, "Failed to cement block: {}", hash);
 
 				// Requeue failed blocks for processing later
 				// Add them to the deferred set while still holding the exclusive database write transaction to avoid block processor races
@@ -290,7 +290,7 @@ void nano::confirming_set::run_batch (std::unique_lock<std::mutex> & lock)
 	lock.unlock ();
 }
 
-void nano::confirming_set::cleanup (std::unique_lock<std::mutex> & lock)
+void nano::cementing_set::cleanup (std::unique_lock<std::mutex> & lock)
 {
 	debug_assert (lock.owns_lock ());
 	debug_assert (!mutex.try_lock ());
@@ -307,7 +307,7 @@ void nano::confirming_set::cleanup (std::unique_lock<std::mutex> & lock)
 	{
 		if (should_evict (*it) || deferred.size () > config.max_deferred)
 		{
-			stats.inc (nano::stat::type::confirming_set, nano::stat::detail::evicted);
+			stats.inc (nano::stat::type::cementing_set, nano::stat::detail::evicted);
 			debug_assert (ledger.any.block_exists (ledger.tx_begin_read (), it->hash));
 			evicted.push_back (*it);
 			it = deferred.erase (it);
@@ -330,7 +330,7 @@ void nano::confirming_set::cleanup (std::unique_lock<std::mutex> & lock)
 	}
 }
 
-nano::container_info nano::confirming_set::container_info () const
+nano::container_info nano::cementing_set::container_info () const
 {
 	std::lock_guard guard{ mutex };
 

--- a/nano/node/cementing_set.hpp
+++ b/nano/node/cementing_set.hpp
@@ -24,7 +24,7 @@ namespace mi = boost::multi_index;
 
 namespace nano
 {
-class confirming_set_config final
+class cementing_set_config final
 {
 public:
 	// TODO: Serialization & deserialization
@@ -46,14 +46,14 @@ public:
 /**
  * Set of blocks to be durably confirmed
  */
-class confirming_set final
+class cementing_set final
 {
 	friend class confirmation_heightDeathTest_missing_block_Test;
 	friend class confirmation_height_pruned_source_Test;
 
 public:
-	confirming_set (confirming_set_config const &, nano::ledger &, nano::ledger_notifications &, nano::stats &, nano::logger &);
-	~confirming_set ();
+	cementing_set (cementing_set_config const &, nano::ledger &, nano::ledger_notifications &, nano::stats &, nano::logger &);
+	~cementing_set ();
 
 	void start ();
 	void stop ();
@@ -81,7 +81,7 @@ public: // Events
 	nano::observer_set<std::shared_ptr<nano::block>> cemented_observers;
 
 private: // Dependencies
-	confirming_set_config const & config;
+	cementing_set_config const & config;
 	nano::ledger & ledger;
 	nano::ledger_notifications & ledger_notifications;
 	nano::stats & stats;

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -73,7 +73,7 @@ void nano::election::confirm_once (nano::unique_lock<nano::mutex> & lock)
 		extended_status.status.election_duration.count (),
 		extended_status.status.confirmation_request_count);
 
-		node.confirming_set.add (status_l.winner->hash (), shared_from_this ());
+		node.cementing_set.add (status_l.winner->hash (), shared_from_this ());
 
 		lock.unlock ();
 

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -16,7 +16,7 @@ class bucketing;
 class bootstrap_config;
 class bootstrap_server;
 class bootstrap_service;
-class confirming_set;
+class cementing_set;
 class election;
 class election_status;
 class fork_cache;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -8,7 +8,7 @@
 #include <nano/lib/work_version.hpp>
 #include <nano/node/active_elections.hpp>
 #include <nano/node/bootstrap/bootstrap_service.hpp>
-#include <nano/node/confirming_set.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/endpoint.hpp>
 #include <nano/node/json_handler.hpp>
@@ -1200,7 +1200,7 @@ void nano::json_handler::block_confirm ()
 			if (!node.ledger.confirmed.block_exists_or_pruned (transaction, hash))
 			{
 				// Start new confirmation for unconfirmed (or not being confirmed) block
-				if (!node.confirming_set.contains (hash))
+				if (!node.cementing_set.contains (hash))
 				{
 					node.start_election (std::move (block_l));
 				}

--- a/nano/node/local_block_broadcaster.cpp
+++ b/nano/node/local_block_broadcaster.cpp
@@ -2,7 +2,7 @@
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/block_processor.hpp>
-#include <nano/node/confirming_set.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/ledger_notifications.hpp>
 #include <nano/node/local_block_broadcaster.hpp>
 #include <nano/node/network.hpp>
@@ -11,12 +11,12 @@
 
 #include <boost/range/iterator_range.hpp>
 
-nano::local_block_broadcaster::local_block_broadcaster (local_block_broadcaster_config const & config_a, nano::node & node_a, nano::ledger_notifications & ledger_notifications_a, nano::network & network_a, nano::confirming_set & confirming_set_a, nano::stats & stats_a, nano::logger & logger_a, bool enabled_a) :
+nano::local_block_broadcaster::local_block_broadcaster (local_block_broadcaster_config const & config_a, nano::node & node_a, nano::ledger_notifications & ledger_notifications_a, nano::network & network_a, nano::cementing_set & cementing_set_a, nano::stats & stats_a, nano::logger & logger_a, bool enabled_a) :
 	config{ config_a },
 	node{ node_a },
 	ledger_notifications{ ledger_notifications_a },
 	network{ network_a },
-	confirming_set{ confirming_set_a },
+	cementing_set{ cementing_set_a },
 	stats{ stats_a },
 	logger{ logger_a },
 	enabled{ enabled_a },
@@ -66,7 +66,7 @@ nano::local_block_broadcaster::local_block_broadcaster (local_block_broadcaster_
 		}
 	});
 
-	confirming_set.cemented_observers.add ([this] (auto const & block) {
+	cementing_set.cemented_observers.add ([this] (auto const & block) {
 		nano::lock_guard<nano::mutex> guard{ mutex };
 		auto erased = local_blocks.get<tag_hash> ().erase (block->hash ());
 		stats.add (nano::stat::type::local_block_broadcaster, nano::stat::detail::cemented, erased);

--- a/nano/node/local_block_broadcaster.hpp
+++ b/nano/node/local_block_broadcaster.hpp
@@ -53,7 +53,7 @@ public:
 class local_block_broadcaster final
 {
 public:
-	local_block_broadcaster (local_block_broadcaster_config const &, nano::node &, nano::ledger_notifications &, nano::network &, nano::confirming_set &, nano::stats &, nano::logger &, bool enabled = false);
+	local_block_broadcaster (local_block_broadcaster_config const &, nano::node &, nano::ledger_notifications &, nano::network &, nano::cementing_set &, nano::stats &, nano::logger &, bool enabled = false);
 	~local_block_broadcaster ();
 
 	void start ();
@@ -75,7 +75,7 @@ private: // Dependencies
 	nano::node & node;
 	nano::ledger_notifications & ledger_notifications;
 	nano::network & network;
-	nano::confirming_set & confirming_set;
+	nano::cementing_set & cementing_set;
 	nano::stats & stats;
 	nano::logger & logger;
 

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -149,8 +149,8 @@ public:
 	nano::block_processor & block_processor;
 	std::unique_ptr<nano::fork_cache> fork_cache_impl;
 	nano::fork_cache & fork_cache;
-	std::unique_ptr<nano::confirming_set> confirming_set_impl;
-	nano::confirming_set & confirming_set;
+	std::unique_ptr<nano::cementing_set> cementing_set_impl;
+	nano::cementing_set & cementing_set;
 	std::unique_ptr<nano::bucketing> bucketing_impl;
 	nano::bucketing & bucketing;
 	std::unique_ptr<nano::active_elections> active_impl;

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -133,7 +133,7 @@ nano::error nano::node_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("bootstrap_bandwidth_limit", bootstrap_bandwidth_limit, "Outbound bootstrap traffic limit in bytes/sec after which messages will be dropped.\nNote: changing to unlimited bandwidth (0) is not recommended for limited connections.\ntype:uint64");
 	toml.put ("bootstrap_bandwidth_burst_ratio", bootstrap_bandwidth_burst_ratio, "Burst ratio for outbound bootstrap traffic.\ntype:double");
 
-	toml.put ("confirming_set_batch_time", confirming_set_batch_time.count (), "Maximum time the confirming set will hold the database write transaction.\ntype:milliseconds");
+	toml.put ("cementing_set_batch_time", cementing_set_batch_time.count (), "Maximum time the confirming set will hold the database write transaction.\ntype:milliseconds");
 	toml.put ("backup_before_upgrade", backup_before_upgrade, "Backup the ledger database before performing upgrades.\nWarning: uses more disk storage and increases startup time when upgrading.\ntype:bool");
 	toml.put ("max_work_generate_multiplier", max_work_generate_multiplier, "Maximum allowed difficulty multiplier for work generation.\ntype:double,[1..]");
 	toml.put ("max_queued_requests", max_queued_requests, "Limit for number of queued confirmation requests for one channel, after which new requests are dropped until the queue drops below this value.\ntype:uint32");
@@ -594,9 +594,9 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 
 		toml.get<bool> ("backup_before_upgrade", backup_before_upgrade);
 
-		auto confirming_set_batch_time_l (confirming_set_batch_time.count ());
-		toml.get ("confirming_set_batch_time", confirming_set_batch_time_l);
-		confirming_set_batch_time = std::chrono::milliseconds (confirming_set_batch_time_l);
+		auto cementing_set_batch_time_l (cementing_set_batch_time.count ());
+		toml.get ("cementing_set_batch_time", cementing_set_batch_time_l);
+		cementing_set_batch_time = std::chrono::milliseconds (cementing_set_batch_time_l);
 
 		toml.get<double> ("max_work_generate_multiplier", max_work_generate_multiplier);
 

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -14,7 +14,7 @@
 #include <nano/node/bootstrap/bootstrap_config.hpp>
 #include <nano/node/bootstrap/bootstrap_server.hpp>
 #include <nano/node/bounded_backlog.hpp>
-#include <nano/node/confirming_set.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/fork_cache.hpp>
 #include <nano/node/ipc/ipc_config.hpp>
 #include <nano/node/local_block_broadcaster.hpp>
@@ -133,7 +133,7 @@ public:
 	double bootstrap_bandwidth_burst_ratio{ 1. };
 	nano::bootstrap_config bootstrap;
 	nano::bootstrap_server_config bootstrap_server;
-	std::chrono::milliseconds confirming_set_batch_time{ 250 };
+	std::chrono::milliseconds cementing_set_batch_time{ 250 };
 	bool backup_before_upgrade{ false };
 	double max_work_generate_multiplier{ 64. };
 	uint32_t max_queued_requests{ 512 };
@@ -160,7 +160,7 @@ public:
 	nano::message_processor_config message_processor;
 	nano::network_config network;
 	nano::local_block_broadcaster_config local_block_broadcaster;
-	nano::confirming_set_config confirming_set;
+	nano::cementing_set_config cementing_set;
 	nano::monitor_config monitor;
 	nano::backlog_scan_config backlog_scan;
 	nano::bounded_backlog_config bounded_backlog;

--- a/nano/node/scheduler/component.cpp
+++ b/nano/node/scheduler/component.cpp
@@ -5,11 +5,11 @@
 #include <nano/node/scheduler/optimistic.hpp>
 #include <nano/node/scheduler/priority.hpp>
 
-nano::scheduler::component::component (nano::node_config & node_config, nano::node & node, nano::ledger & ledger, nano::ledger_notifications & ledger_notifications, nano::bucketing & bucketing, nano::active_elections & active, nano::online_reps & online_reps, nano::vote_cache & vote_cache, nano::confirming_set & confirming_set, nano::stats & stats, nano::logger & logger) :
+nano::scheduler::component::component (nano::node_config & node_config, nano::node & node, nano::ledger & ledger, nano::ledger_notifications & ledger_notifications, nano::bucketing & bucketing, nano::active_elections & active, nano::online_reps & online_reps, nano::vote_cache & vote_cache, nano::cementing_set & cementing_set, nano::stats & stats, nano::logger & logger) :
 	hinted_impl{ std::make_unique<nano::scheduler::hinted> (node_config.hinted_scheduler, node, vote_cache, active, online_reps, stats) },
 	manual_impl{ std::make_unique<nano::scheduler::manual> (node) },
 	optimistic_impl{ std::make_unique<nano::scheduler::optimistic> (node_config.optimistic_scheduler, node, ledger, active, node_config.network_params.network, stats) },
-	priority_impl{ std::make_unique<nano::scheduler::priority> (node_config, node, ledger, ledger_notifications, bucketing, active, confirming_set, stats, logger) },
+	priority_impl{ std::make_unique<nano::scheduler::priority> (node_config, node, ledger, ledger_notifications, bucketing, active, cementing_set, stats, logger) },
 	hinted{ *hinted_impl },
 	manual{ *manual_impl },
 	optimistic{ *optimistic_impl },

--- a/nano/node/scheduler/component.hpp
+++ b/nano/node/scheduler/component.hpp
@@ -10,7 +10,7 @@ namespace nano::scheduler
 class component final
 {
 public:
-	component (nano::node_config &, nano::node &, nano::ledger &, nano::ledger_notifications &, nano::bucketing &, nano::active_elections &, nano::online_reps &, nano::vote_cache &, nano::confirming_set &, nano::stats &, nano::logger &);
+	component (nano::node_config &, nano::node &, nano::ledger &, nano::ledger_notifications &, nano::bucketing &, nano::active_elections &, nano::online_reps &, nano::vote_cache &, nano::cementing_set &, nano::stats &, nano::logger &);
 	~component ();
 
 	void start ();

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -9,14 +9,14 @@
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_confirmed.hpp>
 
-nano::scheduler::priority::priority (nano::node_config & node_config, nano::node & node_a, nano::ledger & ledger_a, nano::ledger_notifications & ledger_notifications_a, nano::bucketing & bucketing_a, nano::active_elections & active_a, nano::confirming_set & confirming_set_a, nano::stats & stats_a, nano::logger & logger_a) :
+nano::scheduler::priority::priority (nano::node_config & node_config, nano::node & node_a, nano::ledger & ledger_a, nano::ledger_notifications & ledger_notifications_a, nano::bucketing & bucketing_a, nano::active_elections & active_a, nano::cementing_set & cementing_set_a, nano::stats & stats_a, nano::logger & logger_a) :
 	config{ node_config.priority_scheduler },
 	node{ node_a },
 	ledger{ ledger_a },
 	ledger_notifications{ ledger_notifications_a },
 	bucketing{ bucketing_a },
 	active{ active_a },
-	confirming_set{ confirming_set_a },
+	cementing_set{ cementing_set_a },
 	stats{ stats_a },
 	logger{ logger_a }
 {
@@ -39,7 +39,7 @@ nano::scheduler::priority::priority (nano::node_config & node_config, nano::node
 	});
 
 	// Activate successors of cemented blocks
-	confirming_set.batch_cemented.add ([this] (auto const & batch) {
+	cementing_set.batch_cemented.add ([this] (auto const & batch) {
 		if (node.flags.disable_activate_successors)
 		{
 			return;

--- a/nano/node/scheduler/priority.hpp
+++ b/nano/node/scheduler/priority.hpp
@@ -27,7 +27,7 @@ public:
 class priority final
 {
 public:
-	priority (nano::node_config &, nano::node &, nano::ledger &, nano::ledger_notifications &, nano::bucketing &, nano::active_elections &, nano::confirming_set &, nano::stats &, nano::logger &);
+	priority (nano::node_config &, nano::node &, nano::ledger &, nano::ledger_notifications &, nano::bucketing &, nano::active_elections &, nano::cementing_set &, nano::stats &, nano::logger &);
 	~priority ();
 
 	void start ();
@@ -55,7 +55,7 @@ private: // Dependencies
 	nano::ledger_notifications & ledger_notifications;
 	nano::bucketing & bucketing;
 	nano::active_elections & active;
-	nano::confirming_set & confirming_set;
+	nano::cementing_set & cementing_set;
 	nano::stats & stats;
 	nano::logger & logger;
 

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -4,7 +4,7 @@
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/lib/work_version.hpp>
-#include <nano/node/confirming_set.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/wallet.hpp>
@@ -1270,7 +1270,7 @@ bool nano::wallet::search_receivable (store::transaction const & wallet_transact
 							// Receive confirmed block
 							receive_async (hash, representative, amount, account, [] (std::shared_ptr<nano::block> const &) {});
 						}
-						else if (!wallets.node.confirming_set.contains (hash))
+						else if (!wallets.node.cementing_set.contains (hash))
 						{
 							auto block = wallets.node.ledger.any.block_get (block_transaction, hash);
 							if (block)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -8,7 +8,7 @@
 #include <nano/lib/threading.hpp>
 #include <nano/lib/work_version.hpp>
 #include <nano/node/active_elections.hpp>
-#include <nano/node/confirming_set.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/json_handler.hpp>

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -4,7 +4,7 @@
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/work_version.hpp>
 #include <nano/node/active_elections.hpp>
-#include <nano/node/confirming_set.hpp>
+#include <nano/node/cementing_set.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/ledger_notifications.hpp>
 #include <nano/node/make_store.hpp>
@@ -977,10 +977,10 @@ TEST (confirmation_height, dynamic_algorithm)
 		}
 	}
 
-	node->confirming_set.add (state_blocks.front ()->hash ());
+	node->cementing_set.add (state_blocks.front ()->hash ());
 	ASSERT_TIMELY_EQ (20s, node->ledger.cemented_count (), 2);
 
-	node->confirming_set.add (latest_genesis->hash ());
+	node->cementing_set.add (latest_genesis->hash ());
 
 	ASSERT_TIMELY_EQ (20s, node->ledger.cemented_count (), num_blocks + 1);
 
@@ -1146,8 +1146,8 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 	nano::node_config node_config;
 	nano::unchecked_map unchecked{ 0, stats, false };
 	nano::ledger_notifications ledger_notifications{ node_config, stats, logger };
-	nano::confirming_set_config confirming_set_config{};
-	nano::confirming_set confirming_set{ confirming_set_config, ledger, ledger_notifications, stats, logger };
+	nano::cementing_set_config cementing_set_config{};
+	nano::cementing_set cementing_set{ cementing_set_config, ledger, ledger_notifications, stats, logger };
 
 	auto const num_accounts = 100000;
 
@@ -1191,7 +1191,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 
 	for (auto & open_block : open_blocks)
 	{
-		confirming_set.add (open_block->hash ());
+		cementing_set.add (open_block->hash ());
 	}
 
 	system.deadline_set (1000s);
@@ -1242,8 +1242,8 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 	// Now send and receive to self
 	for (int i = 0; i < open_blocks.size (); ++i)
 	{
-		confirming_set.add (send_blocks[i]->hash ());
-		confirming_set.add (receive_blocks[i]->hash ());
+		cementing_set.add (send_blocks[i]->hash ());
+		cementing_set.add (receive_blocks[i]->hash ());
 	}
 
 	system.deadline_set (1000s);
@@ -1253,7 +1253,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 
-	while (confirming_set.size () > 0)
+	while (cementing_set.size () > 0)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -2079,7 +2079,7 @@ TEST (node, wallet_create_block_confirm_conflicts)
 			election->force_confirm ();
 		}
 
-		ASSERT_TIMELY (120s, node->ledger.confirmed.block_exists_or_pruned (node->ledger.tx_begin_read (), latest) && node->confirming_set.size () == 0);
+		ASSERT_TIMELY (120s, node->ledger.confirmed.block_exists_or_pruned (node->ledger.tx_begin_read (), latest) && node->cementing_set.size () == 0);
 		done = true;
 		t.join ();
 	}


### PR DESCRIPTION
Naming of the component was misleading. We distinguish two phases of finalizing blocks: confirmation and cementing. Block is confirmed if it receives quorum of votes from representatives and cemented if the confirmation status is durably written to disk. This distinction is important because a single confirmed block might implicitly cement many predecessors.