### PR TITLE
Fix stats for blocks that failed cementing due to rollbacks

### DIFF
--- a/nano/node/cementing_set.cpp
+++ b/nano/node/cementing_set.cpp
@@ -258,11 +258,10 @@ void nano::cementing_set::run_batch (std::unique_lock<std::mutex> & lock)
 					}
 					cemented_count += added.size ();
 				}
-				else
+				else if (ledger.confirmed.block_exists (transaction, hash))
 				{
 					stats.inc (nano::stat::type::cementing_set, nano::stat::detail::already_cemented);
 					already.push_back (hash);
-					debug_assert (ledger.confirmed.block_exists (transaction, hash));
 				}
 
 				success = ledger.confirmed.block_exists (transaction, hash);


### PR DESCRIPTION
Assertion hit when running live node in debug mode. Non essential for V28 as the rest of the logic handles this case just fine.
```
[2025-04-27 14:10:08.472] [assert] [critical] Assertion `ledger.confirmed.block_exists (transaction, hash)` failed
/tmp/src/nano/node/cementing_set.cpp:265 [void nano::cementing_set::run_batch(std::unique_lock<std::mutex>&)]'
 0# nano::generate_stacktrace[abi:cxx11]() at /tmp/src/nano/lib/stacktrace.cpp:14
 3# nano::cementing_set::run() at /tmp/src/nano/node/cementing_set.cpp:141
 4# nano::cementing_set::start()::{lambda()#1}::operator()() const at /tmp/src/nano/node/cementing_set.cpp:90
 5# void std::__invoke_impl<void, nano::cementing_set::start()::{lambda()#1}>(std::__invoke_other, nano::cementing_set::start()::{lambda()#1}&&) at /usr/include/c++/11/bits/invoke.h:61
 6# std::__invoke_result<nano::cementing_set::start()::{lambda()#1}>::type std::__invoke<nano::cementing_set::start()::{lambda()#1}>(nano::cementing_set::start()::{lambda()#1}&&) at /usr/include/c++/11/bits/invoke.h:97
 7# void std::thread::_Invoker<std::tuple<nano::cementing_set::start()::{lambda()#1}> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) at /usr/include/c++/11/bits/std_thread.h:259
 8# std::thread::_Invoker<std::tuple<nano::cementing_set::start()::{lambda()#1}> >::operator()() at /usr/include/c++/11/bits/std_thread.h:266
 9# std::thread::_State_impl<std::thread::_Invoker<std::tuple<nano::cementing_set::start()::{lambda()#1}> > >::_M_run() at /usr/include/c++/11/bits/std_thread.h:211
10# execute_native_thread_routine in nano_node
11# 0x00007F2D262FFAC3 in /lib/x86_64-linux-gnu/libc.so.6
12# __clone in /lib/x86_64-linux-gnu/libc.so.6
```