### PR TITLE
Use max allowed file descriptor limit

### DIFF
--- a/nano/lib/files.cpp
+++ b/nano/lib/files.cpp
@@ -20,17 +20,25 @@
 
 static std::vector<std::filesystem::path> all_unique_paths;
 
-std::size_t nano::get_file_descriptor_limit ()
+/*
+ *
+ */
+
+nano::file_descriptor_limits nano::get_file_descriptor_limit ()
 {
-	std::size_t fd_limit = std::numeric_limits<std::size_t>::max ();
+	nano::file_descriptor_limits limits{
+		.soft_limit = std::numeric_limits<std::size_t>::max (),
+		.hard_limit = std::numeric_limits<std::size_t>::max (),
+	};
 #ifndef _WIN32
 	rlimit limit{};
 	if (getrlimit (RLIMIT_NOFILE, &limit) == 0)
 	{
-		fd_limit = static_cast<std::size_t> (limit.rlim_cur);
+		limits.soft_limit = static_cast<std::size_t> (limit.rlim_cur);
+		limits.hard_limit = static_cast<std::size_t> (limit.rlim_max);
 	}
 #endif
-	return fd_limit;
+	return limits;
 }
 
 void nano::set_file_descriptor_limit (std::size_t limit)
@@ -59,13 +67,21 @@ void nano::set_file_descriptor_limit (std::size_t limit)
 
 void nano::initialize_file_descriptor_limit ()
 {
-	nano::set_file_descriptor_limit (DEFAULT_FILE_DESCRIPTOR_LIMIT);
-	auto limit = nano::get_file_descriptor_limit ();
-	if (limit < DEFAULT_FILE_DESCRIPTOR_LIMIT)
+	// Attempt to set the file descriptor limit to the maximum allowed value
+	auto limits = nano::get_file_descriptor_limit ();
+	nano::set_file_descriptor_limit (limits.hard_limit);
+
+	auto updated_limits = nano::get_file_descriptor_limit ();
+	if (updated_limits.soft_limit < DEFAULT_FILE_DESCRIPTOR_LIMIT)
 	{
-		std::cerr << "WARNING: Current file descriptor limit of " << limit << " is lower than the " << DEFAULT_FILE_DESCRIPTOR_LIMIT << " recommended. Node was unable to change it." << std::endl;
+		std::cerr << "WARNING: Current file descriptor limit of " << updated_limits.soft_limit << " (hard limit " << updated_limits.hard_limit << ")"
+				  << " is lower than the " << DEFAULT_FILE_DESCRIPTOR_LIMIT << " recommended. Node was unable to change it." << std::endl;
 	}
 }
+
+/*
+ *
+ */
 
 void nano::remove_all_files_in_dir (std::filesystem::path const & dir)
 {

--- a/nano/lib/files.hpp
+++ b/nano/lib/files.hpp
@@ -46,6 +46,10 @@ bool event_log_reg_entry_exists ();
  */
 void create_load_memory_address_files ();
 
+void remove_all_files_in_dir (std::filesystem::path const & dir);
+void move_all_files_to_dir (std::filesystem::path const & from, std::filesystem::path const & to);
+}
+
 /**
  * Some systems, especially in virtualized environments, may have very low file descriptor limits,
  * causing the node to fail. This function attempts to query the limit and returns the value. If the
@@ -53,14 +57,18 @@ void create_load_memory_address_files ();
  * Increasing the limit programmatically can be done only for the soft limit, the hard one requiring
  * super user permissions to modify.
  */
-std::size_t get_file_descriptor_limit ();
-void set_file_descriptor_limit (std::size_t limit);
-/**
- * This should be called from entry points. It sets the file descriptor limit to the maximum allowed and logs any errors.
- */
-constexpr std::size_t DEFAULT_FILE_DESCRIPTOR_LIMIT = 16384;
-void initialize_file_descriptor_limit ();
+namespace nano
+{
+constexpr std::size_t DEFAULT_FILE_DESCRIPTOR_LIMIT = 65535;
 
-void remove_all_files_in_dir (std::filesystem::path const & dir);
-void move_all_files_to_dir (std::filesystem::path const & from, std::filesystem::path const & to);
+struct file_descriptor_limits
+{
+	std::size_t soft_limit;
+	std::size_t hard_limit;
+};
+file_descriptor_limits get_file_descriptor_limit ();
+void set_file_descriptor_limit (std::size_t limit);
+
+// This should be called from entry points. It sets the file descriptor limit to the maximum allowed and logs any errors
+void initialize_file_descriptor_limit ();
 }

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -109,7 +109,8 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 
 		// Print info about number of logical cores detected, those are used to decide how many IO, worker and signature checker threads to spawn
 		logger.info (nano::log::type::daemon, "Hardware concurrency: {} (configured: {})", std::thread::hardware_concurrency (), nano::hardware_concurrency ());
-		logger.info (nano::log::type::daemon, "File descriptors limit: {}", nano::get_file_descriptor_limit ());
+		auto const file_descriptor_limits = nano::get_file_descriptor_limit ();
+		logger.info (nano::log::type::daemon, "File descriptor limit: {} (hard cap: {})", file_descriptor_limits.soft_limit, file_descriptor_limits.hard_limit);
 
 		// for the daemon start up, if the user hasn't specified a port in
 		// the config, we must use the default peering port for the network


### PR DESCRIPTION
The node was hitting the default file descriptor limit and failing. Increasing the limit prevents these RocksDB and DNS errors.

```node-1           | EXECUTING: nano_node --daemon --network=live --data_path=/root/Nano
node-1           | Config file `config-log.toml` not found, using default configuration
node-1           | Logging to file: /root/Nano/log/log_2025-11-28_14-07-42_112245332.log
node-1           | [2025-11-28 14:07:42.112] [daemon] [info] Daemon started
node-1           | [2025-11-28 14:07:42.112] [daemon] [info] Version: TAG_VERSION_STRING
node-1           | [2025-11-28 14:07:42.112] [daemon] [info] Build info: GIT_COMMIT_HASH "GNU C++ version " "11.4.0" "BOOST 108600" BUILT "Nov 12 2025"
node-1           | [2025-11-28 14:07:42.112] [daemon] [info] Data path: /root/Nano
node-1           | [2025-11-28 14:07:42.112] [daemon] [info] Start time: Fri Nov 28 14:07:42 2025 UTC
node-1           | [2025-11-28 14:07:42.114] [daemon] [info] Starting up Nano node...
node-1           | [2025-11-28 14:07:42.114] [daemon] [info] Hardware concurrency: 64 (configured: 64)
node-1           | [2025-11-28 14:07:42.114] [daemon] [info] File descriptors limit: 16384
node-1           | [2025-11-28 14:07:42.114] [init] [info] Using data directory: /root/Nano
...
node-1           | [2025-11-28 14:08:15.132] [node] [error] Error resolving address for keepalive: peering.nano.org:7075 (Too many open files)
node-1           | [2025-11-28 14:08:15.160] [node] [error] Error resolving address for keepalive: peering.nano.org:7075 (Too many open files)
node-1           | [2025-11-28 14:08:15.202] [node] [error] Error resolving address for keepalive: peering.nano.org:7075 (Too many open files)
node-1           | [2025-11-28 14:08:15.217] [rep_crawler] [warning] Updated representative: nano_35btiz1mgfwp95c3ckazmzbp5gepduxtijuijd9xebeau8u1gsbea41smjca at: [::ffff:51.81.243.15]:7075 (was at: [::ffff:147.135.97.16]:51722)
node-1           | [2025-11-28 14:08:15.217] [node] [error] Error resolving address for keepalive: peering.nano.org:7075 (Too many open files)
node-1           | [2025-11-28 14:08:18.219] [node] [error] Error resolving address for keepalive: peering.nano.org:7075 (Too many open files)
node-1           | [2025-11-28 14:08:18.344] [node] [error] Error resolving address for keepalive: peering.nano.org:7075 (Too many open files)
node-1           | [2025-11-28 14:08:18.468] [node] [error] Error resolving address for keepalive: peering.nano.org:7075 (Too many open files)
node-1           | [2025-11-28 14:08:18.525] [rep_crawler] [warning] Updated representative: nano_35btiz1mgfwp95c3ckazmzbp5gepduxtijuijd9xebeau8u1gsbea41smjca at: [::ffff:147.135.97.16]:51722 (was at: [::ffff:51.81.243.15]:7075)
node-1           | [2025-11-28 14:08:18.526] [node] [error] Error resolving address for keepalive: peering.nano.org:7075 (Too many open files)
node-1           | Assertion `status.ok () && "Unable to write to the RocksDB database"` failed: IO error: While open a file for appending: /root/Nano/votes_rocksdb/294943.log: Too many open files
node-1           | /tmp/src/nano/store/rocksdb/transaction.cpp:55 [virtual void nano::store::rocksdb::write_transaction_impl::commit()]'
node-1           |  0# 0x00005BF4A8345739 in nano_node
node-1           |  1# 0x00005BF4A82F1600 in nano_node
node-1           |  2# 0x00005BF4A8277E66 in nano_node
node-1           |  3# 0x00005BF4A8277EAB in nano_node
node-1           |  4# 0x00005BF4A8277EDD in nano_node
node-1           |  5# 0x00005BF4A811245A in nano_node
node-1           |  6# 0x00005BF4A8119160 in nano_node
node-1           |  7# 0x00005BF4A8B15384 in nano_node
node-1           |  8# 0x00007A7F7D8E9AC3 in /lib/x86_64-linux-gnu/libc.so.6
node-1           |  9# 0x00007A7F7D97AA74 in /lib/x86_64-linux-gnu/libc.so.6
node-1           | 
node-1           | [2025-11-28 14:08:19.527] [assert] [critical] Assertion `status.ok () && "Unable to write to the RocksDB database"` failed: IO error: While open a file for appending: /root/Nano/votes_rocksdb/294943.log: Too many open files
node-1           | /tmp/src/nano/store/rocksdb/transaction.cpp:55 [virtual void nano::store::rocksdb::write_transaction_impl::commit()]'
node-1           |  0# 0x00005BF4A8345739 in nano_node
node-1           |  1# 0x00005BF4A82F1600 in nano_node
node-1           |  2# 0x00005BF4A8277E66 in nano_node
node-1           |  3# 0x00005BF4A8277EAB in nano_node
node-1           |  4# 0x00005BF4A8277EDD in nano_node
node-1           |  5# 0x00005BF4A811245A in nano_node
node-1           |  6# 0x00005BF4A8119160 in nano_node
node-1           |  7# 0x00005BF4A8B15384 in nano_node
node-1           |  8# 0x00007A7F7D8E9AC3 in /lib/x86_64-linux-gnu/libc.so.6
node-1           |  9# 0x00007A7F7D97AA74 in /lib/x86_64-linux-gnu/libc.so.6
```