### PR TITLE
Warn about representatives with disabled voting

### DIFF
--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -114,6 +114,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_block_processor_republishing", "Disables block republishing by disabling the local_block_broadcaster component")
 		("disable_search_pending", "Disables the periodic search for pending transactions")
 		("enable_pruning", "Enable experimental ledger pruning")
+		("enable_voting", "Enable voting")
 		("allow_bootstrap_peers_duplicates", "Allow multiple connections to same peer in bootstrap attempts")
 		("fast_bootstrap", "Increase bootstrap speed for high end nodes with higher limits")
 		("block_processor_batch_size", boost::program_options::value<std::size_t>(), "Increase block processor transaction batch write size, default 0 (limited by config block_processor_batch_max_time), 256k for fast_bootstrap")
@@ -152,6 +153,7 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 	flags_a.disable_providing_telemetry_metrics = (vm.count ("disable_providing_telemetry_metrics") > 0);
 	flags_a.disable_block_processor_unchecked_deletion = (vm.count ("disable_block_processor_unchecked_deletion") > 0);
 	flags_a.enable_pruning = (vm.count ("enable_pruning") > 0);
+	flags_a.enable_voting = (vm.count ("enable_voting") > 0);
 	flags_a.allow_bootstrap_peers_duplicates = (vm.count ("allow_bootstrap_peers_duplicates") > 0);
 	flags_a.fast_bootstrap = (vm.count ("fast_bootstrap") > 0);
 	if (flags_a.fast_bootstrap)
@@ -204,7 +206,7 @@ std::error_code nano::update_flags (nano::node_flags & flags_a, boost::program_o
 std::error_code nano::flags_config_conflicts (nano::node_flags const & flags_a, nano::node_config const & config_a)
 {
 	std::error_code ec;
-	if (flags_a.enable_pruning && config_a.enable_voting)
+	if (flags_a.enable_pruning && (config_a.enable_voting || flags_a.enable_voting))
 	{
 		ec = nano::error_cli::ambiguous_pruning_voting_options;
 	}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -367,6 +367,11 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 			}
 		}
 
+		if (flags.enable_voting)
+		{
+			config.enable_voting = true;
+		}
+
 		if (config.enable_voting)
 		{
 			logger.info (nano::log::type::node, "Voting is enabled, more system resources will be used, local representatives: {}", reps.accounts.size ());

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -356,18 +356,28 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 			std::exit (1);
 		}
 
-		if (config.enable_voting)
+		auto reps = wallets.reps ();
+		if (reps.half_principal)
 		{
-			auto reps = wallets.reps ();
-			logger.info (nano::log::type::node, "Voting is enabled, more system resources will be used, local representatives: {}", reps.accounts.size ());
+			logger.info (nano::log::type::node, "Found {} local representatives in wallets", reps.accounts.size ());
+
 			for (auto const & account : reps.accounts)
 			{
 				logger.info (nano::log::type::node, "Local representative: {}", account.to_account ());
 			}
+		}
+
+		if (config.enable_voting)
+		{
+			logger.info (nano::log::type::node, "Voting is enabled, more system resources will be used, local representatives: {}", reps.accounts.size ());
 			if (reps.accounts.size () > 1)
 			{
 				logger.warn (nano::log::type::node, "Voting with more than one representative can limit performance");
 			}
+		}
+		else if (reps.half_principal)
+		{
+			logger.warn (nano::log::type::node, "Found local representatives in wallets, but voting is disabled. To enable voting, set `[node] enable_voting=true` in the `config-node.toml` file or use `--enable_voting` command line argument");
 		}
 
 		if ((network_params.network.is_live_network () || network_params.network.is_beta_network ()) && !flags.inactive_node)

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -202,6 +202,7 @@ public:
 	bool disable_max_peers_per_subnetwork{ false }; // For testing only
 	bool disable_search_pending{ false }; // For testing only
 	bool enable_pruning{ false };
+	bool enable_voting{ false };
 	bool fast_bootstrap{ false };
 	bool read_only{ false };
 	bool disable_connection_cleanup{ false };


### PR DESCRIPTION
This warns the node operator if voting is disabled but local representatives are found in the wallet. It also adds a convenience `--enable_voting` cli option to hopefully make enabling voting more straightforward.