### PR TITLE
Bump max ledger notifications value

### DIFF
--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -145,7 +145,7 @@ public:
 	nano::lmdb_config lmdb_config;
 	nano::database_backend database_backend{ env_database_backend ().value_or (nano::database_backend::lmdb) };
 	bool enable_upnp{ true };
-	std::size_t max_ledger_notifications{ 8 };
+	std::size_t max_ledger_notifications{ 300 };
 
 public:
 	nano::vote_cache_config vote_cache;


### PR DESCRIPTION
During bootstrapping it's expected that there will be around 300 notifications queued per second, as measured on my node. This low default value was causing excessive warnings.