### PR TITLE
Update RocksDb to V10.4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,6 +526,10 @@ target_link_libraries(boost_property_tree INTERFACE Boost::multi_index)
 
 # RocksDB
 include_directories(submodules/rocksdb/include)
+if(WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4702") # Suppress "unreachable
+                                                    # code" warning
+endif()
 set(USE_RTTI
     ON
     CACHE BOOL "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,8 +527,9 @@ target_link_libraries(boost_property_tree INTERFACE Boost::multi_index)
 # RocksDB
 include_directories(submodules/rocksdb/include)
 if(WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4702") # Suppress "unreachable
-                                                    # code" warning
+  set(FAIL_ON_WARNINGS
+      OFF
+      CACHE BOOL "")
 endif()
 set(USE_RTTI
     ON


### PR DESCRIPTION
This PR updates RocksDb to V10.4.2 (latest version as of now)
This version of RocksDb generates a wd4702 "warning as error" on Windows system, so I added a suppression of this warning in Cmake (win32 only)
The full warning is:
```
D:\a\nano-node\nano-node\submodules\rocksdb\util\auto_skip_compressor.cc(89,1): error C2220: the following warning is treated as an error [D:\a\nano-node\nano-node\build\submodules\rocksdb\rocksdb.vcxproj]
D:\a\nano-node\nano-node\submodules\rocksdb\util\auto_skip_compressor.cc(89,1): warning C4702: unreachable code [D:\a\nano-node\nano-node\build\submodules\rocksdb\rocksdb.vcxproj]
```