### PR TITLE
Move successor from sideband to dedicated table

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -158,7 +158,8 @@ TEST (block_store, clear_successor)
 	{
 		auto block1_store (store->block.get (transaction, block1->hash ()));
 		ASSERT_NE (nullptr, block1_store);
-		ASSERT_EQ (0, block1_store->sideband ().successor.number ());
+		auto successor = store->block.successor (transaction, block1->hash ());
+		ASSERT_FALSE (successor.has_value ());
 	}
 
 	// Create block2 - second block in chain (previous = block1)
@@ -180,7 +181,9 @@ TEST (block_store, clear_successor)
 	{
 		auto block1_store (store->block.get (transaction, block1->hash ()));
 		ASSERT_NE (nullptr, block1_store);
-		ASSERT_EQ (block2->hash (), block1_store->sideband ().successor);
+		auto successor = store->block.successor (transaction, block1->hash ());
+		ASSERT_TRUE (successor.has_value ());
+		ASSERT_EQ (block2->hash (), successor.value ());
 	}
 
 	// Clear block1's successor
@@ -190,7 +193,8 @@ TEST (block_store, clear_successor)
 	{
 		auto block1_store (store->block.get (transaction, block1->hash ()));
 		ASSERT_NE (nullptr, block1_store);
-		ASSERT_EQ (0, block1_store->sideband ().successor.number ());
+		auto successor = store->block.successor (transaction, block1->hash ());
+		ASSERT_FALSE (successor.has_value ());
 	}
 }
 

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -86,7 +86,6 @@ TEST (block_store, sideband_serialization)
 	sideband1.account = 1;
 	sideband1.balance = 2;
 	sideband1.height = 3;
-	sideband1.successor = 4;
 	sideband1.timestamp = 5;
 	std::vector<uint8_t> vector;
 	{
@@ -99,7 +98,6 @@ TEST (block_store, sideband_serialization)
 	ASSERT_EQ (sideband1.account, sideband2.account);
 	ASSERT_EQ (sideband1.balance, sideband2.balance);
 	ASSERT_EQ (sideband1.height, sideband2.height);
-	ASSERT_EQ (sideband1.successor, sideband2.successor);
 	ASSERT_EQ (sideband1.timestamp, sideband2.timestamp);
 }
 
@@ -139,41 +137,56 @@ TEST (block_store, clear_successor)
 	nano::logger logger;
 	auto store = nano::make_store (logger, nano::unique_path (), nano::dev::constants);
 
+	nano::keypair key;
 	nano::block_builder builder;
+
 	auto block1 = builder
-				  .open ()
-				  .source (0)
-				  .representative (1)
-				  .account (0)
-				  .sign (nano::keypair ().prv, 0)
+				  .state ()
+				  .account (key.pub)
+				  .previous (0)
+				  .representative (key.pub)
+				  .balance (100)
+				  .link (0)
+				  .sign (key.prv, key.pub)
 				  .work (0)
 				  .build ();
 	block1->sideband_set ({});
 	auto transaction (store->tx_begin_write ());
 	store->block.put (transaction, block1->hash (), *block1);
+
+	// Verify block1 has no successor initially
+	{
+		auto block1_store (store->block.get (transaction, block1->hash ()));
+		ASSERT_NE (nullptr, block1_store);
+		ASSERT_EQ (0, block1_store->sideband ().successor.number ());
+	}
+
+	// Create block2 - second block in chain (previous = block1)
 	auto block2 = builder
-				  .open ()
-				  .source (0)
-				  .representative (2)
-				  .account (0)
-				  .sign (nano::keypair ().prv, 0)
+				  .state ()
+				  .account (key.pub)
+				  .previous (block1->hash ())
+				  .representative (key.pub)
+				  .balance (50)
+				  .link (0)
+				  .sign (key.prv, key.pub)
 				  .work (0)
 				  .build ();
 	block2->sideband_set ({});
+	// When block2 is put, it should automatically set block1's successor to block2
 	store->block.put (transaction, block2->hash (), *block2);
-	auto block2_store (store->block.get (transaction, block1->hash ()));
-	ASSERT_NE (nullptr, block2_store);
-	ASSERT_EQ (0, block2_store->sideband ().successor.number ());
-	auto modified_sideband = block2_store->sideband ();
-	modified_sideband.successor = block2->hash ();
-	block1->sideband_set (modified_sideband);
-	store->block.put (transaction, block1->hash (), *block1);
+
+	// Verify block1's successor is now block2
 	{
 		auto block1_store (store->block.get (transaction, block1->hash ()));
 		ASSERT_NE (nullptr, block1_store);
 		ASSERT_EQ (block2->hash (), block1_store->sideband ().successor);
 	}
+
+	// Clear block1's successor
 	store->block.successor_clear (transaction, block1->hash ());
+
+	// Verify block1's successor is now 0
 	{
 		auto block1_store (store->block.get (transaction, block1->hash ()));
 		ASSERT_NE (nullptr, block1_store);

--- a/nano/lib/block_sideband.cpp
+++ b/nano/lib/block_sideband.cpp
@@ -201,7 +201,6 @@ bool nano::block_sideband::deserialize (nano::stream & stream_a, nano::block_typ
 
 void nano::block_sideband::operator() (nano::object_stream & obs) const
 {
-	obs.write ("successor", successor);
 	obs.write ("account", account);
 	obs.write ("balance", balance);
 	obs.write ("height", height);

--- a/nano/lib/block_sideband.cpp
+++ b/nano/lib/block_sideband.cpp
@@ -93,8 +93,7 @@ std::string nano::state_subtype (nano::block_details const details_a)
  * block_sideband
  */
 
-nano::block_sideband::block_sideband (nano::account const & account_a, nano::block_hash const & successor_a, nano::amount const & balance_a, uint64_t const height_a, nano::seconds_t const timestamp_a, nano::block_details const & details_a, nano::epoch const source_epoch_a) :
-	successor (successor_a),
+nano::block_sideband::block_sideband (nano::account const & account_a, nano::amount const & balance_a, uint64_t const height_a, nano::seconds_t const timestamp_a, nano::block_details const & details_a, nano::epoch const source_epoch_a) :
 	account (account_a),
 	balance (balance_a),
 	height (height_a),
@@ -104,8 +103,7 @@ nano::block_sideband::block_sideband (nano::account const & account_a, nano::blo
 {
 }
 
-nano::block_sideband::block_sideband (nano::account const & account_a, nano::block_hash const & successor_a, nano::amount const & balance_a, uint64_t const height_a, nano::seconds_t const timestamp_a, nano::epoch const epoch_a, bool const is_send, bool const is_receive, bool const is_epoch, nano::epoch const source_epoch_a) :
-	successor (successor_a),
+nano::block_sideband::block_sideband (nano::account const & account_a, nano::amount const & balance_a, uint64_t const height_a, nano::seconds_t const timestamp_a, nano::epoch const epoch_a, bool const is_send, bool const is_receive, bool const is_epoch, nano::epoch const source_epoch_a) :
 	account (account_a),
 	balance (balance_a),
 	height (height_a),
@@ -118,7 +116,6 @@ nano::block_sideband::block_sideband (nano::account const & account_a, nano::blo
 size_t nano::block_sideband::size (nano::block_type type_a)
 {
 	size_t result (0);
-	result += sizeof (successor);
 	if (type_a != nano::block_type::state && type_a != nano::block_type::open)
 	{
 		result += sizeof (account);

--- a/nano/lib/block_sideband.cpp
+++ b/nano/lib/block_sideband.cpp
@@ -142,7 +142,6 @@ size_t nano::block_sideband::size (nano::block_type type_a)
 
 void nano::block_sideband::serialize (nano::stream & stream_a, nano::block_type type_a) const
 {
-	nano::write (stream_a, successor.bytes);
 	if (type_a != nano::block_type::state && type_a != nano::block_type::open)
 	{
 		nano::write (stream_a, account.bytes);
@@ -168,7 +167,6 @@ bool nano::block_sideband::deserialize (nano::stream & stream_a, nano::block_typ
 	bool result (false);
 	try
 	{
-		nano::read (stream_a, successor.bytes);
 		if (type_a != nano::block_type::state && type_a != nano::block_type::open)
 		{
 			nano::read (stream_a, account.bytes);

--- a/nano/lib/block_sideband.hpp
+++ b/nano/lib/block_sideband.hpp
@@ -47,8 +47,8 @@ class block_sideband final
 {
 public:
 	block_sideband () = default;
-	block_sideband (nano::account const & account, nano::block_hash const & successor, nano::amount const & balance, uint64_t height, nano::seconds_t timestamp, nano::block_details const & details, nano::epoch source_epoch);
-	block_sideband (nano::account const & account, nano::block_hash const & successor, nano::amount const & balance, uint64_t height, nano::seconds_t timestamp, nano::epoch epoch, bool is_send, bool is_receive, bool is_epoch, nano::epoch source_epoch);
+	block_sideband (nano::account const & account, nano::amount const & balance, uint64_t height, nano::seconds_t timestamp, nano::block_details const & details, nano::epoch source_epoch);
+	block_sideband (nano::account const & account, nano::amount const & balance, uint64_t height, nano::seconds_t timestamp, nano::epoch epoch, bool is_send, bool is_receive, bool is_epoch, nano::epoch source_epoch);
 
 	void serialize (nano::stream &, nano::block_type) const;
 	bool deserialize (nano::stream &, nano::block_type);

--- a/nano/lib/block_sideband.hpp
+++ b/nano/lib/block_sideband.hpp
@@ -56,7 +56,6 @@ public:
 	static size_t size (nano::block_type);
 
 public:
-	nano::block_hash successor{ 0 };
 	nano::account account{};
 	nano::amount balance{ 0 };
 	uint64_t height{ 0 };

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -344,8 +344,8 @@ std::deque<std::shared_ptr<nano::block>> nano::bootstrap_server::prepare_blocks 
 		{
 			result.push_back (current);
 
-			auto successor = current->sideband ().successor;
-			current = ledger.any.block_get (transaction, successor);
+			auto successor = ledger.any.block_successor (transaction, current->hash ());
+			current = successor ? ledger.any.block_get (transaction, successor.value ()) : nullptr;
 		}
 	}
 	return result;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1158,7 +1158,8 @@ void nano::json_handler::block_info ()
 			response_l.put ("balance", balance.number ().convert_to<std::string> ());
 			response_l.put ("height", std::to_string (block->sideband ().height));
 			response_l.put ("local_timestamp", std::to_string (block->sideband ().timestamp));
-			response_l.put ("successor", block->sideband ().successor.to_string ());
+			auto successor = node.ledger.any.block_successor (transaction, hash);
+			response_l.put ("successor", successor.value_or (0).to_string ());
 			auto confirmed (node.ledger.confirmed.block_exists_or_pruned (transaction, hash));
 			response_l.put ("confirmed", confirmed);
 
@@ -1328,7 +1329,8 @@ void nano::json_handler::blocks_info ()
 					entry.put ("balance", balance.number ().convert_to<std::string> ());
 					entry.put ("height", std::to_string (block->sideband ().height));
 					entry.put ("local_timestamp", std::to_string (block->sideband ().timestamp));
-					entry.put ("successor", block->sideband ().successor.to_string ());
+					auto successor = node.ledger.any.block_successor (transaction, hash);
+					entry.put ("successor", successor.value_or (0).to_string ());
 					auto confirmed (node.ledger.confirmed.block_exists_or_pruned (transaction, hash));
 					entry.put ("confirmed", confirmed);
 

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -137,7 +137,6 @@ nano::ledger_constants::ledger_constants (nano::network_type network_type) :
 {
 	nano_beta_genesis->sideband_set (nano::block_sideband{
 	/* account */ nano_beta_genesis->account_field ().value (),
-	/* successor (block_hash) */ nano::block_hash{ 0 },
 	/* balance (amount) */ nano::amount{ std::numeric_limits<nano::uint128_t>::max () },
 	/* height */ uint64_t{ 1 },
 	/* local_timestamp */ 0,
@@ -149,7 +148,6 @@ nano::ledger_constants::ledger_constants (nano::network_type network_type) :
 
 	nano_dev_genesis->sideband_set (nano::block_sideband{
 	/* account */ nano_dev_genesis->account_field ().value (),
-	/* successor (block_hash) */ nano::block_hash{ 0 },
 	/* balance (amount) */ nano::amount{ std::numeric_limits<nano::uint128_t>::max () },
 	/* height */ uint64_t{ 1 },
 	/* local_timestamp */ 0,
@@ -161,7 +159,6 @@ nano::ledger_constants::ledger_constants (nano::network_type network_type) :
 
 	nano_live_genesis->sideband_set (nano::block_sideband{
 	/* account */ nano_live_genesis->account_field ().value (),
-	/* successor (block_hash) */ nano::block_hash{ 0 },
 	/* balance (amount) */ nano::amount{ std::numeric_limits<nano::uint128_t>::max () },
 	/* height */ uint64_t{ 1 },
 	/* local_timestamp */ 0,
@@ -173,7 +170,6 @@ nano::ledger_constants::ledger_constants (nano::network_type network_type) :
 
 	nano_test_genesis->sideband_set (nano::block_sideband{
 	/* account */ nano_test_genesis->account_field ().value (),
-	/* successor (block_hash) */ nano::block_hash{ 0 },
 	/* balance (amount) */ nano::amount{ std::numeric_limits<nano::uint128_t>::max () },
 	/* height */ uint64_t{ 1 },
 	/* local_timestamp */ 0,

--- a/nano/secure/ledger_processor.cpp
+++ b/nano/secure/ledger_processor.cpp
@@ -53,7 +53,7 @@ void nano::ledger_processor::send_block (nano::send_block & block_a)
 							{
 								auto amount (info->balance.number () - block_a.hashables.balance.number ());
 								ledger.rep_weights.sub (transaction, info->representative, amount);
-								block_a.sideband_set (nano::block_sideband (account, 0, block_a.hashables.balance /* unused */, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+								block_a.sideband_set (nano::block_sideband (account, block_a.hashables.balance /* unused */, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
 								ledger.store.block.put (transaction, hash, block_a);
 								nano::account_info new_info (hash, info->representative, info->open_block, block_a.hashables.balance, nano::seconds_since_epoch (), info->block_count + 1, nano::epoch::epoch_0);
 								ledger.update_account (transaction, account, *info, new_info);
@@ -112,7 +112,7 @@ void nano::ledger_processor::receive_block (nano::receive_block & block_a)
 										{
 											auto new_balance (info->balance.number () + pending.value ().amount.number ());
 											ledger.store.pending.del (transaction, key);
-											block_a.sideband_set (nano::block_sideband (account, 0, new_balance, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+											block_a.sideband_set (nano::block_sideband (account, new_balance, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
 											ledger.store.block.put (transaction, hash, block_a);
 											nano::account_info new_info (hash, info->representative, info->open_block, new_balance, nano::seconds_since_epoch (), info->block_count + 1, nano::epoch::epoch_0);
 											ledger.update_account (transaction, account, *info, new_info);
@@ -164,7 +164,7 @@ void nano::ledger_processor::open_block (nano::open_block & block_a)
 								if (result == nano::block_status::progress)
 								{
 									ledger.store.pending.del (transaction, key);
-									block_a.sideband_set (nano::block_sideband (block_a.hashables.account, 0, pending.value ().amount, 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+									block_a.sideband_set (nano::block_sideband (block_a.hashables.account, pending.value ().amount, 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
 									ledger.store.block.put (transaction, hash, block_a);
 									nano::account_info new_info (hash, block_a.representative_field ().value (), hash, pending.value ().amount.number (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0);
 									ledger.update_account (transaction, block_a.hashables.account, info, new_info);
@@ -209,7 +209,7 @@ void nano::ledger_processor::change_block (nano::change_block & block_a)
 						if (result == nano::block_status::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
-							block_a.sideband_set (nano::block_sideband (account, 0, info->balance, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+							block_a.sideband_set (nano::block_sideband (account, info->balance, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
 							ledger.store.block.put (transaction, hash, block_a);
 							auto balance = previous->balance ();
 							ledger.rep_weights.move (transaction, info->representative, block_a.hashables.representative, balance);
@@ -329,7 +329,7 @@ void nano::ledger_processor::state_block_impl (nano::state_block & block_a)
 					if (result == nano::block_status::progress)
 					{
 						ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::state_block);
-						block_a.sideband_set (nano::block_sideband (block_a.hashables.account /* unused */, 0, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), block_details, source_epoch));
+						block_a.sideband_set (nano::block_sideband (block_a.hashables.account /* unused */, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), block_details, source_epoch));
 						ledger.store.block.put (transaction, hash, block_a);
 
 						if (!info.head.is_zero ())
@@ -419,7 +419,7 @@ void nano::ledger_processor::epoch_block_impl (nano::state_block & block_a)
 							if (result == nano::block_status::progress)
 							{
 								ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::epoch_block);
-								block_a.sideband_set (nano::block_sideband (block_a.hashables.account /* unused */, 0, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+								block_a.sideband_set (nano::block_sideband (block_a.hashables.account /* unused */, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
 								ledger.store.block.put (transaction, hash, block_a);
 								nano::account_info new_info (hash, block_a.hashables.representative, info.open_block.is_zero () ? hash : info.open_block, info.balance, nano::seconds_since_epoch (), info.block_count + 1, epoch);
 								ledger.update_account (transaction, block_a.hashables.account, info, new_info);

--- a/nano/store/lmdb/block.cpp
+++ b/nano/store/lmdb/block.cpp
@@ -94,7 +94,6 @@ std::shared_ptr<nano::block> nano::store::lmdb::block::get (store::transaction c
 		release_assert (!error);
 
 		auto successor_hash = successor (transaction, hash);
-		sideband.successor = successor_hash.value_or (0);
 		result->sideband_set (sideband);
 	}
 	return result;

--- a/nano/store/lmdb/block.cpp
+++ b/nano/store/lmdb/block.cpp
@@ -40,6 +40,7 @@ void nano::store::lmdb::block::put (store::write_transaction const & transaction
 	raw_put (transaction, vector, hash);
 	block_predecessor_mdb_set predecessor (transaction, *this);
 	block.visit (predecessor);
+
 	debug_assert (block.previous ().is_zero () || successor (transaction, block.previous ()) == hash);
 }
 
@@ -53,37 +54,27 @@ void nano::store::lmdb::block::raw_put (store::write_transaction const & transac
 std::optional<nano::block_hash> nano::store::lmdb::block::successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const
 {
 	nano::store::lmdb::db_val value;
-	block_raw_get (transaction_a, hash_a, value);
-	nano::block_hash result;
-	if (value.size () != 0)
+	auto status = store.get (transaction_a, tables::successors, hash_a, value);
+	if (store.success (status))
 	{
-		debug_assert (value.size () >= result.bytes.size ());
-		auto type = block_type_from_raw (value.data ());
-		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()) + block_successor_offset (transaction_a, value.size (), type), result.bytes.size ());
+		debug_assert (value.size () == sizeof (nano::block_hash));
+		nano::block_hash result;
+		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()), value.size ());
 		auto error (nano::try_read (stream, result.bytes));
 		(void)error;
 		debug_assert (!error);
+		if (!result.is_zero ())
+		{
+			return result;
+		}
 	}
-	else
-	{
-		result.clear ();
-	}
-	if (result.is_zero ())
-	{
-		return std::nullopt;
-	}
-	return result;
+	return std::nullopt;
 }
 
 void nano::store::lmdb::block::successor_clear (store::write_transaction const & transaction, nano::block_hash const & hash)
 {
-	nano::store::lmdb::db_val value;
-	block_raw_get (transaction, hash, value);
-	debug_assert (value.size () != 0);
-	auto type = block_type_from_raw (value.data ());
-	std::vector<uint8_t> data (static_cast<uint8_t *> (value.data ()), static_cast<uint8_t *> (value.data ()) + value.size ());
-	std::fill_n (data.begin () + block_successor_offset (transaction, value.size (), type), sizeof (nano::block_hash), uint8_t{ 0 });
-	raw_put (transaction, data, hash);
+	auto status = store.del (transaction, tables::successors, hash);
+	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 }
 
 std::shared_ptr<nano::block> nano::store::lmdb::block::get (store::transaction const & transaction, nano::block_hash const & hash) const
@@ -102,6 +93,9 @@ std::shared_ptr<nano::block> nano::store::lmdb::block::get (store::transaction c
 		nano::block_sideband sideband;
 		error = (sideband.deserialize (stream, type));
 		release_assert (!error);
+
+		auto successor_hash = successor (transaction, hash);
+		sideband.successor = successor_hash.value_or (0);
 		result->sideband_set (sideband);
 	}
 	return result;
@@ -111,6 +105,9 @@ void nano::store::lmdb::block::del (store::write_transaction const & transaction
 {
 	auto status = store.del (transaction_a, tables::blocks, hash_a);
 	store.release_assert_success (status);
+	// Also remove from successors table
+	auto successor_status = store.del (transaction_a, tables::successors, hash_a);
+	release_assert (store.success (successor_status) || store.not_found (successor_status), store.error_string (successor_status));
 }
 
 bool nano::store::lmdb::block::exists (store::transaction const & transaction, nano::block_hash const & hash)
@@ -153,11 +150,6 @@ void nano::store::lmdb::block::block_raw_get (store::transaction const & transac
 	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 }
 
-size_t nano::store::lmdb::block::block_successor_offset (store::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const
-{
-	return entry_size_a - nano::block_sideband::size (type_a);
-}
-
 nano::block_type nano::store::lmdb::block::block_type_from_raw (void * data_a)
 {
 	// The block type is the first byte
@@ -172,13 +164,10 @@ nano::store::lmdb::block_predecessor_mdb_set::block_predecessor_mdb_set (store::
 void nano::store::lmdb::block_predecessor_mdb_set::fill_value (nano::block const & block_a)
 {
 	auto hash = block_a.hash ();
-	nano::store::lmdb::db_val value;
-	block_store.block_raw_get (transaction, block_a.previous (), value);
-	debug_assert (value.size () != 0);
-	auto type = block_store.block_type_from_raw (value.data ());
-	std::vector<uint8_t> data (static_cast<uint8_t *> (value.data ()), static_cast<uint8_t *> (value.data ()) + value.size ());
-	std::copy (hash.bytes.begin (), hash.bytes.end (), data.begin () + block_store.block_successor_offset (transaction, value.size (), type));
-	block_store.raw_put (transaction, data, block_a.previous ());
+	auto previous = block_a.previous ();
+	nano::store::lmdb::db_val value{ sizeof (nano::block_hash), (void *)hash.bytes.data () };
+	auto status = block_store.store.put (transaction, tables::successors, previous, value);
+	release_assert (success (status), error_string (status));
 }
 void nano::store::lmdb::block_predecessor_mdb_set::send_block (nano::send_block const & block_a)
 {

--- a/nano/store/lmdb/block.cpp
+++ b/nano/store/lmdb/block.cpp
@@ -30,7 +30,6 @@ nano::store::lmdb::block::block (nano::store::lmdb::component & store_a) :
 
 void nano::store::lmdb::block::put (store::write_transaction const & transaction, nano::block_hash const & hash, nano::block const & block)
 {
-	debug_assert (block.sideband ().successor.is_zero () || exists (transaction, block.sideband ().successor));
 	std::vector<uint8_t> vector;
 	{
 		nano::vectorstream stream (vector);

--- a/nano/store/lmdb/block.hpp
+++ b/nano/store/lmdb/block.hpp
@@ -41,9 +41,14 @@ public:
 	 */
 	MDB_dbi blocks_handle{ 0 };
 
+	/**
+	 * Maps block hash to successor hash
+	 * nano::block_hash -> nano::block_hash
+	 */
+	MDB_dbi successors_handle{ 0 };
+
 protected:
 	void block_raw_get (store::transaction const & transaction_a, nano::block_hash const & hash_a, db_val & value) const;
-	size_t block_successor_offset (store::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const;
 	static nano::block_type block_type_from_raw (void * data_a);
 };
 } // namespace nano::store::lmdb

--- a/nano/store/lmdb/lmdb.cpp
+++ b/nano/store/lmdb/lmdb.cpp
@@ -1,3 +1,5 @@
+#include <nano/lib/block_sideband.hpp>
+#include <nano/lib/block_type.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/stream.hpp>
 #include <nano/lib/utility.hpp>
@@ -14,6 +16,7 @@
 #include <boost/format.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
+#include <cstring>
 #include <queue>
 #include <stdexcept>
 
@@ -233,6 +236,7 @@ void nano::store::lmdb::component::open_databases (store::transaction const & tr
 	pending_store.pending_handle = pending_store.pending_v0_handle;
 	open_table (transaction_a, "final_votes", flags, final_vote_store.final_votes_handle);
 	open_table (transaction_a, "blocks", MDB_CREATE, block_store.blocks_handle);
+	open_table (transaction_a, "successors", flags, block_store.successors_handle);
 	open_table (transaction_a, "rep_weights", flags, rep_weight_store.rep_weights_handle);
 }
 
@@ -460,6 +464,8 @@ MDB_dbi nano::store::lmdb::component::table_to_dbi (tables table_a) const
 			return confirmation_height_store.confirmation_height_handle;
 		case tables::final_votes:
 			return final_vote_store.final_votes_handle;
+		case tables::successors:
+			return block_store.successors_handle;
 		case tables::rep_weights:
 			return rep_weight_store.rep_weights_handle;
 		default:

--- a/nano/store/rocksdb/block.cpp
+++ b/nano/store/rocksdb/block.cpp
@@ -30,7 +30,6 @@ nano::store::rocksdb::block::block (nano::store::rocksdb::component & store_a) :
 
 void nano::store::rocksdb::block::put (store::write_transaction const & transaction, nano::block_hash const & hash, nano::block const & block)
 {
-	debug_assert (block.sideband ().successor.is_zero () || exists (transaction, block.sideband ().successor));
 	std::vector<uint8_t> vector;
 	{
 		nano::vectorstream stream (vector);
@@ -40,6 +39,7 @@ void nano::store::rocksdb::block::put (store::write_transaction const & transact
 	raw_put (transaction, vector, hash);
 	block_predecessor_rocksdb_set predecessor (transaction, *this);
 	block.visit (predecessor);
+
 	debug_assert (block.previous ().is_zero () || successor (transaction, block.previous ()) == hash);
 }
 
@@ -53,37 +53,30 @@ void nano::store::rocksdb::block::raw_put (store::write_transaction const & tran
 std::optional<nano::block_hash> nano::store::rocksdb::block::successor (store::transaction const & transaction_a, nano::block_hash const & hash_a) const
 {
 	nano::store::rocksdb::db_val value;
-	block_raw_get (transaction_a, hash_a, value);
-	nano::block_hash result;
-	if (value.size () != 0)
+	auto status = store.get (transaction_a, tables::successors, hash_a, value);
+	if (store.success (status))
 	{
-		debug_assert (value.size () >= result.bytes.size ());
-		auto type = block_type_from_raw (value.data ());
-		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()) + block_successor_offset (transaction_a, value.size (), type), result.bytes.size ());
+		debug_assert (value.size () == sizeof (nano::block_hash));
+		nano::block_hash result;
+		nano::bufferstream stream (reinterpret_cast<uint8_t const *> (value.data ()), value.size ());
 		auto error (nano::try_read (stream, result.bytes));
 		(void)error;
 		debug_assert (!error);
+		if (!result.is_zero ())
+		{
+			return result;
+		}
 	}
-	else
-	{
-		result.clear ();
-	}
-	if (result.is_zero ())
-	{
-		return std::nullopt;
-	}
-	return result;
+	return std::nullopt;
 }
 
 void nano::store::rocksdb::block::successor_clear (store::write_transaction const & transaction, nano::block_hash const & hash)
 {
-	nano::store::rocksdb::db_val value;
-	block_raw_get (transaction, hash, value);
-	debug_assert (value.size () != 0);
-	auto type = block_type_from_raw (value.data ());
-	std::vector<uint8_t> data (static_cast<uint8_t *> (value.data ()), static_cast<uint8_t *> (value.data ()) + value.size ());
-	std::fill_n (data.begin () + block_successor_offset (transaction, value.size (), type), sizeof (nano::block_hash), uint8_t{ 0 });
-	raw_put (transaction, data, hash);
+	if (store.exists (transaction, tables::successors, hash))
+	{
+		auto status = store.del (transaction, tables::successors, hash);
+		store.release_assert_success (status);
+	}
 }
 
 std::shared_ptr<nano::block> nano::store::rocksdb::block::get (store::transaction const & transaction, nano::block_hash const & hash) const
@@ -102,6 +95,9 @@ std::shared_ptr<nano::block> nano::store::rocksdb::block::get (store::transactio
 		nano::block_sideband sideband;
 		error = (sideband.deserialize (stream, type));
 		release_assert (!error);
+
+		auto successor_hash = successor (transaction, hash);
+		sideband.successor = successor_hash.value_or (0);
 		result->sideband_set (sideband);
 	}
 	return result;
@@ -111,6 +107,12 @@ void nano::store::rocksdb::block::del (store::write_transaction const & transact
 {
 	auto status = store.del (transaction_a, tables::blocks, hash_a);
 	store.release_assert_success (status);
+	// Also remove from successors table if it exists
+	if (store.exists (transaction_a, tables::successors, hash_a))
+	{
+		auto successor_status = store.del (transaction_a, tables::successors, hash_a);
+		store.release_assert_success (successor_status);
+	}
 }
 
 bool nano::store::rocksdb::block::exists (store::transaction const & transaction, nano::block_hash const & hash)
@@ -153,11 +155,6 @@ void nano::store::rocksdb::block::block_raw_get (store::transaction const & tran
 	release_assert (store.success (status) || store.not_found (status), store.error_string (status));
 }
 
-size_t nano::store::rocksdb::block::block_successor_offset (store::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const
-{
-	return entry_size_a - nano::block_sideband::size (type_a);
-}
-
 nano::block_type nano::store::rocksdb::block::block_type_from_raw (void * data_a)
 {
 	// The block type is the first byte
@@ -173,13 +170,10 @@ nano::block_predecessor_rocksdb_set::block_predecessor_rocksdb_set (store::write
 void nano::block_predecessor_rocksdb_set::fill_value (nano::block const & block_a)
 {
 	auto hash = block_a.hash ();
-	nano::store::rocksdb::db_val value;
-	block_store.block_raw_get (transaction, block_a.previous (), value);
-	debug_assert (value.size () != 0);
-	auto type = block_store.block_type_from_raw (value.data ());
-	std::vector<uint8_t> data (static_cast<uint8_t *> (value.data ()), static_cast<uint8_t *> (value.data ()) + value.size ());
-	std::copy (hash.bytes.begin (), hash.bytes.end (), data.begin () + block_store.block_successor_offset (transaction, value.size (), type));
-	block_store.raw_put (transaction, data, block_a.previous ());
+	auto previous = block_a.previous ();
+	nano::store::rocksdb::db_val value{ sizeof (nano::block_hash), (void *)hash.bytes.data () };
+	auto status = block_store.store.put (transaction, tables::successors, previous, value);
+	release_assert (nano::store::rocksdb::success (status), nano::store::rocksdb::error_string (status));
 }
 
 void nano::block_predecessor_rocksdb_set::send_block (nano::send_block const & block_a)

--- a/nano/store/rocksdb/block.cpp
+++ b/nano/store/rocksdb/block.cpp
@@ -97,7 +97,6 @@ std::shared_ptr<nano::block> nano::store::rocksdb::block::get (store::transactio
 		release_assert (!error);
 
 		auto successor_hash = successor (transaction, hash);
-		sideband.successor = successor_hash.value_or (0);
 		result->sideband_set (sideband);
 	}
 	return result;

--- a/nano/store/rocksdb/block.hpp
+++ b/nano/store/rocksdb/block.hpp
@@ -35,7 +35,6 @@ public:
 
 protected:
 	void block_raw_get (store::transaction const & transaction_a, nano::block_hash const & hash_a, nano::store::rocksdb::db_val & value) const;
-	size_t block_successor_offset (store::transaction const & transaction_a, size_t entry_size_a, nano::block_type type_a) const;
 	static nano::block_type block_type_from_raw (void * data_a);
 };
 } // namespace nano::store::rocksdb

--- a/nano/store/rocksdb/rocksdb.cpp
+++ b/nano/store/rocksdb/rocksdb.cpp
@@ -171,7 +171,8 @@ std::unordered_map<char const *, nano::tables> nano::store::rocksdb::component::
 		{ "confirmation_height", tables::confirmation_height },
 		{ "pruned", tables::pruned },
 		{ "final_votes", tables::final_votes },
-		{ "rep_weights", tables::rep_weights } };
+		{ "rep_weights", tables::rep_weights },
+		{ "successors", tables::successors } };
 
 	debug_assert (map.size () == all_tables ().size () + 1);
 	return map;
@@ -521,6 +522,8 @@ rocksdb::ColumnFamilyHandle * nano::store::rocksdb::component::table_to_column_f
 			return get_column_family ("final_votes");
 		case tables::rep_weights:
 			return get_column_family ("rep_weights");
+		case tables::successors:
+			return get_column_family ("successors");
 		default:
 			release_assert (false);
 			return get_column_family ("");
@@ -807,7 +810,7 @@ void nano::store::rocksdb::component::on_flush (::rocksdb::FlushJobInfo const & 
 
 std::vector<nano::tables> nano::store::rocksdb::component::all_tables () const
 {
-	return std::vector<nano::tables>{ tables::accounts, tables::blocks, tables::confirmation_height, tables::final_votes, tables::meta, tables::online_weight, tables::peers, tables::pending, tables::pruned, tables::vote, tables::rep_weights };
+	return std::vector<nano::tables>{ tables::accounts, tables::blocks, tables::confirmation_height, tables::final_votes, tables::meta, tables::online_weight, tables::peers, tables::pending, tables::pruned, tables::vote, tables::rep_weights, tables::successors };
 }
 
 bool nano::store::rocksdb::component::copy_db (std::filesystem::path const & destination_path)

--- a/nano/store/tables.hpp
+++ b/nano/store/tables.hpp
@@ -17,6 +17,7 @@ enum class tables
 	peers,
 	pending,
 	pruned,
+	successors,
 	vote,
 	rep_weights,
 };


### PR DESCRIPTION
This draft PR is heavily inspired by the Rust Nano implementation that also migrated successors out of the sideband and into a new table in the database. This table maps hash -> successor hash.
Doing this, prepares for splitting the blocks table in two as described in #4053 , and vastly reducing ledger size
Only LMDB is supported in this draft, so Rocksdb tests will fail until implemented
Pr also includes a migration that converts existing database layout to the new one (LMDB only)
Claude code has been assisting me in creating this PR.