### PR TITLE
Disable immediate rebroadcasting of forked blocks

### DIFF
--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -618,7 +618,6 @@ bool nano::election::publish (std::shared_ptr<nano::block> const & block_a)
 			if (status.winner->hash () == block_a->hash ())
 			{
 				status.winner = block_a;
-				node.network.flood_block (block_a, nano::transport::traffic_type::block_broadcast);
 			}
 		}
 	}


### PR DESCRIPTION
There is no need for a separate codepath to flood these blocks, block flooding is already handled elsewhere in election class.