### PR TITLE
Throttle block processing when backlog is above threshold

### DIFF
--- a/nano/core_test/block_processor.cpp
+++ b/nano/core_test/block_processor.cpp
@@ -4,9 +4,66 @@
 #include <nano/node/nodeconfig.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
+#include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
 
 using namespace std::chrono_literals;
+
+TEST (block_processor, backlog_throttling)
+{
+	nano::test::system system;
+
+	nano::node_config node_config;
+	// Backlog won't be rolled back, as we want to test the throttling works when backlog is exceeded
+	node_config.max_backlog = 20;
+	node_config.backlog_scan.enable = false;
+	// Allow at most 4 blocks per second when throttling
+	node_config.block_processor.batch_size = 1;
+	node_config.block_processor.backlog_throttle = 500ms;
+	auto & node = *system.add_node (node_config);
+
+	const int howmany_blocks = 2;
+	const int howmany_chains = 5;
+
+	auto chains = nano::test::setup_chains (system, node, howmany_chains, howmany_blocks, nano::dev::genesis_key, /* do not confirm */ false);
+
+	ASSERT_TIMELY_EQ (20s, node.ledger.block_count (), 21);
+
+	// Prepare live spam blocks
+	int const spam_count = 20;
+
+	auto latest = node.latest (nano::dev::genesis_key.pub);
+	auto balance = node.balance (nano::dev::genesis_key.pub);
+
+	std::vector<std::shared_ptr<nano::block>> blocks;
+	for (int n = 0; n < spam_count; ++n)
+	{
+		nano::keypair throwaway;
+		nano::block_builder builder;
+
+		balance -= 1;
+		auto send = builder
+					.state ()
+					.account (nano::dev::genesis_key.pub)
+					.previous (latest)
+					.representative (nano::dev::genesis_key.pub)
+					.balance (balance)
+					.link (throwaway.pub)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest))
+					.build ();
+
+		latest = send->hash ();
+
+		blocks.push_back (send);
+	}
+
+	// Send them to the node as live blocks
+	nano::test::process_live (node, blocks);
+
+	// Ensure no more than 10 blocks are processed in 5 seconds
+	ASSERT_NEVER (5s, node.ledger.block_count () > 21 + 10);
+}

--- a/nano/core_test/vote_cache.cpp
+++ b/nano/core_test/vote_cache.cpp
@@ -363,7 +363,8 @@ TEST (vote_cache, age_cutoff)
 	auto tops1 = vote_cache.top (0);
 	ASSERT_EQ (tops1.size (), 1);
 	ASSERT_EQ (tops1[0].hash, hash1);
-	ASSERT_EQ (system.stats.count (nano::stat::type::vote_cache, nano::stat::detail::cleanup), 0);
+
+	system.stats.clear ();
 
 	// Wait for first cleanup
 	auto check = [&] () {

--- a/nano/lib/interval.hpp
+++ b/nano/lib/interval.hpp
@@ -20,7 +20,7 @@ public:
 	}
 
 private:
-	std::chrono::steady_clock::time_point last{ std::chrono::steady_clock::now () };
+	std::chrono::steady_clock::time_point last{};
 };
 
 class interval_mt
@@ -40,6 +40,6 @@ public:
 
 private:
 	std::mutex mutex;
-	std::chrono::steady_clock::time_point last{ std::chrono::steady_clock::now () };
+	std::chrono::steady_clock::time_point last{};
 };
 }

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -224,6 +224,7 @@ enum class detail
 	process_blocking,
 	process_blocking_timeout,
 	force,
+	cooldown_backlog,
 
 	// block source
 	live,

--- a/nano/node/block_processor.cpp
+++ b/nano/node/block_processor.cpp
@@ -19,8 +19,9 @@
  * block_processor
  */
 
-nano::block_processor::block_processor (nano::node_config const & node_config, nano::ledger & ledger_a, nano::ledger_notifications & ledger_notifications_a, nano::unchecked_map & unchecked_a, nano::stats & stats_a, nano::logger & logger_a) :
-	config{ node_config.block_processor },
+nano::block_processor::block_processor (nano::node_config const & node_config_a, nano::ledger & ledger_a, nano::ledger_notifications & ledger_notifications_a, nano::unchecked_map & unchecked_a, nano::stats & stats_a, nano::logger & logger_a) :
+	config{ node_config_a.block_processor },
+	node_config{ node_config_a },
 	network_params{ node_config.network_params },
 	ledger{ ledger_a },
 	ledger_notifications{ ledger_notifications_a },
@@ -204,9 +205,50 @@ void nano::block_processor::rollback_competitor (secure::write_transaction & tra
 	}
 }
 
+double nano::block_processor::backlog_factor () const
+{
+	if (node_config.max_backlog == 0 || ledger.backlog_count () <= node_config.max_backlog)
+	{
+		return 0.0;
+	}
+	return std::min (1.0, static_cast<double> (ledger.backlog_count ()) / static_cast<double> (node_config.max_backlog));
+}
+
+void nano::block_processor::wait_backlog (nano::unique_lock<nano::mutex> & lock)
+{
+	debug_assert (lock.owns_lock ());
+	debug_assert (!mutex.try_lock ());
+
+	double const factor = backlog_factor ();
+
+	if (factor < 1.0)
+	{
+		return;
+	}
+
+	auto scaling = [] (double factor) {
+		// This uses a power of approximately 3.32, which gives ~1x at 1.0 and ~10x at 2.0
+		return std::pow (factor, 3.32);
+	};
+
+	auto const throttle_wait = std::min (config.backlog_throttle * scaling (factor), config.backlog_throttle_max * 1.0);
+
+	if (log_backlog_interval.elapse (15s))
+	{
+		logger.warn (nano::log::type::block_processor, "Backlog exceeded, throttling for {}ms (backlog size: {})",
+		throttle_wait.count (),
+		ledger.backlog_count ());
+	}
+
+	stats.inc (nano::stat::type::block_processor, nano::stat::detail::cooldown_backlog);
+
+	condition.wait_for (lock, throttle_wait, [&] {
+		return stopped || backlog_factor () < 1.0;
+	});
+}
+
 void nano::block_processor::run ()
 {
-	nano::interval log_interval;
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped)
 	{
@@ -219,6 +261,8 @@ void nano::block_processor::run ()
 			return;
 		}
 
+		wait_backlog (lock);
+
 		lock.unlock ();
 
 		// It's possible that ledger processing happens faster than the notifications can be processed by other components, cooldown here
@@ -230,7 +274,7 @@ void nano::block_processor::run ()
 
 		if (!queue.empty ())
 		{
-			if (log_interval.elapse (15s))
+			if (log_processing_interval.elapse (15s))
 			{
 				logger.info (nano::log::type::block_processor, "{} blocks (+ {} forced) in processing queue",
 				queue.size (),
@@ -459,6 +503,8 @@ nano::error nano::block_processor_config::serialize (nano::tomlconfig & toml) co
 	toml.put ("priority_live", priority_live, "Priority for live network blocks. Higher priority gets processed more frequently. \ntype:uint64");
 	toml.put ("priority_bootstrap", priority_bootstrap, "Priority for bootstrap blocks. Higher priority gets processed more frequently. \ntype:uint64");
 	toml.put ("priority_local", priority_local, "Priority for local RPC blocks. Higher priority gets processed more frequently. \ntype:uint64");
+	toml.put ("backlog_throttle", backlog_throttle.count (), "Throttling interval for processing blocks when backlog is above threshold. \ntype:milliseconds");
+	toml.put ("backlog_throttle_max", backlog_throttle_max.count (), "Maximum throttling interval for processing blocks when backlog is above threshold. \ntype:milliseconds");
 
 	return toml.get_error ();
 }
@@ -470,6 +516,8 @@ nano::error nano::block_processor_config::deserialize (nano::tomlconfig & toml)
 	toml.get ("priority_live", priority_live);
 	toml.get ("priority_bootstrap", priority_bootstrap);
 	toml.get ("priority_local", priority_local);
+	toml.get_duration ("backlog_throttle", backlog_throttle);
+	toml.get_duration ("backlog_throttle_max", backlog_throttle_max);
 
 	return toml.get_error ();
 }


### PR DESCRIPTION
This reduces block processing rate when backlog limit is extended. This should remedy a situation where the background bounded backlog rollbacks can't keep up with the rate of newly processed blocks. However, it's important to keep in mind that even if backlog exceeds the limit, we still want to allow a certain non-zero block processing rate in case high-priority blocks are published.