### PR TITLE
Ignore trended weight sampling if online weight is below minimum threshold

### DIFF
--- a/nano/core_test/online_reps.cpp
+++ b/nano/core_test/online_reps.cpp
@@ -1,5 +1,4 @@
-#include "nano/node/election.hpp"
-
+#include <nano/node/election.hpp>
 #include <nano/node/online_reps.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/secure/vote.hpp>
@@ -14,18 +13,17 @@ TEST (online_reps, basic)
 	auto & node1 = *system.add_node ();
 	// 1 sample of minimum weight
 	ASSERT_EQ (node1.config.online_weight_minimum, node1.online_reps.trended ());
-	auto vote (std::make_shared<nano::vote> ());
 	ASSERT_EQ (0, node1.online_reps.online ());
 	node1.online_reps.observe (nano::dev::genesis_key.pub);
 	ASSERT_EQ (nano::dev::constants.genesis_amount, node1.online_reps.online ());
 	// 1 minimum, 1 maximum
-	ASSERT_EQ (node1.config.online_weight_minimum, node1.online_reps.trended ());
 	node1.online_reps.force_sample ();
 	ASSERT_EQ (nano::dev::constants.genesis_amount, node1.online_reps.trended ());
+	// Clearing simulates all reps going offline (network error, etc)
+	// Should remain at the latest trended weight until enough weight reconnects
 	node1.online_reps.clear ();
-	// 2 minimum, 1 maximum
 	node1.online_reps.force_sample ();
-	ASSERT_EQ (node1.config.online_weight_minimum, node1.online_reps.trended ());
+	ASSERT_EQ (nano::dev::constants.genesis_amount, node1.online_reps.trended ());
 }
 
 TEST (online_reps, rep_crawler)

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -680,6 +680,7 @@ enum class detail
 	sanitize_old,
 	sanitize_future,
 	sample,
+	sample_skipped,
 	rep_new,
 	rep_update,
 	rep_trim,

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -113,11 +113,13 @@ void nano::online_reps::run ()
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 	last_sample = std::chrono::steady_clock::now ();
+	bool sampled = true; // Use full interval before first sample
 	while (!stopped)
 	{
 		condition.wait_for (lock, nano::is_dev_run () ? 100ms : 1s, [this] () {
 			return stopped;
 		});
+
 		if (stopped)
 		{
 			return;
@@ -128,20 +130,36 @@ void nano::online_reps::run ()
 
 		// Sample trended weight if the next sample time has been reached
 		auto const now = std::chrono::steady_clock::now ();
-		auto const next_sample = last_sample + config.network_params.node.weight_interval;
+		// Reduce interval if the last sample was skipped
+		auto const interval = sampled ? config.network_params.node.weight_interval : config.network_params.node.weight_interval / 2;
+		auto const next_sample = last_sample + interval;
 		if (now >= next_sample)
 		{
 			trim ();
 			lock.unlock ();
-			sample ();
+
+			sampled = sample ();
+
 			lock.lock ();
 			last_sample = now;
 		}
 	}
 }
 
-void nano::online_reps::sample ()
+bool nano::online_reps::sample ()
 {
+	auto current_online = online ();
+
+	if (current_online < config.online_weight_minimum.number ())
+	{
+		stats.inc (nano::stat::type::online_reps, nano::stat::detail::sample_skipped);
+		logger.warn (nano::log::type::online_reps, "Current online weight {} is below minimum threshold {}. This often occurs when the node cannot reach enough peers; check network connectivity and peer count.",
+		nano::uint128_union{ current_online }.format_balance (nano_ratio, 1, true),
+		nano::uint128_union{ config.online_weight_minimum.number () }.format_balance (nano_ratio, 1, true));
+
+		return false; // Skipped
+	}
+
 	stats.inc (nano::stat::type::online_reps, nano::stat::detail::sample);
 
 	auto transaction = ledger.tx_begin_write (nano::store::writer::online_weight);
@@ -150,7 +168,7 @@ void nano::online_reps::sample ()
 	trim_trended (transaction);
 
 	// Put current online weight sample into the database
-	ledger.store.online_weight.put (transaction, nano::seconds_since_epoch (), online ());
+	ledger.store.online_weight.put (transaction, nano::seconds_since_epoch (), current_online);
 
 	// Update current trended weight
 	auto trended_result = calculate_trended (transaction);
@@ -162,6 +180,8 @@ void nano::online_reps::sample ()
 	logger.info (nano::log::type::online_reps, "Updated trended weight: {} (samples: {})",
 	nano::uint128_union{ trended_result.trended }.format_balance (nano_ratio, 1, true),
 	trended_result.samples);
+
+	return true; // Sampled
 }
 
 nano::uint128_t nano::online_reps::calculate_online () const

--- a/nano/node/online_reps.hpp
+++ b/nano/node/online_reps.hpp
@@ -58,7 +58,7 @@ private: // Dependencies
 private:
 	void run ();
 	/** Called periodically to sample online weight */
-	void sample ();
+	bool sample ();
 	void trim ();
 	/** Remove old records from the database */
 	void trim_trended (nano::store::write_transaction const &);


### PR DESCRIPTION
This change prevents the online weight sampling from recording samples when the current online weight is below the configured minimum threshold (`[node].online_weight_minimum`). The intent is to avoid skewing the trended weight calculation during network connectivity issues when the node can't see enough peers.