### PR TITLE
Make `nano::async::task::join` safe to call from multiple threads

### DIFF
--- a/nano/node/transport/tcp_channel.cpp
+++ b/nano/node/transport/tcp_channel.cpp
@@ -24,7 +24,6 @@ nano::transport::tcp_channel::tcp_channel (nano::node & node_a, std::shared_ptr<
 nano::transport::tcp_channel::~tcp_channel ()
 {
 	close ();
-	release_assert (!sending_task.joinable ());
 }
 
 void nano::transport::tcp_channel::close ()
@@ -58,7 +57,7 @@ asio::awaitable<void> nano::transport::tcp_channel::start_sending (nano::async::
 
 void nano::transport::tcp_channel::stop ()
 {
-	if (sending_task.joinable ())
+	if (sending_task.running ())
 	{
 		// Node context must be running to gracefully stop async tasks
 		debug_assert (!node.io_ctx.stopped ());

--- a/nano/node/transport/tcp_listener.cpp
+++ b/nano/node/transport/tcp_listener.cpp
@@ -34,7 +34,6 @@ nano::transport::tcp_listener::tcp_listener (uint16_t port_a, tcp_config const &
 nano::transport::tcp_listener::~tcp_listener ()
 {
 	debug_assert (!cleanup_thread.joinable ());
-	debug_assert (!task.joinable ());
 	debug_assert (connection_count () == 0);
 	debug_assert (attempt_count () == 0);
 }

--- a/nano/secure/transaction.hpp
+++ b/nano/secure/transaction.hpp
@@ -111,7 +111,7 @@ public:
 		return guard.is_owned ();
 	}
 
-	std::shared_future<void> get_future ()
+	std::shared_future<void> get_future () const
 	{
 		return future; // Give a copy of the shared future
 	}


### PR DESCRIPTION
This is a fix of a problem that was uncovered during one of recent CI runs. As far as I can tell this only happens when running test suite. Stacktrace:
```
[ RUN      ] network.reconnect_cached
libc++abi: terminating due to uncaught exception of type std::__1::system_error: condition_variable wait failed: Invalid argument
../ci/tests/run-tests.sh: line 52: 28700 Abort trap: 6           (core dumped) "${executable}" "$@"
Error: Test failed: core_test
Analyzing core dumps...
Core dump location: /cores
Executable: ./core_test
Core dump files
Analyzing core dump: /cores/core.28700
  Using lldb for analysis...
  (lldb) target create "./core_test" --core "/cores/core.28700"
  Core file '/cores/core.28700' (arm64) was loaded.
  (lldb) thread backtrace all
  warning: could not execute support code to read Objective-C class data in the process. This may reduce the quality of type information available.
  
  * thread #1
    * frame #0: 0x00000001898495d0 libsystem_kernel.dylib`__pthread_kill + 8
      frame #1: 0x0000000189881c20 libsystem_pthread.dylib`pthread_kill + 288
      frame #2: 0x000000018978ea30 libsystem_c.dylib`abort + 180
      frame #3: 0x0000000189838d08 libc++abi.dylib`abort_message + 132
      frame #4: 0x0000000189828fa4 libc++abi.dylib`demangling_terminate_handler() + 320
      frame #5: 0x00000001894c3c00 libobjc.A.dylib`_objc_terminate() + 160
      frame #6: 0x00000001898380cc libc++abi.dylib`std::__terminate(void (*)()) + 16
      frame #7: 0x0000000189838070 libc++abi.dylib`std::terminate() + 108
      frame #8: 0x00000001897a600c libc++.1.dylib`__clang_call_terminate + 12
      frame #9: 0x00000001897a7b44 libc++.1.dylib`std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 76
      frame #10: 0x00000001897ab4a4 libc++.1.dylib`std::__1::__assoc_sub_state::__sub_wait(std::__1::unique_lock<std::__1::mutex>&) + 56
      frame #11: 0x00000001897ab548 libc++.1.dylib`std::__1::__assoc_sub_state::wait() + 56
      frame #12: 0x000000010104a0c8 core_test`std::__1::future<void>::wait[abi:ue170006](this=0x000000013186e748) const at future:1268:34
      frame #13: 0x0000000101015898 core_test`nano::async::task::join(this=0x000000013186e740) at async.hpp:265:10
      frame #14: 0x0000000101d92d38 core_test`nano::transport::tcp_channel::stop(this=0x000000013186e618) at tcp_channel.cpp:68:16
      frame #15: 0x0000000101d92b78 core_test`nano::transport::tcp_channel::close(this=0x000000013186e618) at tcp_channel.cpp:32:2
      frame #16: 0x000000010143a1b4 core_test`network_reconnect_cached_Test::TestBody(this=0x000060000319d490) at network.cpp:1038:12
      frame #17: 0x0000000102ff1a1c core_test`void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(object=0x000060000319d490, method=0x00000000000000010000000000000020, location="the test body") at gtest.cc:2612:10
      frame #18: 0x0000000102fb5a0c core_test`void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(object=0x000060000319d490, method=0x00000000000000010000000000000020, location="the test body") at gtest.cc:2648:14
      frame #19: 0x0000000102fb595c core_test`testing::Test::Run(this=0x000060000319d490) at gtest.cc:2687:5
      frame #20: 0x0000000102fb68d0 core_test`testing::TestInfo::Run(this=0x0000000131629d90) at gtest.cc:2836:11
      frame #21: 0x0000000102fb795c core_test`testing::TestSuite::Run(this=0x0000000131626e90) at gtest.cc:3015:30
      frame #22: 0x0000000102fc5ba8 core_test`testing::internal::UnitTestImpl::RunAllTests(this=0x0000000131604f60) at gtest.cc:5920:44
      frame #23: 0x0000000102ff6888 core_test`bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(object=0x0000000131604f60, method=(core_test`testing::internal::UnitTestImpl::RunAllTests() at gtest.cc:5797), location="auxiliary test code (environments or event listeners)") at gtest.cc:2612:10
      frame #24: 0x0000000102fc5548 core_test`bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(object=0x0000000131604f60, method=(core_test`testing::internal::UnitTestImpl::RunAllTests() at gtest.cc:5797), location="auxiliary test code (environments or event listeners)") at gtest.cc:2648:14
      frame #25: 0x0000000102fc5434 core_test`testing::UnitTest::Run(this=0x0000000103627b70) at gtest.cc:5484:10
      frame #26: 0x0000000100faab54 core_test`RUN_ALL_TESTS() at gtest.h:2317:73
      frame #27: 0x0000000100faaaa8 core_test`main(argc=1, argv=0x000000016ee5a4c0) at entry.cpp:26:13
      frame #28: 0x00000001894f7154 dyld`start + 2476
```