### PR TITLE
Fix active election cementing races and improve stale election handling

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(
   random.cpp
   random_pool.cpp
   rate_limiting.cpp
+  recently_cache.cpp
   rep_crawler.cpp
   receivable.cpp
   peer_history.cpp

--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -1580,13 +1580,13 @@ TEST (active_elections, broadcast_block_on_activation)
 	ASSERT_TIMELY (5s, node2->block_or_pruned_exists (send1->hash ()));
 }
 
-TEST (active_elections, bootstrap_stale)
+TEST (active_elections, stale_election)
 {
 	nano::test::system system;
 
 	// Configure node with short stale threshold for testing
 	nano::node_config node_config = system.default_config ();
-	node_config.active_elections.bootstrap_stale_threshold = 2s; // Short threshold for faster testing
+	node_config.active_elections.stale_threshold = 2s; // Short threshold for faster testing
 
 	auto & node = *system.add_node (node_config);
 
@@ -1603,6 +1603,12 @@ TEST (active_elections, bootstrap_stale)
 				.work (*system.work.generate (nano::dev::genesis->hash ()))
 				.build ();
 
+	std::atomic<bool> stale_detected{ false };
+	node.active.election_stale.add ([&] (auto const & election) {
+		EXPECT_EQ (send->qualified_root (), election->qualified_root);
+		stale_detected = true;
+	});
+
 	// Process the block and start an election
 	node.process_active (send);
 
@@ -1611,10 +1617,59 @@ TEST (active_elections, bootstrap_stale)
 	ASSERT_TIMELY (5s, (election = node.active.election (send->qualified_root ())) != nullptr);
 
 	// Check initial state
-	ASSERT_EQ (0, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::bootstrap_stale));
+	ASSERT_EQ (0, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::stale));
 
-	// Wait for bootstrap_stale_threshold to pass and the statistic to be incremented
-	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::bootstrap_stale) > 0);
+	// Wait for stale_threshold to pass and stats to be incremented
+	ASSERT_TIMELY (5s, stale_detected);
+	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::stale) > 0);
+}
+
+TEST (active_elections, stale_election_multiple)
+{
+	nano::test::system system;
+
+	// Configure node with short stale threshold for testing
+	nano::node_config node_config = system.default_config ();
+	node_config.active_elections.stale_threshold = 2s; // Short threshold for faster testing
+
+	auto & node = *system.add_node (node_config);
+
+	// Create 10 independent blocks that will each have their own election
+	auto blocks = nano::test::setup_independent_blocks (system, node, 10);
+
+	// Track which elections had stale events fired
+	nano::locked<std::set<nano::qualified_root>> stale_detected;
+
+	node.active.election_stale.add ([&] (auto const & election) {
+		stale_detected.lock ()->insert (election->qualified_root);
+	});
+
+	// Start elections for all blocks
+	ASSERT_TRUE (nano::test::start_elections (system, node, blocks));
+
+	// Ensure all elections are active
+	ASSERT_TIMELY_EQ (5s, node.active.size (), blocks.size ());
+	for (auto const & block : blocks)
+	{
+		ASSERT_TRUE (node.active.active (block->qualified_root ()));
+	}
+
+	// Check initial state
+	ASSERT_EQ (0, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::stale));
+
+	// Wait for stale_threshold to pass (2s) plus some buffer
+	// The stale event should fire for ALL elections that are stale
+	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::stale) >= blocks.size ());
+
+	// Check that all elections had their stale event fired
+	ASSERT_TIMELY_EQ (5s, blocks.size (), stale_detected.lock ()->size ());
+
+	// Verify each block's election was marked as stale
+	for (auto const & block : blocks)
+	{
+		ASSERT_TRUE (stale_detected.lock ()->count (block->qualified_root ()) > 0)
+		<< "Election for block " << block->hash ().to_string () << " was not marked as stale";
+	}
 }
 
 TEST (active_elections, transition_optimistic_to_priority)

--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -20,7 +20,9 @@
 
 #include <gtest/gtest.h>
 
+#include <future>
 #include <numeric>
+#include <random>
 
 using namespace std::chrono_literals;
 
@@ -147,17 +149,18 @@ TEST (active_elections, confirm_frontier)
 	// start node2 later so that we do not get the gossip traffic
 	auto & node2 = *system.add_node (node_config2, node_flags2);
 
-	// Add representative to disabled rep crawler
-	auto peers (node2.network.random_set (1));
-	ASSERT_FALSE (peers.empty ());
-	node2.rep_crawler.force_add_rep (nano::dev::genesis_key.pub, *peers.begin ());
-
 	ASSERT_EQ (nano::block_status::progress, node2.process (send));
 	ASSERT_TIMELY (5s, !node2.active.empty ());
 
 	// Save election to check request count afterwards
 	std::shared_ptr<nano::election> election2;
 	ASSERT_TIMELY (5s, election2 = node2.active.election (send->qualified_root ()));
+
+	// Add representative to disabled rep crawler
+	auto peers (node2.network.random_set (1));
+	ASSERT_FALSE (peers.empty ());
+	node2.rep_crawler.force_add_rep (nano::dev::genesis_key.pub, *peers.begin ());
+
 	ASSERT_TIMELY (5s, nano::test::confirmed (node2, { send }));
 	ASSERT_TIMELY_EQ (5s, node2.ledger.cemented_count (), 2);
 	ASSERT_TIMELY (5s, node2.active.empty ());
@@ -1694,4 +1697,128 @@ TEST (active_elections, transition_hinted_to_priority)
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::transition_priority));
 	ASSERT_EQ (0, node.active.size (nano::election_behavior::hinted));
 	ASSERT_EQ (1, node.active.size (nano::election_behavior::priority));
+}
+
+TEST (active_elections, cancel_cemented_races)
+{
+	nano::test::system system;
+	nano::node_config config = system.default_config ();
+
+	// Disable schedulers and backlog scan to have full control
+	config.backlog_scan.enable = false;
+	config.priority_scheduler.enable = false;
+	config.hinted_scheduler.enable = false;
+	config.optimistic_scheduler.enable = false;
+
+	auto & node = *system.add_node (config);
+
+	// Create many chains with many blocks
+	const int chain_count = 10;
+	const int blocks_per_chain = 20;
+	const auto duration = 2s;
+
+	auto const chains = nano::test::setup_chains (system, node, chain_count,
+	blocks_per_chain,
+	nano::dev::genesis_key,
+	false); // Don't auto-confirm
+
+	// Collect all blocks for random access
+	std::vector<std::shared_ptr<nano::block>> all_blocks;
+	for (auto & [account, blocks] : chains)
+	{
+		all_blocks.insert (all_blocks.end (), blocks.begin (), blocks.end ());
+	}
+
+	std::atomic<bool> stop_tasks{ false };
+
+	// Cement chain heads
+	auto cementing_task = std::async (std::launch::async, [&] () {
+		for (auto & [account, blocks] : chains)
+		{
+			// Cement using the cementing set so that notifications are properly handled
+			node.cementing_set.add (blocks.back ()->hash ());
+			std::this_thread::sleep_for (10ms);
+		}
+	});
+
+	// Insert elections continuously
+	auto insertion_task = std::async (std::launch::async, [&] () {
+		std::random_device rd;
+		std::mt19937 gen (rd ());
+		std::uniform_int_distribution<> dis (0, all_blocks.size () - 1);
+
+		while (!stop_tasks)
+		{
+			auto block = all_blocks[dis (gen)];
+			node.active.insert (block, nano::election_behavior::priority);
+			std::this_thread::yield ();
+		}
+	});
+
+	// Let tasks run for 2 seconds
+	WAIT (2s);
+
+	// Signal tasks to stop
+	stop_tasks = true;
+
+	// Wait for all async tasks to complete
+	cementing_task.wait ();
+	insertion_task.wait ();
+
+	// Wait for all cementing operations to complete
+	ASSERT_TIMELY (5s, node.cementing_set.size () == 0);
+
+	// Verify all blocks were cemented
+	auto transaction = node.ledger.tx_begin_read ();
+	for (auto & [account, blocks] : chains)
+	{
+		for (auto & block : blocks)
+		{
+			ASSERT_TRUE (node.ledger.confirmed.block_exists (transaction, block->hash ()));
+		}
+	}
+
+	// Critical assertion: No elections should remain active
+	ASSERT_TIMELY (5s, node.active.empty ());
+}
+
+TEST (active_elections, cancel_already_cemented)
+{
+	nano::test::system system;
+
+	nano::node_config config;
+	// Configure checkup interval for faster test execution
+	config.active_elections.checkup_interval = 100ms;
+
+	auto & node = *system.add_node (config);
+
+	// Create a chain of blocks
+	auto const chain_count = 1;
+	auto const blocks_per_chain = 5;
+	auto const chains = nano::test::setup_chains (system, node, chain_count, blocks_per_chain, nano::dev::genesis_key, false);
+
+	auto & [account, blocks] = *chains.begin ();
+	auto last_block = blocks.back ();
+
+	// First, cement the block through direct ledger confirmation process, skips callbacks
+	{
+		auto transaction = node.ledger.tx_begin_write ();
+		node.ledger.confirm (transaction, last_block->hash ());
+	}
+
+	// Verify the block is actually cemented
+	ASSERT_TRUE (node.ledger.confirmed.block_exists (node.ledger.tx_begin_read (), last_block->hash ()));
+
+	// Now start an election for the already cemented block
+	auto election = node.active.insert (last_block, nano::election_behavior::priority);
+	ASSERT_NE (nullptr, election.election);
+
+	// Wait for the cleanup thread to detect and cancel the election
+	// The cleanup thread runs every checkup_interval (100ms) and only cancels elections
+	// that have been running for at least 3 * aec_loop_interval (3 * 50ms = 150ms by default)
+	ASSERT_TIMELY (5s, node.active.empty ());
+
+	// Verify that the election was cancelled by the checkup thread
+	ASSERT_GT (node.stats.count (nano::stat::type::active_elections, nano::stat::detail::cancel_checkup), 0)
+	<< "Expected election to be cancelled by checkup thread";
 }

--- a/nano/core_test/cementing_set.cpp
+++ b/nano/core_test/cementing_set.cpp
@@ -180,7 +180,7 @@ TEST (confirmation_callback, confirmed_history)
 		// Confirm send1
 		election->force_confirm ();
 		ASSERT_TIMELY_EQ (10s, node->active.size (), 0);
-		ASSERT_EQ (0, node->active.recently_cemented.list ().size ());
+		ASSERT_EQ (0, node->active.recently_cemented.size ());
 		ASSERT_TRUE (node->active.empty ());
 
 		auto transaction = node->ledger.tx_begin_read ();
@@ -200,7 +200,7 @@ TEST (confirmation_callback, confirmed_history)
 	ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out), 1);
 
 	// Each block that's confirmed is in the recently_cemented history
-	ASSERT_EQ (2, node->active.recently_cemented.list ().size ());
+	ASSERT_EQ (2, node->active.recently_cemented.size ());
 	ASSERT_TRUE (node->active.empty ());
 
 	// Confirm the callback is not called under this circumstance

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1605,7 +1605,7 @@ TEST (node, block_confirm)
 	ASSERT_TIMELY (5s, election = node2.active.election (send1_copy->qualified_root ()));
 	// Make node2 genesis representative so it can vote
 	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
-	ASSERT_TIMELY_EQ (10s, node1.active.recently_cemented.list ().size (), 1);
+	ASSERT_TIMELY_EQ (10s, node1.active.recently_cemented.size (), 1);
 }
 
 TEST (node, confirm_quorum)

--- a/nano/core_test/recently_cache.cpp
+++ b/nano/core_test/recently_cache.cpp
@@ -1,0 +1,210 @@
+#include <nano/lib/blockbuilders.hpp>
+#include <nano/node/election_status.hpp>
+#include <nano/node/recently_cemented_cache.hpp>
+#include <nano/node/recently_confirmed_cache.hpp>
+#include <nano/test_common/random.hpp>
+#include <nano/test_common/system.hpp>
+#include <nano/test_common/testutil.hpp>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+std::shared_ptr<nano::block> make_test_block ()
+{
+	nano::block_builder builder;
+	return builder.state ()
+	.account (nano::dev::genesis_key.pub)
+	.previous (nano::test::random_hash ())
+	.representative (nano::dev::genesis_key.pub)
+	.balance (nano::dev::constants.genesis_amount - 1)
+	.link (nano::dev::genesis_key.pub)
+	.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+	.work (0)
+	.build ();
+}
+
+nano::election_status make_test_election_status ()
+{
+	auto block = make_test_block ();
+	nano::election_status status;
+	status.winner = block;
+	status.type = nano::election_status_type::active_confirmed_quorum;
+	status.election_end = std::chrono::system_clock::now ();
+	status.election_duration = std::chrono::milliseconds (100);
+	return status;
+}
+}
+
+/*
+ * recently_confirmed_cache
+ */
+
+TEST (recently_confirmed_cache, construction)
+{
+	nano::recently_confirmed_cache cache (10);
+	ASSERT_EQ (0, cache.size ());
+}
+
+TEST (recently_confirmed_cache, put)
+{
+	nano::recently_confirmed_cache cache (3);
+	std::vector<nano::qualified_root> roots;
+	std::vector<nano::block_hash> hashes;
+
+	// Add entries and test size limit
+	for (int i = 0; i < 5; ++i)
+	{
+		auto root = nano::test::random_qualified_root ();
+		auto hash = nano::test::random_hash ();
+		roots.push_back (root);
+		hashes.push_back (hash);
+		cache.put (root, hash);
+	}
+
+	ASSERT_EQ (3, cache.size ());
+
+	// Test duplicate filtering
+	cache.put (roots[4], hashes[4]);
+	ASSERT_EQ (3, cache.size ());
+
+	// First entries should have been evicted (LRU)
+	ASSERT_FALSE (cache.contains (roots[0]));
+	ASSERT_FALSE (cache.contains (roots[1]));
+
+	// Last entries should still be present
+	ASSERT_TRUE (cache.contains (roots[2]));
+	ASSERT_TRUE (cache.contains (roots[3]));
+	ASSERT_TRUE (cache.contains (roots[4]));
+}
+
+TEST (recently_confirmed_cache, erase)
+{
+	nano::recently_confirmed_cache cache (10);
+	auto root = nano::test::random_qualified_root ();
+	auto hash = nano::test::random_hash ();
+
+	cache.put (root, hash);
+	ASSERT_TRUE (cache.contains (hash));
+	ASSERT_EQ (1, cache.size ());
+
+	cache.erase (hash);
+	ASSERT_FALSE (cache.contains (hash));
+	ASSERT_FALSE (cache.contains (root));
+	ASSERT_EQ (0, cache.size ());
+}
+
+TEST (recently_confirmed_cache, clear)
+{
+	nano::recently_confirmed_cache cache (10);
+	for (int i = 0; i < 5; ++i)
+	{
+		auto root = nano::test::random_qualified_root ();
+		auto hash = nano::test::random_hash ();
+		cache.put (root, hash);
+	}
+
+	ASSERT_EQ (5, cache.size ());
+	cache.clear ();
+	ASSERT_EQ (0, cache.size ());
+}
+
+/*
+ * recently_cemented_cache
+ */
+
+TEST (recently_cemented_cache, construction)
+{
+	nano::recently_cemented_cache cache (10);
+	ASSERT_EQ (0, cache.size ());
+}
+
+TEST (recently_cemented_cache, put)
+{
+	nano::recently_cemented_cache cache (3);
+	std::vector<nano::election_status> statuses;
+
+	// Add entries and test size limit
+	for (int i = 0; i < 5; ++i)
+	{
+		auto status = make_test_election_status ();
+		statuses.push_back (status);
+		cache.put (status);
+	}
+
+	ASSERT_EQ (3, cache.size ());
+
+	// Test duplicate filtering
+	cache.put (statuses[4]);
+	ASSERT_EQ (3, cache.size ());
+
+	// First entries should have been evicted (LRU)
+	ASSERT_FALSE (cache.contains (statuses[0].winner->qualified_root ()));
+	ASSERT_FALSE (cache.contains (statuses[1].winner->qualified_root ()));
+
+	// Last entries should still be present
+	ASSERT_TRUE (cache.contains (statuses[2].winner->qualified_root ()));
+	ASSERT_TRUE (cache.contains (statuses[3].winner->qualified_root ()));
+	ASSERT_TRUE (cache.contains (statuses[4].winner->qualified_root ()));
+}
+
+TEST (recently_cemented_cache, erase)
+{
+	nano::recently_cemented_cache cache (10);
+	auto status = make_test_election_status ();
+
+	cache.put (status);
+	ASSERT_TRUE (cache.contains (status.winner->hash ()));
+	ASSERT_EQ (1, cache.size ());
+
+	cache.erase (status.winner->hash ());
+	ASSERT_FALSE (cache.contains (status.winner->hash ()));
+	ASSERT_FALSE (cache.contains (status.winner->qualified_root ()));
+	ASSERT_EQ (0, cache.size ());
+}
+
+TEST (recently_cemented_cache, clear)
+{
+	nano::recently_cemented_cache cache (10);
+	for (int i = 0; i < 5; ++i)
+	{
+		auto status = make_test_election_status ();
+		cache.put (status);
+	}
+
+	ASSERT_EQ (5, cache.size ());
+	cache.clear ();
+	ASSERT_EQ (0, cache.size ());
+}
+
+TEST (recently_cemented_cache, list)
+{
+	nano::recently_cemented_cache cache (10);
+
+	// Test empty list
+	auto list = cache.list ();
+	ASSERT_TRUE (list.empty ());
+
+	// Add entries and test list functionality
+	std::vector<nano::election_status> statuses;
+	for (int i = 0; i < 5; ++i)
+	{
+		auto status = make_test_election_status ();
+		statuses.push_back (status);
+		cache.put (status);
+	}
+
+	// Test full list
+	list = cache.list ();
+	ASSERT_EQ (5, list.size ());
+
+	// List should be in reverse order (most recent first)
+	for (size_t i = 0; i < list.size (); ++i)
+	{
+		ASSERT_EQ (statuses[4 - i].winner->hash (), list[i].winner->hash ());
+	}
+
+	// Test list with limit
+	auto limited_list = cache.list (3);
+	ASSERT_EQ (3, limited_list.size ());
+}

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -519,6 +519,7 @@ enum class detail
 	cancel_dependent,
 	cancel_checkup,
 	forks_cached,
+	stale,
 	bootstrap_stale,
 
 	// unchecked

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -144,6 +144,7 @@ enum class detail
 	total,
 	loop,
 	loop_cleanup,
+	loop_checkup,
 	process,
 	processed,
 	ignored,
@@ -516,6 +517,7 @@ enum class detail
 	stopped,
 	confirm_dependent,
 	cancel_dependent,
+	cancel_checkup,
 	forks_cached,
 	bootstrap_stale,
 

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -49,6 +49,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::aec_loop:
 			thread_role_name_string = "AEC";
 			break;
+		case nano::thread_role::name::aec_checkup:
+			thread_role_name_string = "AEC checkup";
+			break;
 		case nano::thread_role::name::aec_notifications:
 			thread_role_name_string = "AEC notif";
 			break;

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -21,6 +21,7 @@ enum class name
 	block_processing,
 	ledger_notifications,
 	aec_loop,
+	aec_checkup,
 	aec_notifications,
 	wallet_actions,
 	bootstrap_initiator,

--- a/nano/lib/timer.hpp
+++ b/nano/lib/timer.hpp
@@ -100,29 +100,29 @@ private:
 
 using millis_t = uint64_t;
 
-inline millis_t milliseconds_since_epoch ()
+inline millis_t milliseconds_since_epoch (std::chrono::system_clock::time_point tp = std::chrono::system_clock::now ())
 {
-	return std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()).count ();
+	return std::chrono::duration_cast<std::chrono::milliseconds> (tp.time_since_epoch ()).count ();
 }
 
-inline std::chrono::time_point<std::chrono::system_clock> from_milliseconds_since_epoch (nano::millis_t millis)
+inline std::chrono::system_clock::time_point from_milliseconds_since_epoch (nano::millis_t millis)
 {
-	return std::chrono::time_point<std::chrono::system_clock> (std::chrono::milliseconds{ millis });
+	return std::chrono::system_clock::time_point (std::chrono::milliseconds{ millis });
 }
 
 using seconds_t = uint64_t;
 
-inline seconds_t seconds_since_epoch ()
+inline seconds_t seconds_since_epoch (std::chrono::system_clock::time_point tp = std::chrono::system_clock::now ())
 {
-	return std::chrono::duration_cast<std::chrono::seconds> (std::chrono::system_clock::now ().time_since_epoch ()).count ();
+	return std::chrono::duration_cast<std::chrono::seconds> (tp.time_since_epoch ()).count ();
 }
 
-inline std::chrono::time_point<std::chrono::system_clock> from_seconds_since_epoch (nano::seconds_t seconds)
+inline std::chrono::system_clock::time_point from_seconds_since_epoch (nano::seconds_t seconds)
 {
-	return std::chrono::time_point<std::chrono::system_clock> (std::chrono::seconds{ seconds });
+	return std::chrono::system_clock::time_point (std::chrono::seconds{ seconds });
 }
 
-inline nano::millis_t time_difference (nano::millis_t start, nano::millis_t end)
+inline millis_t time_difference (millis_t start, millis_t end)
 {
 	return end > start ? (end - start) : 0;
 }

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -4,7 +4,6 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/node/active_elections.hpp>
-#include <nano/node/bootstrap/bootstrap_service.hpp>
 #include <nano/node/cementing_set.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
@@ -507,9 +506,6 @@ void nano::active_elections::tick_elections (nano::unique_lock<nano::mutex> & lo
 	nano::confirmation_solicitor solicitor (node.network, node.config);
 	solicitor.prepare (node.rep_crawler.principal_representatives (std::numeric_limits<std::size_t>::max ()));
 
-	nano::timer<std::chrono::milliseconds> elapsed (nano::timer_state::started);
-
-	std::deque<std::shared_ptr<nano::election>> stale_elections;
 	for (auto const & election : election_list)
 	{
 		bool tick_result = election->tick (solicitor);
@@ -517,33 +513,9 @@ void nano::active_elections::tick_elections (nano::unique_lock<nano::mutex> & lo
 		{
 			erase (election->qualified_root);
 		}
-		else if (election->duration () > config.stale_threshold)
-		{
-			stale_elections.push_back (election);
-		}
 	}
 
 	solicitor.flush ();
-
-	if (stale_interval.elapse (config.stale_threshold / 2))
-	{
-		node.stats.add (nano::stat::type::active_elections, nano::stat::detail::bootstrap_stale, stale_elections.size ());
-
-		for (auto const & election : stale_elections)
-		{
-			node.logger.debug (nano::log::type::active_elections, "Bootstrapping account: {} with stale election with root: {}, blocks: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms)",
-			election->account,
-			election->qualified_root,
-			fmt::join (election->blocks_hashes (), ", "), // TODO: Lazy eval
-			to_string (election->behavior ()),
-			to_string (election->state ()),
-			election->voter_count (),
-			election->block_count (),
-			election->duration ().count ());
-
-			node.bootstrap.prioritize (election->account);
-		}
-	}
 }
 
 bool nano::active_elections::predicate () const
@@ -601,6 +573,8 @@ void nano::active_elections::checkup_elections (nano::unique_lock<nano::mutex> &
 	auto const now = std::chrono::steady_clock::now ();
 	auto const min_duration = node.network_params.network.aec_loop_interval * 3;
 
+	std::deque<std::shared_ptr<nano::election>> stale_elections;
+
 	for (auto const & election : all_elections)
 	{
 		// Only cancel elections if they have been running for a minimum duration of time
@@ -620,6 +594,33 @@ void nano::active_elections::checkup_elections (nano::unique_lock<nano::mutex> &
 				election->block_count (),
 				election->duration ().count ());
 			}
+		}
+		else if (election->duration () > config.stale_threshold)
+		{
+			stale_elections.push_back (election);
+		}
+	}
+
+	node.logger.debug (nano::log::type::active_elections, "Checkup found {} stale elections", stale_elections.size ());
+
+	// Notify about stale elections at most once per half stale threshold, avoid too frequent notifications
+	if (stale_interval.elapse (config.stale_threshold / 2))
+	{
+		node.stats.add (nano::stat::type::active_elections, nano::stat::detail::stale, stale_elections.size ());
+
+		for (auto const & election : stale_elections)
+		{
+			node.logger.debug (nano::log::type::active_elections, "Stale election for account: {} with root: {} blocks: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms)",
+			election->account,
+			election->qualified_root,
+			fmt::join (election->blocks_hashes (), ", "), // TODO: Lazy eval
+			to_string (election->behavior ()),
+			to_string (election->state ()),
+			election->voter_count (),
+			election->block_count (),
+			election->duration ().count ());
+
+			election_stale.notify (election);
 		}
 	}
 }

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -17,6 +17,7 @@
 #include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
+#include <nano/secure/ledger_set_confirmed.hpp>
 #include <nano/store/component.hpp>
 
 #include <ranges>
@@ -116,6 +117,11 @@ void nano::active_elections::start ()
 		nano::thread_role::set (nano::thread_role::name::aec_loop);
 		run ();
 	});
+
+	checkup_thread = std::thread ([this] () {
+		nano::thread_role::set (nano::thread_role::name::aec_checkup);
+		run_checkup ();
+	});
 }
 
 void nano::active_elections::stop ()
@@ -125,10 +131,8 @@ void nano::active_elections::stop ()
 		stopped = true;
 	}
 	condition.notify_all ();
-	if (thread.joinable ())
-	{
-		thread.join ();
-	}
+	join_or_pass (thread);
+	join_or_pass (checkup_thread);
 	workers.stop ();
 
 	clear ();
@@ -421,6 +425,11 @@ auto nano::active_elections::block_cemented (std::shared_ptr<nano::block> const 
 	node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::cemented);
 	node.stats.inc (nano::stat::type::active_elections_cemented, to_stat_detail (status.type));
 
+	node.logger.debug (nano::log::type::active_elections, "Cemented root: {} with block: {} (status: {})",
+	block->qualified_root (),
+	block->hash (),
+	to_string (status.type));
+
 	node.logger.trace (nano::log::type::active_elections, nano::log::detail::active_cemented,
 	nano::log::arg{ "block", block },
 	nano::log::arg{ "confirmation_root", confirmation_root },
@@ -508,7 +517,7 @@ void nano::active_elections::tick_elections (nano::unique_lock<nano::mutex> & lo
 		{
 			erase (election->qualified_root);
 		}
-		else if (election->duration () > config.bootstrap_stale_threshold)
+		else if (election->duration () > config.stale_threshold)
 		{
 			stale_elections.push_back (election);
 		}
@@ -516,7 +525,7 @@ void nano::active_elections::tick_elections (nano::unique_lock<nano::mutex> & lo
 
 	solicitor.flush ();
 
-	if (bootstrap_stale_interval.elapse (config.bootstrap_stale_threshold / 2))
+	if (stale_interval.elapse (config.stale_threshold / 2))
 	{
 		node.stats.add (nano::stat::type::active_elections, nano::stat::detail::bootstrap_stale, stale_elections.size ());
 
@@ -563,6 +572,80 @@ void nano::active_elections::run ()
 			condition.wait_for (lock, node.network_params.network.aec_loop_interval / 2, [this] {
 				return stopped || predicate ();
 			});
+		}
+	}
+}
+
+void nano::active_elections::checkup_elections (nano::unique_lock<nano::mutex> & lock)
+{
+	auto all_elections = index.list ();
+
+	lock.unlock ();
+
+	auto transaction = node.ledger.tx_begin_read ();
+
+	auto should_cancel = [&] (std::shared_ptr<nano::election> const & election) {
+		auto const target = node.ledger.any.block_successor (transaction, election->qualified_root);
+		if (target)
+		{
+			// Cancel if the election's block is already cemented
+			return node.ledger.confirmed.block_exists (transaction, *target);
+		}
+		else
+		{
+			// No successor means the block is not in the ledger, rather unexpected
+			return true; // Cancel the election
+		}
+	};
+
+	auto const now = std::chrono::steady_clock::now ();
+	auto const min_duration = node.network_params.network.aec_loop_interval * 3;
+
+	for (auto const & election : all_elections)
+	{
+		// Only cancel elections if they have been running for a minimum duration of time
+		// Usually the normal cemented callback will handle the cleanup
+		if ((now - election->get_state_start ()) > min_duration && should_cancel (election))
+		{
+			bool cancelled = election->cancel ();
+			if (cancelled)
+			{
+				node.stats.inc (nano::stat::type::active_elections, nano::stat::detail::cancel_checkup);
+				node.logger.debug (nano::log::type::active_elections, "Checkup cancelled election for root: {} with blocks: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms)",
+				election->qualified_root,
+				fmt::join (election->blocks_hashes (), ", "), // TODO: Lazy eval
+				to_string (election->behavior ()),
+				to_string (election->state ()),
+				election->voter_count (),
+				election->block_count (),
+				election->duration ().count ());
+			}
+		}
+	}
+}
+
+void nano::active_elections::run_checkup ()
+{
+	nano::unique_lock<nano::mutex> lock{ mutex };
+	while (!stopped)
+	{
+		// Ignore predicate in condition, this loop should be woken up periodically
+		condition.wait_for (lock, config.checkup_interval, [this] {
+			return stopped;
+		});
+
+		if (stopped)
+		{
+			return;
+		}
+
+		if (!index.empty ())
+		{
+			node.stats.inc (nano::stat::type::active, nano::stat::detail::loop_checkup);
+
+			checkup_elections (lock);
+			debug_assert (!lock.owns_lock ());
+			lock.lock ();
 		}
 	}
 }
@@ -637,7 +720,7 @@ std::vector<std::shared_ptr<nano::election>> nano::active_elections::list_active
 		{
 			break;
 		}
-		result_l.push_back (entry.election);
+		result_l.push_back (entry);
 	}
 	return result_l;
 }
@@ -734,7 +817,7 @@ nano::error nano::active_elections_config::serialize (nano::tomlconfig & toml) c
 	toml.put ("confirmation_history_size", confirmation_history_size, "Maximum confirmation history size. If tracking the rate of block confirmations, the websocket feature is recommended instead. \ntype:uint64");
 	toml.put ("confirmation_cache", confirmation_cache, "Maximum number of confirmed elections kept in cache to prevent restarting an election. \ntype:uint64");
 	toml.put ("max_election_winners", max_election_winners, "Maximum size of election winner details set. \ntype:uint64");
-	toml.put ("bootstrap_stale_threshold", bootstrap_stale_threshold.count (), "Time after which additional bootstrap attempts are made to find missing blocks for an election. \ntype:seconds");
+	toml.put ("stale_threshold", stale_threshold.count (), "Time after which additional bootstrap attempts are made to find missing blocks for an election. \ntype:seconds");
 	return toml.get_error ();
 }
 
@@ -746,7 +829,7 @@ nano::error nano::active_elections_config::deserialize (nano::tomlconfig & toml)
 	toml.get ("confirmation_history_size", confirmation_history_size);
 	toml.get ("confirmation_cache", confirmation_cache);
 	toml.get ("max_election_winners", max_election_winners);
-	toml.get_duration ("bootstrap_stale_threshold", bootstrap_stale_threshold);
+	toml.get_duration ("stale_threshold", stale_threshold);
 
 	return toml.get_error ();
 }
@@ -776,6 +859,11 @@ nano::stat::type nano::to_stat_type (nano::election_state state)
 	}
 	debug_assert (false);
 	return {};
+}
+
+std::string_view nano::to_string (nano::election_status_type type)
+{
+	return nano::enum_util::name (type);
 }
 
 nano::stat::detail nano::to_stat_detail (nano::election_status_type type)

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -30,7 +30,7 @@ nano::active_elections::active_elections (nano::node & node_a, nano::ledger_noti
 	ledger_notifications{ ledger_notifications_a },
 	cementing_set{ cementing_set_a },
 	recently_confirmed{ config.confirmation_cache },
-	recently_cemented{ config.confirmation_history_size },
+	recently_cemented{ config.confirmation_cache },
 	workers{ 1, nano::thread_role::name::aec_notifications }
 {
 	// Cementing blocks might implicitly confirm dependent elections
@@ -157,7 +157,7 @@ auto nano::active_elections::insert (std::shared_ptr<nano::block> const & block,
 
 	if (!index.exists (root))
 	{
-		if (!recently_confirmed.exists (root))
+		if (!recently_confirmed.contains (root) && !recently_cemented.contains (root))
 		{
 			result.inserted = true;
 
@@ -307,7 +307,7 @@ void nano::active_elections::erase_election (nano::unique_lock<nano::mutex> & lo
 {
 	debug_assert (!mutex.try_lock ());
 	debug_assert (lock.owns_lock ());
-	debug_assert (!election->confirmed () || recently_confirmed.exists (election->qualified_root));
+	debug_assert (!election->confirmed () || recently_confirmed.contains (election->qualified_root));
 
 	auto blocks_l = election->blocks ();
 	node.vote_router.disconnect (*election);
@@ -814,7 +814,6 @@ nano::error nano::active_elections_config::serialize (nano::tomlconfig & toml) c
 	toml.put ("size", size, "Number of active elections. Elections beyond this limit have limited survival time.\nWarning: modifying this value may result in a lower confirmation rate. \ntype:uint64,[250..]");
 	toml.put ("hinted_limit_percentage", hinted_limit_percentage, "Limit of hinted elections as percentage of `active_elections_size` \ntype:uint64");
 	toml.put ("optimistic_limit_percentage", optimistic_limit_percentage, "Limit of optimistic elections as percentage of `active_elections_size`. \ntype:uint64");
-	toml.put ("confirmation_history_size", confirmation_history_size, "Maximum confirmation history size. If tracking the rate of block confirmations, the websocket feature is recommended instead. \ntype:uint64");
 	toml.put ("confirmation_cache", confirmation_cache, "Maximum number of confirmed elections kept in cache to prevent restarting an election. \ntype:uint64");
 	toml.put ("max_election_winners", max_election_winners, "Maximum size of election winner details set. \ntype:uint64");
 	toml.put ("stale_threshold", stale_threshold.count (), "Time after which additional bootstrap attempts are made to find missing blocks for an election. \ntype:seconds");
@@ -826,7 +825,6 @@ nano::error nano::active_elections_config::deserialize (nano::tomlconfig & toml)
 	toml.get ("size", size);
 	toml.get ("hinted_limit_percentage", hinted_limit_percentage);
 	toml.get ("optimistic_limit_percentage", optimistic_limit_percentage);
-	toml.get ("confirmation_history_size", confirmation_history_size);
 	toml.get ("confirmation_cache", confirmation_cache);
 	toml.get ("max_election_winners", max_election_winners);
 	toml.get_duration ("stale_threshold", stale_threshold);

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -37,10 +37,8 @@ public:
 	std::size_t hinted_limit_percentage{ 20 };
 	// Limit of optimistic elections as percentage of `active_elections_size`
 	std::size_t optimistic_limit_percentage{ 10 };
-	// Maximum confirmation history size
-	std::size_t confirmation_history_size{ 2048 };
 	// Maximum cache size for recently_confirmed
-	std::size_t confirmation_cache{ 65536 };
+	std::size_t confirmation_cache{ 1024 * 64 };
 	// Maximum size of election winner details set
 	std::size_t max_election_winners{ 1024 * 16 };
 

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -44,7 +44,8 @@ public:
 	// Maximum size of election winner details set
 	std::size_t max_election_winners{ 1024 * 16 };
 
-	std::chrono::seconds bootstrap_stale_threshold{ 60s };
+	std::chrono::milliseconds checkup_interval{ 1s };
+	std::chrono::seconds stale_threshold{ nano::is_dev_run () ? 1s : 60s };
 };
 
 /**
@@ -116,7 +117,9 @@ public: // Events
 private:
 	bool predicate () const;
 	void run ();
+	void run_checkup ();
 	void tick_elections (nano::unique_lock<nano::mutex> &);
+	void checkup_elections (nano::unique_lock<nano::mutex> &);
 
 	// Erase all blocks from active and, if not confirmed, clear digests from network filters
 	void erase_election (nano::unique_lock<nano::mutex> & lock_a, std::shared_ptr<nano::election>);
@@ -156,10 +159,11 @@ private:
 	nano::condition_variable condition;
 	bool stopped{ false };
 	std::thread thread;
+	std::thread checkup_thread;
 
 	nano::thread_pool workers;
 
-	nano::interval bootstrap_stale_interval;
+	nano::interval stale_interval;
 	nano::interval warning_interval;
 
 public: // Tests

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -111,6 +111,7 @@ public:
 
 public: // Events
 	nano::observer_set<> vacancy_updated;
+	nano::observer_set<std::shared_ptr<nano::election>> election_stale;
 
 private:
 	bool predicate () const;

--- a/nano/node/active_elections_index.cpp
+++ b/nano/node/active_elections_index.cpp
@@ -93,10 +93,15 @@ auto nano::active_elections_index::info (std::shared_ptr<nano::election> const &
 	return std::nullopt;
 }
 
-auto nano::active_elections_index::list () const -> std::deque<entry>
+auto nano::active_elections_index::list () const -> std::deque<std::shared_ptr<nano::election>>
 {
-	auto r = entries.get<tag_sequenced> () | std::views::transform ([] (auto const & entry) { return entry; });
+	auto r = entries.get<tag_sequenced> () | std::views::transform ([] (auto const & entry) { return entry.election; });
 	return { r.begin (), r.end () };
+}
+
+bool nano::active_elections_index::empty () const
+{
+	return entries.empty ();
 }
 
 size_t nano::active_elections_index::size () const

--- a/nano/node/active_elections_index.hpp
+++ b/nano/node/active_elections_index.hpp
@@ -55,12 +55,13 @@ public:
 	size_t size () const;
 	size_t size (nano::election_behavior) const;
 	size_t size (nano::election_behavior, nano::bucket_index) const;
+	bool empty () const;
 
 	// Returns election with the highest priority value. NOTE: Lower "priority" is better
 	using priority_result = std::pair<std::shared_ptr<nano::election>, nano::priority_timestamp>;
 	priority_result last (nano::election_behavior, nano::bucket_index) const;
 
-	std::deque<entry> list () const;
+	std::deque<std::shared_ptr<nano::election>> list () const;
 
 	// Return list of elections with a timestamp before the specified cutoff time
 	std::deque<std::shared_ptr<nano::election>> list (

--- a/nano/node/bounded_backlog.cpp
+++ b/nano/node/bounded_backlog.cpp
@@ -274,7 +274,7 @@ bool nano::bounded_backlog::should_rollback (nano::block_hash const & hash) cons
 	{
 		return false;
 	}
-	if (node.active.recently_confirmed.exists (hash))
+	if (node.active.recently_confirmed.contains (hash))
 	{
 		return false;
 	}

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -50,7 +50,7 @@ void nano::election::confirm_once (nano::unique_lock<nano::mutex> & lock)
 
 	if (just_confirmed)
 	{
-		status.election_end = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ());
+		status.election_end = std::chrono::system_clock::now (); // Timestamp as system time
 		status.election_duration = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - election_start);
 		status.confirmation_request_count = confirmation_request_count;
 		status.block_count = nano::narrow_cast<decltype (status.block_count)> (last_blocks.size ());

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -46,6 +46,7 @@ void nano::election::confirm_once (nano::unique_lock<nano::mutex> & lock)
 
 	bool just_confirmed = state_m != nano::election_state::confirmed;
 	state_m = nano::election_state::confirmed;
+	state_start = std::chrono::steady_clock::now ();
 
 	if (just_confirmed)
 	{
@@ -153,7 +154,7 @@ bool nano::election::state_change (nano::election_state expected_a, nano::electi
 		if (state_m == expected_a)
 		{
 			state_m = desired_a;
-			state_start = std::chrono::steady_clock::now ().time_since_epoch ();
+			state_start = std::chrono::steady_clock::now ();
 			result = false;
 
 			if (update_action)
@@ -335,7 +336,7 @@ bool nano::election::tick (nano::confirmation_solicitor & solicitor)
 	switch (state_m)
 	{
 		case nano::election_state::passive:
-			if (base_latency () * passive_duration_factor < std::chrono::steady_clock::now ().time_since_epoch () - state_start)
+			if (base_latency () * passive_duration_factor < std::chrono::steady_clock::now () - state_start)
 			{
 				state_change (nano::election_state::passive, nano::election_state::active);
 			}

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -77,7 +77,7 @@ private: // State management
 	static unsigned constexpr active_request_count_min = 2;
 	nano::election_state state_m{ election_state::passive };
 
-	std::chrono::steady_clock::duration state_start{ std::chrono::steady_clock::now ().time_since_epoch () };
+	std::chrono::steady_clock::time_point state_start{ std::chrono::steady_clock::now () };
 
 	// These are modified while not holding the mutex from transition_time only
 	std::chrono::steady_clock::time_point last_block{};
@@ -103,6 +103,7 @@ public: // Status
 	nano::election_extended_status current_status () const;
 	std::shared_ptr<nano::block> winner () const;
 	std::chrono::milliseconds duration () const;
+
 	std::atomic<unsigned> confirmation_request_count{ 0 };
 	std::atomic<unsigned> vote_broadcast_count{ 0 };
 
@@ -140,9 +141,15 @@ public: // Interface
 	nano::vote_info get_last_vote (nano::account const & account);
 	void set_last_vote (nano::account const & account, nano::vote_info vote_info);
 	nano::election_status get_status () const;
+
 	std::chrono::steady_clock::time_point get_election_start () const
 	{
 		return election_start;
+	}
+	std::chrono::steady_clock::time_point get_state_start () const
+	{
+		nano::lock_guard<nano::mutex> guard{ mutex };
+		return state_start;
 	}
 
 private: // Dependencies

--- a/nano/node/election_status.hpp
+++ b/nano/node/election_status.hpp
@@ -23,6 +23,7 @@ enum class election_status_type : uint8_t
 	stopped = 5
 };
 
+std::string_view to_string (election_status_type);
 nano::stat::detail to_stat_detail (election_status_type);
 
 /* Holds a summary of an election */

--- a/nano/node/election_status.hpp
+++ b/nano/node/election_status.hpp
@@ -33,8 +33,8 @@ public:
 	std::shared_ptr<nano::block> winner;
 	nano::amount tally{ 0 };
 	nano::amount final_tally{ 0 };
-	std::chrono::milliseconds election_end{ std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::system_clock::now ().time_since_epoch ()) };
-	std::chrono::milliseconds election_duration{ std::chrono::duration_values<std::chrono::milliseconds>::zero () };
+	std::chrono::system_clock::time_point election_end{};
+	std::chrono::milliseconds election_duration{};
 	unsigned confirmation_request_count{ 0 };
 	unsigned vote_broadcast_count{ 0 };
 	unsigned block_count{ 0 };

--- a/nano/node/ipc/ipc_broker.cpp
+++ b/nano/node/ipc/ipc_broker.cpp
@@ -54,7 +54,7 @@ void nano::ipc::broker::start ()
 				confirmation->block = nano::ipc::flatbuffers_builder::block_to_union (*status_a.winner, amount_a, is_state_send_a, is_state_epoch_a);
 				confirmation->election_info = std::make_unique<nanoapi::ElectionInfoT> ();
 				confirmation->election_info->duration = status_a.election_duration.count ();
-				confirmation->election_info->time = status_a.election_end.count ();
+				confirmation->election_info->time = milliseconds_since_epoch (status_a.election_end);
 				confirmation->election_info->tally = status_a.tally.to_string_dec ();
 				confirmation->election_info->block_count = status_a.block_count;
 				confirmation->election_info->voter_count = status_a.voter_count;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2062,7 +2062,9 @@ void nano::json_handler::confirmation_history ()
 	}
 	if (!ec)
 	{
-		for (auto const & status : node.active.recently_cemented.list ())
+		// TODO: Allow passing a count parameter to limit the number of results
+		// Default to 2000 for now since it was the previous limit
+		for (auto const & status : node.active.recently_cemented.list (2000))
 		{
 			if (hash.is_zero () || status.winner->hash () == hash)
 			{
@@ -4919,7 +4921,7 @@ void nano::json_handler::wallet_representative_set ()
 				for (auto & account : accounts)
 				{
 					wallet->change_async (
-					account, representative, [] (std::shared_ptr<nano::block> const &) {}, 0, false);
+					account, representative, [] (std::shared_ptr<nano::block> const &) { }, 0, false);
 				}
 			}
 		}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2071,7 +2071,7 @@ void nano::json_handler::confirmation_history ()
 				boost::property_tree::ptree election;
 				election.put ("hash", status.winner->hash ().to_string ());
 				election.put ("duration", status.election_duration.count ());
-				election.put ("time", status.election_end.count ());
+				election.put ("time", milliseconds_since_epoch (status.election_end));
 				election.put ("tally", status.tally.to_string_dec ());
 				election.add ("final", status.final_tally.to_string_dec ());
 				election.put ("blocks", std::to_string (status.block_count));
@@ -4921,7 +4921,7 @@ void nano::json_handler::wallet_representative_set ()
 				for (auto & account : accounts)
 				{
 					wallet->change_async (
-					account, representative, [] (std::shared_ptr<nano::block> const &) { }, 0, false);
+					account, representative, [] (std::shared_ptr<nano::block> const &) {}, 0, false);
 				}
 			}
 		}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -18,6 +18,7 @@
 #include <nano/node/bucketing.hpp>
 #include <nano/node/cementing_set.hpp>
 #include <nano/node/daemonconfig.hpp>
+#include <nano/node/election.hpp>
 #include <nano/node/election_status.hpp>
 #include <nano/node/endpoint.hpp>
 #include <nano/node/fork_cache.hpp>
@@ -216,6 +217,11 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	vote_cache.rep_weight_query = [this] (nano::account const & rep) {
 		return ledger.weight (rep);
 	};
+
+	// Prioritize bootstrapping accounts with stale elections to find alternative forks
+	active.election_stale.add ([this] (auto const & election) {
+		bootstrap.prioritize (election->account);
+	});
 
 	// TODO: Hook this direclty in the schedulers
 	backlog_scan.batch_activated.add ([this] (auto const & batch) {

--- a/nano/node/recently_cemented_cache.cpp
+++ b/nano/node/recently_cemented_cache.cpp
@@ -1,9 +1,8 @@
+#include <nano/lib/blocks.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/recently_cemented_cache.hpp>
 
-/*
- * class recently_cemented
- */
+#include <ranges>
 
 nano::recently_cemented_cache::recently_cemented_cache (std::size_t max_size_a) :
 	max_size{ max_size_a }
@@ -13,23 +12,53 @@ nano::recently_cemented_cache::recently_cemented_cache (std::size_t max_size_a) 
 void nano::recently_cemented_cache::put (const nano::election_status & status)
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	cemented.push_back (status);
-	if (cemented.size () > max_size)
+	entries.emplace_back (entry{ status.winner->qualified_root (), status.winner->hash (), status });
+	if (entries.size () > max_size)
 	{
-		cemented.pop_front ();
+		entries.pop_front (); // Remove oldest
 	}
 }
 
-nano::recently_cemented_cache::queue_t nano::recently_cemented_cache::list () const
+void nano::recently_cemented_cache::erase (const nano::block_hash & hash)
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	return cemented;
+	entries.get<tag_hash> ().erase (hash);
+}
+
+void nano::recently_cemented_cache::clear ()
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	entries.clear ();
+}
+
+auto nano::recently_cemented_cache::list (size_t max_count) const -> std::deque<nano::election_status>
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	std::deque<nano::election_status> result;
+	auto it = entries.rbegin ();
+	for (size_t i = 0; i < max_count && it != entries.rend (); ++i, ++it)
+	{
+		result.push_back (it->status);
+	}
+	return result;
 }
 
 std::size_t nano::recently_cemented_cache::size () const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	return cemented.size ();
+	return entries.size ();
+}
+
+bool nano::recently_cemented_cache::contains (const nano::qualified_root & root) const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return entries.get<tag_root> ().contains (root);
+}
+
+bool nano::recently_cemented_cache::contains (const nano::block_hash & hash) const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return entries.get<tag_hash> ().contains (hash);
 }
 
 nano::container_info nano::recently_cemented_cache::container_info () const
@@ -37,6 +66,6 @@ nano::container_info nano::recently_cemented_cache::container_info () const
 	nano::lock_guard<nano::mutex> guard{ mutex };
 
 	nano::container_info info;
-	info.put ("cemented", cemented);
+	info.put ("entries", entries);
 	return info;
 }

--- a/nano/node/recently_cemented_cache.hpp
+++ b/nano/node/recently_cemented_cache.hpp
@@ -1,14 +1,20 @@
 #pragma once
 
 #include <nano/lib/locks.hpp>
+#include <nano/lib/numbers.hpp>
+#include <nano/lib/numbers_templ.hpp>
 #include <nano/node/election_status.hpp>
+#include <nano/secure/common.hpp>
+
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/random_access_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index_container.hpp>
 
 #include <deque>
 
-namespace nano
-{
-class container_info_component;
-}
+namespace mi = boost::multi_index;
 
 namespace nano
 {
@@ -18,18 +24,44 @@ namespace nano
 class recently_cemented_cache final
 {
 public:
-	using queue_t = std::deque<nano::election_status>;
-
-	explicit recently_cemented_cache (std::size_t max_size);
+	explicit recently_cemented_cache (size_t max_size);
 
 	void put (nano::election_status const &);
-	queue_t list () const;
+	void erase (nano::block_hash const &);
+	void clear ();
 	std::size_t size () const;
+
+	// Returns up to max_count most recent entries
+	std::deque<nano::election_status> list (size_t max_count = std::numeric_limits<size_t>::max ()) const;
+
+	bool contains (nano::qualified_root const &) const;
+	bool contains (nano::block_hash const &) const;
 
 	nano::container_info container_info () const;
 
 private:
-	queue_t cemented;
+	struct entry
+	{
+		nano::qualified_root root;
+		nano::block_hash hash;
+		nano::election_status status;
+	};
+
+	// clang-format off
+	class tag_hash {};
+	class tag_root {};
+	class tag_sequenced {};
+
+	using ordered_entries = boost::multi_index_container<entry,
+	mi::indexed_by<
+		mi::sequenced<mi::tag<tag_sequenced>>,
+		mi::hashed_unique<mi::tag<tag_root>,
+			mi::member<entry, nano::qualified_root, &entry::root>>,
+		mi::hashed_unique<mi::tag<tag_hash>,
+			mi::member<entry, nano::block_hash, &entry::hash>>>>;
+	// clang-format on
+	ordered_entries entries;
+
 	std::size_t const max_size;
 
 	mutable nano::mutex mutex;

--- a/nano/node/recently_confirmed_cache.cpp
+++ b/nano/node/recently_confirmed_cache.cpp
@@ -1,10 +1,6 @@
 #include <nano/lib/utility.hpp>
 #include <nano/node/recently_confirmed_cache.hpp>
 
-/*
- * class recently_confirmed
- */
-
 nano::recently_confirmed_cache::recently_confirmed_cache (std::size_t max_size_a) :
 	max_size{ max_size_a }
 {
@@ -13,47 +9,47 @@ nano::recently_confirmed_cache::recently_confirmed_cache (std::size_t max_size_a
 void nano::recently_confirmed_cache::put (const nano::qualified_root & root, const nano::block_hash & hash)
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	confirmed.get<tag_sequence> ().emplace_back (root, hash);
-	if (confirmed.size () > max_size)
+	entries.emplace_back (root, hash);
+	if (entries.size () > max_size)
 	{
-		confirmed.get<tag_sequence> ().pop_front ();
+		entries.pop_front ();
 	}
 }
 
 void nano::recently_confirmed_cache::erase (const nano::block_hash & hash)
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	confirmed.get<tag_hash> ().erase (hash);
+	entries.get<tag_hash> ().erase (hash);
 }
 
 void nano::recently_confirmed_cache::clear ()
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	confirmed.clear ();
+	entries.clear ();
 }
 
-bool nano::recently_confirmed_cache::exists (const nano::block_hash & hash) const
+bool nano::recently_confirmed_cache::contains (const nano::block_hash & hash) const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	return confirmed.get<tag_hash> ().find (hash) != confirmed.get<tag_hash> ().end ();
+	return entries.get<tag_hash> ().contains (hash);
 }
 
-bool nano::recently_confirmed_cache::exists (const nano::qualified_root & root) const
+bool nano::recently_confirmed_cache::contains (const nano::qualified_root & root) const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	return confirmed.get<tag_root> ().find (root) != confirmed.get<tag_root> ().end ();
+	return entries.get<tag_root> ().contains (root);
 }
 
 std::size_t nano::recently_confirmed_cache::size () const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	return confirmed.size ();
+	return entries.size ();
 }
 
 nano::recently_confirmed_cache::entry_t nano::recently_confirmed_cache::back () const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	return confirmed.back ();
+	return entries.back ();
 }
 
 nano::container_info nano::recently_confirmed_cache::container_info () const
@@ -61,6 +57,6 @@ nano::container_info nano::recently_confirmed_cache::container_info () const
 	nano::lock_guard<nano::mutex> guard{ mutex };
 
 	nano::container_info info;
-	info.put ("confirmed", confirmed);
+	info.put ("entries", entries);
 	return info;
 }

--- a/nano/node/recently_confirmed_cache.hpp
+++ b/nano/node/recently_confirmed_cache.hpp
@@ -15,11 +15,6 @@ namespace mi = boost::multi_index;
 
 namespace nano
 {
-class container_info_component;
-}
-
-namespace nano
-{
 class recently_confirmed_cache final
 {
 public:
@@ -32,8 +27,8 @@ public:
 	void clear ();
 	std::size_t size () const;
 
-	bool exists (nano::qualified_root const &) const;
-	bool exists (nano::block_hash const &) const;
+	bool contains (nano::qualified_root const &) const;
+	bool contains (nano::block_hash const &) const;
 
 	nano::container_info container_info () const;
 
@@ -44,17 +39,17 @@ private:
 	// clang-format off
 	class tag_hash {};
 	class tag_root {};
-	class tag_sequence {};
+	class tag_sequenced {};
 
-	using ordered_recent_confirmations = boost::multi_index_container<entry_t,
+	using ordered_entries = boost::multi_index_container<entry_t,
 	mi::indexed_by<
-		mi::sequenced<mi::tag<tag_sequence>>,
+		mi::sequenced<mi::tag<tag_sequenced>>,
 		mi::hashed_unique<mi::tag<tag_root>,
 			mi::member<entry_t, nano::qualified_root, &entry_t::first>>,
 		mi::hashed_unique<mi::tag<tag_hash>,
 			mi::member<entry_t, nano::block_hash, &entry_t::second>>>>;
 	// clang-format on
-	ordered_recent_confirmations confirmed;
+	ordered_entries entries;
 
 	std::size_t const max_size;
 

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -301,7 +301,7 @@ auto nano::rep_crawler::prepare_query_target () const -> hash_root_t
 	for (auto const & block : random_blocks)
 	{
 		// Avoid blocks that could still have live votes coming in
-		if (active.recently_confirmed.exists (block->hash ()))
+		if (active.recently_confirmed.contains (block->hash ()))
 		{
 			continue;
 		}

--- a/nano/node/vote_router.cpp
+++ b/nano/node/vote_router.cpp
@@ -86,7 +86,7 @@ std::unordered_map<nano::block_hash, nano::vote_code> nano::vote_router::vote (s
 			}
 			else
 			{
-				if (recently_confirmed.exists (hash))
+				if (recently_confirmed.contains (hash))
 				{
 					results[hash] = nano::vote_code::late;
 				}

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -772,7 +772,7 @@ nano::websocket::message nano::websocket::message_builder::block_confirmed (std:
 	{
 		boost::property_tree::ptree election_node_l;
 		election_node_l.add ("duration", election_status.election_duration.count ());
-		election_node_l.add ("time", election_status.election_end.count ());
+		election_node_l.add ("time", milliseconds_since_epoch (election_status.election_end));
 		election_node_l.add ("tally", election_status.tally.to_string_dec ());
 		election_node_l.add ("final", election_status.final_tally.to_string_dec ());
 		election_node_l.add ("blocks", std::to_string (election_status.block_count));

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -337,6 +337,8 @@ std::error_code nano::test::system::poll (std::chrono::nanoseconds const & wait_
 		}
 	}
 
+	std::this_thread::yield ();
+
 	std::error_code ec;
 	if (std::chrono::steady_clock::now () > deadline)
 	{

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -57,25 +57,30 @@
 	}
 
 /** Expects that the condition becomes true within the deadline */
-#define EXPECT_TIMELY(time, condition)                  \
-	system.deadline_set (time);                         \
-	{                                                   \
-		std::error_code _ec;                            \
-		while (!(condition) && !(_ec = system.poll ())) \
-		{                                               \
-		}                                               \
-		EXPECT_NO_ERROR (_ec);                          \
+#define EXPECT_TIMELY(time, condition) \
+	system.deadline_set (time);        \
+	{                                  \
+		std::error_code _ec;           \
+		while (!_ec && !(condition))   \
+		{                              \
+			_ec = system.poll ();      \
+		}                              \
+		EXPECT_NO_ERROR (_ec);         \
 	}
 
 /*
  * Asserts that the `val1 == val2` condition becomes true within the deadline
  * Condition must hold for at least 2 consecutive reads
  */
-#define ASSERT_TIMELY_EQ(time, val1, val2)         \
-	system.deadline_set (time);                    \
-	while (!((val1) == (val2)) && !system.poll ()) \
-	{                                              \
-	}                                              \
+#define ASSERT_TIMELY_EQ(time, val1, val2)  \
+	system.deadline_set (time);             \
+	{                                       \
+		std::error_code _ec;                \
+		while (!_ec && !((val1) == (val2))) \
+		{                                   \
+			_ec = system.poll ();           \
+		}                                   \
+	}                                       \
 	ASSERT_EQ (val1, val2);
 
 /*


### PR DESCRIPTION
Fixes a bug where elections for blocks being cemented were inserted into AEC, unnecessarily consuming bucket space and slowing down confirmation rate.

  - **Active Elections**: Added checkup thread to detect and cancel elections for already-cemented blocks and issue notifications about stale elections. Refactored recently_confirmed_cache and recently_cemented_cache.
  - **Testing**: Tests for cementing race scenarios and cache behavior.