### PR TITLE
Rework active election container

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(
   fakes/websocket_client.hpp
   fakes/work_peer.hpp
   active_elections.cpp
+  active_elections_index.cpp
   assert.cpp
   async.cpp
   backlog.cpp

--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -336,7 +336,7 @@ TEST (active_elections, DISABLED_keep_local)
 	// ASSERT_EQ (1, node.scheduler.size ());
 }
 
-TEST (inactive_votes_cache, basic)
+TEST (active_elections, cached_vote_basic)
 {
 	nano::test::system system (1);
 	auto & node = *system.nodes[0];
@@ -360,7 +360,7 @@ TEST (inactive_votes_cache, basic)
 /**
  * This test case confirms that a non final vote cannot cause an election to become confirmed
  */
-TEST (inactive_votes_cache, non_final)
+TEST (active_elections, cached_vote_non_final)
 {
 	nano::test::system system (1);
 	auto & node = *system.nodes[0];
@@ -386,7 +386,7 @@ TEST (inactive_votes_cache, non_final)
 	ASSERT_FALSE (election->confirmed ());
 }
 
-TEST (inactive_votes_cache, fork)
+TEST (active_elections, cached_vote_fork)
 {
 	nano::test::system system{ 1 };
 	auto & node = *system.nodes[0];
@@ -426,7 +426,7 @@ TEST (inactive_votes_cache, fork)
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::election_vote, nano::stat::detail::cache));
 }
 
-TEST (inactive_votes_cache, existing_vote)
+TEST (active_elections, cached_vote_existing)
 {
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
@@ -480,7 +480,7 @@ TEST (inactive_votes_cache, existing_vote)
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::election_vote, nano::stat::detail::cache));
 }
 
-TEST (inactive_votes_cache, multiple_votes)
+TEST (active_elections, cached_vote_multiple)
 {
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
@@ -533,7 +533,7 @@ TEST (inactive_votes_cache, multiple_votes)
 	ASSERT_EQ (2, node.stats.count (nano::stat::type::election_vote, nano::stat::detail::cache));
 }
 
-TEST (inactive_votes_cache, election_start)
+TEST (active_elections, cached_vote_election_start)
 {
 	nano::test::system system;
 	nano::node_config node_config = system.default_config ();
@@ -691,7 +691,6 @@ TEST (active_elections, vote_replays)
 	// Open new account
 	auto vote_open1 = nano::test::make_final_vote (nano::dev::genesis_key, { open1 });
 	ASSERT_EQ (nano::vote_code::vote, node.vote_router.vote (vote_open1).at (open1->hash ()));
-	ASSERT_EQ (nano::vote_code::replay, node.vote_router.vote (vote_open1).at (open1->hash ()));
 	ASSERT_TIMELY (5s, node.active.empty ());
 	ASSERT_EQ (nano::vote_code::late, node.vote_router.vote (vote_open1).at (open1->hash ()));
 	ASSERT_EQ (nano::Knano_ratio, node.ledger.weight (key.pub));
@@ -1613,4 +1612,86 @@ TEST (active_elections, bootstrap_stale)
 
 	// Wait for bootstrap_stale_threshold to pass and the statistic to be incremented
 	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::bootstrap_stale) > 0);
+}
+
+TEST (active_elections, transition_optimistic_to_priority)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+
+	// Create a block for optimistic election
+	nano::state_block_builder builder;
+	auto block = builder
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (nano::keypair{}.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .build ();
+
+	ASSERT_TRUE (nano::test::process (node, { block }));
+
+	// Start optimistic election
+	auto result = node.active.insert (block, nano::election_behavior::optimistic);
+	ASSERT_TRUE (result.inserted);
+	auto election = result.election;
+	ASSERT_EQ (nano::election_behavior::optimistic, election->behavior ());
+
+	// Verify initial sizes
+	ASSERT_EQ (1, node.active.size (nano::election_behavior::optimistic));
+	ASSERT_EQ (0, node.active.size (nano::election_behavior::priority));
+
+	// Transition to priority
+	auto transition_result = node.active.insert (block, nano::election_behavior::priority);
+	ASSERT_FALSE (transition_result.inserted);
+	ASSERT_EQ (election, transition_result.election);
+
+	// Verify transition
+	ASSERT_EQ (nano::election_behavior::priority, election->behavior ());
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::transition_priority));
+	ASSERT_EQ (0, node.active.size (nano::election_behavior::optimistic));
+	ASSERT_EQ (1, node.active.size (nano::election_behavior::priority));
+}
+
+TEST (active_elections, transition_hinted_to_priority)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+
+	// Create a block for hinted election
+	nano::state_block_builder builder;
+	auto block = builder
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (nano::keypair{}.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .build ();
+
+	ASSERT_TRUE (nano::test::process (node, { block }));
+
+	// Start hinted election
+	auto result = node.active.insert (block, nano::election_behavior::hinted);
+	ASSERT_TRUE (result.inserted);
+	auto election = result.election;
+	ASSERT_EQ (nano::election_behavior::hinted, election->behavior ());
+
+	// Verify initial sizes
+	ASSERT_EQ (1, node.active.size (nano::election_behavior::hinted));
+	ASSERT_EQ (0, node.active.size (nano::election_behavior::priority));
+
+	// Transition to priority
+	auto transition_result = node.active.insert (block, nano::election_behavior::priority);
+	ASSERT_FALSE (transition_result.inserted);
+	ASSERT_EQ (election, transition_result.election);
+
+	// Verify transition
+	ASSERT_EQ (nano::election_behavior::priority, election->behavior ());
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::transition_priority));
+	ASSERT_EQ (0, node.active.size (nano::election_behavior::hinted));
+	ASSERT_EQ (1, node.active.size (nano::election_behavior::priority));
 }

--- a/nano/core_test/active_elections_index.cpp
+++ b/nano/core_test/active_elections_index.cpp
@@ -1,0 +1,462 @@
+#include <nano/node/active_elections_index.hpp>
+#include <nano/node/election.hpp>
+#include <nano/test_common/chains.hpp>
+#include <nano/test_common/random.hpp>
+#include <nano/test_common/system.hpp>
+#include <nano/test_common/testutil.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <deque>
+#include <numeric>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+// Full node is necessary to create elections
+class test_context final
+{
+public:
+	nano::test::system system;
+	nano::node & node;
+	std::deque<std::shared_ptr<nano::block>> blocks;
+
+	explicit test_context (size_t count = 10) :
+		node{ *system.add_node () }
+	{
+		auto chain = nano::test::setup_chain (system, node, count);
+		blocks.insert (blocks.end (), chain.begin (), chain.end ());
+	}
+
+	std::shared_ptr<nano::block> next_block ()
+	{
+		debug_assert (!blocks.empty ());
+		auto block = blocks.front ();
+		blocks.pop_front ();
+		return block;
+	}
+
+	std::shared_ptr<nano::election> random_election (nano::election_behavior behavior = nano::election_behavior::priority)
+	{
+		return std::make_shared<nano::election> (node, next_block (), nullptr, nullptr, behavior);
+	}
+};
+}
+
+TEST (active_elections_index, insert)
+{
+	test_context context{ 10 };
+	nano::active_elections_index index;
+
+	// Create elections with different behaviors and buckets
+	auto election1 = context.random_election (nano::election_behavior::priority);
+	auto election2 = context.random_election (nano::election_behavior::hinted);
+	auto election3 = context.random_election (nano::election_behavior::optimistic);
+
+	// Test initial state
+	ASSERT_EQ (index.size (), 0);
+	ASSERT_FALSE (index.exists (election1));
+
+	// Insert first election
+	index.insert (election1, nano::election_behavior::priority, 1, 100);
+	ASSERT_EQ (index.size (), 1);
+	ASSERT_TRUE (index.exists (election1));
+	ASSERT_TRUE (index.exists (election1->qualified_root));
+	ASSERT_EQ (index.size (nano::election_behavior::priority), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::priority, 1), 1);
+
+	// Insert second election with different behavior
+	index.insert (election2, nano::election_behavior::hinted, 2, 200);
+	ASSERT_EQ (index.size (), 2);
+	ASSERT_TRUE (index.exists (election2));
+	ASSERT_EQ (index.size (nano::election_behavior::hinted), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::hinted, 2), 1);
+
+	// Insert third election
+	index.insert (election3, nano::election_behavior::optimistic, 1, 50);
+	ASSERT_EQ (index.size (), 3);
+	ASSERT_EQ (index.size (nano::election_behavior::optimistic), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::optimistic, 1), 1);
+}
+
+TEST (active_elections_index, erase)
+{
+	test_context context{ 5 };
+	nano::active_elections_index index;
+
+	auto election1 = context.random_election ();
+	auto election2 = context.random_election ();
+	auto election3 = context.random_election ();
+
+	// Insert elections
+	index.insert (election1, nano::election_behavior::priority, 1, 100);
+	index.insert (election2, nano::election_behavior::priority, 1, 200);
+	index.insert (election3, nano::election_behavior::hinted, 2, 300);
+
+	ASSERT_EQ (index.size (), 3);
+	ASSERT_EQ (index.size (nano::election_behavior::priority), 2);
+	ASSERT_EQ (index.size (nano::election_behavior::priority, 1), 2);
+
+	// Erase existing election
+	ASSERT_TRUE (index.erase (election1));
+	ASSERT_EQ (index.size (), 2);
+	ASSERT_FALSE (index.exists (election1));
+	ASSERT_FALSE (index.exists (election1->qualified_root));
+	ASSERT_EQ (index.size (nano::election_behavior::priority), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::priority, 1), 1);
+
+	// Try to erase non-existent election
+	ASSERT_FALSE (index.erase (election1));
+	ASSERT_EQ (index.size (), 2);
+
+	// Erase remaining elections
+	ASSERT_TRUE (index.erase (election2));
+	ASSERT_TRUE (index.erase (election3));
+	ASSERT_EQ (index.size (), 0);
+	ASSERT_EQ (index.size (nano::election_behavior::priority), 0);
+	ASSERT_EQ (index.size (nano::election_behavior::hinted), 0);
+}
+
+TEST (active_elections_index, update)
+{
+	test_context context{ 5 };
+	nano::active_elections_index index;
+
+	auto election1 = context.random_election ();
+	auto election2 = context.random_election ();
+
+	// Insert elections
+	index.insert (election1, nano::election_behavior::priority, 1, 100);
+	index.insert (election2, nano::election_behavior::hinted, 2, 200);
+
+	ASSERT_EQ (index.size (nano::election_behavior::priority), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::hinted), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::priority, 1), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::hinted, 2), 1);
+
+	// Update election1 behavior from priority to optimistic
+	index.update (election1, nano::election_behavior::optimistic);
+
+	ASSERT_EQ (index.size (), 2);
+	ASSERT_EQ (index.size (nano::election_behavior::priority), 0);
+	ASSERT_EQ (index.size (nano::election_behavior::optimistic), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::hinted), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::priority, 1), 0);
+	ASSERT_EQ (index.size (nano::election_behavior::optimistic, 1), 1);
+
+	// Verify election still exists
+	ASSERT_TRUE (index.exists (election1));
+
+	// Update with same behavior (no change)
+	index.update (election2, nano::election_behavior::hinted);
+	ASSERT_EQ (index.size (nano::election_behavior::hinted), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::hinted, 2), 1);
+}
+
+TEST (active_elections_index, exists)
+{
+	test_context context{ 3 };
+	nano::active_elections_index index;
+
+	auto election1 = context.random_election ();
+	auto election2 = context.random_election ();
+	auto election3 = context.random_election ();
+
+	// Test non-existent elections
+	ASSERT_FALSE (index.exists (election1));
+	ASSERT_FALSE (index.exists (election1->qualified_root));
+
+	// Insert election1
+	index.insert (election1, nano::election_behavior::priority, 1, 100);
+
+	// Test exists with election pointer
+	ASSERT_TRUE (index.exists (election1));
+	ASSERT_FALSE (index.exists (election2));
+	ASSERT_FALSE (index.exists (election3));
+
+	// Test exists with qualified_root
+	ASSERT_TRUE (index.exists (election1->qualified_root));
+	ASSERT_FALSE (index.exists (election2->qualified_root));
+	ASSERT_FALSE (index.exists (election3->qualified_root));
+
+	// Add more elections and test
+	index.insert (election2, nano::election_behavior::hinted, 2, 200);
+	ASSERT_TRUE (index.exists (election2));
+	ASSERT_TRUE (index.exists (election2->qualified_root));
+}
+
+TEST (active_elections_index, election_lookup)
+{
+	test_context context{ 3 };
+	nano::active_elections_index index;
+
+	auto election1 = context.random_election ();
+	auto election2 = context.random_election ();
+
+	// Test lookup on empty index
+	ASSERT_EQ (index.election (election1->qualified_root), nullptr);
+
+	// Insert elections
+	index.insert (election1, nano::election_behavior::priority, 1, 100);
+	index.insert (election2, nano::election_behavior::hinted, 2, 200);
+
+	// Test successful lookup
+	ASSERT_EQ (index.election (election1->qualified_root), election1);
+	ASSERT_EQ (index.election (election2->qualified_root), election2);
+
+	// Test lookup for non-existent root
+	auto election3 = context.random_election ();
+	ASSERT_EQ (index.election (election3->qualified_root), nullptr);
+
+	// Test info method
+	auto info1 = index.info (election1);
+	ASSERT_TRUE (info1.has_value ());
+	ASSERT_EQ (info1->election, election1);
+	ASSERT_EQ (info1->behavior, nano::election_behavior::priority);
+	ASSERT_EQ (info1->bucket, 1);
+	ASSERT_EQ (info1->priority, 100);
+
+	auto info3 = index.info (election3);
+	ASSERT_FALSE (info3.has_value ());
+}
+
+TEST (active_elections_index, size_operations)
+{
+	test_context context{ 10 };
+	nano::active_elections_index index;
+
+	// Test empty index
+	ASSERT_EQ (index.size (), 0);
+	ASSERT_EQ (index.size (nano::election_behavior::priority), 0);
+	ASSERT_EQ (index.size (nano::election_behavior::priority, 1), 0);
+
+	// Add elections with different behaviors and buckets
+	auto e1 = context.random_election ();
+	auto e2 = context.random_election ();
+	auto e3 = context.random_election ();
+	auto e4 = context.random_election ();
+	auto e5 = context.random_election ();
+
+	index.insert (e1, nano::election_behavior::priority, 1, 100);
+	index.insert (e2, nano::election_behavior::priority, 1, 200);
+	index.insert (e3, nano::election_behavior::priority, 2, 300);
+	index.insert (e4, nano::election_behavior::hinted, 1, 400);
+	index.insert (e5, nano::election_behavior::optimistic, 3, 500);
+
+	// Test total size
+	ASSERT_EQ (index.size (), 5);
+
+	// Test size by behavior
+	ASSERT_EQ (index.size (nano::election_behavior::priority), 3);
+	ASSERT_EQ (index.size (nano::election_behavior::hinted), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::optimistic), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::manual), 0);
+
+	// Test size by behavior and bucket
+	ASSERT_EQ (index.size (nano::election_behavior::priority, 1), 2);
+	ASSERT_EQ (index.size (nano::election_behavior::priority, 2), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::priority, 3), 0);
+	ASSERT_EQ (index.size (nano::election_behavior::hinted, 1), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::optimistic, 3), 1);
+}
+
+TEST (active_elections_index, last)
+{
+	test_context context{ 10 };
+	nano::active_elections_index index;
+
+	// Test empty index
+	auto [empty_election, empty_priority] = index.last (nano::election_behavior::priority, 1);
+	ASSERT_EQ (empty_election, nullptr);
+	ASSERT_EQ (empty_priority, std::numeric_limits<nano::priority_timestamp>::max ());
+
+	// Add elections with different priorities
+	auto e1 = context.random_election ();
+	auto e2 = context.random_election ();
+	auto e3 = context.random_election ();
+	auto e4 = context.random_election ();
+
+	index.insert (e1, nano::election_behavior::priority, 1, 300); // Highest priority value in bucket 1
+	index.insert (e2, nano::election_behavior::priority, 1, 100);
+	index.insert (e3, nano::election_behavior::priority, 1, 200);
+	index.insert (e4, nano::election_behavior::priority, 2, 50); // Only election in bucket 2
+
+	// Test last for bucket 1 (should return e1 with priority 300 - highest value)
+	auto [top1_election, top1_priority] = index.last (nano::election_behavior::priority, 1);
+	ASSERT_EQ (top1_election, e1);
+	ASSERT_EQ (top1_priority, 300);
+
+	// Test last for bucket 2 (should return e4 with priority 50)
+	auto [top2_election, top2_priority] = index.last (nano::election_behavior::priority, 2);
+	ASSERT_EQ (top2_election, e4);
+	ASSERT_EQ (top2_priority, 50);
+
+	// Test last for empty bucket
+	auto [top3_election, top3_priority] = index.last (nano::election_behavior::priority, 3);
+	ASSERT_EQ (top3_election, nullptr);
+	ASSERT_EQ (top3_priority, std::numeric_limits<nano::priority_timestamp>::max ());
+
+	// Test last for different behavior
+	auto e5 = context.random_election ();
+	index.insert (e5, nano::election_behavior::hinted, 1, 75);
+	auto [top4_election, top4_priority] = index.last (nano::election_behavior::hinted, 1);
+	ASSERT_EQ (top4_election, e5);
+	ASSERT_EQ (top4_priority, 75);
+}
+
+TEST (active_elections_index, list_with_cutoff)
+{
+	test_context context{ 5 };
+	nano::active_elections_index index;
+
+	auto e1 = context.random_election ();
+	auto e2 = context.random_election ();
+	auto e3 = context.random_election ();
+
+	// Insert elections (they start with timestamp at epoch)
+	index.insert (e1, nano::election_behavior::priority, 1, 100);
+	index.insert (e2, nano::election_behavior::priority, 2, 200);
+	index.insert (e3, nano::election_behavior::hinted, 1, 300);
+
+	auto initial_time = std::chrono::steady_clock::now ();
+	auto cutoff = initial_time + 1s; // All elections should be before this cutoff
+
+	// Process all elections and update their timestamps to initial_time
+	auto elections_list = index.list (cutoff, initial_time);
+
+	// All elections should have been processed
+	ASSERT_EQ (elections_list.size (), 3);
+	std::set<std::shared_ptr<nano::election>> processed (elections_list.begin (), elections_list.end ());
+	ASSERT_TRUE (processed.count (e1));
+	ASSERT_TRUE (processed.count (e2));
+	ASSERT_TRUE (processed.count (e3));
+
+	// Now test with earlier cutoff - no elections should be processed
+	// because their timestamps were updated to initial_time in the previous list call
+	auto earlier_cutoff = initial_time - 1s;
+	auto elections_list2 = index.list (earlier_cutoff);
+
+	ASSERT_EQ (elections_list2.size (), 0);
+	ASSERT_TRUE (elections_list2.empty ());
+
+	// Test with future time - should process all elections again
+	auto future_time = initial_time + 2s;
+	auto future_cutoff = future_time - 1s; // Between initial_time and future_time
+	auto elections_list3 = index.list (future_cutoff, future_time);
+
+	// All elections should be processed since cutoff is after their timestamp
+	ASSERT_EQ (elections_list3.size (), 3);
+}
+
+TEST (active_elections_index, trigger)
+{
+	test_context context{ 3 };
+	nano::active_elections_index index;
+
+	auto e1 = context.random_election ();
+	auto e2 = context.random_election ();
+
+	// Insert elections (they start with timestamp at epoch)
+	index.insert (e1, nano::election_behavior::priority, 1, 100);
+	index.insert (e2, nano::election_behavior::priority, 2, 200);
+
+	// Process elections to update their timestamps to a future time
+	auto future_time = std::chrono::steady_clock::now () + 1h;
+	auto cutoff = future_time + 1s;
+	index.list (cutoff, future_time);
+
+	// Trigger e1 to reset its timestamp
+	index.trigger (e1);
+
+	// Check that e1 has been triggered (timestamp reset to epoch)
+	// We can verify this by using list with a very early cutoff
+	auto very_early_cutoff = std::chrono::steady_clock::time_point{} + 1ms;
+	auto triggered_elections = index.list (very_early_cutoff);
+
+	// Only e1 should have been processed (because it was triggered)
+	ASSERT_EQ (triggered_elections.size (), 1);
+	ASSERT_EQ (triggered_elections[0], e1);
+}
+
+TEST (active_elections_index, any)
+{
+	test_context context{ 3 };
+	nano::active_elections_index index;
+
+	// Test empty index
+	auto cutoff = std::chrono::steady_clock::now ();
+	ASSERT_FALSE (index.any (cutoff));
+
+	auto e1 = context.random_election ();
+	auto e2 = context.random_election ();
+
+	// Insert elections (they will have timestamp at epoch initially)
+	index.insert (e1, nano::election_behavior::priority, 1, 100);
+	index.insert (e2, nano::election_behavior::priority, 2, 200);
+
+	// Check with cutoff in the future - should find elections
+	auto future_cutoff = std::chrono::steady_clock::now () + 1s;
+	ASSERT_TRUE (index.any (future_cutoff));
+
+	// Update timestamps by processing elections
+	auto now = std::chrono::steady_clock::now ();
+	index.list (future_cutoff, now);
+
+	// Check with cutoff in the past - should not find elections
+	auto past_cutoff = now - 1s;
+	ASSERT_FALSE (index.any (past_cutoff));
+
+	// Trigger one election to reset its timestamp
+	index.trigger (e1);
+
+	// Now should find the triggered election even with past cutoff
+	ASSERT_TRUE (index.any (past_cutoff));
+}
+
+TEST (active_elections_index, clear)
+{
+	test_context context{ 5 };
+	nano::active_elections_index index;
+
+	// Add multiple elections
+	auto e1 = context.random_election ();
+	auto e2 = context.random_election ();
+	auto e3 = context.random_election ();
+	auto e4 = context.random_election ();
+
+	index.insert (e1, nano::election_behavior::priority, 1, 100);
+	index.insert (e2, nano::election_behavior::priority, 2, 200);
+	index.insert (e3, nano::election_behavior::hinted, 1, 300);
+	index.insert (e4, nano::election_behavior::optimistic, 3, 400);
+
+	// Verify index is populated
+	ASSERT_EQ (index.size (), 4);
+	ASSERT_EQ (index.size (nano::election_behavior::priority), 2);
+	ASSERT_EQ (index.size (nano::election_behavior::hinted), 1);
+	ASSERT_EQ (index.size (nano::election_behavior::optimistic), 1);
+	ASSERT_TRUE (index.exists (e1));
+	ASSERT_TRUE (index.exists (e2->qualified_root));
+
+	// Clear the index
+	index.clear ();
+
+	// Verify everything is cleared
+	ASSERT_EQ (index.size (), 0);
+	ASSERT_EQ (index.size (nano::election_behavior::priority), 0);
+	ASSERT_EQ (index.size (nano::election_behavior::hinted), 0);
+	ASSERT_EQ (index.size (nano::election_behavior::optimistic), 0);
+	ASSERT_EQ (index.size (nano::election_behavior::manual), 0);
+	ASSERT_FALSE (index.exists (e1));
+	ASSERT_FALSE (index.exists (e2));
+	ASSERT_FALSE (index.exists (e3));
+	ASSERT_FALSE (index.exists (e4));
+	ASSERT_FALSE (index.exists (e1->qualified_root));
+
+	// Test that we can still use the index after clearing
+	index.insert (e1, nano::election_behavior::manual, 0, 50);
+	ASSERT_EQ (index.size (), 1);
+	ASSERT_TRUE (index.exists (e1));
+	ASSERT_EQ (index.size (nano::election_behavior::manual), 1);
+}

--- a/nano/core_test/active_elections_index.cpp
+++ b/nano/core_test/active_elections_index.cpp
@@ -40,7 +40,7 @@ public:
 
 	std::shared_ptr<nano::election> random_election (nano::election_behavior behavior = nano::election_behavior::priority)
 	{
-		return std::make_shared<nano::election> (node, next_block (), nullptr, nullptr, behavior);
+		return std::make_shared<nano::election> (node, next_block (), behavior);
 	}
 };
 }

--- a/nano/core_test/bootstrap_server.cpp
+++ b/nano/core_test/bootstrap_server.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/test_common/chains.hpp>
+#include <nano/test_common/random.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -46,11 +46,11 @@ TEST (confirmation_solicitor, batches)
 		nano::lock_guard<nano::mutex> guard (node2.active.mutex);
 		for (size_t i (0); i < nano::network::confirm_req_hashes_max; ++i)
 		{
-			auto election (std::make_shared<nano::election> (node2, send, nullptr, nullptr, nano::election_behavior::priority));
+			auto election (std::make_shared<nano::election> (node2, send, nano::election_behavior::priority));
 			ASSERT_FALSE (solicitor.add (*election));
 		}
 		// Reached the maximum amount of requests for the channel
-		auto election (std::make_shared<nano::election> (node2, send, nullptr, nullptr, nano::election_behavior::priority));
+		auto election (std::make_shared<nano::election> (node2, send, nano::election_behavior::priority));
 		// Broadcasting should be immediate
 		ASSERT_EQ (0, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
 		ASSERT_FALSE (solicitor.broadcast (*election));
@@ -92,7 +92,7 @@ TEST (confirmation_solicitor, different_hash)
 				.work (*system.work.generate (nano::dev::genesis->hash ()))
 				.build ();
 	send->sideband_set ({});
-	auto election (std::make_shared<nano::election> (node2, send, nullptr, nullptr, nano::election_behavior::priority));
+	auto election (std::make_shared<nano::election> (node2, send, nano::election_behavior::priority));
 	// Add a vote for something else, not the winner
 	election->last_votes[representative.account] = { std::chrono::steady_clock::now (), 1, 1 };
 	// Ensure the request and broadcast goes through
@@ -136,7 +136,7 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 				.work (*system.work.generate (nano::dev::genesis->hash ()))
 				.build ();
 	send->sideband_set ({});
-	auto election (std::make_shared<nano::election> (node2, send, nullptr, nullptr, nano::election_behavior::priority));
+	auto election (std::make_shared<nano::election> (node2, send, nano::election_behavior::priority));
 	// Add a vote for something else, not the winner
 	for (auto const & rep : representatives)
 	{
@@ -149,7 +149,7 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	ASSERT_TIMELY_EQ (6s, max_representatives + 1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
 
 	solicitor.prepare (representatives);
-	auto election2 (std::make_shared<nano::election> (node2, send, nullptr, nullptr, nano::election_behavior::priority));
+	auto election2 (std::make_shared<nano::election> (node2, send, nano::election_behavior::priority));
 	ASSERT_FALSE (solicitor.add (*election2));
 	ASSERT_FALSE (solicitor.broadcast (*election2));
 

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -19,7 +19,7 @@ TEST (election, construction)
 	nano::test::system system (1);
 	auto & node = *system.nodes[0];
 	auto election = std::make_shared<nano::election> (
-	node, nano::dev::genesis, [] (auto const &) {}, [] (auto const &) {}, nano::election_behavior::priority);
+	node, nano::dev::genesis, nano::election_behavior::priority, [] (auto const &) {}, [] (auto const &) {}, [] (auto const &) {});
 }
 
 TEST (election, behavior)

--- a/nano/core_test/fork_cache.cpp
+++ b/nano/core_test/fork_cache.cpp
@@ -1,4 +1,5 @@
 #include <nano/node/fork_cache.hpp>
+#include <nano/test_common/random.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -4,6 +4,7 @@
 #include <nano/node/endpoint.hpp>
 #include <nano/node/network.hpp>
 #include <nano/secure/vote.hpp>
+#include <nano/test_common/random.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>

--- a/nano/core_test/message_deserializer.cpp
+++ b/nano/core_test/message_deserializer.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/transport/message_deserializer.hpp>
 #include <nano/secure/vote.hpp>
+#include <nano/test_common/random.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 

--- a/nano/core_test/vote_cache.cpp
+++ b/nano/core_test/vote_cache.cpp
@@ -1,5 +1,6 @@
 #include <nano/node/election.hpp>
 #include <nano/node/vote_cache.hpp>
+#include <nano/test_common/random.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -515,6 +515,7 @@ enum class detail
 	started,
 	stopped,
 	confirm_dependent,
+	cancel_dependent,
 	forks_cached,
 	bootstrap_stale,
 

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -16,6 +16,8 @@ add_library(
   ${platform_sources}
   active_elections.hpp
   active_elections.cpp
+  active_elections_index.hpp
+  active_elections_index.cpp
   backlog_scan.hpp
   backlog_scan.cpp
   bandwidth_limiter.hpp

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -57,12 +57,14 @@ nano::active_elections::active_elections (nano::node & node_a, nano::ledger_noti
 			{
 				transaction.refresh_if_needed ();
 
-				// Dependent elections are implicitly confirmed when their block is cemented
-				// TODO: Should this be the case? Maybe just cancel the election and issue block cemented notification?
+				// Dependent elections are cancelled when their block is cemented
 				if (election)
 				{
-					node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::confirm_dependent);
-					election->try_confirm (status.winner->hash ()); // TODO: This should either confirm or cancel the election
+					bool cancelled = election->cancel ();
+					if (cancelled)
+					{
+						node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::cancel_dependent);
+					}
 				}
 
 				notify_observers (transaction, status, votes);

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -32,8 +32,6 @@ nano::active_elections::active_elections (nano::node & node_a, nano::ledger_noti
 	recently_cemented{ config.confirmation_history_size },
 	workers{ 1, nano::thread_role::name::aec_notifications }
 {
-	count_by_behavior.fill (0); // Zero initialize array
-
 	// Cementing blocks might implicitly confirm dependent elections
 	cementing_set.batch_cemented.add ([this] (auto const & cemented) {
 		std::deque<block_cemented_result> results;
@@ -125,26 +123,257 @@ void nano::active_elections::stop ()
 	clear ();
 }
 
-void nano::active_elections::run ()
+auto nano::active_elections::insert (std::shared_ptr<nano::block> const & block, nano::election_behavior behavior, nano::bucket_index bucket, nano::priority_timestamp priority, erased_callback_t erased_callback) -> insert_result
+{
+	release_assert (block);
+	release_assert (block->has_sideband ());
+
+	nano::unique_lock<nano::mutex> lock{ mutex };
+
+	insert_result result{ nullptr, false };
+
+	if (stopped)
+	{
+		return result;
+	}
+
+	auto const root = block->qualified_root ();
+	auto const hash = block->hash ();
+
+	if (!index.exists (root))
+	{
+		if (!recently_confirmed.exists (root))
+		{
+			result.inserted = true;
+
+			// Passing this callback into the election is important
+			// We need to observe and update the online voting weight *before* election quorum is checked
+			auto observe_rep_callback = [&node = node] (auto const & rep) {
+				node.online_reps.observe (rep);
+			};
+
+			result.election = nano::make_shared<nano::election> (node, block, nullptr, observe_rep_callback, behavior);
+
+			// Store erased callback if provided
+			if (erased_callback)
+			{
+				erased_callbacks[root] = std::move (erased_callback);
+			}
+
+			// Insert the election into index
+			index.insert (result.election, behavior, bucket, priority);
+
+			node.vote_router.connect (hash, result.election);
+
+			auto should_activate_immediately = [&] () {
+				// Broadcast votes immediately for priority elections
+				if (behavior == nano::election_behavior::priority)
+				{
+					return true;
+				}
+				// Skip passive phase for blocks without cached votes to avoid bootstrap delays
+				if (!node.vote_cache.contains (hash))
+				{
+					return true;
+				}
+				return false;
+			};
+
+			bool activate_immediately = should_activate_immediately ();
+			if (activate_immediately)
+			{
+				node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::activate_immediately);
+				result.election->transition_active ();
+			}
+
+			node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::started);
+			node.stats.inc (nano::stat::type::active_elections_started, to_stat_detail (behavior));
+
+			node.logger.trace (nano::log::type::active_elections, nano::log::detail::active_started,
+			nano::log::arg{ "behavior", behavior },
+			nano::log::arg{ "election", result.election });
+
+			node.logger.debug (nano::log::type::active_elections, "Started new election for root: {} with blocks: {} (behavior: {}, active immediately: {})",
+			root,
+			fmt::join (result.election->blocks_hashes (), ", "), // TODO: Lazy eval
+			to_string (behavior),
+			activate_immediately);
+		}
+		else
+		{
+			// Result is not set
+		}
+	}
+	else
+	{
+		result.election = index.election (root);
+
+		// Upgrade to priority election to enable immediate vote broadcasting.
+		auto previous_behavior = result.election->behavior ();
+		if (behavior == nano::election_behavior::priority && previous_behavior != nano::election_behavior::priority)
+		{
+			bool transitioned = result.election->transition_priority ();
+			if (transitioned)
+			{
+				index.update (result.election, behavior);
+				node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::transition_priority);
+			}
+			else
+			{
+				node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::transition_priority_failed);
+			}
+		}
+	}
+
+	lock.unlock ();
+
+	if (result.inserted)
+	{
+		release_assert (result.election);
+
+		// Notifications
+		node.observers.active_started.notify (hash);
+		vacancy_updated.notify ();
+
+		// Let the election know about already observed votes
+		node.vote_cache_processor.trigger (hash);
+
+		// Let the election know about already observed forks
+		auto forks = node.fork_cache.get (root);
+		node.stats.add (nano::stat::type::active_elections, nano::stat::detail::forks_cached, forks.size ());
+		for (auto const & fork : forks)
+		{
+			publish (fork);
+		}
+	}
+
+	// Votes are generated for inserted or ongoing elections
+	if (result.election)
+	{
+		result.election->broadcast_vote ();
+	}
+
+	return result;
+}
+
+bool nano::active_elections::publish (std::shared_ptr<nano::block> const & block)
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
-	while (!stopped)
+
+	if (auto election = index.election (block->qualified_root ()))
 	{
-		auto const stamp = std::chrono::steady_clock::now ();
+		lock.unlock ();
 
-		node.stats.inc (nano::stat::type::active, nano::stat::detail::loop);
+		bool result = election->publish (block); // false => new block was added
+		if (!result)
+		{
+			node.vote_router.connect (block->hash (), election);
+			node.vote_cache_processor.trigger (block->hash ());
 
-		tick_elections (lock);
-		debug_assert (!lock.owns_lock ());
-		lock.lock ();
+			node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::fork);
 
-		auto const min_sleep = node.network_params.network.aec_loop_interval / 2;
-		auto const wakeup = std::max (stamp + node.network_params.network.aec_loop_interval, std::chrono::steady_clock::now () + min_sleep);
+			node.logger.debug (nano::log::type::active_elections, "Block was added to an existing election: {} with root: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms)",
+			block->hash (),
+			election->qualified_root,
+			to_string (election->behavior ()),
+			to_string (election->state ()),
+			election->voter_count (),
+			election->block_count (),
+			election->duration ().count ());
 
-		condition.wait_until (lock, wakeup, [this, wakeup] {
-			return stopped || std::chrono::steady_clock::now () >= wakeup;
-		});
+			return false; // Added
+		}
 	}
+
+	return true; // Not added
+}
+
+void nano::active_elections::erase_election (nano::unique_lock<nano::mutex> & lock, std::shared_ptr<nano::election> election)
+{
+	debug_assert (!mutex.try_lock ());
+	debug_assert (lock.owns_lock ());
+	debug_assert (!election->confirmed () || recently_confirmed.exists (election->qualified_root));
+
+	auto blocks_l = election->blocks ();
+	node.vote_router.disconnect (*election);
+
+	// Erase from index
+	bool erased = index.erase (election);
+	release_assert (erased);
+
+	// Get and remove the erased callback
+	auto callback_it = erased_callbacks.find (election->qualified_root);
+	erased_callback_t erased_callback;
+	if (callback_it != erased_callbacks.end ())
+	{
+		erased_callback = std::move (callback_it->second);
+		erased_callbacks.erase (callback_it);
+	}
+
+	node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::stopped);
+	node.stats.inc (nano::stat::type::active_elections, election->confirmed () ? nano::stat::detail::confirmed : nano::stat::detail::unconfirmed);
+	node.stats.inc (nano::stat::type::active_elections_stopped, to_stat_detail (election->state ()));
+	node.stats.inc (to_stat_type (election->state ()), to_stat_detail (election->behavior ()));
+
+	node.logger.trace (nano::log::type::active_elections, nano::log::detail::active_stopped, nano::log::arg{ "election", election });
+
+	node.logger.debug (nano::log::type::active_elections, "Erased election for root: {} with blocks: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms)",
+	election->qualified_root,
+	fmt::join (election->blocks_hashes (), ", "), // TODO: Lazy eval
+	to_string (election->behavior ()),
+	to_string (election->state ()),
+	election->voter_count (),
+	election->block_count (),
+	election->duration ().count ());
+
+	lock.unlock ();
+
+	// Track election duration
+	node.stats.sample (nano::stat::sample::active_election_duration, election->duration ().count (), { 0, 1000 * 60 * 10 /* 0-10 minutes range */ });
+
+	// Notify observers without holding the lock
+	if (erased_callback)
+	{
+		erased_callback (election);
+	}
+
+	vacancy_updated.notify ();
+
+	for (auto const & [hash, block] : blocks_l)
+	{
+		// Notify observers about dropped elections & blocks lost confirmed elections
+		if (!election->confirmed () || hash != election->winner ()->hash ())
+		{
+			node.observers.active_stopped.notify (hash);
+		}
+
+		if (!election->confirmed ())
+		{
+			// Clear from publish filter
+			node.network.filter.clear (block);
+		}
+	}
+}
+
+bool nano::active_elections::erase (nano::qualified_root const & root)
+{
+	nano::unique_lock<nano::mutex> lock{ mutex };
+
+	if (auto election = index.election (root))
+	{
+		release_assert (election->qualified_root == root);
+		erase_election (lock, election);
+		return true;
+	}
+	else
+	{
+		return false;
+	}
+}
+
+bool nano::active_elections::erase (nano::block const & block)
+{
+	return erase (block.qualified_root ());
 }
 
 auto nano::active_elections::block_cemented (std::shared_ptr<nano::block> const & block, nano::block_hash const & confirmation_root, std::shared_ptr<nano::election> const & source_election) -> block_cemented_result
@@ -232,59 +461,6 @@ void nano::active_elections::notify_observers (nano::secure::transaction const &
 	}
 }
 
-int64_t nano::active_elections::limit (nano::election_behavior behavior) const
-{
-	switch (behavior)
-	{
-		case nano::election_behavior::manual:
-		{
-			return std::numeric_limits<int64_t>::max ();
-		}
-		case nano::election_behavior::priority:
-		{
-			return static_cast<int64_t> (config.size);
-		}
-		case nano::election_behavior::hinted:
-		{
-			const uint64_t limit = config.hinted_limit_percentage * config.size / 100;
-			return static_cast<int64_t> (limit);
-		}
-		case nano::election_behavior::optimistic:
-		{
-			const uint64_t limit = config.optimistic_limit_percentage * config.size / 100;
-			return static_cast<int64_t> (limit);
-		}
-	}
-
-	debug_assert (false, "unknown election behavior");
-	return 0;
-}
-
-int64_t nano::active_elections::vacancy (nano::election_behavior behavior) const
-{
-	auto election_vacancy = [this] (nano::election_behavior behavior) -> int64_t {
-		nano::lock_guard<nano::mutex> guard{ mutex };
-		switch (behavior)
-		{
-			case nano::election_behavior::manual:
-				return std::numeric_limits<int64_t>::max ();
-			case nano::election_behavior::priority:
-				return limit (nano::election_behavior::priority) - static_cast<int64_t> (roots.size ());
-			case nano::election_behavior::hinted:
-			case nano::election_behavior::optimistic:
-				return limit (behavior) - count_by_behavior[behavior];
-		}
-		debug_assert (false); // Unknown enum
-		return 0;
-	};
-
-	auto election_winners_vacancy = [this] () -> int64_t {
-		return static_cast<int64_t> (config.max_election_winners) - static_cast<int64_t> (cementing_set.size ());
-	};
-
-	return std::min (election_vacancy (behavior), election_winners_vacancy ());
-}
-
 void nano::active_elections::tick_elections (nano::unique_lock<nano::mutex> & lock)
 {
 	debug_assert (lock.owns_lock ());
@@ -334,68 +510,79 @@ void nano::active_elections::tick_elections (nano::unique_lock<nano::mutex> & lo
 	}
 }
 
-void nano::active_elections::cleanup_election (nano::unique_lock<nano::mutex> & lock_a, std::shared_ptr<nano::election> election)
+void nano::active_elections::run ()
 {
-	debug_assert (!mutex.try_lock ());
-	debug_assert (lock_a.owns_lock ());
-	debug_assert (!election->confirmed () || recently_confirmed.exists (election->qualified_root));
-
-	// Keep track of election count by election type
-	release_assert (count_by_behavior[election->behavior ()] > 0);
-	count_by_behavior[election->behavior ()]--;
-
-	auto blocks_l = election->blocks ();
-	node.vote_router.disconnect (*election);
-
-	// Erase root info
-	auto it = roots.get<tag_root> ().find (election->qualified_root);
-	release_assert (it != roots.get<tag_root> ().end ());
-	entry entry = *it;
-	roots.get<tag_root> ().erase (it);
-
-	node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::stopped);
-	node.stats.inc (nano::stat::type::active_elections, election->confirmed () ? nano::stat::detail::confirmed : nano::stat::detail::unconfirmed);
-	node.stats.inc (nano::stat::type::active_elections_stopped, to_stat_detail (election->state ()));
-	node.stats.inc (to_stat_type (election->state ()), to_stat_detail (election->behavior ()));
-
-	node.logger.trace (nano::log::type::active_elections, nano::log::detail::active_stopped, nano::log::arg{ "election", election });
-
-	node.logger.debug (nano::log::type::active_elections, "Erased election for root: {} with blocks: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms)",
-	election->qualified_root,
-	fmt::join (election->blocks_hashes (), ", "), // TODO: Lazy eval
-	to_string (election->behavior ()),
-	to_string (election->state ()),
-	election->voter_count (),
-	election->block_count (),
-	election->duration ().count ());
-
-	lock_a.unlock ();
-
-	// Track election duration
-	node.stats.sample (nano::stat::sample::active_election_duration, election->duration ().count (), { 0, 1000 * 60 * 10 /* 0-10 minutes range */ });
-
-	// Notify observers without holding the lock
-	if (entry.erased_callback)
+	nano::unique_lock<nano::mutex> lock{ mutex };
+	while (!stopped)
 	{
-		entry.erased_callback (election);
+		auto const stamp = std::chrono::steady_clock::now ();
+
+		node.stats.inc (nano::stat::type::active, nano::stat::detail::loop);
+
+		tick_elections (lock);
+		debug_assert (!lock.owns_lock ());
+		lock.lock ();
+
+		auto const min_sleep = node.network_params.network.aec_loop_interval / 2;
+		auto const wakeup = std::max (stamp + node.network_params.network.aec_loop_interval, std::chrono::steady_clock::now () + min_sleep);
+
+		condition.wait_until (lock, wakeup, [this, wakeup] {
+			return stopped || std::chrono::steady_clock::now () >= wakeup;
+		});
 	}
+}
 
-	vacancy_updated.notify ();
-
-	for (auto const & [hash, block] : blocks_l)
+int64_t nano::active_elections::limit (nano::election_behavior behavior) const
+{
+	switch (behavior)
 	{
-		// Notify observers about dropped elections & blocks lost confirmed elections
-		if (!election->confirmed () || hash != election->winner ()->hash ())
+		case nano::election_behavior::manual:
 		{
-			node.observers.active_stopped.notify (hash);
+			return std::numeric_limits<int64_t>::max ();
 		}
-
-		if (!election->confirmed ())
+		case nano::election_behavior::priority:
 		{
-			// Clear from publish filter
-			node.network.filter.clear (block);
+			return static_cast<int64_t> (config.size);
+		}
+		case nano::election_behavior::hinted:
+		{
+			const uint64_t limit = config.hinted_limit_percentage * config.size / 100;
+			return static_cast<int64_t> (limit);
+		}
+		case nano::election_behavior::optimistic:
+		{
+			const uint64_t limit = config.optimistic_limit_percentage * config.size / 100;
+			return static_cast<int64_t> (limit);
 		}
 	}
+
+	debug_assert (false, "unknown election behavior");
+	return 0;
+}
+
+int64_t nano::active_elections::vacancy (nano::election_behavior behavior) const
+{
+	auto election_vacancy = [this] (nano::election_behavior behavior) -> int64_t {
+		nano::lock_guard<nano::mutex> guard{ mutex };
+		switch (behavior)
+		{
+			case nano::election_behavior::manual:
+				return std::numeric_limits<int64_t>::max ();
+			case nano::election_behavior::priority:
+				return limit (nano::election_behavior::priority) - static_cast<int64_t> (index.size ());
+			case nano::election_behavior::hinted:
+			case nano::election_behavior::optimistic:
+				return limit (behavior) - static_cast<int64_t> (index.size (behavior));
+		}
+		debug_assert (false); // Unknown enum
+		return 0;
+	};
+
+	auto election_winners_vacancy = [this] () -> int64_t {
+		return static_cast<int64_t> (config.max_election_winners) - static_cast<int64_t> (cementing_set.size ());
+	};
+
+	return std::min (election_vacancy (behavior), election_winners_vacancy ());
 }
 
 std::vector<std::shared_ptr<nano::election>> nano::active_elections::list_active (std::size_t max_count)
@@ -407,149 +594,29 @@ std::vector<std::shared_ptr<nano::election>> nano::active_elections::list_active
 std::vector<std::shared_ptr<nano::election>> nano::active_elections::list_active_impl (std::size_t max_count) const
 {
 	std::vector<std::shared_ptr<nano::election>> result_l;
-	result_l.reserve (std::min (max_count, roots.size ()));
+	auto entries = index.list ();
+	result_l.reserve (std::min (max_count, entries.size ()));
+	for (auto const & entry : entries)
 	{
-		auto & sorted_roots_l (roots.get<tag_sequenced> ());
-		for (auto i = sorted_roots_l.begin (), n = sorted_roots_l.end (); i != n && result_l.size () < max_count; ++i)
+		if (result_l.size () >= max_count)
 		{
-			result_l.push_back (i->election);
+			break;
 		}
+		result_l.push_back (entry.election);
 	}
 	return result_l;
-}
-
-nano::election_insertion_result nano::active_elections::insert (std::shared_ptr<nano::block> const & block_a, nano::election_behavior election_behavior_a, erased_callback_t erased_callback_a)
-{
-	release_assert (block_a);
-	release_assert (block_a->has_sideband ());
-
-	nano::unique_lock<nano::mutex> lock{ mutex };
-
-	nano::election_insertion_result result;
-
-	if (stopped)
-	{
-		return result;
-	}
-
-	auto const root = block_a->qualified_root ();
-	auto const hash = block_a->hash ();
-
-	if (auto existing = roots.get<tag_root> ().find (root); existing == roots.get<tag_root> ().end ())
-	{
-		if (!recently_confirmed.exists (root))
-		{
-			result.inserted = true;
-
-			// Passing this callback into the election is important
-			// We need to observe and update the online voting weight *before* election quorum is checked
-			auto observe_rep_callback = [&node = node] (auto const & rep_a) {
-				node.online_reps.observe (rep_a);
-			};
-			result.election = nano::make_shared<nano::election> (node, block_a, nullptr, observe_rep_callback, election_behavior_a);
-
-			roots.get<tag_root> ().emplace (entry{ root, result.election, std::move (erased_callback_a) });
-			node.vote_router.connect (hash, result.election);
-
-			// Keep track of election count by election type
-			release_assert (count_by_behavior[result.election->behavior ()] >= 0);
-			count_by_behavior[result.election->behavior ()]++;
-
-			// Skip passive phase for blocks without cached votes to avoid bootstrap delays
-			bool activate_immediately = false;
-			if (!node.vote_cache.contains (hash))
-			{
-				activate_immediately = true;
-			}
-
-			if (activate_immediately)
-			{
-				node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::activate_immediately);
-				result.election->transition_active ();
-			}
-
-			node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::started);
-			node.stats.inc (nano::stat::type::active_elections_started, to_stat_detail (election_behavior_a));
-
-			node.logger.trace (nano::log::type::active_elections, nano::log::detail::active_started,
-			nano::log::arg{ "behavior", election_behavior_a },
-			nano::log::arg{ "election", result.election });
-
-			node.logger.debug (nano::log::type::active_elections, "Started new election for root: {} with blocks: {} (behavior: {}, active immediately: {})",
-			root,
-			fmt::join (result.election->blocks_hashes (), ", "), // TODO: Lazy eval
-			to_string (election_behavior_a),
-			activate_immediately);
-		}
-		else
-		{
-			// result is not set
-		}
-	}
-	else
-	{
-		result.election = existing->election;
-
-		// Upgrade to priority election to enable immediate vote broadcasting.
-		auto previous_behavior = result.election->behavior ();
-		if (election_behavior_a == nano::election_behavior::priority && previous_behavior != nano::election_behavior::priority)
-		{
-			bool transitioned = result.election->transition_priority ();
-			if (transitioned)
-			{
-				count_by_behavior[previous_behavior]--;
-				count_by_behavior[election_behavior_a]++;
-				node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::transition_priority);
-			}
-			else
-			{
-				node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::transition_priority_failed);
-			}
-		}
-	}
-
-	lock.unlock ();
-
-	if (result.inserted)
-	{
-		release_assert (result.election);
-
-		// Notifications
-		node.observers.active_started.notify (hash);
-		vacancy_updated.notify ();
-
-		// Let the election know about already observed votes
-		node.vote_cache_processor.trigger (hash);
-
-		// Let the election know about already observed forks
-		auto forks = node.fork_cache.get (root);
-		node.stats.add (nano::stat::type::active_elections, nano::stat::detail::forks_cached, forks.size ());
-
-		for (auto const & fork : forks)
-		{
-			publish (fork);
-		}
-	}
-
-	// Votes are generated for inserted or ongoing elections
-	if (result.election)
-	{
-		result.election->broadcast_vote ();
-	}
-
-	return result;
 }
 
 bool nano::active_elections::active (nano::qualified_root const & root_a) const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
-	return roots.get<tag_root> ().find (root_a) != roots.get<tag_root> ().end ();
+	return index.exists (root_a);
 }
 
 bool nano::active_elections::active (nano::block const & block_a) const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	return roots.get<tag_root> ().find (block_a.qualified_root ()) != roots.get<tag_root> ().end ();
+	return index.exists (block_a.qualified_root ());
 }
 
 std::shared_ptr<nano::election> nano::active_elections::election (nano::qualified_root const & root) const
@@ -561,84 +628,31 @@ std::shared_ptr<nano::election> nano::active_elections::election (nano::qualifie
 std::shared_ptr<nano::election> nano::active_elections::election_impl (nano::qualified_root const & root) const
 {
 	debug_assert (!mutex.try_lock ());
-	std::shared_ptr<nano::election> result;
-	auto existing = roots.get<tag_root> ().find (root);
-	if (existing != roots.get<tag_root> ().end ())
-	{
-		result = existing->election;
-	}
-	return result;
-}
-
-bool nano::active_elections::erase (nano::block const & block_a)
-{
-	return erase (block_a.qualified_root ());
-}
-
-bool nano::active_elections::erase (nano::qualified_root const & root_a)
-{
-	nano::unique_lock<nano::mutex> lock{ mutex };
-	auto root_it (roots.get<tag_root> ().find (root_a));
-	if (root_it != roots.get<tag_root> ().end ())
-	{
-		release_assert (root_it->election->qualified_root == root_a);
-		cleanup_election (lock, root_it->election);
-		return true;
-	}
-	return false;
+	return index.election (root);
 }
 
 bool nano::active_elections::empty () const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
-	return roots.empty ();
+	return index.size () == 0;
 }
 
 std::size_t nano::active_elections::size () const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
-	return roots.size ();
+	return index.size ();
 }
 
 std::size_t nano::active_elections::size (nano::election_behavior behavior) const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
-	auto count = count_by_behavior[behavior];
-	debug_assert (count >= 0);
-	return static_cast<std::size_t> (count);
+	return index.size (behavior);
 }
 
-bool nano::active_elections::publish (std::shared_ptr<nano::block> const & block_a)
+std::size_t nano::active_elections::size (nano::election_behavior behavior, nano::bucket_index bucket) const
 {
-	nano::unique_lock<nano::mutex> lock{ mutex };
-	auto existing (roots.get<tag_root> ().find (block_a->qualified_root ()));
-	auto result (true);
-	if (existing != roots.get<tag_root> ().end ())
-	{
-		auto election (existing->election);
-		lock.unlock ();
-		result = election->publish (block_a);
-		if (!result)
-		{
-			lock.lock ();
-			node.vote_router.connect (block_a->hash (), election);
-			lock.unlock ();
-
-			node.vote_cache_processor.trigger (block_a->hash ());
-
-			node.stats.inc (nano::stat::type::active, nano::stat::detail::election_block_conflict);
-
-			node.logger.debug (nano::log::type::active_elections, "Block was added to an existing election: {} with root: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms)",
-			block_a->hash (),
-			election->qualified_root,
-			to_string (election->behavior ()),
-			to_string (election->state ()),
-			election->voter_count (),
-			election->block_count (),
-			election->duration ().count ());
-		}
-	}
-	return result;
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return index.size (behavior, bucket);
 }
 
 void nano::active_elections::clear ()
@@ -646,7 +660,8 @@ void nano::active_elections::clear ()
 	// TODO: Call erased_callback for each election
 	{
 		nano::lock_guard<nano::mutex> guard{ mutex };
-		roots.clear ();
+		index.clear ();
+		erased_callbacks.clear ();
 	}
 	vacancy_updated.notify ();
 }
@@ -656,10 +671,10 @@ nano::container_info nano::active_elections::container_info () const
 	nano::lock_guard<nano::mutex> guard{ mutex };
 
 	nano::container_info info;
-	info.put ("roots", roots.size ());
-	info.put ("normal", static_cast<std::size_t> (count_by_behavior[nano::election_behavior::priority]));
-	info.put ("hinted", static_cast<std::size_t> (count_by_behavior[nano::election_behavior::hinted]));
-	info.put ("optimistic", static_cast<std::size_t> (count_by_behavior[nano::election_behavior::optimistic]));
+	info.put ("roots", index.size ());
+	info.put ("normal", index.size (nano::election_behavior::priority));
+	info.put ("hinted", index.size (nano::election_behavior::hinted));
+	info.put ("optimistic", index.size (nano::election_behavior::optimistic));
 
 	info.add ("recently_confirmed", recently_confirmed.container_info ());
 	info.add ("recently_cemented", recently_cemented.container_info ());

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -157,11 +157,16 @@ auto nano::active_elections::insert (std::shared_ptr<nano::block> const & block,
 
 			// Passing this callback into the election is important
 			// We need to observe and update the online voting weight *before* election quorum is checked
-			auto observe_rep_callback = [&node = node] (auto const & rep) {
+			auto observe_rep_action = [&node = node] (auto const & rep) {
 				node.online_reps.observe (rep);
 			};
 
-			result.election = nano::make_shared<nano::election> (node, block, nullptr, observe_rep_callback, behavior);
+			// On any election state update, schedule a call to tick it immediately
+			auto update_action = [this] (auto const & root) {
+				trigger (root);
+			};
+
+			result.election = std::make_shared<nano::election> (node, block, behavior, nullptr, observe_rep_action, update_action);
 
 			// Store erased callback if provided
 			if (erased_callback)
@@ -496,7 +501,8 @@ void nano::active_elections::tick_elections (nano::unique_lock<nano::mutex> & lo
 	std::deque<std::shared_ptr<nano::election>> stale_elections;
 	for (auto const & election : election_list)
 	{
-		if (election->transition_time (solicitor))
+		bool tick_result = election->tick (solicitor);
+		if (tick_result)
 		{
 			erase (election->qualified_root);
 		}

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -53,9 +53,18 @@ nano::active_elections::active_elections (nano::node & node_a, nano::ledger_noti
 		// Notify observers about cemented blocks on a background thread
 		workers.post ([this, results = std::move (results)] () {
 			auto transaction = node.ledger.tx_begin_read ();
-			for (auto const & [status, votes] : results)
+			for (auto const & [election, status, votes] : results)
 			{
 				transaction.refresh_if_needed ();
+
+				// Dependent elections are implicitly confirmed when their block is cemented
+				// TODO: Should this be the case? Maybe just cancel the election and issue block cemented notification?
+				if (election)
+				{
+					node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::confirm_dependent);
+					election->try_confirm (status.winner->hash ()); // TODO: This should either confirm or cancel the election
+				}
+
 				notify_observers (transaction, status, votes);
 			}
 		});
@@ -165,27 +174,6 @@ auto nano::active_elections::insert (std::shared_ptr<nano::block> const & block,
 
 			node.vote_router.connect (hash, result.election);
 
-			auto should_activate_immediately = [&] () {
-				// Broadcast votes immediately for priority elections
-				if (behavior == nano::election_behavior::priority)
-				{
-					return true;
-				}
-				// Skip passive phase for blocks without cached votes to avoid bootstrap delays
-				if (!node.vote_cache.contains (hash))
-				{
-					return true;
-				}
-				return false;
-			};
-
-			bool activate_immediately = should_activate_immediately ();
-			if (activate_immediately)
-			{
-				node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::activate_immediately);
-				result.election->transition_active ();
-			}
-
 			node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::started);
 			node.stats.inc (nano::stat::type::active_elections_started, to_stat_detail (behavior));
 
@@ -193,11 +181,10 @@ auto nano::active_elections::insert (std::shared_ptr<nano::block> const & block,
 			nano::log::arg{ "behavior", behavior },
 			nano::log::arg{ "election", result.election });
 
-			node.logger.debug (nano::log::type::active_elections, "Started new election for root: {} with blocks: {} (behavior: {}, active immediately: {})",
+			node.logger.debug (nano::log::type::active_elections, "Started new election for root: {} with blocks: {} (behavior: {})",
 			root,
 			fmt::join (result.election->blocks_hashes (), ", "), // TODO: Lazy eval
-			to_string (behavior),
-			activate_immediately);
+			to_string (behavior));
 		}
 		else
 		{
@@ -230,6 +217,23 @@ auto nano::active_elections::insert (std::shared_ptr<nano::block> const & block,
 	if (result.inserted)
 	{
 		release_assert (result.election);
+
+		auto should_activate_immediately = [&] () {
+			// Skip passive phase for blocks without cached votes to avoid bootstrap delays
+			if (!node.vote_cache.contains (hash))
+			{
+				return true;
+			}
+			return false;
+		};
+
+		// Transition to active (broadcasting votes, sending confirm reqs) state if needed
+		bool activate_immediately = should_activate_immediately ();
+		if (activate_immediately)
+		{
+			node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::activate_immediately);
+			result.election->transition_active ();
+		}
 
 		// Notifications
 		node.observers.active_started.notify (hash);
@@ -382,12 +386,7 @@ auto nano::active_elections::block_cemented (std::shared_ptr<nano::block> const 
 	debug_assert (node.block_confirmed (block->hash ()));
 
 	// Dependent elections are implicitly confirmed when their block is cemented
-	auto dependend_election = election_impl (block->qualified_root ());
-	if (dependend_election)
-	{
-		node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::confirm_dependent);
-		dependend_election->try_confirm (block->hash ()); // TODO: This should either confirm or cancel the election
-	}
+	auto election = election_impl (block->qualified_root ());
 
 	nano::election_status status;
 	std::vector<nano::vote_with_weight_info> votes;
@@ -401,7 +400,7 @@ auto nano::active_elections::block_cemented (std::shared_ptr<nano::block> const 
 		votes = source_election->votes_with_weight ();
 		status.type = nano::election_status_type::active_confirmed_quorum;
 	}
-	else if (dependend_election)
+	else if (election)
 	{
 		status.type = nano::election_status_type::active_confirmation_height;
 	}
@@ -420,7 +419,7 @@ auto nano::active_elections::block_cemented (std::shared_ptr<nano::block> const 
 	nano::log::arg{ "confirmation_root", confirmation_root },
 	nano::log::arg{ "source_election", source_election });
 
-	return { status, votes };
+	return { election, status, votes };
 }
 
 void nano::active_elections::notify_observers (nano::secure::transaction const & transaction, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes) const
@@ -461,11 +460,31 @@ void nano::active_elections::notify_observers (nano::secure::transaction const &
 	}
 }
 
+bool nano::active_elections::trigger (nano::qualified_root const & root)
+{
+	bool triggered = false;
+	{
+		nano::lock_guard<nano::mutex> guard{ mutex };
+		if (auto election = index.election (root))
+		{
+			triggered = index.trigger (election);
+		}
+	}
+	if (triggered)
+	{
+		condition.notify_all ();
+	}
+	return triggered;
+}
+
 void nano::active_elections::tick_elections (nano::unique_lock<nano::mutex> & lock)
 {
 	debug_assert (lock.owns_lock ());
 
-	auto const election_list = list_active_impl ();
+	auto const now = std::chrono::steady_clock::now ();
+	auto const cutoff = now - node.network_params.network.aec_loop_interval;
+	auto const election_list = index.list (cutoff, now);
+	debug_assert (!election_list.empty ()); // Shouldn't be called if there are no elections to process
 
 	lock.unlock ();
 
@@ -510,25 +529,33 @@ void nano::active_elections::tick_elections (nano::unique_lock<nano::mutex> & lo
 	}
 }
 
+bool nano::active_elections::predicate () const
+{
+	debug_assert (!mutex.try_lock ());
+
+	auto cutoff = std::chrono::steady_clock::now () - node.network_params.network.aec_loop_interval;
+	return index.any (cutoff);
+}
+
 void nano::active_elections::run ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	while (!stopped)
 	{
-		auto const stamp = std::chrono::steady_clock::now ();
+		if (predicate ())
+		{
+			node.stats.inc (nano::stat::type::active, nano::stat::detail::loop);
 
-		node.stats.inc (nano::stat::type::active, nano::stat::detail::loop);
-
-		tick_elections (lock);
-		debug_assert (!lock.owns_lock ());
-		lock.lock ();
-
-		auto const min_sleep = node.network_params.network.aec_loop_interval / 2;
-		auto const wakeup = std::max (stamp + node.network_params.network.aec_loop_interval, std::chrono::steady_clock::now () + min_sleep);
-
-		condition.wait_until (lock, wakeup, [this, wakeup] {
-			return stopped || std::chrono::steady_clock::now () >= wakeup;
-		});
+			tick_elections (lock);
+			debug_assert (!lock.owns_lock ());
+			lock.lock ();
+		}
+		else
+		{
+			condition.wait_for (lock, node.network_params.network.aec_loop_interval / 2, [this] {
+				return stopped || predicate ();
+			});
+		}
 	}
 }
 

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -80,6 +80,9 @@ public:
 	// Notify this container about a new block (potential fork)
 	bool publish (std::shared_ptr<nano::block> const &);
 
+	// Trigger an immediate election update (e.g. after it is confirmed)
+	bool trigger (nano::qualified_root const &);
+
 	/// Is the root of this block in the roots container
 	bool active (nano::block const &) const;
 	bool active (nano::qualified_root const &) const;
@@ -111,13 +114,20 @@ public: // Events
 	nano::observer_set<> vacancy_updated;
 
 private:
+	bool predicate () const;
 	void run ();
 	void tick_elections (nano::unique_lock<nano::mutex> &);
 
 	// Erase all blocks from active and, if not confirmed, clear digests from network filters
 	void erase_election (nano::unique_lock<nano::mutex> & lock_a, std::shared_ptr<nano::election>);
 
-	using block_cemented_result = std::pair<nano::election_status, std::vector<nano::vote_with_weight_info>>;
+	struct block_cemented_result
+	{
+		std::shared_ptr<nano::election> election;
+		nano::election_status status;
+		std::vector<nano::vote_with_weight_info> votes;
+	};
+
 	block_cemented_result block_cemented (std::shared_ptr<nano::block> const & block, nano::block_hash const & confirmation_root, std::shared_ptr<nano::election> const & source_election);
 	void notify_observers (nano::secure::transaction const &, nano::election_status const & status, std::vector<nano::vote_with_weight_info> const & votes) const;
 
@@ -152,22 +162,8 @@ private:
 	nano::interval bootstrap_stale_interval;
 	nano::interval warning_interval;
 
-	friend class election;
-
 public: // Tests
 	void clear ();
-
-	friend class node_fork_storm_Test;
-	friend class system_block_sequence_Test;
-	friend class node_mass_block_new_Test;
-	friend class active_elections_vote_replays_Test;
-	friend class frontiers_confirmation_prioritize_frontiers_Test;
-	friend class frontiers_confirmation_prioritize_frontiers_max_optimistic_elections_Test;
-	friend class confirmation_height_prioritize_frontiers_overwrite_Test;
-	friend class active_elections_confirmation_consistency_Test;
-	friend class node_deferred_dependent_elections_Test;
-	friend class active_elections_pessimistic_elections_Test;
-	friend class frontiers_confirmation_expired_optimistic_elections_removal_Test;
 };
 
 nano::stat::type to_stat_type (nano::election_state);

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <nano/lib/enum_util.hpp>
 #include <nano/lib/interval.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/observer_set.hpp>
 #include <nano/lib/thread_pool.hpp>
+#include <nano/node/active_elections_index.hpp>
 #include <nano/node/election_behavior.hpp>
-#include <nano/node/election_insertion_result.hpp>
 #include <nano/node/election_status.hpp>
 #include <nano/node/fwd.hpp>
 #include <nano/node/recently_cemented_cache.hpp>
@@ -15,19 +14,11 @@
 #include <nano/node/vote_with_weight_info.hpp>
 #include <nano/secure/common.hpp>
 
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/member.hpp>
-#include <boost/multi_index/random_access_index.hpp>
-#include <boost/multi_index/sequenced_index.hpp>
-#include <boost/multi_index_container.hpp>
-
 #include <condition_variable>
 #include <deque>
 #include <memory>
 #include <thread>
 #include <unordered_map>
-
-namespace mi = boost::multi_index;
 
 namespace nano
 {
@@ -65,34 +56,6 @@ class active_elections final
 public:
 	using erased_callback_t = std::function<void (std::shared_ptr<nano::election>)>;
 
-private: // Elections
-	class entry final
-	{
-	public:
-		nano::qualified_root root;
-		std::shared_ptr<nano::election> election;
-		erased_callback_t erased_callback;
-	};
-
-	friend class nano::election;
-
-	// clang-format off
-	class tag_account {};
-	class tag_root {};
-	class tag_sequenced {};
-	class tag_uncemented {};
-	class tag_arrival {};
-	class tag_hash {};
-
-	using ordered_roots = boost::multi_index_container<entry,
-	mi::indexed_by<
-		mi::sequenced<mi::tag<tag_sequenced>>,
-		mi::hashed_unique<mi::tag<tag_root>,
-			mi::member<entry, nano::qualified_root, &entry::root>>
-	>>;
-	// clang-format on
-	ordered_roots roots;
-
 public:
 	active_elections (nano::node &, nano::ledger_notifications &, nano::cementing_set &);
 	~active_elections ();
@@ -100,31 +63,46 @@ public:
 	void start ();
 	void stop ();
 
-	/**
-	 * Starts new election with a specified behavior type
-	 */
-	nano::election_insertion_result insert (std::shared_ptr<nano::block> const &, nano::election_behavior = nano::election_behavior::priority, erased_callback_t = nullptr);
-	// Is the root of this block in the roots container
-	bool active (nano::block const &) const;
-	bool active (nano::qualified_root const &) const;
-	std::shared_ptr<nano::election> election (nano::qualified_root const &) const;
-	// Returns a list of elections sorted by difficulty
-	std::vector<std::shared_ptr<nano::election>> list_active (std::size_t max_count = std::numeric_limits<std::size_t>::max ());
-	bool erase (nano::block const &);
-	bool erase (nano::qualified_root const &);
-	bool empty () const;
-	std::size_t size () const;
-	std::size_t size (nano::election_behavior) const;
+	struct insert_result
+	{
+		std::shared_ptr<nano::election> election;
+		bool inserted;
+	};
+
+	/// Starts new election
+	insert_result insert (
+	std::shared_ptr<nano::block> const &,
+	nano::election_behavior = nano::election_behavior::priority,
+	nano::bucket_index bucket = 0,
+	nano::priority_timestamp priority = 0,
+	erased_callback_t = nullptr);
+
+	// Notify this container about a new block (potential fork)
 	bool publish (std::shared_ptr<nano::block> const &);
 
-	/**
-	 * Maximum number of elections that should be present in this container
-	 * NOTE: This is only a soft limit, it is possible for this container to exceed this count
-	 */
+	/// Is the root of this block in the roots container
+	bool active (nano::block const &) const;
+	bool active (nano::qualified_root const &) const;
+
+	std::shared_ptr<nano::election> election (nano::qualified_root const &) const;
+
+	/// Returns a list of elections sorted by difficulty
+	std::vector<std::shared_ptr<nano::election>> list_active (std::size_t max_count = std::numeric_limits<std::size_t>::max ());
+
+	bool erase (nano::block const &);
+	bool erase (nano::qualified_root const &);
+
+	bool empty () const;
+
+	size_t size () const;
+	size_t size (nano::election_behavior) const;
+	size_t size (nano::election_behavior, nano::bucket_index) const;
+
+	/// Maximum number of elections that should be present in this container
+	/// NOTE: This is only a soft limit, it is possible for this container to exceed this count
 	int64_t limit (nano::election_behavior behavior) const;
-	/**
-	 * How many election slots are available for specified election type
-	 */
+
+	/// How many election slots are available for specified election type
 	int64_t vacancy (nano::election_behavior behavior) const;
 
 	nano::container_info container_info () const;
@@ -137,7 +115,7 @@ private:
 	void tick_elections (nano::unique_lock<nano::mutex> &);
 
 	// Erase all blocks from active and, if not confirmed, clear digests from network filters
-	void cleanup_election (nano::unique_lock<nano::mutex> & lock_a, std::shared_ptr<nano::election>);
+	void erase_election (nano::unique_lock<nano::mutex> & lock_a, std::shared_ptr<nano::election>);
 
 	using block_cemented_result = std::pair<nano::election_status, std::vector<nano::vote_with_weight_info>>;
 	block_cemented_result block_cemented (std::shared_ptr<nano::block> const & block, nano::block_hash const & confirmation_root, std::shared_ptr<nano::election> const & source_election);
@@ -153,6 +131,10 @@ private: // Dependencies
 	nano::cementing_set & cementing_set;
 
 public:
+	nano::active_elections_index index;
+
+	std::unordered_map<nano::qualified_root, erased_callback_t> erased_callbacks;
+
 	nano::recently_confirmed_cache recently_confirmed;
 	nano::recently_cemented_cache recently_cemented;
 
@@ -161,9 +143,6 @@ public:
 	mutable nano::mutex mutex{ mutex_identifier (mutexes::active) };
 
 private:
-	/** Keeps track of number of elections by election behavior (normal, hinted, optimistic) */
-	nano::enum_array<nano::election_behavior, int64_t> count_by_behavior{};
-
 	nano::condition_variable condition;
 	bool stopped{ false };
 	std::thread thread;

--- a/nano/node/active_elections_index.cpp
+++ b/nano/node/active_elections_index.cpp
@@ -1,0 +1,191 @@
+#include <nano/node/active_elections_index.hpp>
+#include <nano/node/election.hpp>
+
+#include <ranges>
+
+void nano::active_elections_index::insert (std::shared_ptr<nano::election> const & election, nano::election_behavior behavior, nano::bucket_index bucket, nano::priority_timestamp priority)
+{
+	debug_assert (!entries.get<tag_ptr> ().contains (election));
+	debug_assert (!entries.get<tag_root> ().contains (election->qualified_root));
+
+	auto [it, inserted] = entries.emplace_back (entry{ election, election->qualified_root, behavior, bucket, priority });
+	debug_assert (inserted);
+
+	// Update cached size
+	size_by_behavior[{ behavior }]++;
+	size_by_bucket[{ behavior, bucket }]++;
+}
+
+bool nano::active_elections_index::erase (std::shared_ptr<nano::election> const & election)
+{
+	auto maybe_entry = info (election);
+	if (!maybe_entry)
+	{
+		return false; // Not found
+	}
+	auto entry = *maybe_entry;
+
+	auto & index = entries.get<tag_ptr> ();
+	auto erased = index.erase (election);
+	release_assert (erased == 1);
+
+	// Update cached size
+	size_by_behavior[{ entry.behavior }]--;
+	size_by_bucket[{ entry.behavior, entry.bucket }]--;
+
+	return true; // Erased
+}
+
+void nano::active_elections_index::update (std::shared_ptr<nano::election> const & election, nano::election_behavior behavior)
+{
+	auto & index = entries.get<tag_ptr> ();
+	auto existing = index.find (election);
+	if (existing != index.end ())
+	{
+		auto old_behavior = existing->behavior;
+		auto bucket = existing->bucket;
+
+		if (old_behavior != behavior)
+		{
+			// Update cached sizes
+			size_by_behavior[{ old_behavior }]--;
+			size_by_bucket[{ old_behavior, bucket }]--;
+			size_by_behavior[{ behavior }]++;
+			size_by_bucket[{ behavior, bucket }]++;
+
+			// Update the entry
+			index.modify (existing, [behavior] (entry & e) {
+				e.behavior = behavior;
+			});
+		}
+	}
+	else
+	{
+		debug_assert (false, "election not found in index");
+	}
+}
+
+bool nano::active_elections_index::exists (nano::qualified_root const & root) const
+{
+	return entries.get<tag_root> ().contains (root);
+}
+
+bool nano::active_elections_index::exists (std::shared_ptr<nano::election> const & election) const
+{
+	return entries.get<tag_ptr> ().contains (election);
+}
+
+std::shared_ptr<nano::election> nano::active_elections_index::election (nano::qualified_root const & root) const
+{
+	if (auto existing = entries.get<tag_root> ().find (root); existing != entries.get<tag_root> ().end ())
+	{
+		return existing->election;
+	}
+	return nullptr;
+}
+
+auto nano::active_elections_index::info (std::shared_ptr<nano::election> const & election) const -> std::optional<entry>
+{
+	if (auto existing = entries.get<tag_ptr> ().find (election); existing != entries.get<tag_ptr> ().end ())
+	{
+		return *existing;
+	}
+	return std::nullopt;
+}
+
+auto nano::active_elections_index::list () const -> std::deque<entry>
+{
+	auto r = entries.get<tag_sequenced> () | std::views::transform ([] (auto const & entry) { return entry; });
+	return { r.begin (), r.end () };
+}
+
+size_t nano::active_elections_index::size () const
+{
+	return entries.size ();
+}
+
+size_t nano::active_elections_index::size (nano::election_behavior behavior) const
+{
+	if (auto existing = size_by_behavior.find ({ behavior }); existing != size_by_behavior.end ())
+	{
+		return existing->second;
+	}
+	return 0;
+}
+
+size_t nano::active_elections_index::size (nano::election_behavior behavior, nano::bucket_index bucket) const
+{
+	if (auto existing = size_by_bucket.find ({ behavior, bucket }); existing != size_by_bucket.end ())
+	{
+		return existing->second;
+	}
+	return 0;
+}
+
+auto nano::active_elections_index::last (nano::election_behavior behavior, nano::bucket_index bucket) const -> priority_result
+{
+	auto & index = entries.get<tag_key> ();
+
+	// Find the range of entries with matching behavior and bucket
+	auto range = index.equal_range (std::make_tuple (behavior, bucket));
+	if (range.first != range.second)
+	{
+		// Since the index is ordered, the last element has the highest priority (largest value)
+		auto last = std::prev (range.second);
+		return { last->election, last->priority };
+	}
+
+	return { nullptr, std::numeric_limits<nano::priority_timestamp>::max () };
+}
+
+auto nano::active_elections_index::list (std::chrono::steady_clock::time_point cutoff, std::chrono::steady_clock::time_point now) -> std::deque<std::shared_ptr<nano::election>>
+{
+	auto & index = entries.get<tag_timestamp> ();
+
+	// Collect entries to process first to avoid iterator invalidation issues
+	std::deque<decltype (index.begin ())> to_process;
+	auto end = index.upper_bound (cutoff);
+	for (auto it = index.begin (); it != end; ++it)
+	{
+		to_process.push_back (it);
+	}
+
+	// Process and update timestamps
+	for (auto it : to_process)
+	{
+		// Update timestamp to 'now' for processed entries
+		index.modify (it, [now] (entry & e) {
+			e.timestamp = now;
+		});
+	}
+
+	auto r = to_process | std::views::transform ([] (auto const & it) { return it->election; });
+	return { r.begin (), r.end () };
+}
+
+bool nano::active_elections_index::trigger (std::shared_ptr<nano::election> const & election)
+{
+	auto & index = entries.get<tag_ptr> ();
+	if (auto existing = index.find (election); existing != index.end ())
+	{
+		index.modify (existing, [] (entry & e) {
+			e.timestamp = {};
+		});
+		return true;
+	}
+	return false; // Not found
+}
+
+bool nano::active_elections_index::any (std::chrono::steady_clock::time_point cutoff) const
+{
+	auto & index = entries.get<tag_timestamp> ();
+	auto it = index.begin ();
+	return it != index.end () && it->timestamp <= cutoff;
+}
+
+void nano::active_elections_index::clear ()
+{
+	entries.clear ();
+	size_by_behavior.clear ();
+	size_by_bucket.clear ();
+}

--- a/nano/node/active_elections_index.hpp
+++ b/nano/node/active_elections_index.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+#include <nano/lib/numbers_templ.hpp>
+#include <nano/node/fwd.hpp>
+#include <nano/secure/common.hpp>
+
+#include <boost/multi_index/composite_key.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/random_access_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index_container.hpp>
+
+#include <chrono>
+#include <deque>
+#include <functional>
+#include <map>
+#include <optional>
+#include <set>
+#include <unordered_map>
+
+namespace mi = boost::multi_index;
+
+namespace nano
+{
+class active_elections_index
+{
+public:
+	struct entry
+	{
+		std::shared_ptr<nano::election> election;
+
+		nano::qualified_root root;
+		nano::election_behavior behavior;
+		nano::bucket_index bucket;
+		nano::priority_timestamp priority;
+
+		std::chrono::steady_clock::time_point timestamp{};
+	};
+
+public:
+	void insert (std::shared_ptr<nano::election> const &, nano::election_behavior, nano::bucket_index, nano::priority_timestamp);
+	bool erase (std::shared_ptr<nano::election> const &);
+	void update (std::shared_ptr<nano::election> const &, nano::election_behavior);
+
+	bool exists (nano::qualified_root const &) const;
+	bool exists (std::shared_ptr<nano::election> const &) const;
+
+	std::shared_ptr<nano::election> election (nano::qualified_root const &) const;
+	std::optional<entry> info (std::shared_ptr<nano::election> const &) const;
+
+	size_t size () const;
+	size_t size (nano::election_behavior) const;
+	size_t size (nano::election_behavior, nano::bucket_index) const;
+
+	// Returns election with the highest priority value. NOTE: Lower "priority" is better
+	using priority_result = std::pair<std::shared_ptr<nano::election>, nano::priority_timestamp>;
+	priority_result last (nano::election_behavior, nano::bucket_index) const;
+
+	std::deque<entry> list () const;
+
+	// Return list of elections with a timestamp before the specified cutoff time
+	std::deque<std::shared_ptr<nano::election>> list (
+	std::chrono::steady_clock::time_point cutoff,
+	std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now ());
+
+	// Mark an election for update (reset its timestamp)
+	bool trigger (std::shared_ptr<nano::election> const &);
+
+	// Are there any elections with a timestamp before the specified cutoff time
+	bool any (std::chrono::steady_clock::time_point cutoff) const;
+
+	void clear ();
+
+private:
+	// clang-format off
+	class tag_sequenced {};
+	class tag_root {};
+	class tag_ptr {};
+	class tag_key {};
+	class tag_timestamp {};
+
+	using ordered_entries = boost::multi_index_container<entry,
+	mi::indexed_by<
+		mi::sequenced<mi::tag<tag_sequenced>>,
+		mi::hashed_unique<mi::tag<tag_root>,
+			mi::member<entry, nano::qualified_root, &entry::root>>,
+		mi::hashed_unique<mi::tag<tag_ptr>,
+		    mi::member<entry, std::shared_ptr<nano::election>, &entry::election>>,
+		mi::ordered_non_unique<mi::tag<tag_key>,
+			mi::composite_key<entry,
+				mi::member<entry, nano::election_behavior, &entry::behavior>,
+				mi::member<entry, nano::bucket_index, &entry::bucket>,
+				mi::member<entry, nano::priority_timestamp, &entry::priority>>>,
+		mi::ordered_non_unique<mi::tag<tag_timestamp>,
+			mi::member<entry, std::chrono::steady_clock::time_point, &entry::timestamp>>
+	>>;
+	// clang-format on
+	ordered_entries entries;
+
+	// Keep track of the total number of elections to provide constant time lookups
+	using behavior_key_t = nano::election_behavior;
+	std::map<behavior_key_t, size_t> size_by_behavior;
+
+	using bucket_key_t = std::pair<nano::election_behavior, nano::bucket_index>;
+	std::map<bucket_key_t, size_t> size_by_bucket;
+};
+}

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -206,12 +206,6 @@ void nano::election::send_confirm_req (nano::confirmation_solicitor & solicitor_
 	}
 }
 
-void nano::election::transition_active ()
-{
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	state_change (nano::election_state::passive, nano::election_state::active);
-}
-
 bool nano::election::transition_priority ()
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
@@ -239,10 +233,16 @@ bool nano::election::transition_priority ()
 	return true;
 }
 
-void nano::election::cancel ()
+bool nano::election::transition_active ()
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	state_change (state_m, nano::election_state::cancelled);
+	return !state_change (nano::election_state::passive, nano::election_state::active); // Invert since false => success
+}
+
+bool nano::election::cancel ()
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return !state_change (state_m, nano::election_state::cancelled); // Invert since false => success
 }
 
 bool nano::election::confirmed_locked () const

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -23,9 +23,10 @@ std::chrono::milliseconds nano::election::base_latency () const
  * election
  */
 
-nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> const & block_a, std::function<void (std::shared_ptr<nano::block> const &)> const & confirmation_action_a, std::function<void (nano::account const &)> const & vote_action_a, nano::election_behavior election_behavior_a) :
-	confirmation_action (confirmation_action_a),
-	vote_action (vote_action_a),
+nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> const & block_a, nano::election_behavior election_behavior_a, std::function<void (std::shared_ptr<nano::block> const &)> confirmation_action_a, std::function<void (nano::account const &)> vote_action_a, std::function<void (nano::qualified_root const &)> update_action_a) :
+	confirmation_action (std::move (confirmation_action_a)),
+	vote_action (std::move (vote_action_a)),
+	update_action (std::move (update_action_a)),
 	node (node_a),
 	behavior_m (election_behavior_a),
 	status (block_a),
@@ -78,14 +79,19 @@ void nano::election::confirm_once (nano::unique_lock<nano::mutex> & lock)
 
 		lock.unlock ();
 
-		node.active.trigger (qualified_root);
+		if (update_action)
+		{
+			node.election_workers.post ([qualified_root_l = qualified_root, update_action_l = update_action] () {
+				update_action_l (qualified_root_l);
+			});
+		}
 
-		node.election_workers.post ([status_l, confirmation_action_l = confirmation_action] () {
-			if (confirmation_action_l)
-			{
+		if (confirmation_action)
+		{
+			node.election_workers.post ([status_l, confirmation_action_l = confirmation_action] () {
 				confirmation_action_l (status_l.winner);
-			}
-		});
+			});
+		}
 	}
 	else
 	{
@@ -149,6 +155,13 @@ bool nano::election::state_change (nano::election_state expected_a, nano::electi
 			state_m = desired_a;
 			state_start = std::chrono::steady_clock::now ().time_since_epoch ();
 			result = false;
+
+			if (update_action)
+			{
+				node.election_workers.post ([qualified_root_l = qualified_root, update_action_l = update_action] () {
+					update_action_l (qualified_root_l);
+				});
+			}
 		}
 	}
 	return result;
@@ -215,6 +228,13 @@ bool nano::election::transition_priority ()
 	to_string (behavior_m),
 	qualified_root,
 	duration ().count ());
+
+	if (update_action)
+	{
+		node.election_workers.post ([qualified_root_l = qualified_root, update_action_l = update_action] () {
+			update_action_l (qualified_root_l);
+		});
+	}
 
 	return true;
 }
@@ -308,7 +328,7 @@ nano::election_status nano::election::get_status () const
 	return status;
 }
 
-bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a)
+bool nano::election::tick (nano::confirmation_solicitor & solicitor)
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	bool result = false;
@@ -322,12 +342,12 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 			break;
 		case nano::election_state::active:
 			broadcast_vote_locked (lock);
-			broadcast_block (solicitor_a);
-			send_confirm_req (solicitor_a);
+			broadcast_block (solicitor);
+			send_confirm_req (solicitor);
 			break;
 		case nano::election_state::confirmed:
 			result = true; // Return true to indicate this election should be cleaned up
-			broadcast_block (solicitor_a); // Ensure election winner is broadcasted
+			broadcast_block (solicitor); // Ensure election winner is broadcasted
 			state_change (nano::election_state::confirmed, nano::election_state::expired_confirmed);
 			break;
 		case nano::election_state::expired_unconfirmed:
@@ -353,6 +373,7 @@ bool nano::election::transition_time (nano::confirmation_solicitor & solicitor_a
 			status.type = nano::election_status_type::stopped;
 		}
 	}
+
 	return result;
 }
 

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -78,6 +78,8 @@ void nano::election::confirm_once (nano::unique_lock<nano::mutex> & lock)
 
 		lock.unlock ();
 
+		node.active.trigger (qualified_root);
+
 		node.election_workers.post ([status_l, confirmation_action_l = confirmation_action] () {
 			if (confirmation_action_l)
 			{

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -93,9 +93,9 @@ public: // State transitions
 	// Returns true if the election should be cleaned up
 	bool tick (nano::confirmation_solicitor &);
 
-	void transition_active ();
+	bool transition_active ();
 	bool transition_priority ();
-	void cancel ();
+	bool cancel ();
 
 public: // Status
 	bool confirmed () const;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -70,6 +70,7 @@ private:
 	// Callbacks
 	std::function<void (std::shared_ptr<nano::block> const &)> confirmation_action;
 	std::function<void (nano::account const &)> vote_action;
+	std::function<void (nano::qualified_root const &)> update_action;
 
 private: // State management
 	static unsigned constexpr passive_duration_factor = 5;
@@ -89,7 +90,9 @@ private: // State management
 	bool state_change (nano::election_state, nano::election_state);
 
 public: // State transitions
-	bool transition_time (nano::confirmation_solicitor &);
+	// Returns true if the election should be cleaned up
+	bool tick (nano::confirmation_solicitor &);
+
 	void transition_active ();
 	bool transition_priority ();
 	void cancel ();
@@ -110,7 +113,13 @@ public: // Status
 	nano::election_status status;
 
 public: // Interface
-	election (nano::node &, std::shared_ptr<nano::block> const & block, std::function<void (std::shared_ptr<nano::block> const &)> const & confirmation_action, std::function<void (nano::account const &)> const & vote_action, nano::election_behavior behavior);
+	election (
+	nano::node &,
+	std::shared_ptr<nano::block> const & block,
+	nano::election_behavior behavior,
+	std::function<void (std::shared_ptr<nano::block> const &)> confirmation_action = nullptr,
+	std::function<void (nano::account const &)> vote_action = nullptr,
+	std::function<void (nano::qualified_root const &)> update_action = nullptr);
 
 	std::shared_ptr<nano::block> find (nano::block_hash const &) const;
 	/*

--- a/nano/node/scheduler/bucket.cpp
+++ b/nano/node/scheduler/bucket.cpp
@@ -91,7 +91,7 @@ bool nano::scheduler::bucket::activate ()
 		elections.get<tag_root> ().erase (election->qualified_root);
 	};
 
-	auto result = active.insert (block, nano::election_behavior::priority, erase_callback);
+	auto result = active.insert (block, nano::election_behavior::priority, index, priority, erase_callback);
 	if (result.inserted)
 	{
 		release_assert (result.election);

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -833,32 +833,48 @@ TEST (wallet, import)
 TEST (wallet, republish)
 {
 	nano_qt::eventloop_processor processor;
-	nano::test::system system (2);
+
+	// Configure nodes to disable bootstrap, election schedulers, and other background processes for test isolation
+	nano::node_config node_config;
+	node_config.bootstrap.enable = false;
+	node_config.priority_scheduler.enable = false;
+	node_config.optimistic_scheduler.enable = false;
+	node_config.hinted_scheduler.enable = false;
+
+	nano::test::system system;
+	auto & node1 = *system.add_node (node_config);
+	auto & node2 = *system.add_node (node_config);
+
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key;
 	nano::block_hash hash;
 	{
-		auto transaction = system.nodes[0]->ledger.tx_begin_write ();
-		auto latest (system.nodes[0]->ledger.any.account_head (transaction, nano::dev::genesis_key.pub));
+		auto transaction = node1.ledger.tx_begin_write ();
+		auto latest (node1.ledger.any.account_head (transaction, nano::dev::genesis_key.pub));
 		auto block = std::make_shared<nano::send_block> (latest, key.pub, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
 		hash = block->hash ();
-		ASSERT_EQ (nano::block_status::progress, system.nodes[0]->ledger.process (transaction, block));
+		ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, block));
 	}
+
+	// Ensure node2 does not have the block initially
+	ASSERT_FALSE (node2.ledger.any.block_exists (node2.ledger.tx_begin_read (), hash));
+
 	auto account (nano::dev::genesis_key.pub);
-	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
+	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, node1, system.wallet (0), account));
 	wallet->start ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
 	ASSERT_EQ (wallet->advanced.window, wallet->main_stack->currentWidget ());
 	QTest::mouseClick (wallet->advanced.block_viewer, Qt::LeftButton);
 	ASSERT_EQ (wallet->block_viewer.window, wallet->main_stack->currentWidget ());
 	QTest::keyClicks (wallet->block_viewer.hash, hash.to_string ().c_str ());
+
+	// Verify the block exists in node1 before rebroadcast
+	ASSERT_TRUE (node1.ledger.any.block_exists (node1.ledger.tx_begin_read (), hash));
+
 	QTest::mouseClick (wallet->block_viewer.rebroadcast, Qt::LeftButton);
-	ASSERT_FALSE (system.nodes[1]->balance (nano::dev::genesis_key.pub).is_zero ());
-	system.deadline_set (10s);
-	while (system.nodes[1]->balance (nano::dev::genesis_key.pub).is_zero ())
-	{
-		ASSERT_NO_ERROR (system.poll ());
-	}
+
+	// Now verify that the block was received by node2 due to the rebroadcast
+	ASSERT_TIMELY (10s, node2.ledger.any.block_exists (node2.ledger.tx_begin_read (), hash));
 }
 
 TEST (wallet, ignore_empty_adhoc)

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -323,7 +323,7 @@ TEST (node, fork_storm)
 			else
 			{
 				nano::unique_lock<nano::mutex> lock{ node_a->active.mutex };
-				auto election = node_a->active.roots.begin ()->election;
+				auto election = *node_a->active.list_active ().begin ();
 				lock.unlock ();
 				if (election->votes ().size () == 1)
 				{
@@ -1794,7 +1794,7 @@ TEST (node, mass_block_new)
 		// Clear all active
 		{
 			nano::lock_guard<nano::mutex> guard{ node.active.mutex };
-			node.active.roots.clear ();
+			node.active.clear ();
 		}
 	};
 
@@ -2159,12 +2159,12 @@ TEST (system, block_sequence)
 			{
 				message += boost::str (boost::format ("N:%1% b:%2% c:%3% a:%4% s:%5% p:%6%\n") % std::to_string (i->network.port) % std::to_string (i->ledger.block_count ()) % std::to_string (i->ledger.cemented_count ()) % std::to_string (i->active.size ()) % std::to_string (i->scheduler.priority.size ()) % std::to_string (i->network.size ()));
 				nano::lock_guard<nano::mutex> lock{ i->active.mutex };
-				for (auto const & j : i->active.roots)
+				for (auto const & j : i->active.list_active ())
 				{
-					auto election = j.election;
+					auto election = j;
 					if (election->confirmation_request_count > 10)
 					{
-						message += boost::str (boost::format ("\t r:%1% i:%2%\n") % j.root.to_string () % std::to_string (election->confirmation_request_count));
+						message += boost::str (boost::format ("\t r:%1% i:%2%\n") % j->root.to_string () % std::to_string (election->confirmation_request_count));
 						for (auto const & k : election->votes ())
 						{
 							message += boost::str (boost::format ("\t\t r:%1% t:%2%\n") % k.first.to_account () % std::to_string (k.second.timestamp));

--- a/nano/test_common/CMakeLists.txt
+++ b/nano/test_common/CMakeLists.txt
@@ -8,6 +8,8 @@ add_library(
   make_store.cpp
   network.hpp
   network.cpp
+  random.hpp
+  random.cpp
   rate_observer.cpp
   rate_observer.hpp
   system.hpp

--- a/nano/test_common/random.cpp
+++ b/nano/test_common/random.cpp
@@ -1,0 +1,46 @@
+#include <nano/crypto_lib/random_pool.hpp>
+#include <nano/test_common/random.hpp>
+
+nano::hash_or_account nano::test::random_hash_or_account ()
+{
+	nano::hash_or_account random_hash;
+	nano::random_pool::generate_block (random_hash.bytes.data (), random_hash.bytes.size ());
+	return random_hash;
+}
+
+nano::block_hash nano::test::random_hash ()
+{
+	return nano::test::random_hash_or_account ().as_block_hash ();
+}
+
+nano::account nano::test::random_account ()
+{
+	return nano::test::random_hash_or_account ().as_account ();
+}
+
+nano::qualified_root nano::test::random_qualified_root ()
+{
+	return { nano::test::random_hash (), nano::test::random_hash () };
+}
+
+nano::amount nano::test::random_amount ()
+{
+	nano::amount result;
+	nano::random_pool::generate_block (result.bytes.data (), result.bytes.size ());
+	return result;
+}
+
+std::shared_ptr<nano::block> nano::test::random_block ()
+{
+	nano::keypair key;
+	auto block = std::make_shared<nano::state_block> (
+	nano::test::random_account (),
+	nano::test::random_hash (),
+	nano::test::random_account (),
+	nano::test::random_amount (),
+	nano::test::random_hash (),
+	key.prv,
+	key.pub,
+	0);
+	return block;
+}

--- a/nano/test_common/random.hpp
+++ b/nano/test_common/random.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <nano/lib/blocks.hpp>
+#include <nano/secure/common.hpp>
+
+namespace nano::test
+{
+/*
+ * Random generators
+ */
+nano::hash_or_account random_hash_or_account ();
+nano::block_hash random_hash ();
+nano::account random_account ();
+nano::qualified_root random_qualified_root ();
+nano::amount random_amount ();
+std::shared_ptr<nano::block> random_block ();
+}

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -50,23 +50,6 @@ void nano::test::wait_peer_connections (nano::test::system & system_a)
 	wait_peer_count (false);
 }
 
-nano::hash_or_account nano::test::random_hash_or_account ()
-{
-	nano::hash_or_account random_hash;
-	nano::random_pool::generate_block (random_hash.bytes.data (), random_hash.bytes.size ());
-	return random_hash;
-}
-
-nano::block_hash nano::test::random_hash ()
-{
-	return nano::test::random_hash_or_account ().as_block_hash ();
-}
-
-nano::account nano::test::random_account ()
-{
-	return nano::test::random_hash_or_account ().as_account ();
-}
-
 bool nano::test::process (nano::node & node, std::vector<std::shared_ptr<nano::block>> blocks)
 {
 	auto const transaction = node.ledger.tx_begin_write ();

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -266,19 +266,6 @@ namespace test
 	void wait_peer_connections (nano::test::system &);
 
 	/**
-	 * Generate a random block hash
-	 */
-	nano::hash_or_account random_hash_or_account ();
-	/**
-	 * Generate a random block hash
-	 */
-	nano::block_hash random_hash ();
-	/**
-	 * Generate a random block hash
-	 */
-	nano::account random_account ();
-
-	/**
 		Convenience function to call `node::process` function for multiple blocks at once.
 		@return true if all blocks were successfully processed and inserted into ledger
 	 */


### PR DESCRIPTION
This PR refactors the active election container. There are two main motivations for this change: firstly, to split out the election indexing and querying logic from the main active_elections class. This provides better separation of concerns and testability. Secondly, the election update logic is now more efficient, avoiding unnecessary iteration over all elections while providing immediate updates for elections that need it.