### PR TITLE
Do not refresh transactions while holding iterators when pruning

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3409,7 +3409,7 @@ TEST (node, pruning_automatic)
 	ASSERT_TRUE (nano::test::block_or_pruned_all_exists (node1, { nano::dev::genesis, send1, send2 }));
 }
 
-TEST (node, DISABLED_pruning_age)
+TEST (node, pruning_age)
 {
 	nano::test::system system{};
 
@@ -3470,7 +3470,7 @@ TEST (node, DISABLED_pruning_age)
 
 // Test that a node configured with `enable_pruning` will
 // prune DEEP-enough confirmed blocks by explicitly saying `node.ledger_pruning` in the unit test
-TEST (node, DISABLED_pruning_depth)
+TEST (node, pruning_depth)
 {
 	nano::test::system system{};
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -427,12 +427,15 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 				logger.critical (nano::log::type::node, "Incompatibility detected between config node.enable_voting and existing pruned blocks");
 				std::exit (1);
 			}
-			else if (!flags.enable_pruning && !flags.inactive_node)
+			if (!flags.enable_pruning && !flags.inactive_node)
 			{
 				logger.critical (nano::log::type::node, "To start node with existing pruned blocks use launch flag --enable_pruning");
 				std::exit (1);
 			}
+
+			logger.warn (nano::log::type::node, "WARNING: Ledger pruning is enabled. This feature is experimental and may result in node instability! Please see release notes for more information.");
 		}
+
 		cementing_set.cemented_observers.add ([this] (auto const & block) {
 			// TODO: Is it neccessary to call this for all blocks?
 			if (block->is_send ())

--- a/nano/node/pruning.cpp
+++ b/nano/node/pruning.cpp
@@ -122,11 +122,7 @@ bool nano::pruning::collect_ledger_pruning_targets (std::deque<nano::block_hash>
 				release_assert (depth != 0);
 				hash = 0;
 			}
-			if (++depth % batch_read_size_a == 0)
-			{
-				// FIXME: This is triggering an assertion where the iterator is still used after transaction is refreshed
-				transaction.refresh ();
-			}
+			++depth;
 		}
 		if (!hash.is_zero ())
 		{


### PR DESCRIPTION
Pruning code was refreshing database transactions without invalidating iterators:
```
if (++depth % batch_read_size_a == 0)
{
// FIXME: This is triggering an assertion where the iterator is still used after transaction is refreshed
transaction.refresh ();
}
```
This is a naive fix that simply removes the refresh call, with the obvious downside that this might result in long held read transactions.

That said the pruning code is unnecessarily convoluted which makes it error prone, as evidenced by this bug. The pruning feature should be considered experimental and node operators using it need to be aware that it can result in instability.