### PR TITLE
Move message types to `nano::messages` namespace

### DIFF
--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -292,7 +292,7 @@ TEST (change_block, deserialize)
 
 TEST (frontier_req, serialization)
 {
-	nano::frontier_req request1{ nano::dev::network_params.network };
+	nano::messages::frontier_req request1{ nano::dev::network_params.network };
 	request1.start = 1;
 	request1.age = 2;
 	request1.count = 3;
@@ -303,9 +303,9 @@ TEST (frontier_req, serialization)
 	}
 	auto error (false);
 	nano::bufferstream stream (bytes.data (), bytes.size ());
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	nano::frontier_req request2 (error, stream, header);
+	nano::messages::frontier_req request2 (error, stream, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (request1, request2);
 }
@@ -323,7 +323,7 @@ TEST (block, publish_req_serialization)
 				 .sign (nano::keypair ().prv, 2)
 				 .work (3)
 				 .build ();
-	nano::publish req{ nano::dev::network_params.network, block };
+	nano::messages::publish req{ nano::dev::network_params.network, block };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -331,9 +331,9 @@ TEST (block, publish_req_serialization)
 	}
 	auto error (false);
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());
-	nano::message_header header (error, stream2);
+	nano::messages::message_header header (error, stream2);
 	ASSERT_FALSE (error);
-	nano::publish req2 (error, stream2, header);
+	nano::messages::publish req2 (error, stream2, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (req, req2);
 	ASSERT_EQ (*req.block, *req2.block);

--- a/nano/core_test/bootstrap_server.cpp
+++ b/nano/core_test/bootstrap_server.cpp
@@ -17,13 +17,13 @@ namespace
 class responses_helper final
 {
 public:
-	void add (nano::asc_pull_ack const & ack)
+	void add (nano::messages::asc_pull_ack const & ack)
 	{
 		nano::lock_guard<nano::mutex> lock{ mutex };
 		responses.push_back (ack);
 	}
 
-	std::vector<nano::asc_pull_ack> get ()
+	std::vector<nano::messages::asc_pull_ack> get ()
 	{
 		nano::lock_guard<nano::mutex> lock{ mutex };
 		return responses;
@@ -44,7 +44,7 @@ public:
 
 private:
 	nano::mutex mutex;
-	std::vector<nano::asc_pull_ack> responses;
+	std::vector<nano::messages::asc_pull_ack> responses;
 };
 
 /**
@@ -82,14 +82,14 @@ TEST (bootstrap_server, serve_account_blocks)
 	auto [first_account, first_blocks] = chains.front ();
 
 	// Request blocks from account root
-	nano::asc_pull_req request{ node.network_params.network };
+	nano::messages::asc_pull_req request{ node.network_params.network };
 	request.id = 7;
-	request.type = nano::asc_pull_type::blocks;
+	request.type = nano::messages::asc_pull_type::blocks;
 
-	nano::asc_pull_req::blocks_payload request_payload{};
+	nano::messages::asc_pull_req::blocks_payload request_payload{};
 	request_payload.start = first_account;
 	request_payload.count = nano::bootstrap_server::max_blocks;
-	request_payload.start_type = nano::asc_pull_req::hash_type::account;
+	request_payload.start_type = nano::messages::asc_pull_req::hash_type::account;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -101,10 +101,10 @@ TEST (bootstrap_server, serve_account_blocks)
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
 	ASSERT_EQ (response.id, 7);
-	ASSERT_EQ (response.type, nano::asc_pull_type::blocks);
+	ASSERT_EQ (response.type, nano::messages::asc_pull_type::blocks);
 
-	nano::asc_pull_ack::blocks_payload response_payload;
-	ASSERT_NO_THROW (response_payload = std::get<nano::asc_pull_ack::blocks_payload> (response.payload));
+	nano::messages::asc_pull_ack::blocks_payload response_payload;
+	ASSERT_NO_THROW (response_payload = std::get<nano::messages::asc_pull_ack::blocks_payload> (response.payload));
 	ASSERT_EQ (response_payload.blocks.size (), 128);
 	ASSERT_TRUE (compare_blocks (response_payload.blocks, first_blocks));
 
@@ -127,14 +127,14 @@ TEST (bootstrap_server, serve_hash)
 	blocks = nano::block_list_t{ std::next (blocks.begin (), 9), blocks.end () };
 
 	// Request blocks from the middle of the chain
-	nano::asc_pull_req request{ node.network_params.network };
+	nano::messages::asc_pull_req request{ node.network_params.network };
 	request.id = 7;
-	request.type = nano::asc_pull_type::blocks;
+	request.type = nano::messages::asc_pull_type::blocks;
 
-	nano::asc_pull_req::blocks_payload request_payload{};
+	nano::messages::asc_pull_req::blocks_payload request_payload{};
 	request_payload.start = blocks.front ()->hash ();
 	request_payload.count = nano::bootstrap_server::max_blocks;
-	request_payload.start_type = nano::asc_pull_req::hash_type::block;
+	request_payload.start_type = nano::messages::asc_pull_req::hash_type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -146,10 +146,10 @@ TEST (bootstrap_server, serve_hash)
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
 	ASSERT_EQ (response.id, 7);
-	ASSERT_EQ (response.type, nano::asc_pull_type::blocks);
+	ASSERT_EQ (response.type, nano::messages::asc_pull_type::blocks);
 
-	nano::asc_pull_ack::blocks_payload response_payload;
-	ASSERT_NO_THROW (response_payload = std::get<nano::asc_pull_ack::blocks_payload> (response.payload));
+	nano::messages::asc_pull_ack::blocks_payload response_payload;
+	ASSERT_NO_THROW (response_payload = std::get<nano::messages::asc_pull_ack::blocks_payload> (response.payload));
 	ASSERT_EQ (response_payload.blocks.size (), 128);
 	ASSERT_TRUE (compare_blocks (response_payload.blocks, blocks));
 
@@ -172,14 +172,14 @@ TEST (bootstrap_server, serve_hash_one)
 	blocks = nano::block_list_t{ std::next (blocks.begin (), 9), blocks.end () };
 
 	// Request blocks from the middle of the chain
-	nano::asc_pull_req request{ node.network_params.network };
+	nano::messages::asc_pull_req request{ node.network_params.network };
 	request.id = 7;
-	request.type = nano::asc_pull_type::blocks;
+	request.type = nano::messages::asc_pull_type::blocks;
 
-	nano::asc_pull_req::blocks_payload request_payload{};
+	nano::messages::asc_pull_req::blocks_payload request_payload{};
 	request_payload.start = blocks.front ()->hash ();
 	request_payload.count = 1;
-	request_payload.start_type = nano::asc_pull_req::hash_type::block;
+	request_payload.start_type = nano::messages::asc_pull_req::hash_type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -191,10 +191,10 @@ TEST (bootstrap_server, serve_hash_one)
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
 	ASSERT_EQ (response.id, 7);
-	ASSERT_EQ (response.type, nano::asc_pull_type::blocks);
+	ASSERT_EQ (response.type, nano::messages::asc_pull_type::blocks);
 
-	nano::asc_pull_ack::blocks_payload response_payload;
-	ASSERT_NO_THROW (response_payload = std::get<nano::asc_pull_ack::blocks_payload> (response.payload));
+	nano::messages::asc_pull_ack::blocks_payload response_payload;
+	ASSERT_NO_THROW (response_payload = std::get<nano::messages::asc_pull_ack::blocks_payload> (response.payload));
 	ASSERT_EQ (response_payload.blocks.size (), 1);
 	ASSERT_EQ (response_payload.blocks.front ()->hash (), request_payload.start.as_block_hash ());
 }
@@ -211,14 +211,14 @@ TEST (bootstrap_server, serve_end_of_chain)
 	auto [account, blocks] = chains.front ();
 
 	// Request blocks from account frontier
-	nano::asc_pull_req request{ node.network_params.network };
+	nano::messages::asc_pull_req request{ node.network_params.network };
 	request.id = 7;
-	request.type = nano::asc_pull_type::blocks;
+	request.type = nano::messages::asc_pull_type::blocks;
 
-	nano::asc_pull_req::blocks_payload request_payload{};
+	nano::messages::asc_pull_req::blocks_payload request_payload{};
 	request_payload.start = blocks.back ()->hash ();
 	request_payload.count = nano::bootstrap_server::max_blocks;
-	request_payload.start_type = nano::asc_pull_req::hash_type::block;
+	request_payload.start_type = nano::messages::asc_pull_req::hash_type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -230,10 +230,10 @@ TEST (bootstrap_server, serve_end_of_chain)
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
 	ASSERT_EQ (response.id, 7);
-	ASSERT_EQ (response.type, nano::asc_pull_type::blocks);
+	ASSERT_EQ (response.type, nano::messages::asc_pull_type::blocks);
 
-	nano::asc_pull_ack::blocks_payload response_payload;
-	ASSERT_NO_THROW (response_payload = std::get<nano::asc_pull_ack::blocks_payload> (response.payload));
+	nano::messages::asc_pull_ack::blocks_payload response_payload;
+	ASSERT_NO_THROW (response_payload = std::get<nano::messages::asc_pull_ack::blocks_payload> (response.payload));
 	// Response should contain only the last block from chain
 	ASSERT_EQ (response_payload.blocks.size (), 1);
 	ASSERT_EQ (*response_payload.blocks.front (), *blocks.back ());
@@ -250,14 +250,14 @@ TEST (bootstrap_server, serve_missing)
 	auto chains = nano::test::setup_chains (system, node, 1, 128);
 
 	// Request blocks from account frontier
-	nano::asc_pull_req request{ node.network_params.network };
+	nano::messages::asc_pull_req request{ node.network_params.network };
 	request.id = 7;
-	request.type = nano::asc_pull_type::blocks;
+	request.type = nano::messages::asc_pull_type::blocks;
 
-	nano::asc_pull_req::blocks_payload request_payload{};
+	nano::messages::asc_pull_req::blocks_payload request_payload{};
 	request_payload.start = nano::test::random_hash ();
 	request_payload.count = nano::bootstrap_server::max_blocks;
-	request_payload.start_type = nano::asc_pull_req::hash_type::block;
+	request_payload.start_type = nano::messages::asc_pull_req::hash_type::block;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -269,10 +269,10 @@ TEST (bootstrap_server, serve_missing)
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
 	ASSERT_EQ (response.id, 7);
-	ASSERT_EQ (response.type, nano::asc_pull_type::blocks);
+	ASSERT_EQ (response.type, nano::messages::asc_pull_type::blocks);
 
-	nano::asc_pull_ack::blocks_payload response_payload;
-	ASSERT_NO_THROW (response_payload = std::get<nano::asc_pull_ack::blocks_payload> (response.payload));
+	nano::messages::asc_pull_ack::blocks_payload response_payload;
+	ASSERT_NO_THROW (response_payload = std::get<nano::messages::asc_pull_ack::blocks_payload> (response.payload));
 	// There should be nothing sent
 	ASSERT_EQ (response_payload.blocks.size (), 0);
 }
@@ -293,14 +293,14 @@ TEST (bootstrap_server, serve_multiple)
 		for (auto & [account, blocks] : chains)
 		{
 			// Request blocks from account root
-			nano::asc_pull_req request{ node.network_params.network };
+			nano::messages::asc_pull_req request{ node.network_params.network };
 			request.id = next_id++;
-			request.type = nano::asc_pull_type::blocks;
+			request.type = nano::messages::asc_pull_type::blocks;
 
-			nano::asc_pull_req::blocks_payload request_payload{};
+			nano::messages::asc_pull_req::blocks_payload request_payload{};
 			request_payload.start = account;
 			request_payload.count = nano::bootstrap_server::max_blocks;
-			request_payload.start_type = nano::asc_pull_req::hash_type::account;
+			request_payload.start_type = nano::messages::asc_pull_req::hash_type::account;
 
 			request.payload = request_payload;
 			request.update_header ();
@@ -323,10 +323,10 @@ TEST (bootstrap_server, serve_multiple)
 
 			// Ensure we got response exactly for what we asked for
 			ASSERT_EQ (response.id, next_id);
-			ASSERT_EQ (response.type, nano::asc_pull_type::blocks);
+			ASSERT_EQ (response.type, nano::messages::asc_pull_type::blocks);
 
-			nano::asc_pull_ack::blocks_payload response_payload;
-			ASSERT_NO_THROW (response_payload = std::get<nano::asc_pull_ack::blocks_payload> (response.payload));
+			nano::messages::asc_pull_ack::blocks_payload response_payload;
+			ASSERT_NO_THROW (response_payload = std::get<nano::messages::asc_pull_ack::blocks_payload> (response.payload));
 			ASSERT_EQ (response_payload.blocks.size (), 17); // 1 open block + 16 random blocks
 			ASSERT_TRUE (compare_blocks (response_payload.blocks, blocks));
 
@@ -350,13 +350,13 @@ TEST (bootstrap_server, serve_account_info)
 	auto [account, blocks] = chains.front ();
 
 	// Request blocks from account root
-	nano::asc_pull_req request{ node.network_params.network };
+	nano::messages::asc_pull_req request{ node.network_params.network };
 	request.id = 7;
-	request.type = nano::asc_pull_type::account_info;
+	request.type = nano::messages::asc_pull_type::account_info;
 
-	nano::asc_pull_req::account_info_payload request_payload{};
+	nano::messages::asc_pull_req::account_info_payload request_payload{};
 	request_payload.target = account;
-	request_payload.target_type = nano::asc_pull_req::hash_type::account;
+	request_payload.target_type = nano::messages::asc_pull_req::hash_type::account;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -368,10 +368,10 @@ TEST (bootstrap_server, serve_account_info)
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
 	ASSERT_EQ (response.id, 7);
-	ASSERT_EQ (response.type, nano::asc_pull_type::account_info);
+	ASSERT_EQ (response.type, nano::messages::asc_pull_type::account_info);
 
-	nano::asc_pull_ack::account_info_payload response_payload;
-	ASSERT_NO_THROW (response_payload = std::get<nano::asc_pull_ack::account_info_payload> (response.payload));
+	nano::messages::asc_pull_ack::account_info_payload response_payload;
+	ASSERT_NO_THROW (response_payload = std::get<nano::messages::asc_pull_ack::account_info_payload> (response.payload));
 
 	ASSERT_EQ (response_payload.account, account);
 	ASSERT_EQ (response_payload.account_open, blocks.front ()->hash ());
@@ -396,13 +396,13 @@ TEST (bootstrap_server, serve_account_info_missing)
 	auto [account, blocks] = chains.front ();
 
 	// Request blocks from account root
-	nano::asc_pull_req request{ node.network_params.network };
+	nano::messages::asc_pull_req request{ node.network_params.network };
 	request.id = 7;
-	request.type = nano::asc_pull_type::account_info;
+	request.type = nano::messages::asc_pull_type::account_info;
 
-	nano::asc_pull_req::account_info_payload request_payload{};
+	nano::messages::asc_pull_req::account_info_payload request_payload{};
 	request_payload.target = nano::test::random_account ();
-	request_payload.target_type = nano::asc_pull_req::hash_type::account;
+	request_payload.target_type = nano::messages::asc_pull_req::hash_type::account;
 
 	request.payload = request_payload;
 	request.update_header ();
@@ -414,10 +414,10 @@ TEST (bootstrap_server, serve_account_info_missing)
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
 	ASSERT_EQ (response.id, 7);
-	ASSERT_EQ (response.type, nano::asc_pull_type::account_info);
+	ASSERT_EQ (response.type, nano::messages::asc_pull_type::account_info);
 
-	nano::asc_pull_ack::account_info_payload response_payload;
-	ASSERT_NO_THROW (response_payload = std::get<nano::asc_pull_ack::account_info_payload> (response.payload));
+	nano::messages::asc_pull_ack::account_info_payload response_payload;
+	ASSERT_NO_THROW (response_payload = std::get<nano::messages::asc_pull_ack::account_info_payload> (response.payload));
 
 	ASSERT_EQ (response_payload.account, request_payload.target.as_account ());
 	ASSERT_EQ (response_payload.account_open, 0);
@@ -441,11 +441,11 @@ TEST (bootstrap_server, serve_frontiers)
 	auto chains = nano::test::setup_chains (system, node, /* chain count */ 32, /* block count */ 4);
 
 	// Request all frontiers
-	nano::asc_pull_req request{ node.network_params.network };
+	nano::messages::asc_pull_req request{ node.network_params.network };
 	request.id = 7;
-	request.type = nano::asc_pull_type::frontiers;
+	request.type = nano::messages::asc_pull_type::frontiers;
 
-	nano::asc_pull_req::frontiers_payload request_payload{};
+	nano::messages::asc_pull_req::frontiers_payload request_payload{};
 	request_payload.count = nano::bootstrap_server::max_frontiers;
 	request_payload.start = 0;
 
@@ -459,10 +459,10 @@ TEST (bootstrap_server, serve_frontiers)
 	auto response = responses.get ().front ();
 	// Ensure we got response exactly for what we asked for
 	ASSERT_EQ (response.id, 7);
-	ASSERT_EQ (response.type, nano::asc_pull_type::frontiers);
+	ASSERT_EQ (response.type, nano::messages::asc_pull_type::frontiers);
 
-	nano::asc_pull_ack::frontiers_payload response_payload;
-	ASSERT_NO_THROW (response_payload = std::get<nano::asc_pull_ack::frontiers_payload> (response.payload));
+	nano::messages::asc_pull_ack::frontiers_payload response_payload;
+	ASSERT_NO_THROW (response_payload = std::get<nano::messages::asc_pull_ack::frontiers_payload> (response.payload));
 
 	ASSERT_EQ (response_payload.frontiers.size (), chains.size () + 1); // +1 for genesis
 
@@ -494,11 +494,11 @@ TEST (bootstrap_server, serve_frontiers_invalid_count)
 
 	// Zero count
 	{
-		nano::asc_pull_req request{ node.network_params.network };
+		nano::messages::asc_pull_req request{ node.network_params.network };
 		request.id = 7;
-		request.type = nano::asc_pull_type::frontiers;
+		request.type = nano::messages::asc_pull_type::frontiers;
 
-		nano::asc_pull_req::frontiers_payload request_payload{};
+		nano::messages::asc_pull_req::frontiers_payload request_payload{};
 		request_payload.count = 0;
 		request_payload.start = 0;
 
@@ -512,11 +512,11 @@ TEST (bootstrap_server, serve_frontiers_invalid_count)
 
 	// Count larger than allowed
 	{
-		nano::asc_pull_req request{ node.network_params.network };
+		nano::messages::asc_pull_req request{ node.network_params.network };
 		request.id = 7;
-		request.type = nano::asc_pull_type::frontiers;
+		request.type = nano::messages::asc_pull_type::frontiers;
 
-		nano::asc_pull_req::frontiers_payload request_payload{};
+		nano::messages::asc_pull_req::frontiers_payload request_payload{};
 		request_payload.count = nano::bootstrap_server::max_frontiers + 1;
 		request_payload.start = 0;
 
@@ -530,11 +530,11 @@ TEST (bootstrap_server, serve_frontiers_invalid_count)
 
 	// Max numeric value
 	{
-		nano::asc_pull_req request{ node.network_params.network };
+		nano::messages::asc_pull_req request{ node.network_params.network };
 		request.id = 7;
-		request.type = nano::asc_pull_type::frontiers;
+		request.type = nano::messages::asc_pull_type::frontiers;
 
-		nano::asc_pull_req::frontiers_payload request_payload{};
+		nano::messages::asc_pull_req::frontiers_payload request_payload{};
 		request_payload.count = std::numeric_limits<decltype (request_payload.count)>::max ();
 		request_payload.start = 0;
 

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -31,7 +31,7 @@ std::shared_ptr<nano::block> random_block ()
 TEST (message, header_version)
 {
 	// Simplest message type
-	nano::keepalive original{ nano::dev::network_params.network };
+	nano::messages::keepalive original{ nano::dev::network_params.network };
 
 	// Serialize the original keepalive message
 	std::vector<uint8_t> bytes;
@@ -43,19 +43,19 @@ TEST (message, header_version)
 	// Deserialize the byte stream back to a message header
 	nano::bufferstream stream (bytes.data (), bytes.size ());
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
 
 	// Check header versions
 	ASSERT_EQ (nano::dev::network_params.network.protocol_version_min, header.version_min);
 	ASSERT_EQ (nano::dev::network_params.network.protocol_version, header.version_using);
 	ASSERT_EQ (nano::dev::network_params.network.protocol_version, header.version_max);
-	ASSERT_EQ (nano::message_type::keepalive, header.type);
+	ASSERT_EQ (nano::messages::message_type::keepalive, header.type);
 }
 
 TEST (message, keepalive_serialization)
 {
-	nano::keepalive request1{ nano::dev::network_params.network };
+	nano::messages::keepalive request1{ nano::dev::network_params.network };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -63,16 +63,16 @@ TEST (message, keepalive_serialization)
 	}
 	auto error (false);
 	nano::bufferstream stream (bytes.data (), bytes.size ());
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	nano::keepalive request2 (error, stream, header);
+	nano::messages::keepalive request2 (error, stream, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (request1, request2);
 }
 
 TEST (message, keepalive_deserialize)
 {
-	nano::keepalive message1{ nano::dev::network_params.network };
+	nano::messages::keepalive message1{ nano::dev::network_params.network };
 	message1.peers[0] = nano::endpoint (boost::asio::ip::address_v6::loopback (), 10000);
 	std::vector<uint8_t> bytes;
 	{
@@ -81,10 +81,10 @@ TEST (message, keepalive_deserialize)
 	}
 	nano::bufferstream stream (bytes.data (), bytes.size ());
 	auto error (false);
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::keepalive, header.type);
-	nano::keepalive message2 (error, stream, header);
+	ASSERT_EQ (nano::messages::message_type::keepalive, header.type);
+	nano::messages::keepalive message2 (error, stream, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (message1.peers, message2.peers);
 }
@@ -93,7 +93,7 @@ TEST (message, publish)
 {
 	// Create a random block
 	auto block = random_block ();
-	nano::publish original{ nano::dev::network_params.network, block };
+	nano::messages::publish original{ nano::dev::network_params.network, block };
 	ASSERT_FALSE (original.is_originator ());
 
 	// Serialize the original publish message
@@ -106,9 +106,9 @@ TEST (message, publish)
 	// Deserialize the byte stream back to a publish message
 	nano::bufferstream stream (bytes.data (), bytes.size ());
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	nano::publish deserialized (error, stream, header);
+	nano::messages::publish deserialized (error, stream, header);
 	ASSERT_FALSE (error);
 
 	// Assert that the original and deserialized messages are equal
@@ -121,7 +121,7 @@ TEST (message, publish_originator_flag)
 {
 	// Create a random block
 	auto block = random_block ();
-	nano::publish original{ nano::dev::network_params.network, block, /* originator */ true };
+	nano::messages::publish original{ nano::dev::network_params.network, block, /* originator */ true };
 	ASSERT_TRUE (original.is_originator ());
 
 	// Serialize the original publish message
@@ -134,9 +134,9 @@ TEST (message, publish_originator_flag)
 	// Deserialize the byte stream back to a publish message
 	nano::bufferstream stream (bytes.data (), bytes.size ());
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	nano::publish deserialized (error, stream, header);
+	nano::messages::publish deserialized (error, stream, header);
 	ASSERT_FALSE (error);
 
 	// Assert that the originator flag is set correctly in both the original and deserialized messages
@@ -147,7 +147,7 @@ TEST (message, publish_originator_flag)
 
 TEST (message, confirm_header_flags)
 {
-	nano::message_header header_v2{ nano::dev::network_params.network, nano::message_type::confirm_req };
+	nano::messages::message_header header_v2{ nano::dev::network_params.network, nano::messages::message_type::confirm_req };
 	header_v2.confirm_set_v2 (true);
 
 	const uint8_t value = 0b0110'1001;
@@ -165,9 +165,9 @@ TEST (message, confirm_header_flags)
 	nano::bufferstream stream (bytes.data (), bytes.size ());
 
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::confirm_req, header.type);
+	ASSERT_EQ (nano::messages::message_type::confirm_req, header.type);
 
 	ASSERT_TRUE (header.confirm_is_v2 ());
 	ASSERT_EQ (header.count_v2_get (), value);
@@ -175,7 +175,7 @@ TEST (message, confirm_header_flags)
 
 TEST (message, confirm_header_flags_max)
 {
-	nano::message_header header_v2{ nano::dev::network_params.network, nano::message_type::confirm_req };
+	nano::messages::message_header header_v2{ nano::dev::network_params.network, nano::messages::message_type::confirm_req };
 	header_v2.confirm_set_v2 (true);
 	header_v2.count_v2_set (255); // Max count value
 
@@ -190,9 +190,9 @@ TEST (message, confirm_header_flags_max)
 	nano::bufferstream stream (bytes.data (), bytes.size ());
 
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::confirm_req, header.type);
+	ASSERT_EQ (nano::messages::message_type::confirm_req, header.type);
 
 	ASSERT_TRUE (header.confirm_is_v2 ());
 	ASSERT_EQ (header.count_v2_get (), 255);
@@ -221,7 +221,7 @@ TEST (message, confirm_ack_hash_serialization)
 	}
 	nano::keypair representative1;
 	auto vote = nano::test::make_vote (representative1, { hashes }, 0, 0);
-	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
+	nano::messages::confirm_ack con1{ nano::dev::network_params.network, vote };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream1 (bytes);
@@ -229,8 +229,8 @@ TEST (message, confirm_ack_hash_serialization)
 	}
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());
 	bool error (false);
-	nano::message_header header (error, stream2);
-	nano::confirm_ack con2 (error, stream2, header);
+	nano::messages::message_header header (error, stream2);
+	nano::messages::confirm_ack con2 (error, stream2, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (con1, con2);
 	ASSERT_EQ (hashes, con2.vote->hashes);
@@ -263,7 +263,7 @@ TEST (message, confirm_ack_hash_serialization_v2)
 
 	nano::keypair representative1;
 	auto vote = nano::test::make_vote (representative1, { hashes }, 0, 0);
-	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
+	nano::messages::confirm_ack con1{ nano::dev::network_params.network, vote };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream1 (bytes);
@@ -271,8 +271,8 @@ TEST (message, confirm_ack_hash_serialization_v2)
 	}
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());
 	bool error (false);
-	nano::message_header header (error, stream2);
-	nano::confirm_ack con2 (error, stream2, header);
+	nano::messages::message_header header (error, stream2);
+	nano::messages::confirm_ack con2 (error, stream2, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (con1, con2);
 	ASSERT_EQ (hashes, con2.vote->hashes);
@@ -285,7 +285,7 @@ TEST (message, confirm_ack_rebroadcasted_flag)
 {
 	nano::keypair representative1;
 	auto vote = nano::test::make_vote (representative1, std::vector<nano::block_hash> (), 0, 0);
-	nano::confirm_ack con1{ nano::dev::network_params.network, vote, /* rebroadcasted */ true };
+	nano::messages::confirm_ack con1{ nano::dev::network_params.network, vote, /* rebroadcasted */ true };
 	ASSERT_TRUE (con1.is_rebroadcasted ());
 	std::vector<uint8_t> bytes;
 	{
@@ -294,8 +294,8 @@ TEST (message, confirm_ack_rebroadcasted_flag)
 	}
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());
 	bool error (false);
-	nano::message_header header (error, stream2);
-	nano::confirm_ack con2 (error, stream2, header);
+	nano::messages::message_header header (error, stream2);
+	nano::messages::confirm_ack con2 (error, stream2, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (con1, con2);
 	ASSERT_TRUE (con2.vote->hashes.empty ());
@@ -315,7 +315,7 @@ TEST (message, confirm_req_hash_serialization)
 				 .sign (nano::keypair ().prv, 2)
 				 .work (3)
 				 .build ();
-	nano::confirm_req req{ nano::dev::network_params.network, block->hash (), block->root () };
+	nano::messages::confirm_req req{ nano::dev::network_params.network, block->hash (), block->root () };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -323,8 +323,8 @@ TEST (message, confirm_req_hash_serialization)
 	}
 	auto error (false);
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());
-	nano::message_header header (error, stream2);
-	nano::confirm_req req2 (error, stream2, header);
+	nano::messages::message_header header (error, stream2);
+	nano::messages::confirm_req req2 (error, stream2, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (req, req2);
 	ASSERT_EQ (req.roots_hashes, req2.roots_hashes);
@@ -366,7 +366,7 @@ TEST (message, confirm_req_hash_batch_serialization)
 		roots_hashes.push_back (std::make_pair (block->hash (), block->root ()));
 	}
 	roots_hashes.push_back (std::make_pair (open->hash (), open->root ()));
-	nano::confirm_req req{ nano::dev::network_params.network, roots_hashes };
+	nano::messages::confirm_req req{ nano::dev::network_params.network, roots_hashes };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -374,8 +374,8 @@ TEST (message, confirm_req_hash_batch_serialization)
 	}
 	auto error (false);
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());
-	nano::message_header header (error, stream2);
-	nano::confirm_req req2 (error, stream2, header);
+	nano::messages::message_header header (error, stream2);
+	nano::messages::confirm_req req2 (error, stream2, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (req, req2);
 	ASSERT_EQ (req.roots_hashes, req2.roots_hashes);
@@ -421,7 +421,7 @@ TEST (message, confirm_req_hash_batch_serialization_v2)
 		roots_hashes.push_back (std::make_pair (block->hash (), block->root ()));
 	}
 
-	nano::confirm_req req{ nano::dev::network_params.network, roots_hashes };
+	nano::messages::confirm_req req{ nano::dev::network_params.network, roots_hashes };
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -429,8 +429,8 @@ TEST (message, confirm_req_hash_batch_serialization_v2)
 	}
 	auto error (false);
 	nano::bufferstream stream2 (bytes.data (), bytes.size ());
-	nano::message_header header (error, stream2);
-	nano::confirm_req req2 (error, stream2, header);
+	nano::messages::message_header header (error, stream2);
+	nano::messages::confirm_req req2 (error, stream2, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (req, req2);
 	ASSERT_EQ (req.roots_hashes, req2.roots_hashes);
@@ -447,13 +447,13 @@ TEST (confirm_ack, empty_vote_hashes)
 {
 	nano::keypair key;
 	auto vote = std::make_shared<nano::vote> (key.pub, key.prv, 0, 0, std::vector<nano::block_hash>{} /* empty */);
-	nano::confirm_ack message{ nano::dev::network_params.network, vote };
+	nano::messages::confirm_ack message{ nano::dev::network_params.network, vote };
 }
 
 TEST (message, bulk_pull_serialization)
 {
-	nano::bulk_pull message_in{ nano::dev::network_params.network };
-	message_in.header.flag_set (nano::message_header::bulk_pull_ascending_flag);
+	nano::messages::bulk_pull message_in{ nano::dev::network_params.network };
+	message_in.header.flag_set (nano::messages::message_header::bulk_pull_ascending_flag);
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream{ bytes };
@@ -461,20 +461,20 @@ TEST (message, bulk_pull_serialization)
 	}
 	nano::bufferstream stream{ bytes.data (), bytes.size () };
 	bool error = false;
-	nano::message_header header{ error, stream };
+	nano::messages::message_header header{ error, stream };
 	ASSERT_FALSE (error);
-	nano::bulk_pull message_out{ error, stream, header };
+	nano::messages::bulk_pull message_out{ error, stream, header };
 	ASSERT_FALSE (error);
 	ASSERT_TRUE (header.bulk_pull_ascending ());
 }
 
 TEST (message, asc_pull_req_serialization_blocks)
 {
-	nano::asc_pull_req original{ nano::dev::network_params.network };
+	nano::messages::asc_pull_req original{ nano::dev::network_params.network };
 	original.id = 7;
-	original.type = nano::asc_pull_type::blocks;
+	original.type = nano::messages::asc_pull_type::blocks;
 
-	nano::asc_pull_req::blocks_payload original_payload{};
+	nano::messages::asc_pull_req::blocks_payload original_payload{};
 	original_payload.start = nano::test::random_hash ();
 	original_payload.count = 111;
 
@@ -491,18 +491,18 @@ TEST (message, asc_pull_req_serialization_blocks)
 
 	// Header
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::asc_pull_req, header.type);
+	ASSERT_EQ (nano::messages::message_type::asc_pull_req, header.type);
 
 	// Message
-	nano::asc_pull_req message (error, stream, header);
+	nano::messages::asc_pull_req message (error, stream, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (original.id, message.id);
 	ASSERT_EQ (original.type, message.type);
 
-	nano::asc_pull_req::blocks_payload message_payload;
-	ASSERT_NO_THROW (message_payload = std::get<nano::asc_pull_req::blocks_payload> (message.payload));
+	nano::messages::asc_pull_req::blocks_payload message_payload;
+	ASSERT_NO_THROW (message_payload = std::get<nano::messages::asc_pull_req::blocks_payload> (message.payload));
 	ASSERT_EQ (original_payload.start, message_payload.start);
 	ASSERT_EQ (original_payload.count, message_payload.count);
 
@@ -511,11 +511,11 @@ TEST (message, asc_pull_req_serialization_blocks)
 
 TEST (message, asc_pull_req_serialization_account_info)
 {
-	nano::asc_pull_req original{ nano::dev::network_params.network };
+	nano::messages::asc_pull_req original{ nano::dev::network_params.network };
 	original.id = 7;
-	original.type = nano::asc_pull_type::account_info;
+	original.type = nano::messages::asc_pull_type::account_info;
 
-	nano::asc_pull_req::account_info_payload original_payload{};
+	nano::messages::asc_pull_req::account_info_payload original_payload{};
 	original_payload.target = nano::test::random_hash ();
 
 	original.payload = original_payload;
@@ -531,18 +531,18 @@ TEST (message, asc_pull_req_serialization_account_info)
 
 	// Header
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::asc_pull_req, header.type);
+	ASSERT_EQ (nano::messages::message_type::asc_pull_req, header.type);
 
 	// Message
-	nano::asc_pull_req message (error, stream, header);
+	nano::messages::asc_pull_req message (error, stream, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (original.id, message.id);
 	ASSERT_EQ (original.type, message.type);
 
-	nano::asc_pull_req::account_info_payload message_payload;
-	ASSERT_NO_THROW (message_payload = std::get<nano::asc_pull_req::account_info_payload> (message.payload));
+	nano::messages::asc_pull_req::account_info_payload message_payload;
+	ASSERT_NO_THROW (message_payload = std::get<nano::messages::asc_pull_req::account_info_payload> (message.payload));
 	ASSERT_EQ (original_payload.target, message_payload.target);
 
 	ASSERT_TRUE (nano::at_end (stream));
@@ -550,11 +550,11 @@ TEST (message, asc_pull_req_serialization_account_info)
 
 TEST (message, asc_pull_req_serialization_frontiers)
 {
-	nano::asc_pull_req original{ nano::dev::network_params.network };
+	nano::messages::asc_pull_req original{ nano::dev::network_params.network };
 	original.id = 7;
-	original.type = nano::asc_pull_type::frontiers;
+	original.type = nano::messages::asc_pull_type::frontiers;
 
-	nano::asc_pull_req::frontiers_payload original_payload{};
+	nano::messages::asc_pull_req::frontiers_payload original_payload{};
 	original_payload.start = nano::test::random_account ();
 	original_payload.count = 123;
 
@@ -571,18 +571,18 @@ TEST (message, asc_pull_req_serialization_frontiers)
 
 	// Header
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::asc_pull_req, header.type);
+	ASSERT_EQ (nano::messages::message_type::asc_pull_req, header.type);
 
 	// Message
-	nano::asc_pull_req message (error, stream, header);
+	nano::messages::asc_pull_req message (error, stream, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (original.id, message.id);
 	ASSERT_EQ (original.type, message.type);
 
-	nano::asc_pull_req::frontiers_payload message_payload;
-	ASSERT_NO_THROW (message_payload = std::get<nano::asc_pull_req::frontiers_payload> (message.payload));
+	nano::messages::asc_pull_req::frontiers_payload message_payload;
+	ASSERT_NO_THROW (message_payload = std::get<nano::messages::asc_pull_req::frontiers_payload> (message.payload));
 	ASSERT_EQ (original_payload.start, message_payload.start);
 	ASSERT_EQ (original_payload.count, message_payload.count);
 
@@ -591,12 +591,12 @@ TEST (message, asc_pull_req_serialization_frontiers)
 
 TEST (message, asc_pull_ack_serialization_blocks)
 {
-	nano::asc_pull_ack original{ nano::dev::network_params.network };
+	nano::messages::asc_pull_ack original{ nano::dev::network_params.network };
 	original.id = 11;
-	original.type = nano::asc_pull_type::blocks;
+	original.type = nano::messages::asc_pull_type::blocks;
 
-	nano::asc_pull_ack::blocks_payload original_payload{};
-	for (int n = 0; n < nano::asc_pull_ack::blocks_payload::max_blocks; ++n)
+	nano::messages::asc_pull_ack::blocks_payload original_payload{};
+	for (int n = 0; n < nano::messages::asc_pull_ack::blocks_payload::max_blocks; ++n)
 	{
 		original_payload.blocks.push_back (random_block ());
 	}
@@ -614,18 +614,18 @@ TEST (message, asc_pull_ack_serialization_blocks)
 
 	// Header
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::asc_pull_ack, header.type);
+	ASSERT_EQ (nano::messages::message_type::asc_pull_ack, header.type);
 
 	// Message
-	nano::asc_pull_ack message (error, stream, header);
+	nano::messages::asc_pull_ack message (error, stream, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (original.id, message.id);
 	ASSERT_EQ (original.type, message.type);
 
-	nano::asc_pull_ack::blocks_payload message_payload;
-	ASSERT_NO_THROW (message_payload = std::get<nano::asc_pull_ack::blocks_payload> (message.payload));
+	nano::messages::asc_pull_ack::blocks_payload message_payload;
+	ASSERT_NO_THROW (message_payload = std::get<nano::messages::asc_pull_ack::blocks_payload> (message.payload));
 
 	// Compare blocks
 	ASSERT_EQ (original_payload.blocks.size (), message_payload.blocks.size ());
@@ -638,11 +638,11 @@ TEST (message, asc_pull_ack_serialization_blocks)
 
 TEST (message, asc_pull_ack_serialization_account_info)
 {
-	nano::asc_pull_ack original{ nano::dev::network_params.network };
+	nano::messages::asc_pull_ack original{ nano::dev::network_params.network };
 	original.id = 11;
-	original.type = nano::asc_pull_type::account_info;
+	original.type = nano::messages::asc_pull_type::account_info;
 
-	nano::asc_pull_ack::account_info_payload original_payload{};
+	nano::messages::asc_pull_ack::account_info_payload original_payload{};
 	original_payload.account = nano::test::random_account ();
 	original_payload.account_open = nano::test::random_hash ();
 	original_payload.account_head = nano::test::random_hash ();
@@ -663,18 +663,18 @@ TEST (message, asc_pull_ack_serialization_account_info)
 
 	// Header
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::asc_pull_ack, header.type);
+	ASSERT_EQ (nano::messages::message_type::asc_pull_ack, header.type);
 
 	// Message
-	nano::asc_pull_ack message (error, stream, header);
+	nano::messages::asc_pull_ack message (error, stream, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (original.id, message.id);
 	ASSERT_EQ (original.type, message.type);
 
-	nano::asc_pull_ack::account_info_payload message_payload;
-	ASSERT_NO_THROW (message_payload = std::get<nano::asc_pull_ack::account_info_payload> (message.payload));
+	nano::messages::asc_pull_ack::account_info_payload message_payload;
+	ASSERT_NO_THROW (message_payload = std::get<nano::messages::asc_pull_ack::account_info_payload> (message.payload));
 
 	ASSERT_EQ (original_payload.account, message_payload.account);
 	ASSERT_EQ (original_payload.account_open, message_payload.account_open);
@@ -688,12 +688,12 @@ TEST (message, asc_pull_ack_serialization_account_info)
 
 TEST (message, asc_pull_ack_serialization_frontiers)
 {
-	nano::asc_pull_ack original{ nano::dev::network_params.network };
+	nano::messages::asc_pull_ack original{ nano::dev::network_params.network };
 	original.id = 11;
-	original.type = nano::asc_pull_type::frontiers;
+	original.type = nano::messages::asc_pull_type::frontiers;
 
-	nano::asc_pull_ack::frontiers_payload original_payload{};
-	for (int n = 0; n < nano::asc_pull_ack::frontiers_payload::max_frontiers; ++n)
+	nano::messages::asc_pull_ack::frontiers_payload original_payload{};
+	for (int n = 0; n < nano::messages::asc_pull_ack::frontiers_payload::max_frontiers; ++n)
 	{
 		original_payload.frontiers.push_back ({ nano::test::random_account (), nano::test::random_hash () });
 	}
@@ -711,18 +711,18 @@ TEST (message, asc_pull_ack_serialization_frontiers)
 
 	// Header
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::asc_pull_ack, header.type);
+	ASSERT_EQ (nano::messages::message_type::asc_pull_ack, header.type);
 
 	// Message
-	nano::asc_pull_ack message (error, stream, header);
+	nano::messages::asc_pull_ack message (error, stream, header);
 	ASSERT_FALSE (error);
 	ASSERT_EQ (original.id, message.id);
 	ASSERT_EQ (original.type, message.type);
 
-	nano::asc_pull_ack::frontiers_payload message_payload;
-	ASSERT_NO_THROW (message_payload = std::get<nano::asc_pull_ack::frontiers_payload> (message.payload));
+	nano::messages::asc_pull_ack::frontiers_payload message_payload;
+	ASSERT_NO_THROW (message_payload = std::get<nano::messages::asc_pull_ack::frontiers_payload> (message.payload));
 
 	ASSERT_EQ (original_payload.frontiers, message_payload.frontiers);
 
@@ -731,9 +731,9 @@ TEST (message, asc_pull_ack_serialization_frontiers)
 
 TEST (message, node_id_handshake_query_serialization)
 {
-	nano::node_id_handshake::query_payload query{};
+	nano::messages::node_id_handshake::query_payload query{};
 	query.cookie = 7;
-	nano::node_id_handshake original{ nano::dev::network_params.network, query };
+	nano::messages::node_id_handshake original{ nano::dev::network_params.network, query };
 
 	// Serialize
 	std::vector<uint8_t> bytes;
@@ -745,12 +745,12 @@ TEST (message, node_id_handshake_query_serialization)
 
 	// Header
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::node_id_handshake, header.type);
+	ASSERT_EQ (nano::messages::message_type::node_id_handshake, header.type);
 
 	// Message
-	nano::node_id_handshake message{ error, stream, header };
+	nano::messages::node_id_handshake message{ error, stream, header };
 	ASSERT_FALSE (error);
 	ASSERT_TRUE (message.query);
 	ASSERT_FALSE (message.response);
@@ -762,10 +762,10 @@ TEST (message, node_id_handshake_query_serialization)
 
 TEST (message, node_id_handshake_response_serialization)
 {
-	nano::node_id_handshake::response_payload response{};
+	nano::messages::node_id_handshake::response_payload response{};
 	response.node_id = nano::account{ 7 };
 	response.signature = nano::signature{ 11 };
-	nano::node_id_handshake original{ nano::dev::network_params.network, std::nullopt, response };
+	nano::messages::node_id_handshake original{ nano::dev::network_params.network, std::nullopt, response };
 
 	// Serialize
 	std::vector<uint8_t> bytes;
@@ -777,12 +777,12 @@ TEST (message, node_id_handshake_response_serialization)
 
 	// Header
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::node_id_handshake, header.type);
+	ASSERT_EQ (nano::messages::message_type::node_id_handshake, header.type);
 
 	// Message
-	nano::node_id_handshake message{ error, stream, header };
+	nano::messages::node_id_handshake message{ error, stream, header };
 	ASSERT_FALSE (error);
 	ASSERT_FALSE (message.query);
 	ASSERT_TRUE (message.response);
@@ -796,15 +796,15 @@ TEST (message, node_id_handshake_response_serialization)
 
 TEST (message, node_id_handshake_response_v2_serialization)
 {
-	nano::node_id_handshake::response_payload response{};
+	nano::messages::node_id_handshake::response_payload response{};
 	response.node_id = nano::account{ 7 };
 	response.signature = nano::signature{ 11 };
-	nano::node_id_handshake::response_payload::v2_payload v2_pld{};
+	nano::messages::node_id_handshake::response_payload::v2_payload v2_pld{};
 	v2_pld.salt = 17;
 	v2_pld.genesis = nano::block_hash{ 13 };
 	response.v2 = v2_pld;
 
-	nano::node_id_handshake original{ nano::dev::network_params.network, std::nullopt, response };
+	nano::messages::node_id_handshake original{ nano::dev::network_params.network, std::nullopt, response };
 
 	// Serialize
 	std::vector<uint8_t> bytes;
@@ -816,12 +816,12 @@ TEST (message, node_id_handshake_response_v2_serialization)
 
 	// Header
 	bool error = false;
-	nano::message_header header (error, stream);
+	nano::messages::message_header header (error, stream);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (nano::message_type::node_id_handshake, header.type);
+	ASSERT_EQ (nano::messages::message_type::node_id_handshake, header.type);
 
 	// Message
-	nano::node_id_handshake message{ error, stream, header };
+	nano::messages::node_id_handshake message{ error, stream, header };
 	ASSERT_FALSE (error);
 	ASSERT_FALSE (message.query);
 	ASSERT_TRUE (message.response);
@@ -842,7 +842,7 @@ TEST (handshake, signature)
 	auto cookie = nano::random_pool::generate<nano::uint256_union> ();
 	auto cookie_2 = nano::random_pool::generate<nano::uint256_union> ();
 
-	nano::node_id_handshake::response_payload response{};
+	nano::messages::node_id_handshake::response_payload response{};
 	response.node_id = node_id.pub;
 	response.sign (cookie, node_id);
 	ASSERT_TRUE (response.validate (cookie));
@@ -862,9 +862,9 @@ TEST (handshake, signature_v2)
 	auto cookie = nano::random_pool::generate<nano::uint256_union> ();
 	auto cookie_2 = nano::random_pool::generate<nano::uint256_union> ();
 
-	nano::node_id_handshake::response_payload original{};
+	nano::messages::node_id_handshake::response_payload original{};
 	original.node_id = node_id.pub;
-	original.v2 = nano::node_id_handshake::response_payload::v2_payload{};
+	original.v2 = nano::messages::node_id_handshake::response_payload::v2_payload{};
 	original.v2->genesis = nano::test::random_hash ();
 	original.v2->salt = nano::random_pool::generate<nano::uint256_union> ();
 	original.sign (cookie, node_id);

--- a/nano/core_test/message_deserializer.cpp
+++ b/nano/core_test/message_deserializer.cpp
@@ -44,7 +44,7 @@ auto message_deserializer_success_checker (message_type & message_original) -> v
 
 	// Deserializing and testing the success path.
 	message_deserializer->read (
-	[&message_original] (boost::system::error_code ec_a, std::unique_ptr<nano::message> message_a) {
+	[&message_original] (boost::system::error_code ec_a, std::unique_ptr<nano::messages::message> message_a) {
 		auto deserialized_message = dynamic_cast<message_type *> (message_a.get ());
 		// Ensure the message type is supported.
 		ASSERT_NE (deserialized_message, nullptr);
@@ -70,7 +70,7 @@ TEST (message_deserializer, exact_confirm_ack)
 				 .work (*system.work.generate (nano::root (1)))
 				 .build ();
 	auto vote (std::make_shared<nano::vote> (0, nano::keypair ().prv, 0, 0, std::vector<nano::block_hash>{ block->hash () }));
-	nano::confirm_ack message{ nano::dev::network_params.network, vote };
+	nano::messages::confirm_ack message{ nano::dev::network_params.network, vote };
 
 	message_deserializer_success_checker<decltype (message)> (message);
 }
@@ -88,7 +88,7 @@ TEST (message_deserializer, exact_confirm_req_hash)
 				 .work (*system.work.generate (nano::root (1)))
 				 .build ();
 	// This test differs from the previous `exact_confirm_req` because this tests the confirm_req created from the block hash.
-	nano::confirm_req message{ nano::dev::network_params.network, block->hash (), block->root () };
+	nano::messages::confirm_req message{ nano::dev::network_params.network, block->hash (), block->root () };
 
 	message_deserializer_success_checker<decltype (message)> (message);
 }
@@ -105,78 +105,78 @@ TEST (message_deserializer, exact_publish)
 				 .sign (nano::keypair ().prv, 4)
 				 .work (*system.work.generate (nano::root (1)))
 				 .build ();
-	nano::publish message{ nano::dev::network_params.network, block };
+	nano::messages::publish message{ nano::dev::network_params.network, block };
 
 	message_deserializer_success_checker<decltype (message)> (message);
 }
 
 TEST (message_deserializer, exact_keepalive)
 {
-	nano::keepalive message{ nano::dev::network_params.network };
+	nano::messages::keepalive message{ nano::dev::network_params.network };
 
 	message_deserializer_success_checker<decltype (message)> (message);
 }
 
 TEST (message_deserializer, exact_frontier_req)
 {
-	nano::frontier_req message{ nano::dev::network_params.network };
+	nano::messages::frontier_req message{ nano::dev::network_params.network };
 	message_deserializer_success_checker<decltype (message)> (message);
 }
 
 TEST (message_deserializer, exact_telemetry_req)
 {
-	nano::telemetry_req message{ nano::dev::network_params.network };
+	nano::messages::telemetry_req message{ nano::dev::network_params.network };
 	message_deserializer_success_checker<decltype (message)> (message);
 }
 
 TEST (message_deserializer, exact_telemetry_ack)
 {
-	nano::telemetry_data data;
+	nano::messages::telemetry_data data;
 	data.unknown_data.push_back (0xFF);
 
-	nano::telemetry_ack message{ nano::dev::network_params.network, data };
+	nano::messages::telemetry_ack message{ nano::dev::network_params.network, data };
 	message_deserializer_success_checker<decltype (message)> (message);
 }
 
 TEST (message_deserializer, exact_bulk_pull)
 {
-	nano::bulk_pull message{ nano::dev::network_params.network };
-	message.header.flag_set (nano::message_header::bulk_pull_ascending_flag);
+	nano::messages::bulk_pull message{ nano::dev::network_params.network };
+	message.header.flag_set (nano::messages::message_header::bulk_pull_ascending_flag);
 
 	message_deserializer_success_checker<decltype (message)> (message);
 }
 
 TEST (message_deserializer, exact_bulk_pull_account)
 {
-	nano::bulk_pull_account message{ nano::dev::network_params.network };
-	message.flags = nano::bulk_pull_account_flags::pending_address_only;
+	nano::messages::bulk_pull_account message{ nano::dev::network_params.network };
+	message.flags = nano::messages::bulk_pull_account_flags::pending_address_only;
 
 	message_deserializer_success_checker<decltype (message)> (message);
 }
 
 TEST (message_deserializer, exact_bulk_push)
 {
-	nano::bulk_push message{ nano::dev::network_params.network };
+	nano::messages::bulk_push message{ nano::dev::network_params.network };
 	message_deserializer_success_checker<decltype (message)> (message);
 }
 
 TEST (message_deserializer, exact_node_id_handshake)
 {
-	nano::node_id_handshake message{ nano::dev::network_params.network, std::nullopt, std::nullopt };
+	nano::messages::node_id_handshake message{ nano::dev::network_params.network, std::nullopt, std::nullopt };
 	message_deserializer_success_checker<decltype (message)> (message);
 }
 
 TEST (message_deserializer, exact_asc_pull_req)
 {
-	nano::asc_pull_req message{ nano::dev::network_params.network };
+	nano::messages::asc_pull_req message{ nano::dev::network_params.network };
 
 	// The asc_pull_req checks for the message fields and the payload to be filled.
 	message.id = 7;
-	message.type = nano::asc_pull_type::account_info;
+	message.type = nano::messages::asc_pull_type::account_info;
 
-	nano::asc_pull_req::account_info_payload message_payload;
+	nano::messages::asc_pull_req::account_info_payload message_payload;
 	message_payload.target = nano::test::random_account ();
-	message_payload.target_type = nano::asc_pull_req::hash_type::account;
+	message_payload.target_type = nano::messages::asc_pull_req::hash_type::account;
 
 	message.payload = message_payload;
 	message.update_header ();
@@ -186,13 +186,13 @@ TEST (message_deserializer, exact_asc_pull_req)
 
 TEST (message_deserializer, exact_asc_pull_ack)
 {
-	nano::asc_pull_ack message{ nano::dev::network_params.network };
+	nano::messages::asc_pull_ack message{ nano::dev::network_params.network };
 
 	// The asc_pull_ack checks for the message fields and the payload to be filled.
 	message.id = 11;
-	message.type = nano::asc_pull_type::account_info;
+	message.type = nano::messages::asc_pull_type::account_info;
 
-	nano::asc_pull_ack::account_info_payload message_payload;
+	nano::messages::asc_pull_ack::account_info_payload message_payload;
 	message_payload.account = nano::test::random_account ();
 	message_payload.account_open = nano::test::random_hash ();
 	message_payload.account_head = nano::test::random_hash ();

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -307,7 +307,7 @@ TEST (network, send_insufficient_work)
 	auto tcp_channel = node1.network.tcp_channels.find_node_id (node2.get_node_id ());
 	ASSERT_NE (nullptr, tcp_channel);
 
-	nano::publish publish{ nano::dev::network_params.network, block };
+	nano::messages::publish publish{ nano::dev::network_params.network, block };
 	tcp_channel->send (publish, nano::transport::traffic_type::test);
 
 	ASSERT_TIMELY_EQ (5s, 1, node2.stats.count (nano::stat::type::tcp_server_message_error, nano::stat::detail::insufficient_work));
@@ -331,7 +331,7 @@ TEST (receivable_processor, confirm_insufficient_pos)
 	auto election = nano::test::start_election (system, node1, block1->hash ());
 	nano::keypair key1;
 	auto vote = nano::test::make_final_vote (key1, { block1 });
-	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
+	nano::messages::confirm_ack con1{ nano::dev::network_params.network, vote };
 	auto channel1 = std::make_shared<nano::transport::inproc::channel> (node1, node1);
 	ASSERT_EQ (1, election->votes ().size ());
 	node1.inbound (con1, channel1);
@@ -356,7 +356,7 @@ TEST (receivable_processor, confirm_sufficient_pos)
 	ASSERT_EQ (nano::block_status::progress, node1.process (block1));
 	auto election = nano::test::start_election (system, node1, block1->hash ());
 	auto vote = nano::test::make_final_vote (nano::dev::genesis_key, { block1 });
-	nano::confirm_ack con1{ nano::dev::network_params.network, vote };
+	nano::messages::confirm_ack con1{ nano::dev::network_params.network, vote };
 	auto channel1 = std::make_shared<nano::transport::inproc::channel> (node1, node1);
 	ASSERT_EQ (1, election->votes ().size ());
 	node1.inbound (con1, channel1);
@@ -557,15 +557,15 @@ TEST (network, peer_max_tcp_attempts_subnetwork)
 namespace
 {
 // Skip the first 8 bytes of the message header, which is the common header for all messages
-std::vector<uint8_t> message_payload_to_bytes (nano::message const & message)
+std::vector<uint8_t> message_payload_to_bytes (nano::messages::message const & message)
 {
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
 		message.serialize (stream);
 	}
-	debug_assert (bytes.size () > nano::message_header::size);
-	return std::vector<uint8_t> (bytes.begin () + nano::message_header::size, bytes.end ());
+	debug_assert (bytes.size () > nano::messages::message_header::size);
+	return std::vector<uint8_t> (bytes.begin () + nano::messages::message_header::size, bytes.end ());
 }
 }
 
@@ -576,7 +576,7 @@ TEST (network, duplicate_detection)
 	nano::node_flags node_flags;
 	auto & node0 = *system.add_node (node_flags);
 	auto & node1 = *system.add_node (node_flags);
-	nano::publish publish{ nano::dev::network_params.network, nano::dev::genesis };
+	nano::messages::publish publish{ nano::dev::network_params.network, nano::dev::genesis };
 
 	ASSERT_EQ (0, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish_message));
 
@@ -597,7 +597,7 @@ TEST (network, duplicate_revert_publish)
 	nano::node_config node_config = system.default_config ();
 	node_config.block_processor.max_peer_queue = 0;
 	auto & node (*system.add_node (node_config));
-	nano::publish publish{ nano::dev::network_params.network, nano::dev::genesis };
+	nano::messages::publish publish{ nano::dev::network_params.network, nano::dev::genesis };
 	std::vector<uint8_t> bytes = message_payload_to_bytes (publish);
 	// Add to the blocks filter
 	// Should be cleared when dropping due to a full block processor, as long as the message has the optional digest attached
@@ -625,7 +625,7 @@ TEST (network, duplicate_vote_detection)
 	auto & node1 = *system.add_node ();
 
 	auto vote = nano::test::make_vote (nano::dev::genesis_key, { nano::dev::genesis->hash () });
-	nano::confirm_ack message{ nano::dev::network_params.network, vote };
+	nano::messages::confirm_ack message{ nano::dev::network_params.network, vote };
 
 	ASSERT_EQ (0, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_confirm_ack_message));
 
@@ -652,11 +652,11 @@ TEST (network, duplicate_revert_vote)
 	auto & node1 = *system.add_node (node_config);
 
 	auto vote1 = nano::test::make_vote (nano::dev::genesis_key, { nano::dev::genesis->hash () }, 1);
-	nano::confirm_ack message1{ nano::dev::network_params.network, vote1 };
+	nano::messages::confirm_ack message1{ nano::dev::network_params.network, vote1 };
 	auto bytes1 = message_payload_to_bytes (message1);
 
 	auto vote2 = nano::test::make_vote (nano::dev::genesis_key, { nano::dev::genesis->hash () }, 2);
-	nano::confirm_ack message2{ nano::dev::network_params.network, vote2 };
+	nano::messages::confirm_ack message2{ nano::dev::network_params.network, vote2 };
 	auto bytes2 = message_payload_to_bytes (message2);
 
 	// Publish duplicate detection through TCP
@@ -685,7 +685,7 @@ TEST (network, expire_duplicate_filter)
 	auto & node1 = *system.add_node (node_config);
 
 	auto vote = nano::test::make_vote (nano::dev::genesis_key, { nano::dev::genesis->hash () });
-	nano::confirm_ack message{ nano::dev::network_params.network, vote };
+	nano::messages::confirm_ack message{ nano::dev::network_params.network, vote };
 	auto bytes = message_payload_to_bytes (message);
 
 	// Publish duplicate detection through TCP
@@ -708,7 +708,7 @@ TEST (network, expire_duplicate_filter)
 TEST (network, DISABLED_bandwidth_limiter_4_messages)
 {
 	nano::test::system system;
-	nano::publish message{ nano::dev::network_params.network, nano::dev::genesis };
+	nano::messages::publish message{ nano::dev::network_params.network, nano::dev::genesis };
 	auto message_size = message.to_bytes ()->size ();
 	auto message_limit = 4; // must be multiple of the number of channels
 	nano::node_config node_config = system.default_config ();
@@ -738,7 +738,7 @@ TEST (network, DISABLED_bandwidth_limiter_4_messages)
 TEST (network, DISABLED_bandwidth_limiter_2_messages)
 {
 	nano::test::system system;
-	nano::publish message{ nano::dev::network_params.network, nano::dev::genesis };
+	nano::messages::publish message{ nano::dev::network_params.network, nano::dev::genesis };
 	auto message_size = message.to_bytes ()->size ();
 	auto message_limit = 2; // must be multiple of the number of channels
 	nano::node_config node_config = system.default_config ();
@@ -758,7 +758,7 @@ TEST (network, DISABLED_bandwidth_limiter_2_messages)
 TEST (network, bandwidth_limiter_with_burst)
 {
 	nano::test::system system;
-	nano::publish message{ nano::dev::network_params.network, nano::dev::genesis };
+	nano::messages::publish message{ nano::dev::network_params.network, nano::dev::genesis };
 	auto message_size = message.to_bytes ()->size ();
 	auto message_limit = 2; // must be multiple of the number of channels
 	nano::node_config node_config = system.default_config ();
@@ -913,7 +913,7 @@ TEST (network, filter_invalid_network_bytes)
 	ASSERT_NE (nullptr, channel);
 
 	// send a keepalive, from node2 to node1, with the wrong network bytes
-	nano::keepalive keepalive{ nano::dev::network_params.network };
+	nano::messages::keepalive keepalive{ nano::dev::network_params.network };
 	const_cast<nano::network_type &> (keepalive.header.network) = nano::network_type::invalid;
 	channel->send (keepalive, nano::transport::traffic_type::test);
 
@@ -932,7 +932,7 @@ TEST (network, filter_invalid_version_using)
 	ASSERT_NE (nullptr, channel);
 
 	// send a keepalive, from node2 to node1, with the wrong version_using
-	nano::keepalive keepalive{ nano::dev::network_params.network };
+	nano::messages::keepalive keepalive{ nano::dev::network_params.network };
 	const_cast<uint8_t &> (keepalive.header.version_using) = nano::dev::network_params.network.protocol_version_min - 1;
 	channel->send (keepalive, nano::transport::traffic_type::test);
 

--- a/nano/core_test/network_filter.cpp
+++ b/nano/core_test/network_filter.cpp
@@ -24,16 +24,16 @@ TEST (network_filter, unit)
 {
 	nano::network_filter filter (1);
 	auto one_block = [&filter] (std::shared_ptr<nano::block> const & block_a, bool expect_duplicate_a) {
-		nano::publish message{ nano::dev::network_params.network, block_a };
+		nano::messages::publish message{ nano::dev::network_params.network, block_a };
 		auto bytes (message.to_bytes ());
 		nano::bufferstream stream (bytes->data (), bytes->size ());
 
 		// First read the header
 		bool error{ false };
-		nano::message_header header (error, stream);
+		nano::messages::message_header header (error, stream);
 		ASSERT_FALSE (error);
 
-		// This validates nano::message_header::size
+		// This validates nano::messages::message_header::size
 		ASSERT_EQ (bytes->size (), block_a->size (block_a->type ()) + header.size);
 
 		// Now filter the rest of the stream
@@ -90,16 +90,16 @@ TEST (network_filter, many)
 					 .work (0)
 					 .build ();
 
-		nano::publish message{ nano::dev::network_params.network, block };
+		nano::messages::publish message{ nano::dev::network_params.network, block };
 		auto bytes (message.to_bytes ());
 		nano::bufferstream stream (bytes->data (), bytes->size ());
 
 		// First read the header
 		bool error{ false };
-		nano::message_header header (error, stream);
+		nano::messages::message_header header (error, stream);
 		ASSERT_FALSE (error);
 
-		// This validates nano::message_header::size
+		// This validates nano::messages::message_header::size
 		ASSERT_EQ (bytes->size (), block->size + header.size);
 
 		// Now filter the rest of the stream

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -655,7 +655,7 @@ TEST (node, fork_flip)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	nano::publish publish1{ nano::dev::network_params.network, send1 };
+	nano::messages::publish publish1{ nano::dev::network_params.network, send1 };
 	nano::keypair key2;
 	auto send2 = builder.make_block ()
 				 .previous (nano::dev::genesis->hash ())
@@ -664,7 +664,7 @@ TEST (node, fork_flip)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	nano::publish publish2{ nano::dev::network_params.network, send2 };
+	nano::messages::publish publish2{ nano::dev::network_params.network, send2 };
 	node1.inbound (publish1, nano::test::fake_channel (node1));
 	node2.inbound (publish2, nano::test::fake_channel (node2));
 	ASSERT_TIMELY_EQ (5s, 1, node1.active.size ());
@@ -805,7 +805,7 @@ TEST (node, fork_open)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	nano::publish publish1{ nano::dev::network_params.network, send1 };
+	nano::messages::publish publish1{ nano::dev::network_params.network, send1 };
 	auto channel1 = std::make_shared<nano::transport::fake::channel> (node);
 	node.inbound (publish1, channel1);
 	ASSERT_TIMELY (5s, (election = node.active.election (publish1.block->qualified_root ())) != nullptr);
@@ -825,7 +825,7 @@ TEST (node, fork_open)
 				 .sign (key1.prv, key1.pub)
 				 .work (*system.work.generate (key1.pub))
 				 .build ();
-	nano::publish publish2{ nano::dev::network_params.network, open1 };
+	nano::messages::publish publish2{ nano::dev::network_params.network, open1 };
 	node.inbound (publish2, channel1);
 	ASSERT_TIMELY_EQ (5s, 1, node.active.size ());
 
@@ -837,7 +837,7 @@ TEST (node, fork_open)
 				 .sign (key1.prv, key1.pub)
 				 .work (*system.work.generate (key1.pub))
 				 .build ();
-	nano::publish publish3{ nano::dev::network_params.network, open2 };
+	nano::messages::publish publish3{ nano::dev::network_params.network, open2 };
 	node.inbound (publish3, channel1);
 	ASSERT_TIMELY (5s, (election = node.active.election (publish3.block->qualified_root ())) != nullptr);
 
@@ -1000,7 +1000,7 @@ TEST (node, fork_no_vote_quorum)
 	auto transaction (system.wallet (1)->wallets.tx_begin_read ());
 	ASSERT_FALSE (system.wallet (1)->store.fetch (transaction, key1, key3));
 	auto vote = std::make_shared<nano::vote> (key1, key3, 0, 0, std::vector<nano::block_hash>{ send2->hash () });
-	nano::confirm_ack confirm{ nano::dev::network_params.network, vote };
+	nano::messages::confirm_ack confirm{ nano::dev::network_params.network, vote };
 	auto channel = node2.network.find_node_id (node3.node_id.pub);
 	ASSERT_NE (nullptr, channel);
 	channel->send (confirm, nano::transport::traffic_type::test);
@@ -1685,8 +1685,8 @@ TEST (node, DISABLED_local_votes_cache)
 	election->force_confirm ();
 	ASSERT_TIMELY_EQ (3s, node.ledger.cemented_count (), 3);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	nano::confirm_req message1{ nano::dev::network_params.network, send1->hash (), send1->root () };
-	nano::confirm_req message2{ nano::dev::network_params.network, send2->hash (), send2->root () };
+	nano::messages::confirm_req message1{ nano::dev::network_params.network, send1->hash (), send1->root () };
+	nano::messages::confirm_req message2{ nano::dev::network_params.network, send2->hash (), send2->root () };
 	auto channel = std::make_shared<nano::transport::fake::channel> (node);
 	node.inbound (message1, channel);
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes), 1);
@@ -1704,7 +1704,7 @@ TEST (node, DISABLED_local_votes_cache)
 		auto transaction = node.ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node.ledger.process (transaction, send3));
 	}
-	nano::confirm_req message3{ nano::dev::network_params.network, send3->hash (), send3->root () };
+	nano::messages::confirm_req message3{ nano::dev::network_params.network, send3->hash (), send3->root () };
 	node.inbound (message3, channel);
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::requests, nano::stat::detail::requests_generated_votes), 3);
 	ASSERT_TIMELY (3s, !node.history.votes (send1->root (), send1->hash ()).empty ());
@@ -1764,7 +1764,7 @@ TEST (node, DISABLED_local_votes_cache_batch)
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), receive1));
 	std::vector<std::pair<nano::block_hash, nano::root>> batch{ { send2->hash (), send2->root () }, { receive1->hash (), receive1->root () } };
-	nano::confirm_req message{ nano::dev::network_params.network, batch };
+	nano::messages::confirm_req message{ nano::dev::network_params.network, batch };
 	auto channel = std::make_shared<nano::transport::fake::channel> (node);
 	// Generates and sends one vote for both hashes which is then cached
 	node.inbound (message, channel);
@@ -1779,10 +1779,10 @@ TEST (node, DISABLED_local_votes_cache_batch)
 	// Test when votes are different
 	node.history.erase (send2->root ());
 	node.history.erase (receive1->root ());
-	node.inbound (nano::confirm_req{ nano::dev::network_params.network, send2->hash (), send2->root () }, channel);
+	node.inbound (nano::messages::confirm_req{ nano::dev::network_params.network, send2->hash (), send2->root () }, channel);
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out), 3);
 	ASSERT_EQ (3, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
-	node.inbound (nano::confirm_req{ nano::dev::network_params.network, receive1->hash (), receive1->root () }, channel);
+	node.inbound (nano::messages::confirm_req{ nano::dev::network_params.network, receive1->hash (), receive1->root () }, channel);
 	ASSERT_TIMELY_EQ (3s, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out), 4);
 	ASSERT_EQ (4, node.stats.count (nano::stat::type::message, nano::stat::detail::confirm_ack, nano::stat::dir::out));
 	// There are two different votes, so both should be sent in response
@@ -1805,7 +1805,7 @@ TEST (node, DISABLED_local_votes_cache_generate_new_vote)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 
 	// Send a confirm req for genesis block to node
-	nano::confirm_req message1{ nano::dev::network_params.network, nano::dev::genesis->hash (), nano::dev::genesis->root () };
+	nano::messages::confirm_req message1{ nano::dev::network_params.network, nano::dev::genesis->hash (), nano::dev::genesis->root () };
 	auto channel = std::make_shared<nano::transport::fake::channel> (node);
 	node.inbound (message1, channel);
 
@@ -1829,7 +1829,7 @@ TEST (node, DISABLED_local_votes_cache_generate_new_vote)
 	ASSERT_EQ (nano::block_status::progress, node.process (send1));
 	// One of the hashes is cached
 	std::vector<std::pair<nano::block_hash, nano::root>> roots_hashes{ std::make_pair (nano::dev::genesis->hash (), nano::dev::genesis->root ()), std::make_pair (send1->hash (), send1->root ()) };
-	nano::confirm_req message2{ nano::dev::network_params.network, roots_hashes };
+	nano::messages::confirm_req message2{ nano::dev::network_params.network, roots_hashes };
 	node.inbound (message2, channel);
 	ASSERT_TIMELY (3s, !node.history.votes (send1->root (), send1->hash ()).empty ());
 	auto votes2 (node.history.votes (send1->root (), send1->hash ()));
@@ -2276,13 +2276,13 @@ TEST (node, fork_election_invalid_block_signature)
 				 .build ();
 
 	auto channel1 = std::make_shared<nano::transport::fake::channel> (node1);
-	node1.inbound (nano::publish{ nano::dev::network_params.network, send1 }, channel1);
+	node1.inbound (nano::messages::publish{ nano::dev::network_params.network, send1 }, channel1);
 	ASSERT_TIMELY (5s, node1.active.active (send1->qualified_root ()));
 	auto election (node1.active.election (send1->qualified_root ()));
 	ASSERT_NE (nullptr, election);
 	ASSERT_EQ (1, election->blocks ().size ());
-	node1.inbound (nano::publish{ nano::dev::network_params.network, send3 }, channel1);
-	node1.inbound (nano::publish{ nano::dev::network_params.network, send2 }, channel1);
+	node1.inbound (nano::messages::publish{ nano::dev::network_params.network, send3 }, channel1);
+	node1.inbound (nano::messages::publish{ nano::dev::network_params.network, send2 }, channel1);
 	ASSERT_TIMELY (3s, election->blocks ().size () > 1);
 	ASSERT_EQ (election->blocks ()[send2->hash ()]->block_signature (), send2->block_signature ());
 }

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -253,7 +253,7 @@ TEST (peer_container, depeer_on_outdated_version)
 	ASSERT_NE (nullptr, channel);
 
 	// send a keepalive, from node2 to node1, with the wrong version_using
-	nano::keepalive keepalive{ nano::dev::network_params.network };
+	nano::messages::keepalive keepalive{ nano::dev::network_params.network };
 	const_cast<uint8_t &> (keepalive.header.version_using) = nano::dev::network_params.network.protocol_version_min - 1;
 	ASSERT_TIMELY (5s, channel->alive ());
 	channel->send (keepalive, nano::transport::traffic_type::test);

--- a/nano/core_test/rep_crawler.cpp
+++ b/nano/core_test/rep_crawler.cpp
@@ -327,7 +327,7 @@ TEST (rep_crawler, ignore_rebroadcasted)
 	node1.rep_crawler.force_query (nano::dev::genesis->hash (), channel1to2);
 
 	auto tick = [&] () {
-		nano::confirm_ack msg{ nano::dev::network_params.network, vote, /* rebroadcasted */ true };
+		nano::messages::confirm_ack msg{ nano::dev::network_params.network, vote, /* rebroadcasted */ true };
 		channel2to1->send (msg, nano::transport::traffic_type::test);
 		return false;
 	};

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -470,23 +470,23 @@ TEST (request_aggregator, cannot_vote)
 
 namespace
 {
-std::future<nano::confirm_ack> observe_confirm_ack (std::shared_ptr<nano::transport::test_channel> const & channel)
+std::future<nano::messages::confirm_ack> observe_confirm_ack (std::shared_ptr<nano::transport::test_channel> const & channel)
 {
-	std::promise<nano::confirm_ack> promise;
+	std::promise<nano::messages::confirm_ack> promise;
 	auto future = promise.get_future ();
 
-	struct confirm_ack_visitor : public nano::message_visitor
+	struct confirm_ack_visitor : public nano::messages::message_visitor
 	{
-		std::optional<nano::confirm_ack> result;
+		std::optional<nano::messages::confirm_ack> result;
 
-		void confirm_ack (nano::confirm_ack const & msg) override
+		void confirm_ack (nano::messages::confirm_ack const & msg) override
 		{
 			result = msg;
 		}
 	};
 
 	channel->observers.clear ();
-	channel->observers.add (nano::wrap_move_only ([&, promise = std::move (promise)] (nano::message const & message, nano::transport::traffic_type const & type) mutable {
+	channel->observers.add (nano::wrap_move_only ([&, promise = std::move (promise)] (nano::messages::message const & message, nano::transport::traffic_type const & type) mutable {
 		confirm_ack_visitor visitor{};
 		message.visit (visitor);
 		if (visitor.result)

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -211,7 +211,7 @@ TEST (system, transport_basic)
 	ASSERT_EQ (0, node1.stats.count (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in));
 	nano::transport::inproc::channel channel{ node0, node1 };
 	// Send a keepalive message since they are easy to construct
-	nano::keepalive junk{ nano::dev::network_params.network };
+	nano::messages::keepalive junk{ nano::dev::network_params.network };
 	channel.send (junk, nano::transport::traffic_type::test);
 	// Ensure the keepalive has been reecived on the target.
 	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in) > 0);

--- a/nano/core_test/tcp_listener.cpp
+++ b/nano/core_test/tcp_listener.cpp
@@ -174,8 +174,8 @@ TEST (tcp_listener, node_id_handshake)
 	auto bootstrap_endpoint (system.nodes[0]->tcp_listener.endpoint ());
 	auto cookie (system.nodes[0]->network.syn_cookies.assign (nano::transport::map_tcp_to_endpoint (bootstrap_endpoint)));
 	ASSERT_TRUE (cookie);
-	nano::node_id_handshake::query_payload query{ *cookie };
-	nano::node_id_handshake node_id_handshake{ nano::dev::network_params.network, query };
+	nano::messages::node_id_handshake::query_payload query{ *cookie };
+	nano::messages::node_id_handshake node_id_handshake{ nano::dev::network_params.network, query };
 	auto input (node_id_handshake.to_shared_const_buffer ());
 	std::atomic<bool> write_done (false);
 	socket->async_connect (bootstrap_endpoint, [&input, socket, &write_done] (boost::system::error_code const & ec) {
@@ -189,8 +189,8 @@ TEST (tcp_listener, node_id_handshake)
 
 	ASSERT_TIMELY (5s, write_done);
 
-	nano::node_id_handshake::response_payload response_zero{ 0 };
-	nano::node_id_handshake node_id_handshake_response{ nano::dev::network_params.network, std::nullopt, response_zero };
+	nano::messages::node_id_handshake::response_payload response_zero{ 0 };
+	nano::messages::node_id_handshake node_id_handshake_response{ nano::dev::network_params.network, std::nullopt, response_zero };
 	auto output (node_id_handshake_response.to_bytes ());
 	std::atomic<bool> done (false);
 	socket->async_read (output, output->size (), [&output, &done] (boost::system::error_code const & ec, size_t size_a) {
@@ -224,8 +224,8 @@ TEST (tcp_listener, timeout_node_id_handshake)
 	auto socket (std::make_shared<nano::transport::tcp_socket> (*node0));
 	auto cookie (node0->network.syn_cookies.assign (nano::transport::map_tcp_to_endpoint (node0->tcp_listener.endpoint ())));
 	ASSERT_TRUE (cookie);
-	nano::node_id_handshake::query_payload query{ *cookie };
-	nano::node_id_handshake node_id_handshake{ nano::dev::network_params.network, query };
+	nano::messages::node_id_handshake::query_payload query{ *cookie };
+	nano::messages::node_id_handshake node_id_handshake{ nano::dev::network_params.network, query };
 	auto channel = std::make_shared<nano::transport::tcp_channel> (*node0, socket);
 	socket->async_connect (node0->tcp_listener.endpoint (), [&node_id_handshake, channel] (boost::system::error_code const & ec) {
 		ASSERT_FALSE (ec);

--- a/nano/core_test/tcp_server.cpp
+++ b/nano/core_test/tcp_server.cpp
@@ -55,7 +55,7 @@ TEST (tcp_server, handshake_deserialization_failure)
 	// Create an invalid message header with wrong message type and invalid size
 	std::vector<uint8_t> malformed_data;
 
-	nano::message_header header (nano::dev::network_params.network, static_cast<nano::message_type> (0xFF)); // Invalid message type
+	nano::messages::message_header header (nano::dev::network_params.network, static_cast<nano::messages::message_type> (0xFF)); // Invalid message type
 	header.version_using = 0x12; // Some version
 	header.version_min = 0x01;
 	header.extensions = 0;
@@ -104,7 +104,7 @@ TEST (tcp_server, handshake_incomplete_message)
 
 	// Send only partial header (not enough bytes for a complete header)
 	std::vector<uint8_t> partial_header;
-	nano::message_header header (nano::dev::network_params.network, nano::message_type::node_id_handshake);
+	nano::messages::message_header header (nano::dev::network_params.network, nano::messages::message_type::node_id_handshake);
 
 	// Serialize header but only send first few bytes
 	{
@@ -144,7 +144,7 @@ TEST (tcp_server, handshake_invalid_message_type_aborts)
 	std::vector<uint8_t> invalid_handshake_data;
 
 	// Use a valid message type that's not a handshake (e.g., keepalive)
-	nano::message_header header (nano::dev::network_params.network, nano::message_type::keepalive);
+	nano::messages::message_header header (nano::dev::network_params.network, nano::messages::message_type::keepalive);
 	header.version_using = nano::dev::network_params.network.protocol_version;
 	header.version_min = nano::dev::network_params.network.protocol_version_min;
 	header.extensions = 0;
@@ -156,7 +156,7 @@ TEST (tcp_server, handshake_invalid_message_type_aborts)
 	}
 
 	// Add a valid keepalive message body
-	nano::keepalive message (nano::dev::network_params.network);
+	nano::messages::keepalive message (nano::dev::network_params.network);
 	{
 		nano::vectorstream stream (invalid_handshake_data);
 		message.serialize (stream);
@@ -192,17 +192,17 @@ TEST (tcp_server, handshake_self_connection_rejected)
 	ASSERT_TIMELY_EQ (5s, node->tcp_listener.all_sockets ().size (), 1);
 
 	// Create a handshake response claiming to be from the same node
-	nano::node_id_handshake::query_payload query{ nano::random_pool::generate<nano::uint256_union> () };
+	nano::messages::node_id_handshake::query_payload query{ nano::random_pool::generate<nano::uint256_union> () };
 
-	nano::node_id_handshake::response_payload response;
+	nano::messages::node_id_handshake::response_payload response;
 	response.node_id = node->node_id.pub; // Use our own node ID
-	response.v2 = nano::node_id_handshake::response_payload::v2_payload{
+	response.v2 = nano::messages::node_id_handshake::response_payload::v2_payload{
 		nano::random_pool::generate<nano::uint256_union> (), // salt
 		node->network_params.ledger.genesis->hash () // genesis
 	};
 	response.sign (query.cookie, node->node_id); // Sign with our own key
 
-	nano::node_id_handshake handshake_msg (node->network_params.network, query, response);
+	nano::messages::node_id_handshake handshake_msg (node->network_params.network, query, response);
 
 	// Send the handshake with our own node ID
 	auto shared_const_buffer = handshake_msg.to_shared_const_buffer ();
@@ -234,8 +234,8 @@ TEST (tcp_server, handshake_multiple_queries_rejected)
 	ASSERT_TIMELY_EQ (5s, node->tcp_listener.all_sockets ().size (), 1);
 
 	// Send first handshake query
-	nano::node_id_handshake::query_payload query1{ nano::random_pool::generate<nano::uint256_union> () };
-	nano::node_id_handshake handshake1 (node->network_params.network, query1);
+	nano::messages::node_id_handshake::query_payload query1{ nano::random_pool::generate<nano::uint256_union> () };
+	nano::messages::node_id_handshake handshake1 (node->network_params.network, query1);
 
 	auto buffer1 = handshake1.to_shared_const_buffer ();
 	auto [write_ec1, bytes_written1] = client_socket->blocking_write (buffer1, buffer1.size ());
@@ -243,8 +243,8 @@ TEST (tcp_server, handshake_multiple_queries_rejected)
 	ASSERT_EQ (bytes_written1, buffer1.size ());
 
 	// Send second handshake query (should be rejected)
-	nano::node_id_handshake::query_payload query2{ nano::random_pool::generate<nano::uint256_union> () };
-	nano::node_id_handshake handshake2 (node->network_params.network, query2);
+	nano::messages::node_id_handshake::query_payload query2{ nano::random_pool::generate<nano::uint256_union> () };
+	nano::messages::node_id_handshake handshake2 (node->network_params.network, query2);
 
 	auto buffer2 = handshake2.to_shared_const_buffer ();
 	auto [write_ec2, bytes_written2] = client_socket->blocking_write (buffer2, buffer2.size ());
@@ -277,7 +277,7 @@ TEST (tcp_server, handshake_outdated_protocol_version)
 	// Create a handshake message with outdated protocol version
 	std::vector<uint8_t> handshake_data;
 
-	nano::message_header header (nano::dev::network_params.network, nano::message_type::node_id_handshake);
+	nano::messages::message_header header (nano::dev::network_params.network, nano::messages::message_type::node_id_handshake);
 	header.version_using = node->network_params.network.protocol_version_min - 1; // Use version below minimum
 	header.version_min = node->network_params.network.protocol_version_min - 1;
 	header.extensions = 0;
@@ -289,8 +289,8 @@ TEST (tcp_server, handshake_outdated_protocol_version)
 	}
 
 	// Add a basic handshake payload
-	nano::node_id_handshake::query_payload query{ nano::random_pool::generate<nano::uint256_union> () };
-	nano::node_id_handshake handshake_msg (node->network_params.network, query);
+	nano::messages::node_id_handshake::query_payload query{ nano::random_pool::generate<nano::uint256_union> () };
+	nano::messages::node_id_handshake handshake_msg (node->network_params.network, query);
 	{
 		nano::vectorstream stream (handshake_data);
 		handshake_msg.serialize (stream);
@@ -335,7 +335,7 @@ TEST (tcp_server, handshake_wrong_network_id)
 	: nano::network_type::nano_live_network;
 	nano::network_constants wrong_network_constants (nano::work_thresholds::publish_dev, wrong_network);
 
-	nano::message_header header (wrong_network_constants, nano::message_type::node_id_handshake);
+	nano::messages::message_header header (wrong_network_constants, nano::messages::message_type::node_id_handshake);
 	header.version_using = node->network_params.network.protocol_version;
 	header.version_min = node->network_params.network.protocol_version_min;
 	header.extensions = 0;
@@ -347,8 +347,8 @@ TEST (tcp_server, handshake_wrong_network_id)
 	}
 
 	// Add a basic handshake payload
-	nano::node_id_handshake::query_payload query{ nano::random_pool::generate<nano::uint256_union> () };
-	nano::node_id_handshake handshake_msg (node->network_params.network, query);
+	nano::messages::node_id_handshake::query_payload query{ nano::random_pool::generate<nano::uint256_union> () };
+	nano::messages::node_id_handshake handshake_msg (node->network_params.network, query);
 	{
 		nano::vectorstream stream (handshake_data);
 		handshake_msg.serialize (stream);

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -14,7 +14,7 @@ using namespace std::chrono_literals;
 TEST (telemetry, signatures)
 {
 	nano::keypair node_id;
-	nano::telemetry_data data;
+	nano::messages::telemetry_data data;
 	data.node_id = node_id.pub;
 	data.major_version = 20;
 	data.minor_version = 1;
@@ -34,7 +34,7 @@ TEST (telemetry, signatures)
 TEST (telemetry, unknown_data)
 {
 	nano::keypair node_id;
-	nano::telemetry_data data;
+	nano::messages::telemetry_data data;
 	data.node_id = node_id.pub;
 	data.major_version = 20;
 	data.minor_version = 1;
@@ -66,7 +66,7 @@ TEST (telemetry, basic)
 	auto channel = node_client->network.find_node_id (node_server->get_node_id ());
 	ASSERT_NE (nullptr, channel);
 
-	std::optional<nano::telemetry_data> telemetry_data;
+	std::optional<nano::messages::telemetry_data> telemetry_data;
 	ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 	ASSERT_EQ (node_server->get_node_id (), telemetry_data->node_id);
 
@@ -87,7 +87,7 @@ TEST (telemetry, basic)
 	// Wait the cache period and check cache is not used
 	WAIT (3s);
 
-	std::optional<nano::telemetry_data> telemetry_data_4;
+	std::optional<nano::messages::telemetry_data> telemetry_data_4;
 	ASSERT_TIMELY (5s, telemetry_data_4 = node_client->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 	ASSERT_NE (*telemetry_data, *telemetry_data_4);
 }
@@ -139,7 +139,7 @@ TEST (telemetry, dos_tcp)
 	auto channel = node_client->network.tcp_channels.find_node_id (node_server->get_node_id ());
 	ASSERT_NE (nullptr, channel);
 
-	nano::telemetry_req message{ nano::dev::network_params.network };
+	nano::messages::telemetry_req message{ nano::dev::network_params.network };
 	for (int i = 0; i < 10; ++i)
 	{
 		channel->send (message, nano::transport::traffic_type::test, [] (boost::system::error_code const & ec, size_t size_a) {
@@ -174,7 +174,7 @@ TEST (telemetry, disable_metrics)
 	auto channel1 = node_server->network.find_node_id (node_client->get_node_id ());
 	ASSERT_NE (nullptr, channel1);
 
-	std::optional<nano::telemetry_data> telemetry_data;
+	std::optional<nano::messages::telemetry_data> telemetry_data;
 	ASSERT_TIMELY (5s, telemetry_data = node_server->telemetry.get_telemetry (channel1->get_remote_endpoint ()));
 
 	ASSERT_TRUE (nano::test::compare_telemetry (*telemetry_data, *node_client));
@@ -188,10 +188,10 @@ TEST (telemetry, max_possible_size)
 	auto node_client = system.add_node (node_flags);
 	auto node_server = system.add_node (node_flags);
 
-	nano::telemetry_data data;
-	data.unknown_data.resize (nano::message_header::telemetry_size_mask.to_ulong () - nano::telemetry_data::latest_size);
+	nano::messages::telemetry_data data;
+	data.unknown_data.resize (nano::messages::message_header::telemetry_size_mask.to_ulong () - nano::messages::telemetry_data::latest_size);
 
-	nano::telemetry_ack message{ nano::dev::network_params.network, data };
+	nano::messages::telemetry_ack message{ nano::dev::network_params.network, data };
 
 	auto channel = node_client->network.tcp_channels.find_node_id (node_server->get_node_id ());
 	ASSERT_NE (nullptr, channel);
@@ -216,12 +216,12 @@ TEST (telemetry, maker_pruning)
 	auto channel = node_client->network.find_node_id (node_server->get_node_id ());
 	ASSERT_NE (nullptr, channel);
 
-	std::optional<nano::telemetry_data> telemetry_data;
+	std::optional<nano::messages::telemetry_data> telemetry_data;
 	ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (channel->get_remote_endpoint ()));
 	ASSERT_EQ (node_server->get_node_id (), telemetry_data->node_id);
 
 	// Ensure telemetry response indicates pruned node
-	ASSERT_EQ (nano::telemetry_maker::nf_pruned_node, static_cast<nano::telemetry_maker> (telemetry_data->maker));
+	ASSERT_EQ (nano::messages::telemetry_maker::nf_pruned_node, static_cast<nano::messages::telemetry_maker> (telemetry_data->maker));
 }
 
 TEST (telemetry, invalid_signature)
@@ -232,7 +232,7 @@ TEST (telemetry, invalid_signature)
 	auto telemetry = node.local_telemetry ();
 	telemetry.block_count = 9999; // Change data so signature is no longer valid
 
-	auto message = nano::telemetry_ack{ nano::dev::network_params.network, telemetry };
+	auto message = nano::messages::telemetry_ack{ nano::dev::network_params.network, telemetry };
 	node.inbound (message, nano::test::fake_channel (node));
 
 	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::telemetry, nano::stat::detail::invalid_signature) > 0);
@@ -246,7 +246,7 @@ TEST (telemetry, mismatched_node_id)
 
 	auto telemetry = node.local_telemetry ();
 
-	auto message = nano::telemetry_ack{ nano::dev::network_params.network, telemetry };
+	auto message = nano::messages::telemetry_ack{ nano::dev::network_params.network, telemetry };
 	node.inbound (message, nano::test::fake_channel (node, /* node id */ { 123 }));
 
 	ASSERT_TIMELY (5s, node.stats.count (nano::stat::type::telemetry, nano::stat::detail::node_id_mismatch) > 0);

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -167,7 +167,7 @@ TEST (websocket, started_election)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	nano::publish publish1{ nano::dev::network_params.network, send1 };
+	nano::messages::publish publish1{ nano::dev::network_params.network, send1 };
 	auto channel1 = std::make_shared<nano::transport::fake::channel> (*node1);
 	node1->inbound (publish1, channel1);
 	ASSERT_TIMELY (1s, node1->active.election (send1->qualified_root ()));
@@ -215,7 +215,7 @@ TEST (websocket, stopped_election)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	nano::publish publish1{ nano::dev::network_params.network, send1 };
+	nano::messages::publish publish1{ nano::dev::network_params.network, send1 };
 	auto channel1 = std::make_shared<nano::transport::fake::channel> (*node1);
 	node1->inbound (publish1, channel1);
 	ASSERT_TIMELY (5s, node1->active.election (send1->qualified_root ()));
@@ -1091,7 +1091,7 @@ TEST (websocket, telemetry)
 
 	auto & contents = event.get_child ("message");
 	nano::jsonconfig telemetry_contents (contents);
-	nano::telemetry_data telemetry_data;
+	nano::messages::telemetry_data telemetry_data;
 	telemetry_data.deserialize_json (telemetry_contents, false);
 
 	ASSERT_TRUE (nano::test::compare_telemetry (telemetry_data, *node2));

--- a/nano/fuzzer_test/fuzz_buffer.cpp
+++ b/nano/fuzzer_test/fuzz_buffer.cpp
@@ -16,40 +16,40 @@ namespace
 std::shared_ptr<nano::test::system> system0;
 std::shared_ptr<nano::node> node0;
 
-class fuzz_visitor : public nano::message_visitor
+class fuzz_visitor : public nano::messages::message_visitor
 {
 public:
-	virtual void keepalive (nano::keepalive const &) override
+	virtual void keepalive (nano::messages::keepalive const &) override
 	{
 	}
-	virtual void publish (nano::publish const &) override
+	virtual void publish (nano::messages::publish const &) override
 	{
 	}
-	virtual void confirm_req (nano::confirm_req const &) override
+	virtual void confirm_req (nano::messages::confirm_req const &) override
 	{
 	}
-	virtual void confirm_ack (nano::confirm_ack const &) override
+	virtual void confirm_ack (nano::messages::confirm_ack const &) override
 	{
 	}
-	virtual void bulk_pull (nano::bulk_pull const &) override
+	virtual void bulk_pull (nano::messages::bulk_pull const &) override
 	{
 	}
-	virtual void bulk_pull_account (nano::bulk_pull_account const &) override
+	virtual void bulk_pull_account (nano::messages::bulk_pull_account const &) override
 	{
 	}
-	virtual void bulk_push (nano::bulk_push const &) override
+	virtual void bulk_push (nano::messages::bulk_push const &) override
 	{
 	}
-	virtual void frontier_req (nano::frontier_req const &) override
+	virtual void frontier_req (nano::messages::frontier_req const &) override
 	{
 	}
-	virtual void node_id_handshake (nano::node_id_handshake const &) override
+	virtual void node_id_handshake (nano::messages::node_id_handshake const &) override
 	{
 	}
-	virtual void telemetry_req (nano::telemetry_req const &) override
+	virtual void telemetry_req (nano::messages::telemetry_req const &) override
 	{
 	}
-	virtual void telemetry_ack (nano::telemetry_ack const &) override
+	virtual void telemetry_ack (nano::messages::telemetry_ack const &) override
 	{
 	}
 };
@@ -68,7 +68,7 @@ void fuzz_message_parser (uint8_t const * Data, size_t Size)
 	}
 
 	fuzz_visitor visitor;
-	nano::message_parser parser (node0->network.filter, node0->block_uniquer, node0->vote_uniquer, visitor, node0->work);
+	nano::messages::message_parser parser (node0->network.filter, node0->block_uniquer, node0->vote_uniquer, visitor, node0->work);
 	parser.deserialize_buffer (Data, Size);
 }
 

--- a/nano/messages/asc_pull.cpp
+++ b/nano/messages/asc_pull.cpp
@@ -5,27 +5,29 @@
 #include <nano/messages/asc_pull.hpp>
 #include <nano/messages/message_visitor.hpp>
 
+namespace nano::messages
+{
 /*
  * asc_pull_req
  */
 
-nano::asc_pull_req::asc_pull_req (const nano::network_constants & constants) :
-	message (constants, nano::message_type::asc_pull_req)
+asc_pull_req::asc_pull_req (const nano::network_constants & constants) :
+	message (constants, message_type::asc_pull_req)
 {
 }
 
-nano::asc_pull_req::asc_pull_req (bool & error, nano::stream & stream, const nano::message_header & header) :
+asc_pull_req::asc_pull_req (bool & error, nano::stream & stream, const message_header & header) :
 	message (header)
 {
 	error = deserialize (stream);
 }
 
-void nano::asc_pull_req::visit (nano::message_visitor & visitor) const
+void asc_pull_req::visit (message_visitor & visitor) const
 {
 	visitor.asc_pull_req (*this);
 }
 
-void nano::asc_pull_req::serialize (nano::stream & stream) const
+void asc_pull_req::serialize (nano::stream & stream) const
 {
 	header.serialize (stream);
 	nano::write (stream, type);
@@ -34,9 +36,9 @@ void nano::asc_pull_req::serialize (nano::stream & stream) const
 	serialize_payload (stream);
 }
 
-bool nano::asc_pull_req::deserialize (nano::stream & stream)
+bool asc_pull_req::deserialize (nano::stream & stream)
 {
-	debug_assert (header.type == nano::message_type::asc_pull_req);
+	debug_assert (header.type == message_type::asc_pull_req);
 	bool error = false;
 	try
 	{
@@ -52,14 +54,14 @@ bool nano::asc_pull_req::deserialize (nano::stream & stream)
 	return error;
 }
 
-void nano::asc_pull_req::serialize_payload (nano::stream & stream) const
+void asc_pull_req::serialize_payload (nano::stream & stream) const
 {
 	debug_assert (verify_consistency ());
 
 	std::visit ([&stream] (auto && pld) { pld.serialize (stream); }, payload);
 }
 
-void nano::asc_pull_req::deserialize_payload (nano::stream & stream)
+void asc_pull_req::deserialize_payload (nano::stream & stream)
 {
 	switch (type)
 	{
@@ -89,7 +91,7 @@ void nano::asc_pull_req::deserialize_payload (nano::stream & stream)
 	}
 }
 
-void nano::asc_pull_req::update_header ()
+void asc_pull_req::update_header ()
 {
 	// TODO: Avoid serializing the payload twice
 	std::vector<uint8_t> bytes;
@@ -102,17 +104,17 @@ void nano::asc_pull_req::update_header ()
 	header.extensions = std::bitset<16> (bytes.size ());
 }
 
-std::size_t nano::asc_pull_req::size (const nano::message_header & header)
+std::size_t asc_pull_req::size (const message_header & header)
 {
 	uint16_t payload_length = nano::narrow_cast<uint16_t> (header.extensions.to_ulong ());
 	return partial_size + payload_length;
 }
 
-bool nano::asc_pull_req::verify_consistency () const
+bool asc_pull_req::verify_consistency () const
 {
 	struct consistency_visitor
 	{
-		nano::asc_pull_type type;
+		asc_pull_type type;
 
 		void operator() (empty_payload) const
 		{
@@ -135,9 +137,9 @@ bool nano::asc_pull_req::verify_consistency () const
 	return true; // Just for convenience of calling from asserts
 }
 
-void nano::asc_pull_req::operator() (nano::object_stream & obs) const
+void asc_pull_req::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 
 	obs.write ("type", type);
 	obs.write ("id", id);
@@ -149,21 +151,21 @@ void nano::asc_pull_req::operator() (nano::object_stream & obs) const
  * asc_pull_req::blocks_payload
  */
 
-void nano::asc_pull_req::blocks_payload::serialize (nano::stream & stream) const
+void asc_pull_req::blocks_payload::serialize (nano::stream & stream) const
 {
 	nano::write (stream, start);
 	nano::write (stream, count);
 	nano::write (stream, start_type);
 }
 
-void nano::asc_pull_req::blocks_payload::deserialize (nano::stream & stream)
+void asc_pull_req::blocks_payload::deserialize (nano::stream & stream)
 {
 	nano::read (stream, start);
 	nano::read (stream, count);
 	nano::read (stream, start_type);
 }
 
-void nano::asc_pull_req::blocks_payload::operator() (nano::object_stream & obs) const
+void asc_pull_req::blocks_payload::operator() (nano::object_stream & obs) const
 {
 	obs.write ("start", start);
 	obs.write ("start_type", start_type);
@@ -174,19 +176,19 @@ void nano::asc_pull_req::blocks_payload::operator() (nano::object_stream & obs) 
  * asc_pull_req::account_info_payload
  */
 
-void nano::asc_pull_req::account_info_payload::serialize (stream & stream) const
+void asc_pull_req::account_info_payload::serialize (stream & stream) const
 {
 	nano::write (stream, target);
 	nano::write (stream, target_type);
 }
 
-void nano::asc_pull_req::account_info_payload::deserialize (stream & stream)
+void asc_pull_req::account_info_payload::deserialize (stream & stream)
 {
 	nano::read (stream, target);
 	nano::read (stream, target_type);
 }
 
-void nano::asc_pull_req::account_info_payload::operator() (nano::object_stream & obs) const
+void asc_pull_req::account_info_payload::operator() (nano::object_stream & obs) const
 {
 	obs.write ("target", target);
 	obs.write ("target_type", target_type);
@@ -196,19 +198,19 @@ void nano::asc_pull_req::account_info_payload::operator() (nano::object_stream &
  * asc_pull_req::frontiers_payload
  */
 
-void nano::asc_pull_req::frontiers_payload::serialize (nano::stream & stream) const
+void asc_pull_req::frontiers_payload::serialize (nano::stream & stream) const
 {
 	nano::write (stream, start);
 	nano::write_big_endian (stream, count);
 }
 
-void nano::asc_pull_req::frontiers_payload::deserialize (nano::stream & stream)
+void asc_pull_req::frontiers_payload::deserialize (nano::stream & stream)
 {
 	nano::read (stream, start);
 	nano::read_big_endian (stream, count);
 }
 
-void nano::asc_pull_req::frontiers_payload::operator() (nano::object_stream & obs) const
+void asc_pull_req::frontiers_payload::operator() (nano::object_stream & obs) const
 {
 	obs.write ("start", start);
 	obs.write ("count", count);
@@ -218,23 +220,23 @@ void nano::asc_pull_req::frontiers_payload::operator() (nano::object_stream & ob
  * asc_pull_ack
  */
 
-nano::asc_pull_ack::asc_pull_ack (const nano::network_constants & constants) :
-	message (constants, nano::message_type::asc_pull_ack)
+asc_pull_ack::asc_pull_ack (const nano::network_constants & constants) :
+	message (constants, message_type::asc_pull_ack)
 {
 }
 
-nano::asc_pull_ack::asc_pull_ack (bool & error, nano::stream & stream, const nano::message_header & header) :
+asc_pull_ack::asc_pull_ack (bool & error, nano::stream & stream, const message_header & header) :
 	message (header)
 {
 	error = deserialize (stream);
 }
 
-void nano::asc_pull_ack::visit (nano::message_visitor & visitor) const
+void asc_pull_ack::visit (message_visitor & visitor) const
 {
 	visitor.asc_pull_ack (*this);
 }
 
-void nano::asc_pull_ack::serialize (nano::stream & stream) const
+void asc_pull_ack::serialize (nano::stream & stream) const
 {
 	debug_assert (header.extensions.to_ulong () > 0); // Block payload must have at least `not_a_block` terminator
 	header.serialize (stream);
@@ -244,9 +246,9 @@ void nano::asc_pull_ack::serialize (nano::stream & stream) const
 	serialize_payload (stream);
 }
 
-bool nano::asc_pull_ack::deserialize (nano::stream & stream)
+bool asc_pull_ack::deserialize (nano::stream & stream)
 {
-	debug_assert (header.type == nano::message_type::asc_pull_ack);
+	debug_assert (header.type == message_type::asc_pull_ack);
 	bool error = false;
 	try
 	{
@@ -262,14 +264,14 @@ bool nano::asc_pull_ack::deserialize (nano::stream & stream)
 	return error;
 }
 
-void nano::asc_pull_ack::serialize_payload (nano::stream & stream) const
+void asc_pull_ack::serialize_payload (nano::stream & stream) const
 {
 	debug_assert (verify_consistency ());
 
 	std::visit ([&stream] (auto && pld) { pld.serialize (stream); }, payload);
 }
 
-void nano::asc_pull_ack::deserialize_payload (nano::stream & stream)
+void asc_pull_ack::deserialize_payload (nano::stream & stream)
 {
 	switch (type)
 	{
@@ -299,7 +301,7 @@ void nano::asc_pull_ack::deserialize_payload (nano::stream & stream)
 	}
 }
 
-void nano::asc_pull_ack::update_header ()
+void asc_pull_ack::update_header ()
 {
 	// TODO: Avoid serializing the payload twice
 	std::vector<uint8_t> bytes;
@@ -312,17 +314,17 @@ void nano::asc_pull_ack::update_header ()
 	header.extensions = std::bitset<16> (bytes.size ());
 }
 
-std::size_t nano::asc_pull_ack::size (const nano::message_header & header)
+std::size_t asc_pull_ack::size (const message_header & header)
 {
 	uint16_t payload_length = nano::narrow_cast<uint16_t> (header.extensions.to_ulong ());
 	return partial_size + payload_length;
 }
 
-bool nano::asc_pull_ack::verify_consistency () const
+bool asc_pull_ack::verify_consistency () const
 {
 	struct consistency_visitor
 	{
-		nano::asc_pull_type type;
+		asc_pull_type type;
 
 		void operator() (empty_payload) const
 		{
@@ -345,9 +347,9 @@ bool nano::asc_pull_ack::verify_consistency () const
 	return true; // Just for convenience of calling from asserts
 }
 
-void nano::asc_pull_ack::operator() (nano::object_stream & obs) const
+void asc_pull_ack::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 
 	obs.write ("type", type);
 	obs.write ("id", id);
@@ -359,7 +361,7 @@ void nano::asc_pull_ack::operator() (nano::object_stream & obs) const
  * asc_pull_ack::blocks_payload
  */
 
-void nano::asc_pull_ack::blocks_payload::serialize (nano::stream & stream) const
+void asc_pull_ack::blocks_payload::serialize (nano::stream & stream) const
 {
 	debug_assert (blocks.size () <= max_blocks);
 
@@ -372,7 +374,7 @@ void nano::asc_pull_ack::blocks_payload::serialize (nano::stream & stream) const
 	nano::write (stream, nano::block_type::not_a_block);
 }
 
-void nano::asc_pull_ack::blocks_payload::deserialize (nano::stream & stream)
+void asc_pull_ack::blocks_payload::deserialize (nano::stream & stream)
 {
 	auto current = nano::deserialize_block (stream);
 	while (current && blocks.size () < max_blocks)
@@ -382,7 +384,7 @@ void nano::asc_pull_ack::blocks_payload::deserialize (nano::stream & stream)
 	}
 }
 
-void nano::asc_pull_ack::blocks_payload::operator() (nano::object_stream & obs) const
+void asc_pull_ack::blocks_payload::operator() (nano::object_stream & obs) const
 {
 	obs.write_range ("blocks", blocks);
 }
@@ -391,7 +393,7 @@ void nano::asc_pull_ack::blocks_payload::operator() (nano::object_stream & obs) 
  * asc_pull_ack::account_info_payload
  */
 
-void nano::asc_pull_ack::account_info_payload::serialize (nano::stream & stream) const
+void asc_pull_ack::account_info_payload::serialize (nano::stream & stream) const
 {
 	nano::write (stream, account);
 	nano::write (stream, account_open);
@@ -401,7 +403,7 @@ void nano::asc_pull_ack::account_info_payload::serialize (nano::stream & stream)
 	nano::write_big_endian (stream, account_conf_height);
 }
 
-void nano::asc_pull_ack::account_info_payload::deserialize (nano::stream & stream)
+void asc_pull_ack::account_info_payload::deserialize (nano::stream & stream)
 {
 	nano::read (stream, account);
 	nano::read (stream, account_open);
@@ -411,7 +413,7 @@ void nano::asc_pull_ack::account_info_payload::deserialize (nano::stream & strea
 	nano::read_big_endian (stream, account_conf_height);
 }
 
-void nano::asc_pull_ack::account_info_payload::operator() (nano::object_stream & obs) const
+void asc_pull_ack::account_info_payload::operator() (nano::object_stream & obs) const
 {
 	obs.write ("account", account);
 	obs.write ("open", account_open);
@@ -425,14 +427,14 @@ void nano::asc_pull_ack::account_info_payload::operator() (nano::object_stream &
  * asc_pull_ack::frontiers_payload
  */
 
-void nano::asc_pull_ack::frontiers_payload::serialize_frontier (nano::stream & stream, nano::asc_pull_ack::frontiers_payload::frontier const & frontier)
+void asc_pull_ack::frontiers_payload::serialize_frontier (nano::stream & stream, asc_pull_ack::frontiers_payload::frontier const & frontier)
 {
 	auto const & [account, hash] = frontier;
 	nano::write (stream, account);
 	nano::write (stream, hash);
 }
 
-nano::asc_pull_ack::frontiers_payload::frontier nano::asc_pull_ack::frontiers_payload::deserialize_frontier (nano::stream & stream)
+asc_pull_ack::frontiers_payload::frontier asc_pull_ack::frontiers_payload::deserialize_frontier (nano::stream & stream)
 {
 	nano::account account;
 	nano::block_hash hash;
@@ -441,7 +443,7 @@ nano::asc_pull_ack::frontiers_payload::frontier nano::asc_pull_ack::frontiers_pa
 	return { account, hash };
 }
 
-void nano::asc_pull_ack::frontiers_payload::serialize (nano::stream & stream) const
+void asc_pull_ack::frontiers_payload::serialize (nano::stream & stream) const
 {
 	debug_assert (frontiers.size () <= max_frontiers);
 
@@ -452,7 +454,7 @@ void nano::asc_pull_ack::frontiers_payload::serialize (nano::stream & stream) co
 	serialize_frontier (stream, { nano::account{ 0 }, nano::block_hash{ 0 } });
 }
 
-void nano::asc_pull_ack::frontiers_payload::deserialize (nano::stream & stream)
+void asc_pull_ack::frontiers_payload::deserialize (nano::stream & stream)
 {
 	auto current = deserialize_frontier (stream);
 	while ((!current.first.is_zero () && !current.second.is_zero ()) && frontiers.size () < max_frontiers)
@@ -462,11 +464,12 @@ void nano::asc_pull_ack::frontiers_payload::deserialize (nano::stream & stream)
 	}
 }
 
-void nano::asc_pull_ack::frontiers_payload::operator() (nano::object_stream & obs) const
+void asc_pull_ack::frontiers_payload::operator() (nano::object_stream & obs) const
 {
 	obs.write_range ("frontiers", frontiers, [] (auto const & entry, nano::object_stream & obs) {
 		auto & [account, hash] = entry;
 		obs.write ("account", account);
 		obs.write ("hash", hash);
 	});
+}
 }

--- a/nano/messages/asc_pull.hpp
+++ b/nano/messages/asc_pull.hpp
@@ -9,7 +9,7 @@
 #include <utility>
 #include <variant>
 
-namespace nano
+namespace nano::messages
 {
 /**
  * Type of requested asc pull data
@@ -31,13 +31,13 @@ public:
 	using id_t = uint64_t;
 
 	explicit asc_pull_req (nano::network_constants const &);
-	asc_pull_req (bool & error, nano::stream &, nano::message_header const &);
+	asc_pull_req (bool & error, nano::stream &, message_header const &);
 
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
-	void visit (nano::message_visitor &) const override;
+	void visit (message_visitor &) const override;
 
-	static std::size_t size (nano::message_header const &);
+	static std::size_t size (message_header const &);
 
 	/**
 	 * Update payload size stored in header
@@ -125,13 +125,13 @@ public:
 	using id_t = asc_pull_req::id_t;
 
 	explicit asc_pull_ack (nano::network_constants const &);
-	asc_pull_ack (bool & error, nano::stream &, nano::message_header const &);
+	asc_pull_ack (bool & error, nano::stream &, message_header const &);
 
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
-	void visit (nano::message_visitor &) const override;
+	void visit (message_visitor &) const override;
 
-	static std::size_t size (nano::message_header const &);
+	static std::size_t size (message_header const &);
 
 	/**
 	 * Update payload size stored in header

--- a/nano/messages/bulk_pull.cpp
+++ b/nano/messages/bulk_pull.cpp
@@ -6,12 +6,14 @@
 
 #include <boost/endian/conversion.hpp>
 
-nano::bulk_pull::bulk_pull (nano::network_constants const & constants) :
-	message (constants, nano::message_type::bulk_pull)
+namespace nano::messages
+{
+bulk_pull::bulk_pull (nano::network_constants const & constants) :
+	message (constants, message_type::bulk_pull)
 {
 }
 
-nano::bulk_pull::bulk_pull (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
+bulk_pull::bulk_pull (bool & error_a, nano::stream & stream_a, message_header const & header_a) :
 	message (header_a)
 {
 	if (!error_a)
@@ -20,12 +22,12 @@ nano::bulk_pull::bulk_pull (bool & error_a, nano::stream & stream_a, nano::messa
 	}
 }
 
-void nano::bulk_pull::visit (nano::message_visitor & visitor_a) const
+void bulk_pull::visit (message_visitor & visitor_a) const
 {
 	visitor_a.bulk_pull (*this);
 }
 
-void nano::bulk_pull::serialize (nano::stream & stream_a) const
+void bulk_pull::serialize (nano::stream & stream_a) const
 {
 	/*
 	 * Ensure the "count_present" flag is set if there
@@ -54,9 +56,9 @@ void nano::bulk_pull::serialize (nano::stream & stream_a) const
 	}
 }
 
-bool nano::bulk_pull::deserialize (nano::stream & stream_a)
+bool bulk_pull::deserialize (nano::stream & stream_a)
 {
-	debug_assert (header.type == nano::message_type::bulk_pull);
+	debug_assert (header.type == message_type::bulk_pull);
 	auto error (false);
 	try
 	{
@@ -92,21 +94,22 @@ bool nano::bulk_pull::deserialize (nano::stream & stream_a)
 	return error;
 }
 
-bool nano::bulk_pull::is_count_present () const
+bool bulk_pull::is_count_present () const
 {
 	return header.extensions.test (count_present_flag);
 }
 
-void nano::bulk_pull::set_count_present (bool value_a)
+void bulk_pull::set_count_present (bool value_a)
 {
 	header.extensions.set (count_present_flag, value_a);
 }
 
-void nano::bulk_pull::operator() (nano::object_stream & obs) const
+void bulk_pull::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 
 	obs.write ("start", start);
 	obs.write ("end", end);
 	obs.write ("count", count);
+}
 }

--- a/nano/messages/bulk_pull.hpp
+++ b/nano/messages/bulk_pull.hpp
@@ -5,23 +5,23 @@
 
 #include <cstdint>
 
-namespace nano
+namespace nano::messages
 {
 class bulk_pull final : public message
 {
 public:
 	using count_t = uint32_t;
 	explicit bulk_pull (nano::network_constants const & constants);
-	bulk_pull (bool &, nano::stream &, nano::message_header const &);
+	bulk_pull (bool &, nano::stream &, message_header const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
-	void visit (nano::message_visitor &) const override;
+	void visit (message_visitor &) const override;
 	nano::hash_or_account start{ 0 };
 	nano::block_hash end{ 0 };
 	count_t count{ 0 };
 	bool is_count_present () const;
 	void set_count_present (bool);
-	static std::size_t constexpr count_present_flag = nano::message_header::bulk_pull_count_present_flag;
+	static std::size_t constexpr count_present_flag = message_header::bulk_pull_count_present_flag;
 	static std::size_t constexpr extended_parameters_size = 8;
 	static std::size_t constexpr size = sizeof (start) + sizeof (end);
 

--- a/nano/messages/bulk_pull_account.cpp
+++ b/nano/messages/bulk_pull_account.cpp
@@ -4,12 +4,14 @@
 #include <nano/messages/bulk_pull_account.hpp>
 #include <nano/messages/message_visitor.hpp>
 
-nano::bulk_pull_account::bulk_pull_account (nano::network_constants const & constants) :
-	message (constants, nano::message_type::bulk_pull_account)
+namespace nano::messages
+{
+bulk_pull_account::bulk_pull_account (nano::network_constants const & constants) :
+	message (constants, message_type::bulk_pull_account)
 {
 }
 
-nano::bulk_pull_account::bulk_pull_account (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
+bulk_pull_account::bulk_pull_account (bool & error_a, nano::stream & stream_a, message_header const & header_a) :
 	message (header_a)
 {
 	if (!error_a)
@@ -18,12 +20,12 @@ nano::bulk_pull_account::bulk_pull_account (bool & error_a, nano::stream & strea
 	}
 }
 
-void nano::bulk_pull_account::visit (nano::message_visitor & visitor_a) const
+void bulk_pull_account::visit (message_visitor & visitor_a) const
 {
 	visitor_a.bulk_pull_account (*this);
 }
 
-void nano::bulk_pull_account::serialize (nano::stream & stream_a) const
+void bulk_pull_account::serialize (nano::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	write (stream_a, account);
@@ -31,9 +33,9 @@ void nano::bulk_pull_account::serialize (nano::stream & stream_a) const
 	write (stream_a, flags);
 }
 
-bool nano::bulk_pull_account::deserialize (nano::stream & stream_a)
+bool bulk_pull_account::deserialize (nano::stream & stream_a)
 {
-	debug_assert (header.type == nano::message_type::bulk_pull_account);
+	debug_assert (header.type == message_type::bulk_pull_account);
 	auto error (false);
 	try
 	{
@@ -49,11 +51,12 @@ bool nano::bulk_pull_account::deserialize (nano::stream & stream_a)
 	return error;
 }
 
-void nano::bulk_pull_account::operator() (nano::object_stream & obs) const
+void bulk_pull_account::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 
 	obs.write ("account", account);
 	obs.write ("minimum_amount", minimum_amount);
 	obs.write ("flags", static_cast<uint8_t> (flags)); // TODO: Prettier flag printing
+}
 }

--- a/nano/messages/bulk_pull_account.hpp
+++ b/nano/messages/bulk_pull_account.hpp
@@ -4,16 +4,16 @@
 #include <nano/messages/message.hpp>
 #include <nano/messages/message_type.hpp>
 
-namespace nano
+namespace nano::messages
 {
 class bulk_pull_account final : public message
 {
 public:
 	explicit bulk_pull_account (nano::network_constants const & constants);
-	bulk_pull_account (bool &, nano::stream &, nano::message_header const &);
+	bulk_pull_account (bool &, nano::stream &, message_header const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
-	void visit (nano::message_visitor &) const override;
+	void visit (message_visitor &) const override;
 	nano::account account;
 	nano::amount minimum_amount;
 	bulk_pull_account_flags flags;

--- a/nano/messages/bulk_push.cpp
+++ b/nano/messages/bulk_push.cpp
@@ -3,33 +3,36 @@
 #include <nano/messages/bulk_push.hpp>
 #include <nano/messages/message_visitor.hpp>
 
-nano::bulk_push::bulk_push (nano::network_constants const & constants) :
-	message (constants, nano::message_type::bulk_push)
+namespace nano::messages
+{
+bulk_push::bulk_push (nano::network_constants const & constants) :
+	message (constants, message_type::bulk_push)
 {
 }
 
-nano::bulk_push::bulk_push (nano::message_header const & header_a) :
+bulk_push::bulk_push (message_header const & header_a) :
 	message (header_a)
 {
 }
 
-bool nano::bulk_push::deserialize (nano::stream & stream_a)
+bool bulk_push::deserialize (nano::stream & stream_a)
 {
-	debug_assert (header.type == nano::message_type::bulk_push);
+	debug_assert (header.type == message_type::bulk_push);
 	return false;
 }
 
-void nano::bulk_push::serialize (nano::stream & stream_a) const
+void bulk_push::serialize (nano::stream & stream_a) const
 {
 	header.serialize (stream_a);
 }
 
-void nano::bulk_push::visit (nano::message_visitor & visitor_a) const
+void bulk_push::visit (message_visitor & visitor_a) const
 {
 	visitor_a.bulk_push (*this);
 }
 
-void nano::bulk_push::operator() (nano::object_stream & obs) const
+void bulk_push::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
+}
 }

--- a/nano/messages/bulk_push.hpp
+++ b/nano/messages/bulk_push.hpp
@@ -2,16 +2,16 @@
 
 #include <nano/messages/message.hpp>
 
-namespace nano
+namespace nano::messages
 {
 class bulk_push final : public message
 {
 public:
 	explicit bulk_push (nano::network_constants const & constants);
-	explicit bulk_push (nano::message_header const &);
+	explicit bulk_push (message_header const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
-	void visit (nano::message_visitor &) const override;
+	void visit (message_visitor &) const override;
 
 public: // Logging
 	void operator() (nano::object_stream &) const override;

--- a/nano/messages/common.hpp
+++ b/nano/messages/common.hpp
@@ -3,7 +3,7 @@
 #include <nano/lib/assert.hpp>
 #include <nano/lib/stream.hpp>
 
-namespace nano
+namespace nano::messages
 {
 struct empty_payload
 {

--- a/nano/messages/confirm.cpp
+++ b/nano/messages/confirm.cpp
@@ -7,11 +7,13 @@
 #include <nano/messages/confirm.hpp>
 #include <nano/messages/message_visitor.hpp>
 
+namespace nano::messages
+{
 /*
  * confirm_req
  */
 
-nano::confirm_req::confirm_req (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
+confirm_req::confirm_req (bool & error_a, nano::stream & stream_a, message_header const & header_a) :
 	message (header_a)
 {
 	if (!error_a)
@@ -20,8 +22,8 @@ nano::confirm_req::confirm_req (bool & error_a, nano::stream & stream_a, nano::m
 	}
 }
 
-nano::confirm_req::confirm_req (nano::network_constants const & constants, std::vector<std::pair<nano::block_hash, nano::root>> const & roots_hashes_a) :
-	message (constants, nano::message_type::confirm_req),
+confirm_req::confirm_req (nano::network_constants const & constants, std::vector<std::pair<nano::block_hash, nano::root>> const & roots_hashes_a) :
+	message (constants, message_type::confirm_req),
 	roots_hashes (roots_hashes_a)
 {
 	debug_assert (!roots_hashes.empty ());
@@ -43,17 +45,17 @@ nano::confirm_req::confirm_req (nano::network_constants const & constants, std::
 	}
 }
 
-nano::confirm_req::confirm_req (nano::network_constants const & constants, nano::block_hash const & hash_a, nano::root const & root_a) :
+confirm_req::confirm_req (nano::network_constants const & constants, nano::block_hash const & hash_a, nano::root const & root_a) :
 	confirm_req (constants, std::vector<std::pair<nano::block_hash, nano::root>>{ { hash_a, root_a } })
 {
 }
 
-void nano::confirm_req::visit (nano::message_visitor & visitor_a) const
+void confirm_req::visit (message_visitor & visitor_a) const
 {
 	visitor_a.confirm_req (*this);
 }
 
-void nano::confirm_req::serialize (nano::stream & stream_a) const
+void confirm_req::serialize (nano::stream & stream_a) const
 {
 	debug_assert (!roots_hashes.empty ());
 
@@ -67,9 +69,9 @@ void nano::confirm_req::serialize (nano::stream & stream_a) const
 	}
 }
 
-bool nano::confirm_req::deserialize (nano::stream & stream_a)
+bool confirm_req::deserialize (nano::stream & stream_a)
 {
-	debug_assert (header.type == nano::message_type::confirm_req);
+	debug_assert (header.type == message_type::confirm_req);
 
 	bool result = false;
 	try
@@ -97,7 +99,7 @@ bool nano::confirm_req::deserialize (nano::stream & stream_a)
 	return result;
 }
 
-bool nano::confirm_req::operator== (nano::confirm_req const & other_a) const
+bool confirm_req::operator== (confirm_req const & other_a) const
 {
 	bool equal (false);
 	if (!roots_hashes.empty () && !other_a.roots_hashes.empty ())
@@ -107,7 +109,7 @@ bool nano::confirm_req::operator== (nano::confirm_req const & other_a) const
 	return equal;
 }
 
-uint8_t nano::confirm_req::hash_count (const nano::message_header & header)
+uint8_t confirm_req::hash_count (const message_header & header)
 {
 	if (header.confirm_is_v2 ())
 	{
@@ -119,15 +121,15 @@ uint8_t nano::confirm_req::hash_count (const nano::message_header & header)
 	}
 }
 
-std::size_t nano::confirm_req::size (nano::message_header const & header)
+std::size_t confirm_req::size (message_header const & header)
 {
 	auto const count = hash_count (header);
 	return count * (sizeof (decltype (roots_hashes)::value_type::first) + sizeof (decltype (roots_hashes)::value_type::second));
 }
 
-void nano::confirm_req::operator() (nano::object_stream & obs) const
+void confirm_req::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 
 	// Write roots as: [ { root: ##, hash: ## } ,...]
 	obs.write_range ("roots", roots_hashes, [] (auto const & root_hash, nano::object_stream & obs) {
@@ -141,7 +143,7 @@ void nano::confirm_req::operator() (nano::object_stream & obs) const
  * confirm_ack
  */
 
-nano::confirm_ack::confirm_ack (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a, nano::network_filter::digest_t const & digest_a, nano::vote_uniquer * uniquer_a) :
+confirm_ack::confirm_ack (bool & error_a, nano::stream & stream_a, message_header const & header_a, nano::network_filter::digest_t const & digest_a, nano::vote_uniquer * uniquer_a) :
 	message (header_a),
 	vote{ nano::make_shared<nano::vote> (error_a, stream_a) },
 	digest{ digest_a }
@@ -152,8 +154,8 @@ nano::confirm_ack::confirm_ack (bool & error_a, nano::stream & stream_a, nano::m
 	}
 }
 
-nano::confirm_ack::confirm_ack (nano::network_constants const & constants, std::shared_ptr<nano::vote> const & vote_a, bool rebroadcasted_a) :
-	message (constants, nano::message_type::confirm_ack),
+confirm_ack::confirm_ack (nano::network_constants const & constants, std::shared_ptr<nano::vote> const & vote_a, bool rebroadcasted_a) :
+	message (constants, message_type::confirm_ack),
 	vote{ vote_a }
 {
 	debug_assert (vote->hashes.size () < 256);
@@ -173,24 +175,24 @@ nano::confirm_ack::confirm_ack (nano::network_constants const & constants, std::
 	}
 }
 
-void nano::confirm_ack::serialize (nano::stream & stream_a) const
+void confirm_ack::serialize (nano::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	vote->serialize (stream_a);
 }
 
-bool nano::confirm_ack::operator== (nano::confirm_ack const & other_a) const
+bool confirm_ack::operator== (confirm_ack const & other_a) const
 {
 	auto result (*vote == *other_a.vote);
 	return result;
 }
 
-void nano::confirm_ack::visit (nano::message_visitor & visitor_a) const
+void confirm_ack::visit (message_visitor & visitor_a) const
 {
 	visitor_a.confirm_ack (*this);
 }
 
-uint8_t nano::confirm_ack::hash_count (const nano::message_header & header)
+uint8_t confirm_ack::hash_count (const message_header & header)
 {
 	if (header.confirm_is_v2 ())
 	{
@@ -202,21 +204,22 @@ uint8_t nano::confirm_ack::hash_count (const nano::message_header & header)
 	}
 }
 
-std::size_t nano::confirm_ack::size (const nano::message_header & header)
+std::size_t confirm_ack::size (const message_header & header)
 {
 	auto const count = hash_count (header);
 	return nano::vote::size (count);
 }
 
-bool nano::confirm_ack::is_rebroadcasted () const
+bool confirm_ack::is_rebroadcasted () const
 {
 	return header.flag_test (rebroadcasted_flag);
 }
 
-void nano::confirm_ack::operator() (nano::object_stream & obs) const
+void confirm_ack::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 
 	obs.write ("vote", vote);
 	obs.write ("rebroadcasted", is_rebroadcasted ());
+}
 }

--- a/nano/messages/confirm.hpp
+++ b/nano/messages/confirm.hpp
@@ -10,7 +10,7 @@
 #include <utility>
 #include <vector>
 
-namespace nano
+namespace nano::messages
 {
 /*
  * Binary Format:
@@ -29,20 +29,20 @@ namespace nano
 class confirm_req final : public message
 {
 public:
-	confirm_req (bool & error, nano::stream &, nano::message_header const &);
+	confirm_req (bool & error, nano::stream &, message_header const &);
 	confirm_req (nano::network_constants const & constants, std::vector<std::pair<nano::block_hash, nano::root>> const &);
 	confirm_req (nano::network_constants const & constants, nano::block_hash const &, nano::root const &);
 
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
-	void visit (nano::message_visitor &) const override;
-	bool operator== (nano::confirm_req const &) const;
+	void visit (message_visitor &) const override;
+	bool operator== (confirm_req const &) const;
 	std::string roots_string () const;
 
-	static std::size_t size (nano::message_header const &);
+	static std::size_t size (message_header const &);
 
 private:
-	static uint8_t hash_count (nano::message_header const &);
+	static uint8_t hash_count (message_header const &);
 
 public: // Payload
 	std::vector<std::pair<nano::block_hash, nano::root>> roots_hashes;
@@ -69,20 +69,20 @@ public: // Logging
 class confirm_ack final : public message
 {
 public:
-	confirm_ack (bool & error, nano::stream &, nano::message_header const &, nano::network_filter::digest_t const & digest = 0, nano::vote_uniquer * = nullptr);
+	confirm_ack (bool & error, nano::stream &, message_header const &, nano::network_filter::digest_t const & digest = 0, nano::vote_uniquer * = nullptr);
 	confirm_ack (nano::network_constants const & constants, std::shared_ptr<nano::vote> const &, bool rebroadcasted = false);
 
 	void serialize (nano::stream &) const override;
-	void visit (nano::message_visitor &) const override;
-	bool operator== (nano::confirm_ack const &) const;
+	void visit (message_visitor &) const override;
+	bool operator== (confirm_ack const &) const;
 
-	static std::size_t size (nano::message_header const &);
+	static std::size_t size (message_header const &);
 
 	static uint8_t constexpr rebroadcasted_flag = 2; // 0x0004
 	bool is_rebroadcasted () const;
 
 private:
-	static uint8_t hash_count (nano::message_header const &);
+	static uint8_t hash_count (message_header const &);
 
 public: // Payload
 	std::shared_ptr<nano::vote> vote;

--- a/nano/messages/deserialize_message.cpp
+++ b/nano/messages/deserialize_message.cpp
@@ -17,7 +17,7 @@
 
 auto nano::deserialize_message (
 nano::buffer_view buffer,
-nano::message_header const & header,
+nano::messages::message_header const & header,
 nano::network_constants const & network_constants,
 nano::network_filter * network_filter,
 nano::block_uniquer * block_uniquer,
@@ -28,10 +28,10 @@ nano::vote_uniquer * vote_uniquer)
 
 	switch (header.type)
 	{
-		case nano::message_type::keepalive:
+		case nano::messages::message_type::keepalive:
 		{
 			bool error = false;
-			auto message = std::make_unique<nano::keepalive> (error, stream, header);
+			auto message = std::make_unique<nano::messages::keepalive> (error, stream, header);
 			if (!error && at_end (stream))
 			{
 				return { std::move (message), deserialize_message_status::success };
@@ -39,7 +39,7 @@ nano::vote_uniquer * vote_uniquer)
 			return { nullptr, deserialize_message_status::invalid_keepalive_message };
 		}
 		break;
-		case nano::message_type::publish:
+		case nano::messages::message_type::publish:
 		{
 			nano::uint128_t digest{ 0 };
 			if (network_filter)
@@ -51,7 +51,7 @@ nano::vote_uniquer * vote_uniquer)
 			}
 
 			bool error = false;
-			auto message = std::make_unique<nano::publish> (error, stream, header, digest, block_uniquer);
+			auto message = std::make_unique<nano::messages::publish> (error, stream, header, digest, block_uniquer);
 			if (!error && at_end (stream) || !message->block)
 			{
 				if (!network_constants.work.validate_entry (*message->block))
@@ -66,10 +66,10 @@ nano::vote_uniquer * vote_uniquer)
 			return { nullptr, deserialize_message_status::invalid_publish_message };
 		}
 		break;
-		case nano::message_type::confirm_req:
+		case nano::messages::message_type::confirm_req:
 		{
 			bool error = false;
-			auto message = std::make_unique<nano::confirm_req> (error, stream, header);
+			auto message = std::make_unique<nano::messages::confirm_req> (error, stream, header);
 			if (!error && at_end (stream))
 			{
 				return { std::move (message), deserialize_message_status::success };
@@ -77,7 +77,7 @@ nano::vote_uniquer * vote_uniquer)
 			return { nullptr, deserialize_message_status::invalid_confirm_req_message };
 		}
 		break;
-		case nano::message_type::confirm_ack:
+		case nano::messages::message_type::confirm_ack:
 		{
 			nano::uint128_t digest{ 0 };
 			if (network_filter)
@@ -89,7 +89,7 @@ nano::vote_uniquer * vote_uniquer)
 			}
 
 			bool error = false;
-			auto message = std::make_unique<nano::confirm_ack> (error, stream, header, digest, vote_uniquer);
+			auto message = std::make_unique<nano::messages::confirm_ack> (error, stream, header, digest, vote_uniquer);
 			if (!error && at_end (stream))
 			{
 				return { std::move (message), deserialize_message_status::success };
@@ -97,10 +97,10 @@ nano::vote_uniquer * vote_uniquer)
 			return { nullptr, deserialize_message_status::invalid_confirm_ack_message };
 		}
 		break;
-		case nano::message_type::node_id_handshake:
+		case nano::messages::message_type::node_id_handshake:
 		{
 			bool error = false;
-			auto message = std::make_unique<nano::node_id_handshake> (error, stream, header);
+			auto message = std::make_unique<nano::messages::node_id_handshake> (error, stream, header);
 			if (!error && at_end (stream))
 			{
 				return { std::move (message), deserialize_message_status::success };
@@ -108,15 +108,15 @@ nano::vote_uniquer * vote_uniquer)
 			return { nullptr, deserialize_message_status::invalid_node_id_handshake_message };
 		}
 		break;
-		case nano::message_type::telemetry_req:
+		case nano::messages::message_type::telemetry_req:
 		{
-			return { std::make_unique<nano::telemetry_req> (header), deserialize_message_status::success };
+			return { std::make_unique<nano::messages::telemetry_req> (header), deserialize_message_status::success };
 		}
 		break;
-		case nano::message_type::telemetry_ack:
+		case nano::messages::message_type::telemetry_ack:
 		{
 			bool error = false;
-			auto message = std::make_unique<nano::telemetry_ack> (error, stream, header);
+			auto message = std::make_unique<nano::messages::telemetry_ack> (error, stream, header);
 			if (!error) // Intentionally not checking at_end here for forward compatibility
 			{
 				return { std::move (message), deserialize_message_status::success };
@@ -124,10 +124,10 @@ nano::vote_uniquer * vote_uniquer)
 			return { nullptr, deserialize_message_status::invalid_telemetry_ack_message };
 		}
 		break;
-		case nano::message_type::bulk_pull:
+		case nano::messages::message_type::bulk_pull:
 		{
 			bool error = false;
-			auto message = std::make_unique<nano::bulk_pull> (error, stream, header);
+			auto message = std::make_unique<nano::messages::bulk_pull> (error, stream, header);
 			if (!error && at_end (stream))
 			{
 				return { std::move (message), deserialize_message_status::success };
@@ -135,10 +135,10 @@ nano::vote_uniquer * vote_uniquer)
 			return { nullptr, deserialize_message_status::invalid_bulk_pull_message };
 		}
 		break;
-		case nano::message_type::bulk_pull_account:
+		case nano::messages::message_type::bulk_pull_account:
 		{
 			bool error = false;
-			auto message = std::make_unique<nano::bulk_pull_account> (error, stream, header);
+			auto message = std::make_unique<nano::messages::bulk_pull_account> (error, stream, header);
 			if (!error && at_end (stream))
 			{
 				return { std::move (message), deserialize_message_status::success };
@@ -146,15 +146,15 @@ nano::vote_uniquer * vote_uniquer)
 			return { nullptr, deserialize_message_status::invalid_bulk_pull_account_message };
 		}
 		break;
-		case nano::message_type::bulk_push:
+		case nano::messages::message_type::bulk_push:
 		{
-			return { std::make_unique<nano::bulk_push> (header), deserialize_message_status::success };
+			return { std::make_unique<nano::messages::bulk_push> (header), deserialize_message_status::success };
 		}
 		break;
-		case nano::message_type::frontier_req:
+		case nano::messages::message_type::frontier_req:
 		{
 			bool error = false;
-			auto message = std::make_unique<nano::frontier_req> (error, stream, header);
+			auto message = std::make_unique<nano::messages::frontier_req> (error, stream, header);
 			if (!error && at_end (stream))
 			{
 				return { std::move (message), deserialize_message_status::success };
@@ -162,10 +162,10 @@ nano::vote_uniquer * vote_uniquer)
 			return { nullptr, deserialize_message_status::invalid_frontier_req_message };
 		}
 		break;
-		case nano::message_type::asc_pull_req:
+		case nano::messages::message_type::asc_pull_req:
 		{
 			bool error = false;
-			auto message = std::make_unique<nano::asc_pull_req> (error, stream, header);
+			auto message = std::make_unique<nano::messages::asc_pull_req> (error, stream, header);
 			if (!error)
 			{
 				return { std::move (message), deserialize_message_status::success };
@@ -173,10 +173,10 @@ nano::vote_uniquer * vote_uniquer)
 			return { nullptr, deserialize_message_status::invalid_asc_pull_req_message };
 		}
 		break;
-		case nano::message_type::asc_pull_ack:
+		case nano::messages::message_type::asc_pull_ack:
 		{
 			bool error = false;
-			auto message = std::make_unique<nano::asc_pull_ack> (error, stream, header);
+			auto message = std::make_unique<nano::messages::asc_pull_ack> (error, stream, header);
 			if (!error)
 			{
 				return { std::move (message), deserialize_message_status::success };

--- a/nano/messages/deserialize_message.hpp
+++ b/nano/messages/deserialize_message.hpp
@@ -37,11 +37,11 @@ enum class deserialize_message_status
 nano::stat::detail to_stat_detail (deserialize_message_status);
 std::string_view to_string (deserialize_message_status);
 
-using deserialize_message_result = std::tuple<std::unique_ptr<nano::message>, nano::deserialize_message_status>;
+using deserialize_message_result = std::tuple<std::unique_ptr<nano::messages::message>, nano::deserialize_message_status>;
 
 deserialize_message_result deserialize_message (
 nano::buffer_view buffer,
-nano::message_header const & header,
+nano::messages::message_header const & header,
 nano::network_constants const &,
 nano::network_filter * = nullptr,
 nano::block_uniquer * = nullptr,

--- a/nano/messages/frontier_req.cpp
+++ b/nano/messages/frontier_req.cpp
@@ -4,12 +4,14 @@
 #include <nano/messages/frontier_req.hpp>
 #include <nano/messages/message_visitor.hpp>
 
-nano::frontier_req::frontier_req (nano::network_constants const & constants) :
-	message (constants, nano::message_type::frontier_req)
+namespace nano::messages
+{
+frontier_req::frontier_req (nano::network_constants const & constants) :
+	message (constants, message_type::frontier_req)
 {
 }
 
-nano::frontier_req::frontier_req (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
+frontier_req::frontier_req (bool & error_a, nano::stream & stream_a, message_header const & header_a) :
 	message (header_a)
 {
 	if (!error_a)
@@ -18,7 +20,7 @@ nano::frontier_req::frontier_req (bool & error_a, nano::stream & stream_a, nano:
 	}
 }
 
-void nano::frontier_req::serialize (nano::stream & stream_a) const
+void frontier_req::serialize (nano::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	write (stream_a, start.bytes);
@@ -26,9 +28,9 @@ void nano::frontier_req::serialize (nano::stream & stream_a) const
 	write (stream_a, count);
 }
 
-bool nano::frontier_req::deserialize (nano::stream & stream_a)
+bool frontier_req::deserialize (nano::stream & stream_a)
 {
-	debug_assert (header.type == nano::message_type::frontier_req);
+	debug_assert (header.type == message_type::frontier_req);
 	auto error (false);
 	try
 	{
@@ -44,21 +46,22 @@ bool nano::frontier_req::deserialize (nano::stream & stream_a)
 	return error;
 }
 
-void nano::frontier_req::visit (nano::message_visitor & visitor_a) const
+void frontier_req::visit (message_visitor & visitor_a) const
 {
 	visitor_a.frontier_req (*this);
 }
 
-bool nano::frontier_req::operator== (nano::frontier_req const & other_a) const
+bool frontier_req::operator== (frontier_req const & other_a) const
 {
 	return start == other_a.start && age == other_a.age && count == other_a.count;
 }
 
-void nano::frontier_req::operator() (nano::object_stream & obs) const
+void frontier_req::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 
 	obs.write ("start", start);
 	obs.write ("age", age);
 	obs.write ("count", count);
+}
 }

--- a/nano/messages/frontier_req.hpp
+++ b/nano/messages/frontier_req.hpp
@@ -5,17 +5,17 @@
 
 #include <cstdint>
 
-namespace nano
+namespace nano::messages
 {
 class frontier_req final : public message
 {
 public:
 	explicit frontier_req (nano::network_constants const & constants);
-	frontier_req (bool &, nano::stream &, nano::message_header const &);
+	frontier_req (bool &, nano::stream &, message_header const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
-	void visit (nano::message_visitor &) const override;
-	bool operator== (nano::frontier_req const &) const;
+	void visit (message_visitor &) const override;
+	bool operator== (frontier_req const &) const;
 	nano::account start;
 	uint32_t age;
 	uint32_t count;

--- a/nano/messages/fwd.hpp
+++ b/nano/messages/fwd.hpp
@@ -2,7 +2,7 @@
 
 #include <nano/lib/fwd.hpp>
 
-namespace nano
+namespace nano::messages
 {
 enum class message_type : uint8_t;
 enum class bulk_pull_account_flags : uint8_t;

--- a/nano/messages/keepalive.cpp
+++ b/nano/messages/keepalive.cpp
@@ -6,8 +6,10 @@
 
 #include <boost/asio/ip/address_v6.hpp>
 
-nano::keepalive::keepalive (nano::network_constants const & constants) :
-	message (constants, nano::message_type::keepalive)
+namespace nano::messages
+{
+keepalive::keepalive (nano::network_constants const & constants) :
+	message (constants, message_type::keepalive)
 {
 	nano::endpoint endpoint (boost::asio::ip::address_v6{}, 0);
 	for (auto i (peers.begin ()), n (peers.end ()); i != n; ++i)
@@ -16,7 +18,7 @@ nano::keepalive::keepalive (nano::network_constants const & constants) :
 	}
 }
 
-nano::keepalive::keepalive (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
+keepalive::keepalive (bool & error_a, nano::stream & stream_a, message_header const & header_a) :
 	message (header_a)
 {
 	if (!error_a)
@@ -25,12 +27,12 @@ nano::keepalive::keepalive (bool & error_a, nano::stream & stream_a, nano::messa
 	}
 }
 
-void nano::keepalive::visit (nano::message_visitor & visitor_a) const
+void keepalive::visit (message_visitor & visitor_a) const
 {
 	visitor_a.keepalive (*this);
 }
 
-void nano::keepalive::serialize (nano::stream & stream_a) const
+void keepalive::serialize (nano::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	for (auto i (peers.begin ()), j (peers.end ()); i != j; ++i)
@@ -42,9 +44,9 @@ void nano::keepalive::serialize (nano::stream & stream_a) const
 	}
 }
 
-bool nano::keepalive::deserialize (nano::stream & stream_a)
+bool keepalive::deserialize (nano::stream & stream_a)
 {
-	debug_assert (header.type == nano::message_type::keepalive);
+	debug_assert (header.type == message_type::keepalive);
 	auto error (false);
 	for (auto i (peers.begin ()), j (peers.end ()); i != j && !error; ++i)
 	{
@@ -62,14 +64,15 @@ bool nano::keepalive::deserialize (nano::stream & stream_a)
 	return error;
 }
 
-bool nano::keepalive::operator== (nano::keepalive const & other_a) const
+bool keepalive::operator== (keepalive const & other_a) const
 {
 	return peers == other_a.peers;
 }
 
-void nano::keepalive::operator() (nano::object_stream & obs) const
+void keepalive::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 
 	obs.write_range ("peers", peers);
+}
 }

--- a/nano/messages/keepalive.hpp
+++ b/nano/messages/keepalive.hpp
@@ -5,7 +5,7 @@
 
 #include <array>
 
-namespace nano
+namespace nano::messages
 {
 /*
  * Binary Format:
@@ -19,11 +19,11 @@ class keepalive final : public message
 {
 public:
 	explicit keepalive (nano::network_constants const & constants);
-	keepalive (bool &, nano::stream &, nano::message_header const &);
-	void visit (nano::message_visitor &) const override;
+	keepalive (bool &, nano::stream &, message_header const &);
+	void visit (message_visitor &) const override;
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
-	bool operator== (nano::keepalive const &) const;
+	bool operator== (keepalive const &) const;
 	std::array<nano::endpoint, 8> peers;
 	static std::size_t constexpr size = 8 * (16 + 2);
 

--- a/nano/messages/message.cpp
+++ b/nano/messages/message.cpp
@@ -2,17 +2,19 @@
 #include <nano/lib/stream.hpp>
 #include <nano/messages/message.hpp>
 
-nano::message::message (nano::network_constants const & constants, nano::message_type type_a) :
+namespace nano::messages
+{
+message::message (nano::network_constants const & constants, message_type type_a) :
 	header (constants, type_a)
 {
 }
 
-nano::message::message (nano::message_header const & header_a) :
+message::message (message_header const & header_a) :
 	header (header_a)
 {
 }
 
-std::shared_ptr<std::vector<uint8_t>> nano::message::to_bytes () const
+std::shared_ptr<std::vector<uint8_t>> message::to_bytes () const
 {
 	auto bytes = std::make_shared<std::vector<uint8_t>> ();
 	nano::vectorstream stream (*bytes);
@@ -20,17 +22,18 @@ std::shared_ptr<std::vector<uint8_t>> nano::message::to_bytes () const
 	return bytes;
 }
 
-nano::shared_const_buffer nano::message::to_shared_const_buffer () const
+nano::shared_const_buffer message::to_shared_const_buffer () const
 {
 	return shared_const_buffer (to_bytes ());
 }
 
-nano::message_type nano::message::type () const
+message_type message::type () const
 {
 	return header.type;
 }
 
-void nano::message::operator() (nano::object_stream & obs) const
+void message::operator() (nano::object_stream & obs) const
 {
 	obs.write ("header", header);
+}
 }

--- a/nano/messages/message.hpp
+++ b/nano/messages/message.hpp
@@ -9,25 +9,25 @@
 #include <memory>
 #include <vector>
 
-namespace nano
+namespace nano::messages
 {
 class message
 {
 public:
-	explicit message (nano::network_constants const &, nano::message_type);
-	explicit message (nano::message_header const &);
+	explicit message (nano::network_constants const &, message_type);
+	explicit message (message_header const &);
 	virtual ~message () = default;
 
 	virtual void serialize (nano::stream &) const = 0;
-	virtual void visit (nano::message_visitor &) const = 0;
+	virtual void visit (message_visitor &) const = 0;
 
 	std::shared_ptr<std::vector<uint8_t>> to_bytes () const;
 	nano::shared_const_buffer to_shared_const_buffer () const;
 
-	nano::message_type type () const;
+	message_type type () const;
 
 public:
-	nano::message_header header;
+	message_header header;
 
 public: // Logging
 	virtual void operator() (nano::object_stream &) const;

--- a/nano/messages/message_header.cpp
+++ b/nano/messages/message_header.cpp
@@ -17,7 +17,9 @@
 
 #include <boost/endian/conversion.hpp>
 
-nano::message_header::message_header (nano::network_constants const & constants, nano::message_type type_a) :
+namespace nano::messages
+{
+message_header::message_header (nano::network_constants const & constants, message_type type_a) :
 	network{ constants.current_network },
 	version_max{ constants.protocol_version },
 	version_using{ constants.protocol_version },
@@ -26,7 +28,7 @@ nano::message_header::message_header (nano::network_constants const & constants,
 {
 }
 
-nano::message_header::message_header (bool & error_a, nano::stream & stream_a)
+message_header::message_header (bool & error_a, nano::stream & stream_a)
 {
 	if (!error_a)
 	{
@@ -34,7 +36,7 @@ nano::message_header::message_header (bool & error_a, nano::stream & stream_a)
 	}
 }
 
-void nano::message_header::serialize (nano::stream & stream_a) const
+void message_header::serialize (nano::stream & stream_a) const
 {
 	nano::write (stream_a, boost::endian::native_to_big (static_cast<uint16_t> (network)));
 	nano::write (stream_a, version_max);
@@ -44,7 +46,7 @@ void nano::message_header::serialize (nano::stream & stream_a) const
 	nano::write (stream_a, static_cast<uint16_t> (extensions.to_ullong ()));
 }
 
-bool nano::message_header::deserialize (nano::stream & stream_a)
+bool message_header::deserialize (nano::stream & stream_a)
 {
 	auto error (false);
 	try
@@ -68,28 +70,28 @@ bool nano::message_header::deserialize (nano::stream & stream_a)
 	return error;
 }
 
-nano::block_type nano::message_header::block_type () const
+nano::block_type message_header::block_type () const
 {
 	return static_cast<nano::block_type> (((extensions & block_type_mask) >> 8).to_ullong ());
 }
 
-void nano::message_header::block_type_set (nano::block_type type_a)
+void message_header::block_type_set (nano::block_type type_a)
 {
 	extensions &= ~block_type_mask;
 	extensions |= (extensions_bitset_t{ static_cast<unsigned long long> (type_a) } << 8);
 }
 
-uint8_t nano::message_header::count_get () const
+uint8_t message_header::count_get () const
 {
-	debug_assert (type == nano::message_type::confirm_ack || type == nano::message_type::confirm_req);
+	debug_assert (type == message_type::confirm_ack || type == message_type::confirm_req);
 	debug_assert (!flag_test (confirm_v2_flag)); // Only valid for v1
 
 	return static_cast<uint8_t> (((extensions & count_mask) >> 12).to_ullong ());
 }
 
-void nano::message_header::count_set (uint8_t count_a)
+void message_header::count_set (uint8_t count_a)
 {
-	debug_assert (type == nano::message_type::confirm_ack || type == nano::message_type::confirm_req);
+	debug_assert (type == message_type::confirm_ack || type == message_type::confirm_req);
 	debug_assert (!flag_test (confirm_v2_flag)); // Only valid for v1
 	debug_assert (count_a < 16); // Max 4 bits
 
@@ -101,9 +103,9 @@ void nano::message_header::count_set (uint8_t count_a)
  * We need those shenanigans because we need to keep compatibility with previous protocol versions (<= V25.1)
  */
 
-uint8_t nano::message_header::count_v2_get () const
+uint8_t message_header::count_v2_get () const
 {
-	debug_assert (type == nano::message_type::confirm_ack || type == nano::message_type::confirm_req);
+	debug_assert (type == message_type::confirm_ack || type == message_type::confirm_req);
 	debug_assert (flag_test (confirm_v2_flag)); // Only valid for v2
 
 	// Extract 2 parts of 4 bits
@@ -113,9 +115,9 @@ uint8_t nano::message_header::count_v2_get () const
 	return static_cast<uint8_t> (((left << 4) | right).to_ullong ());
 }
 
-void nano::message_header::count_v2_set (uint8_t count)
+void message_header::count_v2_set (uint8_t count)
 {
-	debug_assert (type == nano::message_type::confirm_ack || type == nano::message_type::confirm_req);
+	debug_assert (type == message_type::confirm_ack || type == message_type::confirm_req);
 	debug_assert (flag_test (confirm_v2_flag)); // Only valid for v2
 
 	extensions &= ~(count_v2_mask_left | count_v2_mask_right);
@@ -128,24 +130,24 @@ void nano::message_header::count_v2_set (uint8_t count)
 	extensions |= (left << 12) | (right << 4);
 }
 
-bool nano::message_header::flag_test (uint8_t flag) const
+bool message_header::flag_test (uint8_t flag) const
 {
 	// Extension bits at index >= 8 are block type & count
 	debug_assert (flag < 8);
 	return extensions.test (flag);
 }
 
-void nano::message_header::flag_set (uint8_t flag, bool enable)
+void message_header::flag_set (uint8_t flag, bool enable)
 {
 	// Extension bits at index >= 8 are block type & count
 	debug_assert (flag < 8);
 	extensions.set (flag, enable);
 }
 
-bool nano::message_header::bulk_pull_is_count_present () const
+bool message_header::bulk_pull_is_count_present () const
 {
 	auto result (false);
-	if (type == nano::message_type::bulk_pull)
+	if (type == message_type::bulk_pull)
 	{
 		if (extensions.test (bulk_pull_count_present_flag))
 		{
@@ -155,10 +157,10 @@ bool nano::message_header::bulk_pull_is_count_present () const
 	return result;
 }
 
-bool nano::message_header::bulk_pull_ascending () const
+bool message_header::bulk_pull_ascending () const
 {
 	auto result (false);
-	if (type == nano::message_type::bulk_pull)
+	if (type == message_type::bulk_pull)
 	{
 		if (extensions.test (bulk_pull_ascending_flag))
 		{
@@ -168,10 +170,10 @@ bool nano::message_header::bulk_pull_ascending () const
 	return result;
 }
 
-bool nano::message_header::frontier_req_is_only_confirmed_present () const
+bool message_header::frontier_req_is_only_confirmed_present () const
 {
 	auto result (false);
-	if (type == nano::message_type::frontier_req)
+	if (type == message_type::frontier_req)
 	{
 		if (extensions.test (frontier_req_only_confirmed))
 		{
@@ -181,71 +183,71 @@ bool nano::message_header::frontier_req_is_only_confirmed_present () const
 	return result;
 }
 
-bool nano::message_header::confirm_is_v2 () const
+bool message_header::confirm_is_v2 () const
 {
-	debug_assert (type == nano::message_type::confirm_ack || type == nano::message_type::confirm_req);
+	debug_assert (type == message_type::confirm_ack || type == message_type::confirm_req);
 	return flag_test (confirm_v2_flag);
 }
 
-void nano::message_header::confirm_set_v2 (bool value)
+void message_header::confirm_set_v2 (bool value)
 {
-	debug_assert (type == nano::message_type::confirm_ack || type == nano::message_type::confirm_req);
+	debug_assert (type == message_type::confirm_ack || type == message_type::confirm_req);
 	flag_set (confirm_v2_flag, value);
 }
 
-std::size_t nano::message_header::payload_length_bytes () const
+std::size_t message_header::payload_length_bytes () const
 {
 	switch (type)
 	{
-		case nano::message_type::bulk_pull:
+		case message_type::bulk_pull:
 		{
-			return nano::bulk_pull::size + (bulk_pull_is_count_present () ? nano::bulk_pull::extended_parameters_size : 0);
+			return bulk_pull::size + (bulk_pull_is_count_present () ? bulk_pull::extended_parameters_size : 0);
 		}
-		case nano::message_type::bulk_push:
-		case nano::message_type::telemetry_req:
+		case message_type::bulk_push:
+		case message_type::telemetry_req:
 		{
 			// These don't have a payload
 			return 0;
 		}
-		case nano::message_type::frontier_req:
+		case message_type::frontier_req:
 		{
-			return nano::frontier_req::size;
+			return frontier_req::size;
 		}
-		case nano::message_type::bulk_pull_account:
+		case message_type::bulk_pull_account:
 		{
-			return nano::bulk_pull_account::size;
+			return bulk_pull_account::size;
 		}
-		case nano::message_type::keepalive:
+		case message_type::keepalive:
 		{
-			return nano::keepalive::size;
+			return keepalive::size;
 		}
-		case nano::message_type::publish:
+		case message_type::publish:
 		{
 			return nano::block::size (block_type ());
 		}
-		case nano::message_type::confirm_ack:
+		case message_type::confirm_ack:
 		{
-			return nano::confirm_ack::size (*this);
+			return confirm_ack::size (*this);
 		}
-		case nano::message_type::confirm_req:
+		case message_type::confirm_req:
 		{
-			return nano::confirm_req::size (*this);
+			return confirm_req::size (*this);
 		}
-		case nano::message_type::node_id_handshake:
+		case message_type::node_id_handshake:
 		{
-			return nano::node_id_handshake::size (*this);
+			return node_id_handshake::size (*this);
 		}
-		case nano::message_type::telemetry_ack:
+		case message_type::telemetry_ack:
 		{
-			return nano::telemetry_ack::size (*this);
+			return telemetry_ack::size (*this);
 		}
-		case nano::message_type::asc_pull_req:
+		case message_type::asc_pull_req:
 		{
-			return nano::asc_pull_req::size (*this);
+			return asc_pull_req::size (*this);
 		}
-		case nano::message_type::asc_pull_ack:
+		case message_type::asc_pull_ack:
 		{
-			return nano::asc_pull_ack::size (*this);
+			return asc_pull_ack::size (*this);
 		}
 		default:
 		{
@@ -255,23 +257,23 @@ std::size_t nano::message_header::payload_length_bytes () const
 	}
 }
 
-bool nano::message_header::is_valid_message_type () const
+bool message_header::is_valid_message_type () const
 {
 	switch (type)
 	{
-		case nano::message_type::bulk_pull:
-		case nano::message_type::bulk_push:
-		case nano::message_type::telemetry_req:
-		case nano::message_type::frontier_req:
-		case nano::message_type::bulk_pull_account:
-		case nano::message_type::keepalive:
-		case nano::message_type::publish:
-		case nano::message_type::confirm_ack:
-		case nano::message_type::confirm_req:
-		case nano::message_type::node_id_handshake:
-		case nano::message_type::telemetry_ack:
-		case nano::message_type::asc_pull_req:
-		case nano::message_type::asc_pull_ack:
+		case message_type::bulk_pull:
+		case message_type::bulk_push:
+		case message_type::telemetry_req:
+		case message_type::frontier_req:
+		case message_type::bulk_pull_account:
+		case message_type::keepalive:
+		case message_type::publish:
+		case message_type::confirm_ack:
+		case message_type::confirm_req:
+		case message_type::node_id_handshake:
+		case message_type::telemetry_ack:
+		case message_type::asc_pull_req:
+		case message_type::asc_pull_ack:
 		{
 			return true;
 		}
@@ -282,7 +284,7 @@ bool nano::message_header::is_valid_message_type () const
 	}
 }
 
-void nano::message_header::operator() (nano::object_stream & obs) const
+void message_header::operator() (nano::object_stream & obs) const
 {
 	obs.write ("type", type);
 	obs.write ("network", to_string (network));
@@ -291,4 +293,5 @@ void nano::message_header::operator() (nano::object_stream & obs) const
 	obs.write ("version_min", static_cast<uint16_t> (version_min));
 	obs.write ("version_max", static_cast<uint16_t> (version_max));
 	obs.write ("extensions", static_cast<uint16_t> (extensions.to_ulong ()));
+}
 }

--- a/nano/messages/message_header.hpp
+++ b/nano/messages/message_header.hpp
@@ -8,7 +8,7 @@
 #include <bitset>
 #include <cstdint>
 
-namespace nano
+namespace nano::messages
 {
 /*
  * Common Header Binary Format:
@@ -27,7 +27,7 @@ class message_header final
 public:
 	using extensions_bitset_t = std::bitset<16>;
 
-	message_header (nano::network_constants const &, nano::message_type);
+	message_header (nano::network_constants const &, message_type);
 	message_header (bool &, nano::stream &);
 
 	void serialize (nano::stream &) const;
@@ -38,7 +38,7 @@ public: // Payload
 	uint8_t version_max;
 	uint8_t version_using;
 	uint8_t version_min;
-	nano::message_type type;
+	message_type type;
 	extensions_bitset_t extensions;
 
 public:

--- a/nano/messages/message_type.cpp
+++ b/nano/messages/message_type.cpp
@@ -3,17 +3,20 @@
 #include <nano/lib/stats_enums.hpp>
 #include <nano/messages/message_type.hpp>
 
-std::string_view nano::to_string (nano::message_type type)
+namespace nano::messages
+{
+std::string_view to_string (message_type type)
 {
 	return nano::enum_util::name (type);
 }
 
-nano::stat::detail nano::to_stat_detail (nano::message_type type)
+nano::stat::detail to_stat_detail (message_type type)
 {
 	return nano::enum_util::cast<nano::stat::detail> (type);
 }
 
-nano::log::detail nano::to_log_detail (nano::message_type type)
+nano::log::detail to_log_detail (message_type type)
 {
 	return nano::enum_util::cast<nano::log::detail> (type);
+}
 }

--- a/nano/messages/message_type.hpp
+++ b/nano/messages/message_type.hpp
@@ -6,7 +6,7 @@
 #include <cstdint>
 #include <string_view>
 
-namespace nano
+namespace nano::messages
 {
 /**
  * Message types are serialized to the network and existing values must thus never change as
@@ -32,9 +32,9 @@ enum class message_type : uint8_t
 	asc_pull_ack = 0x0f,
 };
 
-std::string_view to_string (nano::message_type);
-stat::detail to_stat_detail (nano::message_type);
-log::detail to_log_detail (nano::message_type);
+std::string_view to_string (message_type);
+nano::stat::detail to_stat_detail (message_type);
+nano::log::detail to_log_detail (message_type);
 
 enum class bulk_pull_account_flags : uint8_t
 {

--- a/nano/messages/message_visitor.hpp
+++ b/nano/messages/message_visitor.hpp
@@ -11,65 +11,65 @@
 #include <nano/messages/publish.hpp>
 #include <nano/messages/telemetry.hpp>
 
-namespace nano
+namespace nano::messages
 {
 class message_visitor
 {
 public:
 	virtual ~message_visitor () = default;
 
-	virtual void keepalive (nano::keepalive const & message)
+	virtual void keepalive (keepalive const & message)
 	{
 		default_handler (message);
 	};
-	virtual void publish (nano::publish const & message)
+	virtual void publish (publish const & message)
 	{
 		default_handler (message);
 	}
-	virtual void confirm_req (nano::confirm_req const & message)
+	virtual void confirm_req (confirm_req const & message)
 	{
 		default_handler (message);
 	}
-	virtual void confirm_ack (nano::confirm_ack const & message)
+	virtual void confirm_ack (confirm_ack const & message)
 	{
 		default_handler (message);
 	}
-	virtual void bulk_pull (nano::bulk_pull const & message)
+	virtual void bulk_pull (bulk_pull const & message)
 	{
 		default_handler (message);
 	}
-	virtual void bulk_pull_account (nano::bulk_pull_account const & message)
+	virtual void bulk_pull_account (bulk_pull_account const & message)
 	{
 		default_handler (message);
 	}
-	virtual void bulk_push (nano::bulk_push const & message)
+	virtual void bulk_push (bulk_push const & message)
 	{
 		default_handler (message);
 	}
-	virtual void frontier_req (nano::frontier_req const & message)
+	virtual void frontier_req (frontier_req const & message)
 	{
 		default_handler (message);
 	}
-	virtual void node_id_handshake (nano::node_id_handshake const & message)
+	virtual void node_id_handshake (node_id_handshake const & message)
 	{
 		default_handler (message);
 	}
-	virtual void telemetry_req (nano::telemetry_req const & message)
+	virtual void telemetry_req (telemetry_req const & message)
 	{
 		default_handler (message);
 	}
-	virtual void telemetry_ack (nano::telemetry_ack const & message)
+	virtual void telemetry_ack (telemetry_ack const & message)
 	{
 		default_handler (message);
 	}
-	virtual void asc_pull_req (nano::asc_pull_req const & message)
+	virtual void asc_pull_req (asc_pull_req const & message)
 	{
 		default_handler (message);
 	}
-	virtual void asc_pull_ack (nano::asc_pull_ack const & message)
+	virtual void asc_pull_ack (asc_pull_ack const & message)
 	{
 		default_handler (message);
 	}
-	virtual void default_handler (nano::message const &){};
+	virtual void default_handler (message const &){};
 };
 }

--- a/nano/messages/node_id_handshake.cpp
+++ b/nano/messages/node_id_handshake.cpp
@@ -5,18 +5,20 @@
 #include <nano/messages/message_visitor.hpp>
 #include <nano/messages/node_id_handshake.hpp>
 
+namespace nano::messages
+{
 /*
  * node_id_handshake
  */
 
-nano::node_id_handshake::node_id_handshake (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a) :
+node_id_handshake::node_id_handshake (bool & error_a, nano::stream & stream_a, message_header const & header_a) :
 	message (header_a)
 {
 	error_a = deserialize (stream_a);
 }
 
-nano::node_id_handshake::node_id_handshake (nano::network_constants const & constants, std::optional<query_payload> query_a, std::optional<response_payload> response_a) :
-	message (constants, nano::message_type::node_id_handshake),
+node_id_handshake::node_id_handshake (nano::network_constants const & constants, std::optional<query_payload> query_a, std::optional<response_payload> response_a) :
+	message (constants, message_type::node_id_handshake),
 	query{ query_a },
 	response{ response_a }
 {
@@ -32,7 +34,7 @@ nano::node_id_handshake::node_id_handshake (nano::network_constants const & cons
 	}
 }
 
-void nano::node_id_handshake::serialize (nano::stream & stream) const
+void node_id_handshake::serialize (nano::stream & stream) const
 {
 	header.serialize (stream);
 	if (query)
@@ -45,9 +47,9 @@ void nano::node_id_handshake::serialize (nano::stream & stream) const
 	}
 }
 
-bool nano::node_id_handshake::deserialize (nano::stream & stream)
+bool node_id_handshake::deserialize (nano::stream & stream)
 {
-	debug_assert (header.type == nano::message_type::node_id_handshake);
+	debug_assert (header.type == message_type::node_id_handshake);
 	bool error = false;
 	try
 	{
@@ -72,43 +74,43 @@ bool nano::node_id_handshake::deserialize (nano::stream & stream)
 	return error;
 }
 
-bool nano::node_id_handshake::is_query (nano::message_header const & header)
+bool node_id_handshake::is_query (message_header const & header)
 {
-	debug_assert (header.type == nano::message_type::node_id_handshake);
+	debug_assert (header.type == message_type::node_id_handshake);
 	bool result = header.extensions.test (query_flag);
 	return result;
 }
 
-bool nano::node_id_handshake::is_response (nano::message_header const & header)
+bool node_id_handshake::is_response (message_header const & header)
 {
-	debug_assert (header.type == nano::message_type::node_id_handshake);
+	debug_assert (header.type == message_type::node_id_handshake);
 	bool result = header.extensions.test (response_flag);
 	return result;
 }
 
-bool nano::node_id_handshake::is_v2 (nano::message_header const & header)
+bool node_id_handshake::is_v2 (message_header const & header)
 {
-	debug_assert (header.type == nano::message_type::node_id_handshake);
+	debug_assert (header.type == message_type::node_id_handshake);
 	bool result = header.extensions.test (v2_flag);
 	return result;
 }
 
-bool nano::node_id_handshake::is_v2 () const
+bool node_id_handshake::is_v2 () const
 {
 	return is_v2 (header);
 }
 
-void nano::node_id_handshake::visit (nano::message_visitor & visitor_a) const
+void node_id_handshake::visit (message_visitor & visitor_a) const
 {
 	visitor_a.node_id_handshake (*this);
 }
 
-std::size_t nano::node_id_handshake::size () const
+std::size_t node_id_handshake::size () const
 {
 	return size (header);
 }
 
-std::size_t nano::node_id_handshake::size (nano::message_header const & header)
+std::size_t node_id_handshake::size (message_header const & header)
 {
 	std::size_t result = 0;
 	if (is_query (header))
@@ -122,9 +124,9 @@ std::size_t nano::node_id_handshake::size (nano::message_header const & header)
 	return result;
 }
 
-void nano::node_id_handshake::operator() (nano::object_stream & obs) const
+void node_id_handshake::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 
 	obs.write ("query", query);
 	obs.write ("response", response);
@@ -134,17 +136,17 @@ void nano::node_id_handshake::operator() (nano::object_stream & obs) const
  * node_id_handshake::query_payload
  */
 
-void nano::node_id_handshake::query_payload::serialize (nano::stream & stream) const
+void node_id_handshake::query_payload::serialize (nano::stream & stream) const
 {
 	nano::write (stream, cookie);
 }
 
-void nano::node_id_handshake::query_payload::deserialize (nano::stream & stream)
+void node_id_handshake::query_payload::deserialize (nano::stream & stream)
 {
 	nano::read (stream, cookie);
 }
 
-void nano::node_id_handshake::query_payload::operator() (nano::object_stream & obs) const
+void node_id_handshake::query_payload::operator() (nano::object_stream & obs) const
 {
 	obs.write ("cookie", cookie);
 }
@@ -153,7 +155,7 @@ void nano::node_id_handshake::query_payload::operator() (nano::object_stream & o
  * node_id_handshake::response_payload
  */
 
-void nano::node_id_handshake::response_payload::serialize (nano::stream & stream) const
+void node_id_handshake::response_payload::serialize (nano::stream & stream) const
 {
 	if (v2)
 	{
@@ -170,7 +172,7 @@ void nano::node_id_handshake::response_payload::serialize (nano::stream & stream
 	}
 }
 
-void nano::node_id_handshake::response_payload::deserialize (nano::stream & stream, nano::message_header const & header)
+void node_id_handshake::response_payload::deserialize (nano::stream & stream, message_header const & header)
 {
 	if (is_v2 (header))
 	{
@@ -188,12 +190,12 @@ void nano::node_id_handshake::response_payload::deserialize (nano::stream & stre
 	}
 }
 
-std::size_t nano::node_id_handshake::response_payload::size (const nano::message_header & header)
+std::size_t node_id_handshake::response_payload::size (const message_header & header)
 {
 	return is_v2 (header) ? size_v2 : size_v1;
 }
 
-std::vector<uint8_t> nano::node_id_handshake::response_payload::data_to_sign (const nano::uint256_union & cookie) const
+std::vector<uint8_t> node_id_handshake::response_payload::data_to_sign (const nano::uint256_union & cookie) const
 {
 	std::vector<uint8_t> bytes;
 	{
@@ -214,7 +216,7 @@ std::vector<uint8_t> nano::node_id_handshake::response_payload::data_to_sign (co
 	return bytes;
 }
 
-void nano::node_id_handshake::response_payload::sign (const nano::uint256_union & cookie, nano::keypair const & key)
+void node_id_handshake::response_payload::sign (const nano::uint256_union & cookie, nano::keypair const & key)
 {
 	debug_assert (key.pub == node_id);
 	auto data = data_to_sign (cookie);
@@ -222,7 +224,7 @@ void nano::node_id_handshake::response_payload::sign (const nano::uint256_union 
 	debug_assert (validate (cookie));
 }
 
-bool nano::node_id_handshake::response_payload::validate (const nano::uint256_union & cookie) const
+bool node_id_handshake::response_payload::validate (const nano::uint256_union & cookie) const
 {
 	auto data = data_to_sign (cookie);
 	if (nano::validate_message (node_id, data.data (), data.size (), signature)) // true => error
@@ -232,7 +234,7 @@ bool nano::node_id_handshake::response_payload::validate (const nano::uint256_un
 	return true; // OK
 }
 
-void nano::node_id_handshake::response_payload::operator() (nano::object_stream & obs) const
+void node_id_handshake::response_payload::operator() (nano::object_stream & obs) const
 {
 	obs.write ("node_id", node_id);
 	obs.write ("signature", signature);
@@ -243,4 +245,5 @@ void nano::node_id_handshake::response_payload::operator() (nano::object_stream 
 		obs.write ("salt", v2->salt);
 		obs.write ("genesis", v2->genesis);
 	}
+}
 }

--- a/nano/messages/node_id_handshake.hpp
+++ b/nano/messages/node_id_handshake.hpp
@@ -7,7 +7,7 @@
 #include <optional>
 #include <vector>
 
-namespace nano
+namespace nano::messages
 {
 class node_id_handshake final : public message
 {
@@ -31,7 +31,7 @@ public: // Payload definitions
 	{
 	public:
 		void serialize (nano::stream &) const;
-		void deserialize (nano::stream &, nano::message_header const &);
+		void deserialize (nano::stream &, message_header const &);
 
 		void sign (nano::uint256_union const & cookie, nano::keypair const &);
 		bool validate (nano::uint256_union const & cookie) const;
@@ -54,7 +54,7 @@ public: // Payload definitions
 	public:
 		static std::size_t constexpr size_v1 = sizeof (nano::account) + sizeof (nano::signature);
 		static std::size_t constexpr size_v2 = sizeof (nano::account) + sizeof (nano::signature) + sizeof (v2_payload);
-		static std::size_t size (nano::message_header const &);
+		static std::size_t size (message_header const &);
 
 	public: // Logging
 		void operator() (nano::object_stream &) const;
@@ -62,23 +62,23 @@ public: // Payload definitions
 
 public:
 	explicit node_id_handshake (nano::network_constants const &, std::optional<query_payload> query = std::nullopt, std::optional<response_payload> response = std::nullopt);
-	node_id_handshake (bool &, nano::stream &, nano::message_header const &);
+	node_id_handshake (bool &, nano::stream &, message_header const &);
 
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
 
-	void visit (nano::message_visitor &) const override;
+	void visit (message_visitor &) const override;
 	std::size_t size () const;
-	static std::size_t size (nano::message_header const &);
+	static std::size_t size (message_header const &);
 
 public: // Header
 	static uint8_t constexpr query_flag = 0;
 	static uint8_t constexpr response_flag = 1;
 	static uint8_t constexpr v2_flag = 2;
 
-	static bool is_query (nano::message_header const &);
-	static bool is_response (nano::message_header const &);
-	static bool is_v2 (nano::message_header const &);
+	static bool is_query (message_header const &);
+	static bool is_response (message_header const &);
+	static bool is_v2 (message_header const &);
 	bool is_v2 () const;
 
 public: // Payload

--- a/nano/messages/publish.cpp
+++ b/nano/messages/publish.cpp
@@ -4,7 +4,9 @@
 #include <nano/messages/message_visitor.hpp>
 #include <nano/messages/publish.hpp>
 
-nano::publish::publish (bool & error_a, nano::stream & stream_a, nano::message_header const & header_a, nano::network_filter::digest_t const & digest_a, nano::block_uniquer * uniquer_a) :
+namespace nano::messages
+{
+publish::publish (bool & error_a, nano::stream & stream_a, message_header const & header_a, nano::network_filter::digest_t const & digest_a, nano::block_uniquer * uniquer_a) :
 	message (header_a),
 	digest{ digest_a }
 {
@@ -14,48 +16,49 @@ nano::publish::publish (bool & error_a, nano::stream & stream_a, nano::message_h
 	}
 }
 
-nano::publish::publish (nano::network_constants const & constants, std::shared_ptr<nano::block> const & block_a, bool is_originator_a) :
-	message (constants, nano::message_type::publish),
+publish::publish (nano::network_constants const & constants, std::shared_ptr<nano::block> const & block_a, bool is_originator_a) :
+	message (constants, message_type::publish),
 	block{ block_a }
 {
 	header.block_type_set (block->type ());
 	header.flag_set (originator_flag, is_originator_a);
 }
 
-void nano::publish::serialize (nano::stream & stream_a) const
+void publish::serialize (nano::stream & stream_a) const
 {
 	debug_assert (block != nullptr);
 	header.serialize (stream_a);
 	block->serialize (stream_a);
 }
 
-bool nano::publish::deserialize (nano::stream & stream_a, nano::block_uniquer * uniquer_a)
+bool publish::deserialize (nano::stream & stream_a, nano::block_uniquer * uniquer_a)
 {
-	debug_assert (header.type == nano::message_type::publish);
+	debug_assert (header.type == message_type::publish);
 	block = nano::deserialize_block (stream_a, header.block_type (), uniquer_a);
 	auto result (block == nullptr);
 	return result;
 }
 
-void nano::publish::visit (nano::message_visitor & visitor_a) const
+void publish::visit (message_visitor & visitor_a) const
 {
 	visitor_a.publish (*this);
 }
 
-bool nano::publish::operator== (nano::publish const & other_a) const
+bool publish::operator== (publish const & other_a) const
 {
 	return *block == *other_a.block;
 }
 
-bool nano::publish::is_originator () const
+bool publish::is_originator () const
 {
 	return header.flag_test (originator_flag);
 }
 
-void nano::publish::operator() (nano::object_stream & obs) const
+void publish::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 
 	obs.write ("block", block);
 	obs.write ("originator", is_originator ());
+}
 }

--- a/nano/messages/publish.hpp
+++ b/nano/messages/publish.hpp
@@ -6,7 +6,7 @@
 
 #include <memory>
 
-namespace nano
+namespace nano::messages
 {
 /*
  * Binary Format:
@@ -20,13 +20,13 @@ namespace nano
 class publish final : public message
 {
 public:
-	publish (bool &, nano::stream &, nano::message_header const &, nano::network_filter::digest_t const & digest = 0, nano::block_uniquer * = nullptr);
+	publish (bool &, nano::stream &, message_header const &, nano::network_filter::digest_t const & digest = 0, nano::block_uniquer * = nullptr);
 	publish (nano::network_constants const & constants, std::shared_ptr<nano::block> const &, bool is_originator = false);
 
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &, nano::block_uniquer * = nullptr);
-	void visit (nano::message_visitor &) const override;
-	bool operator== (nano::publish const &) const;
+	void visit (message_visitor &) const override;
+	bool operator== (publish const &) const;
 
 	static uint8_t constexpr originator_flag = 2; // 0x0004
 	bool is_originator () const;

--- a/nano/messages/telemetry.cpp
+++ b/nano/messages/telemetry.cpp
@@ -8,51 +8,53 @@
 
 #include <boost/endian/conversion.hpp>
 
+namespace nano::messages
+{
 /*
  * telemetry_req
  */
 
-nano::telemetry_req::telemetry_req (nano::network_constants const & constants) :
-	message (constants, nano::message_type::telemetry_req)
+telemetry_req::telemetry_req (nano::network_constants const & constants) :
+	message (constants, message_type::telemetry_req)
 {
 }
 
-nano::telemetry_req::telemetry_req (nano::message_header const & header_a) :
+telemetry_req::telemetry_req (message_header const & header_a) :
 	message (header_a)
 {
 }
 
-bool nano::telemetry_req::deserialize (nano::stream & stream_a)
+bool telemetry_req::deserialize (nano::stream & stream_a)
 {
-	debug_assert (header.type == nano::message_type::telemetry_req);
+	debug_assert (header.type == message_type::telemetry_req);
 	return false;
 }
 
-void nano::telemetry_req::serialize (nano::stream & stream_a) const
+void telemetry_req::serialize (nano::stream & stream_a) const
 {
 	header.serialize (stream_a);
 }
 
-void nano::telemetry_req::visit (nano::message_visitor & visitor_a) const
+void telemetry_req::visit (message_visitor & visitor_a) const
 {
 	visitor_a.telemetry_req (*this);
 }
 
-void nano::telemetry_req::operator() (nano::object_stream & obs) const
+void telemetry_req::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 }
 
 /*
  * telemetry_ack
  */
 
-nano::telemetry_ack::telemetry_ack (nano::network_constants const & constants) :
-	message (constants, nano::message_type::telemetry_ack)
+telemetry_ack::telemetry_ack (nano::network_constants const & constants) :
+	message (constants, message_type::telemetry_ack)
 {
 }
 
-nano::telemetry_ack::telemetry_ack (bool & error_a, nano::stream & stream_a, nano::message_header const & message_header) :
+telemetry_ack::telemetry_ack (bool & error_a, nano::stream & stream_a, message_header const & message_header) :
 	message (message_header)
 {
 	if (!error_a)
@@ -61,8 +63,8 @@ nano::telemetry_ack::telemetry_ack (bool & error_a, nano::stream & stream_a, nan
 	}
 }
 
-nano::telemetry_ack::telemetry_ack (nano::network_constants const & constants, nano::telemetry_data const & telemetry_data_a) :
-	message (constants, nano::message_type::telemetry_ack),
+telemetry_ack::telemetry_ack (nano::network_constants const & constants, telemetry_data const & telemetry_data_a) :
+	message (constants, message_type::telemetry_ack),
 	data (telemetry_data_a)
 {
 	debug_assert (telemetry_data::size + telemetry_data_a.unknown_data.size () <= message_header::telemetry_size_mask.to_ulong ()); // Maximum size the mask allows
@@ -70,7 +72,7 @@ nano::telemetry_ack::telemetry_ack (nano::network_constants const & constants, n
 	header.extensions |= std::bitset<16> (static_cast<unsigned long long> (telemetry_data::size) + telemetry_data_a.unknown_data.size ());
 }
 
-void nano::telemetry_ack::serialize (nano::stream & stream_a) const
+void telemetry_ack::serialize (nano::stream & stream_a) const
 {
 	header.serialize (stream_a);
 	if (!is_empty_payload ())
@@ -79,10 +81,10 @@ void nano::telemetry_ack::serialize (nano::stream & stream_a) const
 	}
 }
 
-bool nano::telemetry_ack::deserialize (nano::stream & stream_a)
+bool telemetry_ack::deserialize (nano::stream & stream_a)
 {
 	auto error (false);
-	debug_assert (header.type == nano::message_type::telemetry_ack);
+	debug_assert (header.type == message_type::telemetry_ack);
 	try
 	{
 		if (!is_empty_payload ())
@@ -98,29 +100,29 @@ bool nano::telemetry_ack::deserialize (nano::stream & stream_a)
 	return error;
 }
 
-void nano::telemetry_ack::visit (nano::message_visitor & visitor_a) const
+void telemetry_ack::visit (message_visitor & visitor_a) const
 {
 	visitor_a.telemetry_ack (*this);
 }
 
-uint16_t nano::telemetry_ack::size () const
+uint16_t telemetry_ack::size () const
 {
 	return size (header);
 }
 
-uint16_t nano::telemetry_ack::size (nano::message_header const & message_header_a)
+uint16_t telemetry_ack::size (message_header const & message_header_a)
 {
 	return static_cast<uint16_t> ((message_header_a.extensions & message_header::telemetry_size_mask).to_ullong ());
 }
 
-bool nano::telemetry_ack::is_empty_payload () const
+bool telemetry_ack::is_empty_payload () const
 {
 	return size () == 0;
 }
 
-void nano::telemetry_ack::operator() (nano::object_stream & obs) const
+void telemetry_ack::operator() (nano::object_stream & obs) const
 {
-	nano::message::operator() (obs); // Write common data
+	message::operator() (obs); // Write common data
 
 	if (!is_empty_payload ())
 	{
@@ -132,7 +134,7 @@ void nano::telemetry_ack::operator() (nano::object_stream & obs) const
  * telemetry_data
  */
 
-void nano::telemetry_data::deserialize (nano::stream & stream_a, uint16_t payload_length_a)
+void telemetry_data::deserialize (nano::stream & stream_a, uint16_t payload_length_a)
 {
 	read (stream_a, signature);
 	read (stream_a, node_id);
@@ -170,7 +172,7 @@ void nano::telemetry_data::deserialize (nano::stream & stream_a, uint16_t payloa
 	}
 }
 
-void nano::telemetry_data::serialize_without_signature (nano::stream & stream_a) const
+void telemetry_data::serialize_without_signature (nano::stream & stream_a) const
 {
 	// All values should be serialized in big endian
 	write (stream_a, node_id);
@@ -193,13 +195,13 @@ void nano::telemetry_data::serialize_without_signature (nano::stream & stream_a)
 	write (stream_a, unknown_data);
 }
 
-void nano::telemetry_data::serialize (nano::stream & stream_a) const
+void telemetry_data::serialize (nano::stream & stream_a) const
 {
 	write (stream_a, signature);
 	serialize_without_signature (stream_a);
 }
 
-nano::error nano::telemetry_data::serialize_json (nano::jsonconfig & json, bool ignore_identification_metrics_a) const
+nano::error telemetry_data::serialize_json (nano::jsonconfig & json, bool ignore_identification_metrics_a) const
 {
 	json.put ("block_count", block_count);
 	json.put ("cemented_count", cemented_count);
@@ -226,7 +228,7 @@ nano::error nano::telemetry_data::serialize_json (nano::jsonconfig & json, bool 
 	return json.get_error ();
 }
 
-nano::error nano::telemetry_data::deserialize_json (nano::jsonconfig & json, bool ignore_identification_metrics_a)
+nano::error telemetry_data::deserialize_json (nano::jsonconfig & json, bool ignore_identification_metrics_a)
 {
 	if (!ignore_identification_metrics_a)
 	{
@@ -281,17 +283,17 @@ nano::error nano::telemetry_data::deserialize_json (nano::jsonconfig & json, boo
 	return json.get_error ();
 }
 
-bool nano::telemetry_data::operator== (nano::telemetry_data const & data_a) const
+bool telemetry_data::operator== (telemetry_data const & data_a) const
 {
 	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp && active_difficulty == data_a.active_difficulty && unknown_data == data_a.unknown_data);
 }
 
-bool nano::telemetry_data::operator!= (nano::telemetry_data const & data_a) const
+bool telemetry_data::operator!= (telemetry_data const & data_a) const
 {
 	return !(*this == data_a);
 }
 
-void nano::telemetry_data::sign (nano::keypair const & node_id_a)
+void telemetry_data::sign (nano::keypair const & node_id_a)
 {
 	debug_assert (node_id == node_id_a.pub);
 	std::vector<uint8_t> bytes;
@@ -303,7 +305,7 @@ void nano::telemetry_data::sign (nano::keypair const & node_id_a)
 	signature = nano::sign_message (node_id_a.prv, node_id_a.pub, bytes.data (), bytes.size ());
 }
 
-bool nano::telemetry_data::validate_signature () const
+bool telemetry_data::validate_signature () const
 {
 	std::vector<uint8_t> bytes;
 	{
@@ -314,7 +316,8 @@ bool nano::telemetry_data::validate_signature () const
 	return nano::validate_message (node_id, bytes.data (), bytes.size (), signature);
 }
 
-void nano::telemetry_data::operator() (nano::object_stream & obs) const
+void telemetry_data::operator() (nano::object_stream & obs) const
 {
 	// TODO: Telemetry data
+}
 }

--- a/nano/messages/telemetry.hpp
+++ b/nano/messages/telemetry.hpp
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <vector>
 
-namespace nano
+namespace nano::messages
 {
 enum class telemetry_maker : uint8_t
 {
@@ -47,8 +47,8 @@ public:
 	nano::error deserialize_json (nano::jsonconfig &, bool);
 	void sign (nano::keypair const &);
 	bool validate_signature () const;
-	bool operator== (nano::telemetry_data const &) const;
-	bool operator!= (nano::telemetry_data const &) const;
+	bool operator== (telemetry_data const &) const;
+	bool operator!= (telemetry_data const &) const;
 
 	// Size does not include unknown_data
 	static auto constexpr size = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty);
@@ -65,10 +65,10 @@ class telemetry_req final : public message
 {
 public:
 	explicit telemetry_req (nano::network_constants const & constants);
-	explicit telemetry_req (nano::message_header const &);
+	explicit telemetry_req (message_header const &);
 	void serialize (nano::stream &) const override;
 	bool deserialize (nano::stream &);
-	void visit (nano::message_visitor &) const override;
+	void visit (message_visitor &) const override;
 
 public: // Logging
 	void operator() (nano::object_stream &) const override;
@@ -78,15 +78,15 @@ class telemetry_ack final : public message
 {
 public:
 	explicit telemetry_ack (nano::network_constants const & constants);
-	telemetry_ack (bool &, nano::stream &, nano::message_header const &);
+	telemetry_ack (bool &, nano::stream &, message_header const &);
 	telemetry_ack (nano::network_constants const & constants, telemetry_data const &);
 	void serialize (nano::stream &) const override;
-	void visit (nano::message_visitor &) const override;
+	void visit (message_visitor &) const override;
 	bool deserialize (nano::stream &);
 	uint16_t size () const;
 	bool is_empty_payload () const;
-	static uint16_t size (nano::message_header const &);
-	nano::telemetry_data data;
+	static uint16_t size (message_header const &);
+	telemetry_data data;
 
 public: // Logging
 	void operator() (nano::object_stream &) const override;

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -66,21 +66,21 @@ void nano::bootstrap_server::stop ()
 	threads.clear ();
 }
 
-bool nano::bootstrap_server::verify_request_type (nano::asc_pull_type type) const
+bool nano::bootstrap_server::verify_request_type (nano::messages::asc_pull_type type) const
 {
 	switch (type)
 	{
-		case asc_pull_type::invalid:
+		case nano::messages::asc_pull_type::invalid:
 			return false;
-		case asc_pull_type::blocks:
-		case asc_pull_type::account_info:
-		case asc_pull_type::frontiers:
+		case nano::messages::asc_pull_type::blocks:
+		case nano::messages::asc_pull_type::account_info:
+		case nano::messages::asc_pull_type::frontiers:
 			return true;
 	}
 	return false;
 }
 
-bool nano::bootstrap_server::verify (const nano::asc_pull_req & message) const
+bool nano::bootstrap_server::verify (const nano::messages::asc_pull_req & message) const
 {
 	if (!verify_request_type (message.type))
 	{
@@ -89,19 +89,19 @@ bool nano::bootstrap_server::verify (const nano::asc_pull_req & message) const
 
 	struct verify_visitor
 	{
-		bool operator() (nano::empty_payload const &) const
+		bool operator() (nano::messages::empty_payload const &) const
 		{
 			return false;
 		}
-		bool operator() (nano::asc_pull_req::blocks_payload const & pld) const
+		bool operator() (nano::messages::asc_pull_req::blocks_payload const & pld) const
 		{
 			return pld.count > 0 && pld.count <= max_blocks;
 		}
-		bool operator() (nano::asc_pull_req::account_info_payload const & pld) const
+		bool operator() (nano::messages::asc_pull_req::account_info_payload const & pld) const
 		{
 			return !pld.target.is_zero ();
 		}
-		bool operator() (nano::asc_pull_req::frontiers_payload const & pld) const
+		bool operator() (nano::messages::asc_pull_req::frontiers_payload const & pld) const
 		{
 			return pld.count > 0 && pld.count <= max_frontiers;
 		}
@@ -110,7 +110,7 @@ bool nano::bootstrap_server::verify (const nano::asc_pull_req & message) const
 	return std::visit (verify_visitor{}, message.payload);
 }
 
-bool nano::bootstrap_server::request (nano::asc_pull_req const & message, std::shared_ptr<nano::transport::channel> const & channel)
+bool nano::bootstrap_server::request (nano::messages::asc_pull_req const & message, std::shared_ptr<nano::transport::channel> const & channel)
 {
 	if (!config.enable)
 	{
@@ -150,7 +150,7 @@ bool nano::bootstrap_server::request (nano::asc_pull_req const & message, std::s
 	return added;
 }
 
-void nano::bootstrap_server::respond (nano::asc_pull_ack & response, std::shared_ptr<nano::transport::channel> const & channel)
+void nano::bootstrap_server::respond (nano::messages::asc_pull_ack & response, std::shared_ptr<nano::transport::channel> const & channel)
 {
 	stats.inc (nano::stat::type::bootstrap_server, nano::stat::detail::response, nano::stat::dir::out);
 	stats.inc (nano::stat::type::bootstrap_server_response, to_stat_detail (response.type));
@@ -160,19 +160,19 @@ void nano::bootstrap_server::respond (nano::asc_pull_ack & response, std::shared
 	{
 		nano::stats & stats;
 
-		void operator() (nano::empty_payload const &)
+		void operator() (nano::messages::empty_payload const &)
 		{
 			debug_assert (false, "missing payload");
 		}
-		void operator() (nano::asc_pull_ack::blocks_payload const & pld)
+		void operator() (nano::messages::asc_pull_ack::blocks_payload const & pld)
 		{
 			stats.add (nano::stat::type::bootstrap_server, nano::stat::detail::blocks, nano::stat::dir::out, pld.blocks.size ());
 		}
-		void operator() (nano::asc_pull_ack::account_info_payload const & pld)
+		void operator() (nano::messages::asc_pull_ack::account_info_payload const & pld)
 		{
 			stats.inc (nano::stat::type::bootstrap_server, nano::stat::detail::account_info, nano::stat::dir::out);
 		}
-		void operator() (nano::asc_pull_ack::frontiers_payload const & pld)
+		void operator() (nano::messages::asc_pull_ack::frontiers_payload const & pld)
 		{
 			stats.add (nano::stat::type::bootstrap_server, nano::stat::detail::frontiers, nano::stat::dir::out, pld.frontiers.size ());
 		}
@@ -251,18 +251,18 @@ void nano::bootstrap_server::run_batch (nano::unique_lock<nano::mutex> & lock)
 	}
 }
 
-nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::asc_pull_req const & message)
+nano::messages::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::messages::asc_pull_req const & message)
 {
 	return std::visit ([this, &transaction, &message] (auto && request) { return process (transaction, message.id, request); }, message.payload);
 }
 
-nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const &, nano::asc_pull_req::id_t id, nano::empty_payload const & request)
+nano::messages::asc_pull_ack nano::bootstrap_server::process (secure::transaction const &, nano::messages::asc_pull_req::id_t id, nano::messages::empty_payload const & request)
 {
 	// Empty payload should never be possible, but return empty response anyway
 	debug_assert (false, "missing payload");
-	nano::asc_pull_ack response{ network_constants };
+	nano::messages::asc_pull_ack response{ network_constants };
 	response.id = id;
-	response.type = nano::asc_pull_type::invalid;
+	response.type = nano::messages::asc_pull_type::invalid;
 	return response;
 }
 
@@ -270,13 +270,13 @@ nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const &,
  * Blocks request
  */
 
-nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::asc_pull_req::id_t id, nano::asc_pull_req::blocks_payload const & request) const
+nano::messages::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::messages::asc_pull_req::id_t id, nano::messages::asc_pull_req::blocks_payload const & request) const
 {
 	const std::size_t count = std::min (static_cast<std::size_t> (request.count), max_blocks);
 
 	switch (request.start_type)
 	{
-		case asc_pull_req::hash_type::block:
+		case messages::asc_pull_req::hash_type::block:
 		{
 			if (ledger.any.block_exists (transaction, request.start.as_block_hash ()))
 			{
@@ -284,7 +284,7 @@ nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & 
 			}
 		}
 		break;
-		case asc_pull_req::hash_type::account:
+		case messages::asc_pull_req::hash_type::account:
 		{
 			auto info = ledger.any.account_get (transaction, request.start.as_account ());
 			if (info)
@@ -300,18 +300,18 @@ nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & 
 	return prepare_empty_blocks_response (id);
 }
 
-nano::asc_pull_ack nano::bootstrap_server::prepare_response (secure::transaction const & transaction, nano::asc_pull_req::id_t id, nano::block_hash start_block, std::size_t count) const
+nano::messages::asc_pull_ack nano::bootstrap_server::prepare_response (secure::transaction const & transaction, nano::messages::asc_pull_req::id_t id, nano::block_hash start_block, std::size_t count) const
 {
 	debug_assert (count <= max_blocks); // Should be filtered out earlier
 
 	auto blocks = prepare_blocks (transaction, start_block, count);
 	debug_assert (blocks.size () <= count);
 
-	nano::asc_pull_ack response{ network_constants };
+	nano::messages::asc_pull_ack response{ network_constants };
 	response.id = id;
-	response.type = nano::asc_pull_type::blocks;
+	response.type = nano::messages::asc_pull_type::blocks;
 
-	nano::asc_pull_ack::blocks_payload response_payload{};
+	nano::messages::asc_pull_ack::blocks_payload response_payload{};
 	response_payload.blocks = blocks;
 	response.payload = response_payload;
 
@@ -319,13 +319,13 @@ nano::asc_pull_ack nano::bootstrap_server::prepare_response (secure::transaction
 	return response;
 }
 
-nano::asc_pull_ack nano::bootstrap_server::prepare_empty_blocks_response (nano::asc_pull_req::id_t id) const
+nano::messages::asc_pull_ack nano::bootstrap_server::prepare_empty_blocks_response (nano::messages::asc_pull_req::id_t id) const
 {
-	nano::asc_pull_ack response{ network_constants };
+	nano::messages::asc_pull_ack response{ network_constants };
 	response.id = id;
-	response.type = nano::asc_pull_type::blocks;
+	response.type = nano::messages::asc_pull_type::blocks;
 
-	nano::asc_pull_ack::blocks_payload empty_payload{};
+	nano::messages::asc_pull_ack::blocks_payload empty_payload{};
 	response.payload = empty_payload;
 
 	response.update_header ();
@@ -355,21 +355,21 @@ std::deque<std::shared_ptr<nano::block>> nano::bootstrap_server::prepare_blocks 
  * Account info request
  */
 
-nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::asc_pull_req::id_t id, nano::asc_pull_req::account_info_payload const & request) const
+nano::messages::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::messages::asc_pull_req::id_t id, nano::messages::asc_pull_req::account_info_payload const & request) const
 {
-	nano::asc_pull_ack response{ network_constants };
+	nano::messages::asc_pull_ack response{ network_constants };
 	response.id = id;
-	response.type = nano::asc_pull_type::account_info;
+	response.type = nano::messages::asc_pull_type::account_info;
 
 	nano::account target{ 0 };
 	switch (request.target_type)
 	{
-		case asc_pull_req::hash_type::account:
+		case messages::asc_pull_req::hash_type::account:
 		{
 			target = request.target.as_account ();
 		}
 		break;
-		case asc_pull_req::hash_type::block:
+		case messages::asc_pull_req::hash_type::block:
 		{
 			// Try to lookup account assuming target is block hash
 			target = ledger.any.block_account (transaction, request.target.as_block_hash ()).value_or (0);
@@ -377,7 +377,7 @@ nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & 
 		break;
 	}
 
-	nano::asc_pull_ack::account_info_payload response_payload{};
+	nano::messages::asc_pull_ack::account_info_payload response_payload{};
 	response_payload.account = target;
 
 	auto account_info = ledger.any.account_get (transaction, target);
@@ -405,15 +405,15 @@ nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & 
  * Frontiers request
  */
 
-nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::asc_pull_req::id_t id, nano::asc_pull_req::frontiers_payload const & request) const
+nano::messages::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::messages::asc_pull_req::id_t id, nano::messages::asc_pull_req::frontiers_payload const & request) const
 {
 	debug_assert (request.count <= max_frontiers); // Should be filtered out earlier
 
-	nano::asc_pull_ack response{ network_constants };
+	nano::messages::asc_pull_ack response{ network_constants };
 	response.id = id;
-	response.type = nano::asc_pull_type::frontiers;
+	response.type = nano::messages::asc_pull_type::frontiers;
 
-	nano::asc_pull_ack::frontiers_payload response_payload{};
+	nano::messages::asc_pull_ack::frontiers_payload response_payload{};
 	for (auto it = store.account.begin (transaction, request.start), end = store.account.end (transaction); it != end && response_payload.frontiers.size () < request.count; ++it)
 	{
 		response_payload.frontiers.emplace_back (it->first, it->second.head);
@@ -428,15 +428,15 @@ nano::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & 
  *
  */
 
-nano::stat::detail nano::to_stat_detail (nano::asc_pull_type type)
+nano::stat::detail nano::to_stat_detail (nano::messages::asc_pull_type type)
 {
 	switch (type)
 	{
-		case asc_pull_type::blocks:
+		case messages::asc_pull_type::blocks:
 			return nano::stat::detail::blocks;
-		case asc_pull_type::account_info:
+		case messages::asc_pull_type::account_info:
 			return nano::stat::detail::account_info;
-		case asc_pull_type::frontiers:
+		case messages::asc_pull_type::frontiers:
 			return nano::stat::detail::frontiers;
 		default:
 			return nano::stat::detail::invalid;

--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -45,45 +45,45 @@ public:
 	 * Process `asc_pull_req` message coming from network.
 	 * Reply will be sent back over passed in `channel`
 	 */
-	bool request (nano::asc_pull_req const & message, std::shared_ptr<nano::transport::channel> const & channel);
+	bool request (nano::messages::asc_pull_req const & message, std::shared_ptr<nano::transport::channel> const & channel);
 
 public: // Events
-	nano::observer_set<nano::asc_pull_ack const &, std::shared_ptr<nano::transport::channel> const &> on_response;
+	nano::observer_set<nano::messages::asc_pull_ack const &, std::shared_ptr<nano::transport::channel> const &> on_response;
 
 private:
 	// `asc_pull_req` message is small, store by value
-	using request_t = std::pair<nano::asc_pull_req, std::shared_ptr<nano::transport::channel>>; // <request, response channel>
+	using request_t = std::pair<nano::messages::asc_pull_req, std::shared_ptr<nano::transport::channel>>; // <request, response channel>
 
 	void run ();
 	void run_batch (nano::unique_lock<nano::mutex> & lock);
-	nano::asc_pull_ack process (secure::transaction const &, nano::asc_pull_req const & message);
-	void respond (nano::asc_pull_ack &, std::shared_ptr<nano::transport::channel> const &);
+	nano::messages::asc_pull_ack process (secure::transaction const &, nano::messages::asc_pull_req const & message);
+	void respond (nano::messages::asc_pull_ack &, std::shared_ptr<nano::transport::channel> const &);
 
-	nano::asc_pull_ack process (secure::transaction const &, nano::asc_pull_req::id_t id, nano::empty_payload const & request);
+	nano::messages::asc_pull_ack process (secure::transaction const &, nano::messages::asc_pull_req::id_t id, nano::messages::empty_payload const & request);
 
 	/*
 	 * Blocks request
 	 */
-	nano::asc_pull_ack process (secure::transaction const &, nano::asc_pull_req::id_t id, nano::asc_pull_req::blocks_payload const & request) const;
-	nano::asc_pull_ack prepare_response (secure::transaction const &, nano::asc_pull_req::id_t id, nano::block_hash start_block, std::size_t count) const;
-	nano::asc_pull_ack prepare_empty_blocks_response (nano::asc_pull_req::id_t id) const;
+	nano::messages::asc_pull_ack process (secure::transaction const &, nano::messages::asc_pull_req::id_t id, nano::messages::asc_pull_req::blocks_payload const & request) const;
+	nano::messages::asc_pull_ack prepare_response (secure::transaction const &, nano::messages::asc_pull_req::id_t id, nano::block_hash start_block, std::size_t count) const;
+	nano::messages::asc_pull_ack prepare_empty_blocks_response (nano::messages::asc_pull_req::id_t id) const;
 	std::deque<std::shared_ptr<nano::block>> prepare_blocks (secure::transaction const &, nano::block_hash start_block, std::size_t count) const;
 
 	/*
 	 * Account info request
 	 */
-	nano::asc_pull_ack process (secure::transaction const &, nano::asc_pull_req::id_t id, nano::asc_pull_req::account_info_payload const & request) const;
+	nano::messages::asc_pull_ack process (secure::transaction const &, nano::messages::asc_pull_req::id_t id, nano::messages::asc_pull_req::account_info_payload const & request) const;
 
 	/*
 	 * Frontiers request
 	 */
-	nano::asc_pull_ack process (secure::transaction const &, nano::asc_pull_req::id_t id, nano::asc_pull_req::frontiers_payload const & request) const;
+	nano::messages::asc_pull_ack process (secure::transaction const &, nano::messages::asc_pull_req::id_t id, nano::messages::asc_pull_req::frontiers_payload const & request) const;
 
 	/*
 	 * Checks if the request should be dropped early on
 	 */
-	bool verify (nano::asc_pull_req const & message) const;
-	bool verify_request_type (nano::asc_pull_type) const;
+	bool verify (nano::messages::asc_pull_req const & message) const;
+	bool verify_request_type (nano::messages::asc_pull_type) const;
 
 private: // Dependencies
 	bootstrap_server_config const & config;
@@ -103,9 +103,9 @@ private:
 
 public: // Config
 	/** Maximum number of blocks to send in a single response, cannot be higher than capacity of a single `asc_pull_ack` message */
-	constexpr static std::size_t max_blocks = nano::asc_pull_ack::blocks_payload::max_blocks;
-	constexpr static std::size_t max_frontiers = nano::asc_pull_ack::frontiers_payload::max_frontiers;
+	constexpr static std::size_t max_blocks = nano::messages::asc_pull_ack::blocks_payload::max_blocks;
+	constexpr static std::size_t max_frontiers = nano::messages::asc_pull_ack::frontiers_payload::max_frontiers;
 };
 
-nano::stat::detail to_stat_detail (nano::asc_pull_type);
+nano::stat::detail to_stat_detail (nano::messages::asc_pull_type);
 }

--- a/nano/node/bootstrap/bootstrap_service.cpp
+++ b/nano/node/bootstrap/bootstrap_service.cpp
@@ -181,7 +181,7 @@ bool nano::bootstrap_service::send (std::shared_ptr<nano::transport::channel> co
 		tags.get<tag_id> ().insert (tag);
 	}
 
-	nano::asc_pull_req request{ network_constants };
+	nano::messages::asc_pull_req request{ network_constants };
 	request.id = tag.id;
 
 	switch (tag.type)
@@ -189,32 +189,32 @@ bool nano::bootstrap_service::send (std::shared_ptr<nano::transport::channel> co
 		case query_type::blocks_by_hash:
 		case query_type::blocks_by_account:
 		{
-			request.type = nano::asc_pull_type::blocks;
+			request.type = nano::messages::asc_pull_type::blocks;
 
-			nano::asc_pull_req::blocks_payload pld;
+			nano::messages::asc_pull_req::blocks_payload pld;
 			pld.start = tag.start;
 			pld.count = tag.count;
-			pld.start_type = tag.type == query_type::blocks_by_hash ? nano::asc_pull_req::hash_type::block : nano::asc_pull_req::hash_type::account;
+			pld.start_type = tag.type == query_type::blocks_by_hash ? nano::messages::asc_pull_req::hash_type::block : nano::messages::asc_pull_req::hash_type::account;
 			request.payload = pld;
 		}
 		break;
 		case query_type::account_info_by_hash:
 		{
-			request.type = nano::asc_pull_type::account_info;
+			request.type = nano::messages::asc_pull_type::account_info;
 
-			nano::asc_pull_req::account_info_payload pld;
-			pld.target_type = nano::asc_pull_req::hash_type::block; // Query account info by block hash
+			nano::messages::asc_pull_req::account_info_payload pld;
+			pld.target_type = nano::messages::asc_pull_req::hash_type::block; // Query account info by block hash
 			pld.target = tag.start;
 			request.payload = pld;
 		}
 		break;
 		case query_type::frontiers:
 		{
-			request.type = nano::asc_pull_type::frontiers;
+			request.type = nano::messages::asc_pull_type::frontiers;
 
-			nano::asc_pull_req::frontiers_payload pld;
+			nano::messages::asc_pull_req::frontiers_payload pld;
 			pld.start = tag.start.as_account ();
-			pld.count = nano::asc_pull_ack::frontiers_payload::max_frontiers;
+			pld.count = nano::messages::asc_pull_ack::frontiers_payload::max_frontiers;
 			request.payload = pld;
 		}
 		break;
@@ -815,7 +815,7 @@ void nano::bootstrap_service::run_timeouts ()
 	}
 }
 
-void nano::bootstrap_service::process (nano::asc_pull_ack const & message, std::shared_ptr<nano::transport::channel> const & channel)
+void nano::bootstrap_service::process (nano::messages::asc_pull_ack const & message, std::shared_ptr<nano::transport::channel> const & channel)
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
 
@@ -837,19 +837,19 @@ void nano::bootstrap_service::process (nano::asc_pull_ack const & message, std::
 	{
 		query_type type;
 
-		bool operator() (const nano::asc_pull_ack::blocks_payload & response) const
+		bool operator() (const nano::messages::asc_pull_ack::blocks_payload & response) const
 		{
 			return type == query_type::blocks_by_hash || type == query_type::blocks_by_account;
 		}
-		bool operator() (const nano::asc_pull_ack::account_info_payload & response) const
+		bool operator() (const nano::messages::asc_pull_ack::account_info_payload & response) const
 		{
 			return type == query_type::account_info_by_hash;
 		}
-		bool operator() (const nano::asc_pull_ack::frontiers_payload & response) const
+		bool operator() (const nano::messages::asc_pull_ack::frontiers_payload & response) const
 		{
 			return type == query_type::frontiers;
 		}
-		bool operator() (const nano::empty_payload & response) const
+		bool operator() (const nano::messages::empty_payload & response) const
 		{
 			return false; // Should not happen
 		}
@@ -884,7 +884,7 @@ void nano::bootstrap_service::process (nano::asc_pull_ack const & message, std::
 	condition.notify_all ();
 }
 
-bool nano::bootstrap_service::process (const nano::asc_pull_ack::blocks_payload & response, const async_tag & tag)
+bool nano::bootstrap_service::process (const nano::messages::asc_pull_ack::blocks_payload & response, const async_tag & tag)
 {
 	debug_assert (tag.type == query_type::blocks_by_hash || tag.type == query_type::blocks_by_account);
 
@@ -961,7 +961,7 @@ bool nano::bootstrap_service::process (const nano::asc_pull_ack::blocks_payload 
 	return result != verify_result::invalid;
 }
 
-bool nano::bootstrap_service::process (const nano::asc_pull_ack::account_info_payload & response, const async_tag & tag)
+bool nano::bootstrap_service::process (const nano::messages::asc_pull_ack::account_info_payload & response, const async_tag & tag)
 {
 	debug_assert (tag.type == query_type::account_info_by_hash);
 	debug_assert (!tag.hash.is_zero ());
@@ -984,7 +984,7 @@ bool nano::bootstrap_service::process (const nano::asc_pull_ack::account_info_pa
 	return true; // OK, no way to verify the response
 }
 
-bool nano::bootstrap_service::process (const nano::asc_pull_ack::frontiers_payload & response, const async_tag & tag)
+bool nano::bootstrap_service::process (const nano::messages::asc_pull_ack::frontiers_payload & response, const async_tag & tag)
 {
 	debug_assert (tag.type == query_type::frontiers);
 	debug_assert (!tag.start.is_zero ());
@@ -1038,7 +1038,7 @@ bool nano::bootstrap_service::process (const nano::asc_pull_ack::frontiers_paylo
 	return result != verify_result::invalid;
 }
 
-bool nano::bootstrap_service::process (const nano::empty_payload & response, const async_tag & tag)
+bool nano::bootstrap_service::process (const nano::messages::empty_payload & response, const async_tag & tag)
 {
 	stats.inc (nano::stat::type::bootstrap_process, nano::stat::detail::empty);
 	debug_assert (false, "empty payload"); // Should not happen
@@ -1128,7 +1128,7 @@ void nano::bootstrap_service::process_frontiers (std::deque<std::pair<nano::acco
 	}
 }
 
-auto nano::bootstrap_service::verify (const nano::asc_pull_ack::blocks_payload & response, const async_tag & tag) const -> verify_result
+auto nano::bootstrap_service::verify (const nano::messages::asc_pull_ack::blocks_payload & response, const async_tag & tag) const -> verify_result
 {
 	auto const & blocks = response.blocks;
 
@@ -1187,7 +1187,7 @@ auto nano::bootstrap_service::verify (const nano::asc_pull_ack::blocks_payload &
 	return verify_result::ok;
 }
 
-auto nano::bootstrap_service::verify (nano::asc_pull_ack::frontiers_payload const & response, async_tag const & tag) const -> verify_result
+auto nano::bootstrap_service::verify (nano::messages::asc_pull_ack::frontiers_payload const & response, async_tag const & tag) const -> verify_result
 {
 	auto const & frontiers = response.frontiers;
 

--- a/nano/node/bootstrap/bootstrap_service.hpp
+++ b/nano/node/bootstrap/bootstrap_service.hpp
@@ -39,7 +39,7 @@ public:
 	/**
 	 * Process bootstrap messages coming from the network
 	 */
-	void process (nano::asc_pull_ack const & message, std::shared_ptr<nano::transport::channel> const &);
+	void process (nano::messages::asc_pull_ack const & message, std::shared_ptr<nano::transport::channel> const &);
 
 	/**
 	 * Clears priority and blocking accounts state
@@ -153,10 +153,10 @@ private:
 	bool request_frontiers (nano::account, std::shared_ptr<nano::transport::channel> const &, query_source);
 	bool send (std::shared_ptr<nano::transport::channel> const &, async_tag tag);
 
-	bool process (nano::asc_pull_ack::blocks_payload const & response, async_tag const & tag);
-	bool process (nano::asc_pull_ack::account_info_payload const & response, async_tag const & tag);
-	bool process (nano::asc_pull_ack::frontiers_payload const & response, async_tag const & tag);
-	bool process (nano::empty_payload const & response, async_tag const & tag);
+	bool process (nano::messages::asc_pull_ack::blocks_payload const & response, async_tag const & tag);
+	bool process (nano::messages::asc_pull_ack::account_info_payload const & response, async_tag const & tag);
+	bool process (nano::messages::asc_pull_ack::frontiers_payload const & response, async_tag const & tag);
+	bool process (nano::messages::empty_payload const & response, async_tag const & tag);
 
 	void process_frontiers (std::deque<std::pair<nano::account, nano::block_hash>> const & frontiers);
 
@@ -173,8 +173,8 @@ private:
 	 * - nothing_new: when received response indicates that the account chain does not have more blocks
 	 * - ok: otherwise, if all checks pass
 	 */
-	verify_result verify (nano::asc_pull_ack::blocks_payload const & response, async_tag const & tag) const;
-	verify_result verify (nano::asc_pull_ack::frontiers_payload const & response, async_tag const & tag) const;
+	verify_result verify (nano::messages::asc_pull_ack::blocks_payload const & response, async_tag const & tag) const;
+	verify_result verify (nano::messages::asc_pull_ack::frontiers_payload const & response, async_tag const & tag) const;
 
 	size_t count_tags (nano::account const & account, query_source source) const;
 	size_t count_tags (nano::block_hash const & hash, query_source source) const;

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -34,7 +34,7 @@ bool nano::confirmation_solicitor::broadcast (nano::election const & election_a)
 	if (rebroadcasted++ < max_block_broadcasts)
 	{
 		auto const & hash (election_a.status.winner->hash ());
-		nano::publish winner{ config.network_params.network, election_a.status.winner };
+		nano::messages::publish winner{ config.network_params.network, election_a.status.winner };
 		unsigned count = 0;
 		// Directed broadcasting to principal representatives
 		for (auto i (representatives_broadcasts.begin ()), n (representatives_broadcasts.end ()); i != n && count < max_election_broadcasts; ++i)
@@ -101,14 +101,14 @@ void nano::confirmation_solicitor::flush ()
 			roots_hashes_l.push_back (root_hash);
 			if (roots_hashes_l.size () == nano::network::confirm_req_hashes_max)
 			{
-				nano::confirm_req req{ config.network_params.network, roots_hashes_l };
+				nano::messages::confirm_req req{ config.network_params.network, roots_hashes_l };
 				channel->send (req, nano::transport::traffic_type::confirmation_requests);
 				roots_hashes_l.clear ();
 			}
 		}
 		if (!roots_hashes_l.empty ())
 		{
-			nano::confirm_req req{ config.network_params.network, roots_hashes_l };
+			nano::messages::confirm_req req{ config.network_params.network, roots_hashes_l };
 			channel->send (req, nano::transport::traffic_type::confirmation_requests);
 		}
 	}

--- a/nano/node/message_processor.cpp
+++ b/nano/node/message_processor.cpp
@@ -79,7 +79,7 @@ void nano::message_processor::stop ()
 	threads.clear ();
 }
 
-bool nano::message_processor::put (std::unique_ptr<nano::message> message, std::shared_ptr<nano::transport::channel> const & channel)
+bool nano::message_processor::put (std::unique_ptr<nano::messages::message> message, std::shared_ptr<nano::transport::channel> const & channel)
 {
 	release_assert (message != nullptr);
 	release_assert (channel != nullptr);
@@ -166,7 +166,7 @@ void nano::message_processor::run_batch (nano::unique_lock<nano::mutex> & lock)
 
 namespace
 {
-class process_visitor : public nano::message_visitor
+class process_visitor : public nano::messages::message_visitor
 {
 public:
 	process_visitor (nano::node & node_a, std::shared_ptr<nano::transport::channel> const & channel_a) :
@@ -175,7 +175,7 @@ public:
 	{
 	}
 
-	void keepalive (nano::keepalive const & message) override
+	void keepalive (nano::messages::keepalive const & message) override
 	{
 		// Check for self reported peering port
 		auto self_report = message.peers[0];
@@ -188,7 +188,7 @@ public:
 		channel->set_last_keepalive (message);
 	}
 
-	void publish (nano::publish const & message) override
+	void publish (nano::messages::publish const & message) override
 	{
 		// Put blocks that are being initially broadcasted in a separate queue, so that they won't have to compete with rebroadcasted blocks
 		// Both queues have the same priority and size, so the potential for exploiting this is limited
@@ -201,7 +201,7 @@ public:
 		}
 	}
 
-	void confirm_req (nano::confirm_req const & message) override
+	void confirm_req (nano::messages::confirm_req const & message) override
 	{
 		// Don't load nodes with disabled voting
 		// TODO: This check should be cached somewhere
@@ -214,7 +214,7 @@ public:
 		}
 	}
 
-	void confirm_ack (nano::confirm_ack const & message) override
+	void confirm_ack (nano::messages::confirm_ack const & message) override
 	{
 		// Ignore zero account votes
 		if (message.vote->account.is_zero ())
@@ -232,47 +232,47 @@ public:
 		}
 	}
 
-	void bulk_pull (nano::bulk_pull const &) override
+	void bulk_pull (nano::messages::bulk_pull const &) override
 	{
 		debug_assert (false);
 	}
 
-	void bulk_pull_account (nano::bulk_pull_account const &) override
+	void bulk_pull_account (nano::messages::bulk_pull_account const &) override
 	{
 		debug_assert (false);
 	}
 
-	void bulk_push (nano::bulk_push const &) override
+	void bulk_push (nano::messages::bulk_push const &) override
 	{
 		debug_assert (false);
 	}
 
-	void frontier_req (nano::frontier_req const &) override
+	void frontier_req (nano::messages::frontier_req const &) override
 	{
 		debug_assert (false);
 	}
 
-	void node_id_handshake (nano::node_id_handshake const & message) override
+	void node_id_handshake (nano::messages::node_id_handshake const & message) override
 	{
 		node.stats.inc (nano::stat::type::message, nano::stat::detail::node_id_handshake, nano::stat::dir::in);
 	}
 
-	void telemetry_req (nano::telemetry_req const & message) override
+	void telemetry_req (nano::messages::telemetry_req const & message) override
 	{
 		// Ignore telemetry requests as telemetry is being periodically broadcasted since V25+
 	}
 
-	void telemetry_ack (nano::telemetry_ack const & message) override
+	void telemetry_ack (nano::messages::telemetry_ack const & message) override
 	{
 		node.telemetry.process (message, channel);
 	}
 
-	void asc_pull_req (nano::asc_pull_req const & message) override
+	void asc_pull_req (nano::messages::asc_pull_req const & message) override
 	{
 		node.bootstrap_server.request (message, channel);
 	}
 
-	void asc_pull_ack (nano::asc_pull_ack const & message) override
+	void asc_pull_ack (nano::messages::asc_pull_ack const & message) override
 	{
 		node.bootstrap.process (message, channel);
 	}
@@ -283,7 +283,7 @@ private:
 };
 }
 
-void nano::message_processor::process (nano::message const & message, std::shared_ptr<nano::transport::channel> const & channel)
+void nano::message_processor::process (nano::messages::message const & message, std::shared_ptr<nano::transport::channel> const & channel)
 {
 	release_assert (channel != nullptr);
 

--- a/nano/node/message_processor.hpp
+++ b/nano/node/message_processor.hpp
@@ -34,8 +34,8 @@ public:
 	void start ();
 	void stop ();
 
-	bool put (std::unique_ptr<nano::message>, std::shared_ptr<nano::transport::channel> const &);
-	void process (nano::message const &, std::shared_ptr<nano::transport::channel> const &);
+	bool put (std::unique_ptr<nano::messages::message>, std::shared_ptr<nano::transport::channel> const &);
+	void process (nano::messages::message const &, std::shared_ptr<nano::transport::channel> const &);
 
 	nano::container_info container_info () const;
 
@@ -50,7 +50,7 @@ private: // Dependencies
 	nano::logger & logger;
 
 private:
-	using entry_t = std::pair<std::unique_ptr<nano::message>, std::shared_ptr<nano::transport::channel>>;
+	using entry_t = std::pair<std::unique_ptr<nano::messages::message>, std::shared_ptr<nano::transport::channel>>;
 	nano::fair_queue<entry_t, nano::no_value> queue;
 
 	std::atomic<bool> stopped{ false };

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -235,14 +235,14 @@ void nano::network::run_reachout_cached ()
 
 void nano::network::send_keepalive (std::shared_ptr<nano::transport::channel> const & channel) const
 {
-	nano::keepalive message{ node.network_params.network };
+	nano::messages::keepalive message{ node.network_params.network };
 	random_fill (message.peers);
 	channel->send (message, nano::transport::traffic_type::keepalive);
 }
 
 void nano::network::send_keepalive_self (std::shared_ptr<nano::transport::channel> const & channel) const
 {
-	nano::keepalive message{ node.network_params.network };
+	nano::messages::keepalive message{ node.network_params.network };
 	fill_keepalive_self (message.peers);
 	channel->send (message, nano::transport::traffic_type::keepalive);
 }
@@ -256,7 +256,7 @@ bool nano::network::check_capacity (nano::transport::traffic_type type, float sc
 	return !channels.empty () && channels.size () >= target_count / 2; // We need to have at least half of the target capacity available
 }
 
-size_t nano::network::flood_message (nano::message const & message, nano::transport::traffic_type type, float scale) const
+size_t nano::network::flood_message (nano::messages::message const & message, nano::transport::traffic_type type, float scale) const
 {
 	auto channels = list (fanout (scale), [type] (auto const & channel) {
 		return !channel->max (type); // Only use channels that are not full for this traffic type
@@ -272,27 +272,27 @@ size_t nano::network::flood_message (nano::message const & message, nano::transp
 
 size_t nano::network::flood_keepalive (float scale) const
 {
-	nano::keepalive message{ node.network_params.network };
+	nano::messages::keepalive message{ node.network_params.network };
 	random_fill (message.peers);
 	return flood_message (message, nano::transport::traffic_type::keepalive, scale);
 }
 
 size_t nano::network::flood_keepalive_self (float scale) const
 {
-	nano::keepalive message{ node.network_params.network };
+	nano::messages::keepalive message{ node.network_params.network };
 	fill_keepalive_self (message.peers);
 	return flood_message (message, nano::transport::traffic_type::keepalive, scale);
 }
 
 size_t nano::network::flood_block (std::shared_ptr<nano::block> const & block, nano::transport::traffic_type type) const
 {
-	nano::publish message{ node.network_params.network, block };
+	nano::messages::publish message{ node.network_params.network, block };
 	return flood_message (message, type);
 }
 
 size_t nano::network::flood_block_initial (std::shared_ptr<nano::block> const & block) const
 {
-	nano::publish message{ node.network_params.network, block, /* is_originator */ true };
+	nano::messages::publish message{ node.network_params.network, block, /* is_originator */ true };
 
 	size_t result = 0;
 	for (auto const & rep : node.rep_crawler.principal_representatives ())
@@ -310,7 +310,7 @@ size_t nano::network::flood_block_initial (std::shared_ptr<nano::block> const & 
 
 size_t nano::network::flood_vote_rebroadcasted (std::shared_ptr<nano::vote> const & vote, float scale) const
 {
-	nano::confirm_ack message{ node.network_params.network, vote, /* rebroadcasted */ true };
+	nano::messages::confirm_ack message{ node.network_params.network, vote, /* rebroadcasted */ true };
 
 	auto const type = nano::transport::traffic_type::vote_rebroadcast;
 
@@ -329,7 +329,7 @@ size_t nano::network::flood_vote_rebroadcasted (std::shared_ptr<nano::vote> cons
 
 size_t nano::network::flood_vote_non_pr (std::shared_ptr<nano::vote> const & vote, float scale) const
 {
-	nano::confirm_ack message{ node.network_params.network, vote };
+	nano::messages::confirm_ack message{ node.network_params.network, vote };
 
 	auto const type = transport::traffic_type::vote;
 
@@ -348,7 +348,7 @@ size_t nano::network::flood_vote_non_pr (std::shared_ptr<nano::vote> const & vot
 
 size_t nano::network::flood_vote_pr (std::shared_ptr<nano::vote> const & vote) const
 {
-	nano::confirm_ack message{ node.network_params.network, vote };
+	nano::messages::confirm_ack message{ node.network_params.network, vote };
 
 	auto const type = nano::transport::traffic_type::vote;
 
@@ -605,7 +605,7 @@ void nano::network::exclude (std::shared_ptr<nano::transport::channel> const & c
 	erase (*channel);
 }
 
-bool nano::network::verify_handshake_response (const nano::node_id_handshake::response_payload & response, const nano::endpoint & remote_endpoint)
+bool nano::network::verify_handshake_response (const nano::messages::node_id_handshake::response_payload & response, const nano::endpoint & remote_endpoint)
 {
 	// Prevent connection with ourselves
 	if (response.node_id == node.node_id.pub)
@@ -638,23 +638,23 @@ bool nano::network::verify_handshake_response (const nano::node_id_handshake::re
 	return true; // OK
 }
 
-std::optional<nano::node_id_handshake::query_payload> nano::network::prepare_handshake_query (const nano::endpoint & remote_endpoint)
+std::optional<nano::messages::node_id_handshake::query_payload> nano::network::prepare_handshake_query (const nano::endpoint & remote_endpoint)
 {
 	if (auto cookie = syn_cookies.assign (remote_endpoint); cookie)
 	{
-		nano::node_id_handshake::query_payload query{ *cookie };
+		nano::messages::node_id_handshake::query_payload query{ *cookie };
 		return query;
 	}
 	return std::nullopt;
 }
 
-nano::node_id_handshake::response_payload nano::network::prepare_handshake_response (const nano::node_id_handshake::query_payload & query, bool v2) const
+nano::messages::node_id_handshake::response_payload nano::network::prepare_handshake_response (const nano::messages::node_id_handshake::query_payload & query, bool v2) const
 {
-	nano::node_id_handshake::response_payload response{};
+	nano::messages::node_id_handshake::response_payload response{};
 	response.node_id = node.node_id.pub;
 	if (v2)
 	{
-		nano::node_id_handshake::response_payload::v2_payload response_v2{};
+		nano::messages::node_id_handshake::response_payload::v2_payload response_v2{};
 		response_v2.salt = nano::random_pool::generate<uint256_union> ();
 		response_v2.genesis = node.network_params.ledger.genesis->hash ();
 		response.v2 = response_v2;

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -98,7 +98,7 @@ public:
 	// Checks if we have enough channel capacity for the given traffic type
 	bool check_capacity (nano::transport::traffic_type, float scale = 1.0f) const;
 
-	size_t flood_message (nano::message const &, nano::transport::traffic_type, float scale = 1.0f) const;
+	size_t flood_message (nano::messages::message const &, nano::transport::traffic_type, float scale = 1.0f) const;
 	size_t flood_keepalive (float scale = 1.0f) const;
 	size_t flood_keepalive_self (float scale = 0.5f) const;
 	size_t flood_vote_pr (std::shared_ptr<nano::vote> const &) const;
@@ -155,9 +155,9 @@ public:
 
 public: // Handshake
 	/** Verifies that handshake response matches our query. @returns true if OK */
-	bool verify_handshake_response (nano::node_id_handshake::response_payload const & response, nano::endpoint const & remote_endpoint);
-	std::optional<nano::node_id_handshake::query_payload> prepare_handshake_query (nano::endpoint const & remote_endpoint);
-	nano::node_id_handshake::response_payload prepare_handshake_response (nano::node_id_handshake::query_payload const & query, bool v2) const;
+	bool verify_handshake_response (nano::messages::node_id_handshake::response_payload const & response, nano::endpoint const & remote_endpoint);
+	std::optional<nano::messages::node_id_handshake::query_payload> prepare_handshake_query (nano::endpoint const & remote_endpoint);
+	nano::messages::node_id_handshake::response_payload prepare_handshake_response (nano::messages::node_id_handshake::query_payload const & query, bool v2) const;
 
 private:
 	void run_cleanup ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -485,7 +485,7 @@ void nano::node::keepalive (std::string const & address_a, uint16_t port_a)
 	});
 }
 
-void nano::node::inbound (const nano::message & message, const std::shared_ptr<nano::transport::channel> & channel)
+void nano::node::inbound (const nano::messages::message & message, const std::shared_ptr<nano::transport::channel> & channel)
 {
 	debug_assert (channel->owner () == shared_from_this ()); // This node should be the channel owner
 
@@ -930,9 +930,9 @@ nano::account nano::node::get_node_id () const
 	return node_id.pub;
 };
 
-nano::telemetry_data nano::node::local_telemetry () const
+nano::messages::telemetry_data nano::node::local_telemetry () const
 {
-	nano::telemetry_data telemetry_data;
+	nano::messages::telemetry_data telemetry_data;
 	telemetry_data.node_id = node_id.pub;
 	telemetry_data.block_count = ledger.block_count ();
 	telemetry_data.cemented_count = ledger.cemented_count ();
@@ -947,7 +947,7 @@ nano::telemetry_data nano::node::local_telemetry () const
 	telemetry_data.minor_version = nano::get_minor_node_version ();
 	telemetry_data.patch_version = nano::get_patch_node_version ();
 	telemetry_data.pre_release_version = nano::get_pre_release_node_version ();
-	telemetry_data.maker = static_cast<std::underlying_type_t<telemetry_maker>> (ledger.pruning ? telemetry_maker::nf_pruned_node : telemetry_maker::nf_node);
+	telemetry_data.maker = static_cast<std::underlying_type_t<nano::messages::telemetry_maker>> (ledger.pruning ? nano::messages::telemetry_maker::nf_pruned_node : nano::messages::telemetry_maker::nf_node);
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
 	telemetry_data.active_difficulty = default_difficulty (nano::work_version::work_1);
 	// Make sure this is the final operation!

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -47,7 +47,7 @@ public:
 
 	void keepalive (std::string const &, uint16_t);
 	int store_version ();
-	void inbound (nano::message const &, std::shared_ptr<nano::transport::channel> const &);
+	void inbound (nano::messages::message const &, std::shared_ptr<nano::transport::channel> const &);
 	void process_active (std::shared_ptr<nano::block> const &);
 	std::optional<nano::block_status> process_local (std::shared_ptr<nano::block> const &);
 	void process_local_async (std::shared_ptr<nano::block> const &);
@@ -87,7 +87,7 @@ public:
 	void bootstrap_block (nano::block_hash const &);
 
 	nano::account get_node_id () const;
-	nano::telemetry_data local_telemetry () const;
+	nano::messages::telemetry_data local_telemetry () const;
 	std::string identifier () const;
 
 	nano::container_info container_info () const;

--- a/nano/node/node_observers.hpp
+++ b/nano/node/node_observers.hpp
@@ -20,7 +20,7 @@ public:
 	nano::observer_set<nano::account const &, bool> account_balance;
 	nano::observer_set<> disconnect;
 	nano::observer_set<nano::root const &> work_cancel;
-	nano::observer_set<nano::telemetry_data const &, std::shared_ptr<nano::transport::channel> const &> telemetry;
+	nano::observer_set<nano::messages::telemetry_data const &, std::shared_ptr<nano::transport::channel> const &> telemetry;
 	nano::observer_set<std::shared_ptr<nano::transport::tcp_socket>> socket_connected;
 	nano::observer_set<std::shared_ptr<nano::transport::channel>> channel_connected;
 

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -359,7 +359,7 @@ void nano::rep_crawler::query (std::deque<std::shared_ptr<nano::transport::chann
 			lock.unlock ();
 
 			auto const & [hash, root] = hash_root;
-			nano::confirm_req req{ network_constants, hash, root };
+			nano::messages::confirm_req req{ network_constants, hash, root };
 
 			channel->send (req, nano::transport::traffic_type::rep_crawler, [this] (auto & ec, auto size) {
 				stats.inc (nano::stat::type::rep_crawler_ec, to_stat_detail (ec), nano::stat::dir::out);

--- a/nano/node/telemetry.cpp
+++ b/nano/node/telemetry.cpp
@@ -54,7 +54,7 @@ void nano::telemetry::stop ()
 	nano::join_or_pass (thread);
 }
 
-bool nano::telemetry::verify (const nano::telemetry_ack & telemetry, const std::shared_ptr<nano::transport::channel> & channel) const
+bool nano::telemetry::verify (const nano::messages::telemetry_ack & telemetry, const std::shared_ptr<nano::transport::channel> & channel) const
 {
 	if (telemetry.is_empty_payload ())
 	{
@@ -87,7 +87,7 @@ bool nano::telemetry::verify (const nano::telemetry_ack & telemetry, const std::
 	return true; // Telemetry is OK
 }
 
-void nano::telemetry::process (const nano::telemetry_ack & telemetry, const std::shared_ptr<nano::transport::channel> & channel)
+void nano::telemetry::process (const nano::messages::telemetry_ack & telemetry, const std::shared_ptr<nano::transport::channel> & channel)
 {
 	if (!verify (telemetry, channel))
 	{
@@ -213,7 +213,7 @@ void nano::telemetry::request (std::shared_ptr<nano::transport::channel> const &
 {
 	stats.inc (nano::stat::type::telemetry, nano::stat::detail::request);
 
-	nano::telemetry_req message{ network_params.network };
+	nano::messages::telemetry_req message{ network_params.network };
 	channel->send (message, nano::transport::traffic_type::telemetry);
 }
 
@@ -228,11 +228,11 @@ void nano::telemetry::run_broadcasts ()
 	}
 }
 
-void nano::telemetry::broadcast (std::shared_ptr<nano::transport::channel> const & channel, const nano::telemetry_data & telemetry)
+void nano::telemetry::broadcast (std::shared_ptr<nano::transport::channel> const & channel, const nano::messages::telemetry_data & telemetry)
 {
 	stats.inc (nano::stat::type::telemetry, nano::stat::detail::broadcast);
 
-	nano::telemetry_ack message{ network_params.network, telemetry };
+	nano::messages::telemetry_ack message{ network_params.network, telemetry };
 	channel->send (message, nano::transport::traffic_type::telemetry);
 }
 
@@ -261,7 +261,7 @@ bool nano::telemetry::check_timeout (const entry & entry) const
 	return entry.last_updated + network_params.network.telemetry_cache_cutoff >= std::chrono::steady_clock::now ();
 }
 
-std::optional<nano::telemetry_data> nano::telemetry::get_telemetry (const nano::endpoint & endpoint) const
+std::optional<nano::messages::telemetry_data> nano::telemetry::get_telemetry (const nano::endpoint & endpoint) const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 
@@ -275,11 +275,11 @@ std::optional<nano::telemetry_data> nano::telemetry::get_telemetry (const nano::
 	return {};
 }
 
-std::unordered_map<nano::endpoint, nano::telemetry_data> nano::telemetry::get_all_telemetries () const
+std::unordered_map<nano::endpoint, nano::messages::telemetry_data> nano::telemetry::get_all_telemetries () const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 
-	std::unordered_map<nano::endpoint, nano::telemetry_data> result;
+	std::unordered_map<nano::endpoint, nano::messages::telemetry_data> result;
 	for (auto const & entry : telemetries)
 	{
 		if (check_timeout (entry))

--- a/nano/node/telemetry.hpp
+++ b/nano/node/telemetry.hpp
@@ -54,7 +54,7 @@ public:
 	/**
 	 * Process telemetry message from network
 	 */
-	void process (nano::telemetry_ack const &, std::shared_ptr<nano::transport::channel> const &);
+	void process (nano::messages::telemetry_ack const &, std::shared_ptr<nano::transport::channel> const &);
 
 	/**
 	 * Trigger manual telemetry request to all peers
@@ -66,12 +66,12 @@ public:
 	/**
 	 * Returns telemetry for selected endpoint
 	 */
-	std::optional<nano::telemetry_data> get_telemetry (nano::endpoint const &) const;
+	std::optional<nano::messages::telemetry_data> get_telemetry (nano::endpoint const &) const;
 
 	/**
 	 * Returns all available telemetry
 	 */
-	std::unordered_map<nano::endpoint, nano::telemetry_data> get_all_telemetries () const;
+	std::unordered_map<nano::endpoint, nano::messages::telemetry_data> get_all_telemetries () const;
 
 	nano::container_info container_info () const;
 
@@ -87,7 +87,7 @@ private:
 	struct entry
 	{
 		std::shared_ptr<nano::transport::channel> channel;
-		nano::telemetry_data data;
+		nano::messages::telemetry_data data;
 		std::chrono::steady_clock::time_point last_updated;
 
 		nano::endpoint endpoint () const
@@ -106,9 +106,9 @@ private:
 	void cleanup ();
 
 	void request (std::shared_ptr<nano::transport::channel> const &);
-	void broadcast (std::shared_ptr<nano::transport::channel> const &, nano::telemetry_data const &);
+	void broadcast (std::shared_ptr<nano::transport::channel> const &, nano::messages::telemetry_data const &);
 
-	bool verify (nano::telemetry_ack const &, std::shared_ptr<nano::transport::channel> const &) const;
+	bool verify (nano::messages::telemetry_ack const &, std::shared_ptr<nano::transport::channel> const &) const;
 	bool check_timeout (entry const &) const;
 
 private:

--- a/nano/node/transport/channel.cpp
+++ b/nano/node/transport/channel.cpp
@@ -14,7 +14,7 @@ nano::transport::channel::channel (nano::node & node_a) :
 	set_network_version (node_a.network_params.network.protocol_version);
 }
 
-bool nano::transport::channel::send (nano::message const & message, nano::transport::traffic_type traffic_type, callback_t callback)
+bool nano::transport::channel::send (nano::messages::message const & message, nano::transport::traffic_type traffic_type, callback_t callback)
 {
 	bool sent = send_impl (message, traffic_type, std::move (callback));
 	node.stats.inc (sent ? nano::stat::type::message : nano::stat::type::drop, to_stat_detail (message.type ()), nano::stat::dir::out, /* aggregate all */ true);
@@ -39,13 +39,13 @@ nano::endpoint nano::transport::channel::get_peering_endpoint () const
 	return get_remote_endpoint ();
 }
 
-void nano::transport::channel::set_last_keepalive (nano::keepalive const & message)
+void nano::transport::channel::set_last_keepalive (nano::messages::keepalive const & message)
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	last_keepalive = message;
 }
 
-std::optional<nano::keepalive> nano::transport::channel::pop_last_keepalive ()
+std::optional<nano::messages::keepalive> nano::transport::channel::pop_last_keepalive ()
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto result = last_keepalive;

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -30,7 +30,7 @@ public:
 	virtual ~channel () = default;
 
 	/// @returns true if the message was sent (or queued to be sent), false if it was immediately dropped
-	bool send (nano::message const &, nano::transport::traffic_type, callback_t = nullptr);
+	bool send (nano::messages::message const &, nano::transport::traffic_type, callback_t = nullptr);
 
 	virtual void close () = 0;
 
@@ -111,13 +111,13 @@ public:
 	nano::endpoint get_peering_endpoint () const;
 	void set_peering_endpoint (nano::endpoint endpoint);
 
-	void set_last_keepalive (nano::keepalive const & message);
-	std::optional<nano::keepalive> pop_last_keepalive ();
+	void set_last_keepalive (nano::messages::keepalive const & message);
+	std::optional<nano::messages::keepalive> pop_last_keepalive ();
 
 	std::shared_ptr<nano::node> owner () const;
 
 protected:
-	virtual bool send_impl (nano::message const &, nano::transport::traffic_type, callback_t) = 0;
+	virtual bool send_impl (nano::messages::message const &, nano::transport::traffic_type, callback_t) = 0;
 
 protected:
 	nano::node & node;
@@ -130,7 +130,7 @@ private:
 	std::optional<nano::account> node_id{};
 	std::atomic<uint8_t> network_version{ 0 };
 	std::optional<nano::endpoint> peering_endpoint{};
-	std::optional<nano::keepalive> last_keepalive{};
+	std::optional<nano::messages::keepalive> last_keepalive{};
 
 public: // Logging
 	virtual void operator() (nano::object_stream &) const;

--- a/nano/node/transport/fake.cpp
+++ b/nano/node/transport/fake.cpp
@@ -14,7 +14,7 @@ nano::transport::fake::channel::channel (nano::node & node) :
 /**
  * The send function behaves like a null device, it throws the data away and returns success.
  */
-bool nano::transport::fake::channel::send_impl (nano::message const & message, nano::transport::traffic_type traffic_type, nano::transport::channel::callback_t callback)
+bool nano::transport::fake::channel::send_impl (nano::messages::message const & message, nano::transport::traffic_type traffic_type, nano::transport::channel::callback_t callback)
 {
 	auto buffer = message.to_shared_const_buffer ();
 	auto size = buffer.size ();

--- a/nano/node/transport/fake.hpp
+++ b/nano/node/transport/fake.hpp
@@ -50,7 +50,7 @@ namespace transport
 			}
 
 		protected:
-			bool send_impl (nano::message const &, nano::transport::traffic_type, nano::transport::channel::callback_t) override;
+			bool send_impl (nano::messages::message const &, nano::transport::traffic_type, nano::transport::channel::callback_t) override;
 
 		private:
 			nano::endpoint endpoint;

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -18,7 +18,7 @@ nano::transport::inproc::channel::channel (nano::node & node, nano::node & desti
  * Send the buffer to the peer and call the callback function when done. The call never fails.
  * Note that the inbound message visitor will be called before the callback because it is called directly whereas the callback is spawned in the background.
  */
-bool nano::transport::inproc::channel::send_impl (nano::message const & message, nano::transport::traffic_type traffic_type, nano::transport::channel::callback_t callback)
+bool nano::transport::inproc::channel::send_impl (nano::messages::message const & message, nano::transport::traffic_type traffic_type, nano::transport::channel::callback_t callback)
 {
 	auto buffer = message.to_shared_const_buffer ();
 
@@ -34,7 +34,7 @@ bool nano::transport::inproc::channel::send_impl (nano::message const & message,
 
 	auto const message_deserializer = std::make_shared<nano::transport::message_deserializer> (node.network_params.network, node.network.filter, node.block_uniquer, node.vote_uniquer, buffer_read_fn);
 	message_deserializer->read (
-	[this] (boost::system::error_code ec_a, std::unique_ptr<nano::message> message_a) {
+	[this] (boost::system::error_code ec_a, std::unique_ptr<nano::messages::message> message_a) {
 		if (ec_a || !message_a)
 		{
 			return;

--- a/nano/node/transport/inproc.hpp
+++ b/nano/node/transport/inproc.hpp
@@ -40,7 +40,7 @@ namespace transport
 			}
 
 		protected:
-			bool send_impl (nano::message const &, nano::transport::traffic_type, nano::transport::channel::callback_t) override;
+			bool send_impl (nano::messages::message const &, nano::transport::traffic_type, nano::transport::channel::callback_t) override;
 
 		private:
 			nano::node & destination;

--- a/nano/node/transport/loopback.cpp
+++ b/nano/node/transport/loopback.cpp
@@ -13,7 +13,7 @@ nano::transport::loopback_channel::loopback_channel (nano::node & node) :
 	set_network_version (node.network_params.network.protocol_version);
 }
 
-bool nano::transport::loopback_channel::send_impl (nano::message const & message, nano::transport::traffic_type traffic_type, nano::transport::channel::callback_t callback)
+bool nano::transport::loopback_channel::send_impl (nano::messages::message const & message, nano::transport::traffic_type traffic_type, nano::transport::channel::callback_t callback)
 {
 	node.stats.inc (nano::stat::type::message_loopback, to_stat_detail (message.type ()), nano::stat::dir::in);
 

--- a/nano/node/transport/loopback.hpp
+++ b/nano/node/transport/loopback.hpp
@@ -33,7 +33,7 @@ public:
 	}
 
 protected:
-	bool send_impl (nano::message const &, nano::transport::traffic_type, nano::transport::channel::callback_t) override;
+	bool send_impl (nano::messages::message const &, nano::transport::traffic_type, nano::transport::channel::callback_t) override;
 
 private:
 	nano::endpoint const endpoint;

--- a/nano/node/transport/message_deserializer.cpp
+++ b/nano/node/transport/message_deserializer.cpp
@@ -41,7 +41,7 @@ void nano::transport::message_deserializer::received_header (const nano::transpo
 {
 	nano::bufferstream stream{ read_buffer->data (), HEADER_SIZE };
 	auto error = false;
-	nano::message_header header{ error, stream };
+	nano::messages::message_header header{ error, stream };
 	if (error)
 	{
 		status = parse_status::invalid_header;
@@ -100,7 +100,7 @@ void nano::transport::message_deserializer::received_header (const nano::transpo
 	}
 }
 
-void nano::transport::message_deserializer::received_message (nano::message_header header, std::size_t payload_size, const nano::transport::message_deserializer::callback_type && callback)
+void nano::transport::message_deserializer::received_message (nano::messages::message_header header, std::size_t payload_size, const nano::transport::message_deserializer::callback_type && callback)
 {
 	auto message = deserialize (header, payload_size);
 	if (message)
@@ -116,17 +116,17 @@ void nano::transport::message_deserializer::received_message (nano::message_head
 	}
 }
 
-std::unique_ptr<nano::message> nano::transport::message_deserializer::deserialize (nano::message_header header, std::size_t payload_size)
+std::unique_ptr<nano::messages::message> nano::transport::message_deserializer::deserialize (nano::messages::message_header header, std::size_t payload_size)
 {
 	release_assert (payload_size <= MAX_MESSAGE_SIZE);
 	nano::bufferstream stream{ read_buffer->data (), payload_size };
 	switch (header.type)
 	{
-		case nano::message_type::keepalive:
+		case nano::messages::message_type::keepalive:
 		{
 			return deserialize_keepalive (stream, header);
 		}
-		case nano::message_type::publish:
+		case nano::messages::message_type::publish:
 		{
 			// Early filtering to not waste time deserializing duplicates
 			nano::uint128_t digest;
@@ -140,11 +140,11 @@ std::unique_ptr<nano::message> nano::transport::message_deserializer::deserializ
 			}
 			break;
 		}
-		case nano::message_type::confirm_req:
+		case nano::messages::message_type::confirm_req:
 		{
 			return deserialize_confirm_req (stream, header);
 		}
-		case nano::message_type::confirm_ack:
+		case nano::messages::message_type::confirm_ack:
 		{
 			// Early filtering to not waste time deserializing duplicates
 			nano::uint128_t digest;
@@ -158,39 +158,39 @@ std::unique_ptr<nano::message> nano::transport::message_deserializer::deserializ
 			}
 			break;
 		}
-		case nano::message_type::node_id_handshake:
+		case nano::messages::message_type::node_id_handshake:
 		{
 			return deserialize_node_id_handshake (stream, header);
 		}
-		case nano::message_type::telemetry_req:
+		case nano::messages::message_type::telemetry_req:
 		{
 			return deserialize_telemetry_req (stream, header);
 		}
-		case nano::message_type::telemetry_ack:
+		case nano::messages::message_type::telemetry_ack:
 		{
 			return deserialize_telemetry_ack (stream, header);
 		}
-		case nano::message_type::bulk_pull:
+		case nano::messages::message_type::bulk_pull:
 		{
 			return deserialize_bulk_pull (stream, header);
 		}
-		case nano::message_type::bulk_pull_account:
+		case nano::messages::message_type::bulk_pull_account:
 		{
 			return deserialize_bulk_pull_account (stream, header);
 		}
-		case nano::message_type::bulk_push:
+		case nano::messages::message_type::bulk_push:
 		{
 			return deserialize_bulk_push (stream, header);
 		}
-		case nano::message_type::frontier_req:
+		case nano::messages::message_type::frontier_req:
 		{
 			return deserialize_frontier_req (stream, header);
 		}
-		case nano::message_type::asc_pull_req:
+		case nano::messages::message_type::asc_pull_req:
 		{
 			return deserialize_asc_pull_req (stream, header);
 		}
-		case nano::message_type::asc_pull_ack:
+		case nano::messages::message_type::asc_pull_ack:
 		{
 			return deserialize_asc_pull_ack (stream, header);
 		}
@@ -203,10 +203,10 @@ std::unique_ptr<nano::message> nano::transport::message_deserializer::deserializ
 	return {};
 }
 
-std::unique_ptr<nano::keepalive> nano::transport::message_deserializer::deserialize_keepalive (nano::stream & stream, nano::message_header const & header)
+std::unique_ptr<nano::messages::keepalive> nano::transport::message_deserializer::deserialize_keepalive (nano::stream & stream, nano::messages::message_header const & header)
 {
 	auto error = false;
-	auto incoming = std::make_unique<nano::keepalive> (error, stream, header);
+	auto incoming = std::make_unique<nano::messages::keepalive> (error, stream, header);
 	if (!error && nano::at_end (stream))
 	{
 		return incoming;
@@ -218,10 +218,10 @@ std::unique_ptr<nano::keepalive> nano::transport::message_deserializer::deserial
 	return {};
 }
 
-std::unique_ptr<nano::publish> nano::transport::message_deserializer::deserialize_publish (nano::stream & stream, nano::message_header const & header, nano::network_filter::digest_t const & digest_a)
+std::unique_ptr<nano::messages::publish> nano::transport::message_deserializer::deserialize_publish (nano::stream & stream, nano::messages::message_header const & header, nano::network_filter::digest_t const & digest_a)
 {
 	auto error = false;
-	auto incoming = std::make_unique<nano::publish> (error, stream, header, digest_a, &block_uniquer_m);
+	auto incoming = std::make_unique<nano::messages::publish> (error, stream, header, digest_a, &block_uniquer_m);
 	if (!error && nano::at_end (stream))
 	{
 		release_assert (incoming->block);
@@ -241,10 +241,10 @@ std::unique_ptr<nano::publish> nano::transport::message_deserializer::deserializ
 	return {};
 }
 
-std::unique_ptr<nano::confirm_req> nano::transport::message_deserializer::deserialize_confirm_req (nano::stream & stream, nano::message_header const & header)
+std::unique_ptr<nano::messages::confirm_req> nano::transport::message_deserializer::deserialize_confirm_req (nano::stream & stream, nano::messages::message_header const & header)
 {
 	auto error = false;
-	auto incoming = std::make_unique<nano::confirm_req> (error, stream, header);
+	auto incoming = std::make_unique<nano::messages::confirm_req> (error, stream, header);
 	if (!error && nano::at_end (stream))
 	{
 		return incoming;
@@ -256,10 +256,10 @@ std::unique_ptr<nano::confirm_req> nano::transport::message_deserializer::deseri
 	return {};
 }
 
-std::unique_ptr<nano::confirm_ack> nano::transport::message_deserializer::deserialize_confirm_ack (nano::stream & stream, nano::message_header const & header, nano::network_filter::digest_t const & digest_a)
+std::unique_ptr<nano::messages::confirm_ack> nano::transport::message_deserializer::deserialize_confirm_ack (nano::stream & stream, nano::messages::message_header const & header, nano::network_filter::digest_t const & digest_a)
 {
 	auto error = false;
-	auto incoming = std::make_unique<nano::confirm_ack> (error, stream, header, digest_a, &vote_uniquer_m);
+	auto incoming = std::make_unique<nano::messages::confirm_ack> (error, stream, header, digest_a, &vote_uniquer_m);
 	if (!error && nano::at_end (stream))
 	{
 		return incoming;
@@ -271,10 +271,10 @@ std::unique_ptr<nano::confirm_ack> nano::transport::message_deserializer::deseri
 	return {};
 }
 
-std::unique_ptr<nano::node_id_handshake> nano::transport::message_deserializer::deserialize_node_id_handshake (nano::stream & stream, nano::message_header const & header)
+std::unique_ptr<nano::messages::node_id_handshake> nano::transport::message_deserializer::deserialize_node_id_handshake (nano::stream & stream, nano::messages::message_header const & header)
 {
 	bool error = false;
-	auto incoming = std::make_unique<nano::node_id_handshake> (error, stream, header);
+	auto incoming = std::make_unique<nano::messages::node_id_handshake> (error, stream, header);
 	if (!error && nano::at_end (stream))
 	{
 		return incoming;
@@ -286,16 +286,16 @@ std::unique_ptr<nano::node_id_handshake> nano::transport::message_deserializer::
 	return {};
 }
 
-std::unique_ptr<nano::telemetry_req> nano::transport::message_deserializer::deserialize_telemetry_req (nano::stream & stream, nano::message_header const & header)
+std::unique_ptr<nano::messages::telemetry_req> nano::transport::message_deserializer::deserialize_telemetry_req (nano::stream & stream, nano::messages::message_header const & header)
 {
 	// Message does not use stream payload (header only)
-	return std::make_unique<nano::telemetry_req> (header);
+	return std::make_unique<nano::messages::telemetry_req> (header);
 }
 
-std::unique_ptr<nano::telemetry_ack> nano::transport::message_deserializer::deserialize_telemetry_ack (nano::stream & stream, nano::message_header const & header)
+std::unique_ptr<nano::messages::telemetry_ack> nano::transport::message_deserializer::deserialize_telemetry_ack (nano::stream & stream, nano::messages::message_header const & header)
 {
 	bool error = false;
-	auto incoming = std::make_unique<nano::telemetry_ack> (error, stream, header);
+	auto incoming = std::make_unique<nano::messages::telemetry_ack> (error, stream, header);
 	// Intentionally not checking if at the end of stream, because these messages support backwards/forwards compatibility
 	if (!error)
 	{
@@ -308,10 +308,10 @@ std::unique_ptr<nano::telemetry_ack> nano::transport::message_deserializer::dese
 	return {};
 }
 
-std::unique_ptr<nano::bulk_pull> nano::transport::message_deserializer::deserialize_bulk_pull (nano::stream & stream, const nano::message_header & header)
+std::unique_ptr<nano::messages::bulk_pull> nano::transport::message_deserializer::deserialize_bulk_pull (nano::stream & stream, const nano::messages::message_header & header)
 {
 	bool error = false;
-	auto incoming = std::make_unique<nano::bulk_pull> (error, stream, header);
+	auto incoming = std::make_unique<nano::messages::bulk_pull> (error, stream, header);
 	if (!error && nano::at_end (stream))
 	{
 		return incoming;
@@ -323,10 +323,10 @@ std::unique_ptr<nano::bulk_pull> nano::transport::message_deserializer::deserial
 	return {};
 }
 
-std::unique_ptr<nano::bulk_pull_account> nano::transport::message_deserializer::deserialize_bulk_pull_account (nano::stream & stream, const nano::message_header & header)
+std::unique_ptr<nano::messages::bulk_pull_account> nano::transport::message_deserializer::deserialize_bulk_pull_account (nano::stream & stream, const nano::messages::message_header & header)
 {
 	bool error = false;
-	auto incoming = std::make_unique<nano::bulk_pull_account> (error, stream, header);
+	auto incoming = std::make_unique<nano::messages::bulk_pull_account> (error, stream, header);
 	if (!error && nano::at_end (stream))
 	{
 		return incoming;
@@ -338,10 +338,10 @@ std::unique_ptr<nano::bulk_pull_account> nano::transport::message_deserializer::
 	return {};
 }
 
-std::unique_ptr<nano::frontier_req> nano::transport::message_deserializer::deserialize_frontier_req (nano::stream & stream, const nano::message_header & header)
+std::unique_ptr<nano::messages::frontier_req> nano::transport::message_deserializer::deserialize_frontier_req (nano::stream & stream, const nano::messages::message_header & header)
 {
 	bool error = false;
-	auto incoming = std::make_unique<nano::frontier_req> (error, stream, header);
+	auto incoming = std::make_unique<nano::messages::frontier_req> (error, stream, header);
 	if (!error && nano::at_end (stream))
 	{
 		return incoming;
@@ -353,16 +353,16 @@ std::unique_ptr<nano::frontier_req> nano::transport::message_deserializer::deser
 	return {};
 }
 
-std::unique_ptr<nano::bulk_push> nano::transport::message_deserializer::deserialize_bulk_push (nano::stream & stream, const nano::message_header & header)
+std::unique_ptr<nano::messages::bulk_push> nano::transport::message_deserializer::deserialize_bulk_push (nano::stream & stream, const nano::messages::message_header & header)
 {
 	// Message does not use stream payload (header only)
-	return std::make_unique<nano::bulk_push> (header);
+	return std::make_unique<nano::messages::bulk_push> (header);
 }
 
-std::unique_ptr<nano::asc_pull_req> nano::transport::message_deserializer::deserialize_asc_pull_req (nano::stream & stream, const nano::message_header & header)
+std::unique_ptr<nano::messages::asc_pull_req> nano::transport::message_deserializer::deserialize_asc_pull_req (nano::stream & stream, const nano::messages::message_header & header)
 {
 	bool error = false;
-	auto incoming = std::make_unique<nano::asc_pull_req> (error, stream, header);
+	auto incoming = std::make_unique<nano::messages::asc_pull_req> (error, stream, header);
 	// Intentionally not checking if at the end of stream, because these messages support backwards/forwards compatibility
 	if (!error)
 	{
@@ -375,10 +375,10 @@ std::unique_ptr<nano::asc_pull_req> nano::transport::message_deserializer::deser
 	return {};
 }
 
-std::unique_ptr<nano::asc_pull_ack> nano::transport::message_deserializer::deserialize_asc_pull_ack (nano::stream & stream, const nano::message_header & header)
+std::unique_ptr<nano::messages::asc_pull_ack> nano::transport::message_deserializer::deserialize_asc_pull_ack (nano::stream & stream, const nano::messages::message_header & header)
 {
 	bool error = false;
-	auto incoming = std::make_unique<nano::asc_pull_ack> (error, stream, header);
+	auto incoming = std::make_unique<nano::messages::asc_pull_ack> (error, stream, header);
 	// Intentionally not checking if at the end of stream, because these messages support backwards/forwards compatibility
 	if (!error)
 	{

--- a/nano/node/transport/message_deserializer.hpp
+++ b/nano/node/transport/message_deserializer.hpp
@@ -40,7 +40,7 @@ namespace transport
 	class message_deserializer : public std::enable_shared_from_this<nano::transport::message_deserializer>
 	{
 	public:
-		using callback_type = std::function<void (boost::system::error_code, std::unique_ptr<nano::message>)>;
+		using callback_type = std::function<void (boost::system::error_code, std::unique_ptr<nano::messages::message>)>;
 
 		parse_status status{ parse_status::none };
 
@@ -59,26 +59,26 @@ namespace transport
 
 	private:
 		void received_header (callback_type const && callback);
-		void received_message (nano::message_header header, std::size_t payload_size, callback_type const && callback);
+		void received_message (nano::messages::message_header header, std::size_t payload_size, callback_type const && callback);
 
 		/*
 		 * Deserializes message using data in `read_buffer`.
 		 * @return If successful returns non-null message, otherwise sets `status` to error appropriate code and returns nullptr
 		 */
-		std::unique_ptr<nano::message> deserialize (nano::message_header header, std::size_t payload_size);
-		std::unique_ptr<nano::keepalive> deserialize_keepalive (nano::stream &, nano::message_header const &);
-		std::unique_ptr<nano::publish> deserialize_publish (nano::stream &, nano::message_header const &, nano::network_filter::digest_t const & digest);
-		std::unique_ptr<nano::confirm_req> deserialize_confirm_req (nano::stream &, nano::message_header const &);
-		std::unique_ptr<nano::confirm_ack> deserialize_confirm_ack (nano::stream &, nano::message_header const &, nano::network_filter::digest_t const & digest);
-		std::unique_ptr<nano::node_id_handshake> deserialize_node_id_handshake (nano::stream &, nano::message_header const &);
-		std::unique_ptr<nano::telemetry_req> deserialize_telemetry_req (nano::stream &, nano::message_header const &);
-		std::unique_ptr<nano::telemetry_ack> deserialize_telemetry_ack (nano::stream &, nano::message_header const &);
-		std::unique_ptr<nano::bulk_pull> deserialize_bulk_pull (nano::stream &, nano::message_header const &);
-		std::unique_ptr<nano::bulk_pull_account> deserialize_bulk_pull_account (nano::stream &, nano::message_header const &);
-		std::unique_ptr<nano::bulk_push> deserialize_bulk_push (nano::stream &, nano::message_header const &);
-		std::unique_ptr<nano::frontier_req> deserialize_frontier_req (nano::stream &, nano::message_header const &);
-		std::unique_ptr<nano::asc_pull_req> deserialize_asc_pull_req (nano::stream &, nano::message_header const &);
-		std::unique_ptr<nano::asc_pull_ack> deserialize_asc_pull_ack (nano::stream &, nano::message_header const &);
+		std::unique_ptr<nano::messages::message> deserialize (nano::messages::message_header header, std::size_t payload_size);
+		std::unique_ptr<nano::messages::keepalive> deserialize_keepalive (nano::stream &, nano::messages::message_header const &);
+		std::unique_ptr<nano::messages::publish> deserialize_publish (nano::stream &, nano::messages::message_header const &, nano::network_filter::digest_t const & digest);
+		std::unique_ptr<nano::messages::confirm_req> deserialize_confirm_req (nano::stream &, nano::messages::message_header const &);
+		std::unique_ptr<nano::messages::confirm_ack> deserialize_confirm_ack (nano::stream &, nano::messages::message_header const &, nano::network_filter::digest_t const & digest);
+		std::unique_ptr<nano::messages::node_id_handshake> deserialize_node_id_handshake (nano::stream &, nano::messages::message_header const &);
+		std::unique_ptr<nano::messages::telemetry_req> deserialize_telemetry_req (nano::stream &, nano::messages::message_header const &);
+		std::unique_ptr<nano::messages::telemetry_ack> deserialize_telemetry_ack (nano::stream &, nano::messages::message_header const &);
+		std::unique_ptr<nano::messages::bulk_pull> deserialize_bulk_pull (nano::stream &, nano::messages::message_header const &);
+		std::unique_ptr<nano::messages::bulk_pull_account> deserialize_bulk_pull_account (nano::stream &, nano::messages::message_header const &);
+		std::unique_ptr<nano::messages::bulk_push> deserialize_bulk_push (nano::stream &, nano::messages::message_header const &);
+		std::unique_ptr<nano::messages::frontier_req> deserialize_frontier_req (nano::stream &, nano::messages::message_header const &);
+		std::unique_ptr<nano::messages::asc_pull_req> deserialize_asc_pull_req (nano::stream &, nano::messages::message_header const &);
+		std::unique_ptr<nano::messages::asc_pull_ack> deserialize_asc_pull_ack (nano::stream &, nano::messages::message_header const &);
 
 	private:
 		std::shared_ptr<std::vector<uint8_t>> read_buffer;

--- a/nano/node/transport/tcp_channel.cpp
+++ b/nano/node/transport/tcp_channel.cpp
@@ -86,7 +86,7 @@ bool nano::transport::tcp_channel::max (nano::transport::traffic_type traffic_ty
 	return queue.max (traffic_type);
 }
 
-bool nano::transport::tcp_channel::send_impl (nano::message const & message, nano::transport::traffic_type type, nano::transport::channel::callback_t callback)
+bool nano::transport::tcp_channel::send_impl (nano::messages::message const & message, nano::transport::traffic_type type, nano::transport::channel::callback_t callback)
 {
 	auto buffer = message.to_shared_const_buffer ();
 

--- a/nano/node/transport/tcp_channel.hpp
+++ b/nano/node/transport/tcp_channel.hpp
@@ -65,7 +65,7 @@ public:
 	std::string to_string () const override;
 
 protected:
-	bool send_impl (nano::message const &, nano::transport::traffic_type, nano::transport::channel::callback_t) override;
+	bool send_impl (nano::messages::message const &, nano::transport::traffic_type, nano::transport::channel::callback_t) override;
 
 private:
 	void start ();

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -367,7 +367,7 @@ void nano::transport::tcp_channels::purge (std::chrono::steady_clock::time_point
 
 void nano::transport::tcp_channels::keepalive ()
 {
-	nano::keepalive message{ node.network_params.network };
+	nano::messages::keepalive message{ node.network_params.network };
 	node.network.random_fill (message.peers);
 
 	nano::unique_lock<nano::mutex> lock{ mutex };
@@ -392,7 +392,7 @@ void nano::transport::tcp_channels::keepalive ()
 	}
 }
 
-std::optional<nano::keepalive> nano::transport::tcp_channels::sample_keepalive ()
+std::optional<nano::messages::keepalive> nano::transport::tcp_channels::sample_keepalive ()
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 

--- a/nano/node/transport/tcp_channels.hpp
+++ b/nano/node/transport/tcp_channels.hpp
@@ -57,7 +57,7 @@ public:
 	std::unordered_set<std::shared_ptr<nano::transport::channel>> random_set (std::size_t max_count, uint8_t minimum_version = 0) const;
 
 	void keepalive ();
-	std::optional<nano::keepalive> sample_keepalive ();
+	std::optional<nano::messages::keepalive> sample_keepalive ();
 
 	// Connection start
 	bool start_tcp (nano::endpoint const &);

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -100,12 +100,12 @@ auto nano::transport::tcp_server::perform_handshake () -> asio::awaitable<handsh
 		co_await send_handshake_request ();
 	}
 
-	struct handshake_message_visitor : public nano::message_visitor
+	struct handshake_message_visitor : public nano::messages::message_visitor
 	{
 		bool process{ false };
-		std::optional<nano::node_id_handshake> handshake;
+		std::optional<nano::messages::node_id_handshake> handshake;
 
-		void node_id_handshake (nano::node_id_handshake const & msg) override
+		void node_id_handshake (nano::messages::node_id_handshake const & msg) override
 		{
 			process = true;
 			handshake = msg;
@@ -245,11 +245,11 @@ auto nano::transport::tcp_server::receive_message_impl () -> asio::awaitable<nan
 	node.stats.inc (nano::stat::type::tcp_server, nano::stat::detail::read_header, nano::stat::dir::in);
 	node.stats.inc (nano::stat::type::tcp_server_read, nano::stat::detail::header, nano::stat::dir::in);
 
-	auto header_payload = co_await read_socket (nano::message_header::size);
+	auto header_payload = co_await read_socket (nano::messages::message_header::size);
 	auto header_stream = nano::bufferstream{ header_payload.data (), header_payload.size () };
 
 	bool error = false;
-	nano::message_header header{ error, header_stream };
+	nano::messages::message_header header{ error, header_stream };
 
 	if (error)
 	{
@@ -301,7 +301,7 @@ auto nano::transport::tcp_server::read_socket (size_t size) const -> asio::await
 	co_return nano::buffer_view{ buffer->data (), size_read };
 }
 
-auto nano::transport::tcp_server::process_handshake (nano::node_id_handshake const & message) -> asio::awaitable<handshake_status>
+auto nano::transport::tcp_server::process_handshake (nano::messages::node_id_handshake const & message) -> asio::awaitable<handshake_status>
 {
 	if (node.flags.disable_tcp_realtime)
 	{
@@ -370,7 +370,7 @@ auto nano::transport::tcp_server::process_handshake (nano::node_id_handshake con
 auto nano::transport::tcp_server::send_handshake_request () -> asio::awaitable<void>
 {
 	auto query = node.network.prepare_handshake_query (get_remote_endpoint ());
-	nano::node_id_handshake message{ node.network_params.network, query };
+	nano::messages::node_id_handshake message{ node.network_params.network, query };
 
 	node.stats.inc (nano::stat::type::tcp_server, nano::stat::detail::handshake_initiate, nano::stat::dir::out);
 	node.logger.debug (nano::log::type::tcp_server, "Initiating handshake query ({})", get_remote_endpoint ());
@@ -392,11 +392,11 @@ auto nano::transport::tcp_server::send_handshake_request () -> asio::awaitable<v
 	}
 }
 
-auto nano::transport::tcp_server::send_handshake_response (nano::node_id_handshake::query_payload const & query, bool v2) -> asio::awaitable<void>
+auto nano::transport::tcp_server::send_handshake_response (nano::messages::node_id_handshake::query_payload const & query, bool v2) -> asio::awaitable<void>
 {
 	auto response = node.network.prepare_handshake_response (query, v2);
 	auto own_query = node.network.prepare_handshake_query (get_remote_endpoint ());
-	nano::node_id_handshake handshake_response{ node.network_params.network, own_query, response };
+	nano::messages::node_id_handshake handshake_response{ node.network_params.network, own_query, response };
 
 	node.stats.inc (nano::stat::type::tcp_server, nano::stat::detail::handshake_response, nano::stat::dir::out);
 	node.logger.debug (nano::log::type::tcp_server, "Responding to handshake ({})", get_remote_endpoint ());
@@ -422,47 +422,47 @@ auto nano::transport::tcp_server::send_handshake_response (nano::node_id_handsha
  * realtime_message_visitor
  */
 
-void nano::transport::tcp_server::realtime_message_visitor::keepalive (const nano::keepalive & message)
+void nano::transport::tcp_server::realtime_message_visitor::keepalive (const nano::messages::keepalive & message)
 {
 	process = true;
 }
 
-void nano::transport::tcp_server::realtime_message_visitor::publish (const nano::publish & message)
+void nano::transport::tcp_server::realtime_message_visitor::publish (const nano::messages::publish & message)
 {
 	process = true;
 }
 
-void nano::transport::tcp_server::realtime_message_visitor::confirm_req (const nano::confirm_req & message)
+void nano::transport::tcp_server::realtime_message_visitor::confirm_req (const nano::messages::confirm_req & message)
 {
 	process = true;
 }
 
-void nano::transport::tcp_server::realtime_message_visitor::confirm_ack (const nano::confirm_ack & message)
+void nano::transport::tcp_server::realtime_message_visitor::confirm_ack (const nano::messages::confirm_ack & message)
 {
 	process = true;
 }
 
-void nano::transport::tcp_server::realtime_message_visitor::frontier_req (const nano::frontier_req & message)
+void nano::transport::tcp_server::realtime_message_visitor::frontier_req (const nano::messages::frontier_req & message)
 {
 	process = true;
 }
 
-void nano::transport::tcp_server::realtime_message_visitor::telemetry_req (const nano::telemetry_req & message)
+void nano::transport::tcp_server::realtime_message_visitor::telemetry_req (const nano::messages::telemetry_req & message)
 {
 	process = true;
 }
 
-void nano::transport::tcp_server::realtime_message_visitor::telemetry_ack (const nano::telemetry_ack & message)
+void nano::transport::tcp_server::realtime_message_visitor::telemetry_ack (const nano::messages::telemetry_ack & message)
 {
 	process = true;
 }
 
-void nano::transport::tcp_server::realtime_message_visitor::asc_pull_req (const nano::asc_pull_req & message)
+void nano::transport::tcp_server::realtime_message_visitor::asc_pull_req (const nano::messages::asc_pull_req & message)
 {
 	process = true;
 }
 
-void nano::transport::tcp_server::realtime_message_visitor::asc_pull_ack (const nano::asc_pull_ack & message)
+void nano::transport::tcp_server::realtime_message_visitor::asc_pull_ack (const nano::messages::asc_pull_ack & message)
 {
 	process = true;
 }

--- a/nano/node/transport/tcp_server.hpp
+++ b/nano/node/transport/tcp_server.hpp
@@ -56,8 +56,8 @@ private:
 	asio::awaitable<nano::deserialize_message_result> receive_message_impl ();
 	asio::awaitable<nano::buffer_view> read_socket (size_t size) const;
 
-	asio::awaitable<handshake_status> process_handshake (nano::node_id_handshake const & message);
-	asio::awaitable<void> send_handshake_response (nano::node_id_handshake::query_payload const & query, bool v2);
+	asio::awaitable<handshake_status> process_handshake (nano::messages::node_id_handshake const & message);
+	asio::awaitable<void> send_handshake_response (nano::messages::node_id_handshake::query_payload const & query, bool v2);
 	asio::awaitable<void> send_handshake_request ();
 
 private:
@@ -79,20 +79,20 @@ private:
 	bool to_realtime_connection (nano::account const & node_id);
 
 private: // Visitors
-	class realtime_message_visitor : public nano::message_visitor
+	class realtime_message_visitor : public nano::messages::message_visitor
 	{
 	public:
 		bool process{ false };
 
-		void keepalive (nano::keepalive const &) override;
-		void publish (nano::publish const &) override;
-		void confirm_req (nano::confirm_req const &) override;
-		void confirm_ack (nano::confirm_ack const &) override;
-		void frontier_req (nano::frontier_req const &) override;
-		void telemetry_req (nano::telemetry_req const &) override;
-		void telemetry_ack (nano::telemetry_ack const &) override;
-		void asc_pull_req (nano::asc_pull_req const &) override;
-		void asc_pull_ack (nano::asc_pull_ack const &) override;
+		void keepalive (nano::messages::keepalive const &) override;
+		void publish (nano::messages::publish const &) override;
+		void confirm_req (nano::messages::confirm_req const &) override;
+		void confirm_ack (nano::messages::confirm_ack const &) override;
+		void frontier_req (nano::messages::frontier_req const &) override;
+		void telemetry_req (nano::messages::telemetry_req const &) override;
+		void telemetry_ack (nano::messages::telemetry_ack const &) override;
+		void asc_pull_req (nano::messages::asc_pull_req const &) override;
+		void asc_pull_ack (nano::messages::asc_pull_ack const &) override;
 	};
 };
 }

--- a/nano/node/transport/test_channel.cpp
+++ b/nano/node/transport/test_channel.cpp
@@ -6,7 +6,7 @@ nano::transport::test_channel::test_channel (nano::node & node_a) :
 {
 }
 
-bool nano::transport::test_channel::send_impl (nano::message const & message, nano::transport::traffic_type traffic_type, callback_t callback)
+bool nano::transport::test_channel::send_impl (nano::messages::message const & message, nano::transport::traffic_type traffic_type, callback_t callback)
 {
 	observers.notify (message, traffic_type);
 

--- a/nano/node/transport/test_channel.hpp
+++ b/nano/node/transport/test_channel.hpp
@@ -9,7 +9,7 @@ namespace nano::transport
 class test_channel final : public nano::transport::channel
 {
 public:
-	nano::observer_set<nano::message, nano::transport::traffic_type> observers; // Called for each queued message
+	nano::observer_set<nano::messages::message, nano::transport::traffic_type> observers; // Called for each queued message
 
 public:
 	explicit test_channel (nano::node &);
@@ -40,6 +40,6 @@ public:
 	}
 
 protected:
-	bool send_impl (nano::message const &, nano::transport::traffic_type, callback_t) override;
+	bool send_impl (nano::messages::message const &, nano::transport::traffic_type, callback_t) override;
 };
 }

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -247,7 +247,7 @@ void nano::vote_generator::reply (nano::unique_lock<nano::mutex> & lock_a, reque
 			stats.add (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes, stat::dir::in, hashes.size ());
 
 			vote (hashes, roots, [this, channel = request_a.second] (std::shared_ptr<nano::vote> const & vote_a) {
-				nano::confirm_ack confirm{ node.network_params.network, vote_a };
+				nano::messages::confirm_ack confirm{ node.network_params.network, vote_a };
 				channel->send (confirm, nano::transport::traffic_type::vote_reply);
 				stats.inc (nano::stat::type::requests, nano::stat::detail::requests_generated_votes, stat::dir::in);
 			});

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -955,7 +955,7 @@ nano::websocket::message nano::websocket::message_builder::bootstrap_exited (std
 	return message_l;
 }
 
-nano::websocket::message nano::websocket::message_builder::telemetry_received (nano::telemetry_data const & telemetry_data_a, nano::endpoint const & endpoint_a)
+nano::websocket::message nano::websocket::message_builder::telemetry_received (nano::messages::telemetry_data const & telemetry_data_a, nano::endpoint const & endpoint_a)
 {
 	nano::websocket::message message_l (nano::websocket::topic::telemetry);
 	set_common_fields (message_l);
@@ -1069,7 +1069,7 @@ nano::websocket_server::websocket_server (nano::websocket::config & config_a, na
 		}
 	});
 
-	observers.telemetry.add ([this] (nano::telemetry_data const & telemetry_data, std::shared_ptr<nano::transport::channel> const & channel) {
+	observers.telemetry.add ([this] (nano::messages::telemetry_data const & telemetry_data, std::shared_ptr<nano::transport::channel> const & channel) {
 		if (server->any_subscriber (nano::websocket::topic::telemetry))
 		{
 			nano::websocket::message_builder builder{ ledger };

--- a/nano/node/websocket.hpp
+++ b/nano/node/websocket.hpp
@@ -26,10 +26,14 @@ class ledger;
 class logger;
 class node;
 class node_observers;
-class telemetry_data;
 class vote;
 enum class vote_code;
 class wallets;
+}
+
+namespace nano::messages
+{
+class telemetry_data;
 }
 
 namespace nano
@@ -100,7 +104,7 @@ namespace websocket
 		message work_failed (nano::work_version const version, nano::block_hash const & root, uint64_t difficulty, uint64_t publish_threshold, std::chrono::milliseconds const & duration, std::vector<std::string> const & bad_peers);
 		message bootstrap_started (std::string const & id_a, std::string const & mode_a);
 		message bootstrap_exited (std::string const & id_a, std::string const & mode_a, std::chrono::steady_clock::time_point const start_time_a, uint64_t const total_blocks_a);
-		message telemetry_received (nano::telemetry_data const &, nano::endpoint const &);
+		message telemetry_received (nano::messages::telemetry_data const &, nano::endpoint const &);
 		message new_block_arrived (nano::block const & block_a);
 
 	private:

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6733,7 +6733,7 @@ TEST (rpc, telemetry_single)
 		auto response (wait_response (system, rpc_ctx, request, 10s));
 
 		nano::jsonconfig config (response);
-		nano::telemetry_data telemetry_data;
+		nano::messages::telemetry_data telemetry_data;
 		auto const should_ignore_identification_metrics = false;
 		ASSERT_FALSE (telemetry_data.deserialize_json (config, should_ignore_identification_metrics));
 		ASSERT_TRUE (nano::test::compare_telemetry (telemetry_data, *node));
@@ -6761,7 +6761,7 @@ TEST (rpc, telemetry_all)
 	{
 		auto response (wait_response (system, rpc_ctx, request, 10s));
 		nano::jsonconfig config (response);
-		nano::telemetry_data telemetry_data;
+		nano::messages::telemetry_data telemetry_data;
 		auto const should_ignore_identification_metrics = true;
 		ASSERT_FALSE (telemetry_data.deserialize_json (config, should_ignore_identification_metrics));
 		ASSERT_TRUE (nano::test::compare_telemetry_data (telemetry_data, node->local_telemetry ()));
@@ -6776,7 +6776,7 @@ TEST (rpc, telemetry_all)
 	ASSERT_EQ (1, all_metrics.size ());
 
 	nano::jsonconfig config (metrics);
-	nano::telemetry_data data;
+	nano::messages::telemetry_data data;
 	auto const should_ignore_identification_metrics = false;
 	ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
 	ASSERT_TRUE (nano::test::compare_telemetry (data, *node));
@@ -6803,7 +6803,7 @@ TEST (rpc, telemetry_self)
 	auto const should_ignore_identification_metrics = false;
 	{
 		auto response (wait_response (system, rpc_ctx, request, 10s));
-		nano::telemetry_data data;
+		nano::messages::telemetry_data data;
 		nano::jsonconfig config (response);
 		ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
 		ASSERT_TRUE (nano::test::compare_telemetry (data, *node1));
@@ -6812,7 +6812,7 @@ TEST (rpc, telemetry_self)
 	request.put ("address", "[::1]");
 	{
 		auto response (wait_response (system, rpc_ctx, request, 10s));
-		nano::telemetry_data data;
+		nano::messages::telemetry_data data;
 		nano::jsonconfig config (response);
 		ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
 		ASSERT_TRUE (nano::test::compare_telemetry (data, *node1));
@@ -6821,7 +6821,7 @@ TEST (rpc, telemetry_self)
 	request.put ("address", "127.0.0.1");
 	{
 		auto response (wait_response (system, rpc_ctx, request, 10s));
-		nano::telemetry_data data;
+		nano::messages::telemetry_data data;
 		nano::jsonconfig config (response);
 		ASSERT_FALSE (data.deserialize_json (config, should_ignore_identification_metrics));
 		ASSERT_TRUE (nano::test::compare_telemetry (data, *node1));

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1498,7 +1498,7 @@ TEST (telemetry, cache_read_and_timeout)
 	auto node_server = system.add_node (node_flags);
 
 	// Request telemetry metrics
-	std::optional<nano::telemetry_data> telemetry_data;
+	std::optional<nano::messages::telemetry_data> telemetry_data;
 	auto channel = node_client->network.find_node_id (node_server->get_node_id ());
 	ASSERT_NE (channel, nullptr);
 
@@ -1595,12 +1595,12 @@ TEST (telemetry, many_nodes)
 	// This is the node which will request metrics from all other nodes
 	auto node_client = system.nodes.front ();
 
-	std::vector<nano::telemetry_data> telemetry_datas;
+	std::vector<nano::messages::telemetry_data> telemetry_datas;
 	auto peers = node_client->network.list (num_nodes - 1);
 	ASSERT_EQ (peers.size (), num_nodes - 1);
 	for (auto const & peer : peers)
 	{
-		std::optional<nano::telemetry_data> telemetry_data;
+		std::optional<nano::messages::telemetry_data> telemetry_data;
 		ASSERT_TIMELY (5s, telemetry_data = node_client->telemetry.get_telemetry (peer->get_remote_endpoint ()));
 		telemetry_datas.push_back (*telemetry_data);
 	}

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -8,7 +8,7 @@
 
 namespace
 {
-void compare_telemetry_data_impl (const nano::telemetry_data & data_a, const nano::telemetry_data & data_b, bool & result)
+void compare_telemetry_data_impl (const nano::messages::telemetry_data & data_a, const nano::messages::telemetry_data & data_b, bool & result)
 {
 	ASSERT_EQ (data_a.block_count, data_b.block_count);
 	ASSERT_EQ (data_a.cemented_count, data_b.cemented_count);
@@ -23,7 +23,7 @@ void compare_telemetry_data_impl (const nano::telemetry_data & data_a, const nan
 	ASSERT_EQ (data_a.minor_version, nano::get_minor_node_version ());
 	ASSERT_EQ (data_a.patch_version, nano::get_patch_node_version ());
 	ASSERT_EQ (data_a.pre_release_version, nano::get_pre_release_node_version ());
-	ASSERT_EQ (data_a.maker, static_cast<std::underlying_type_t<nano::telemetry_maker>> (nano::telemetry_maker::nf_node));
+	ASSERT_EQ (data_a.maker, static_cast<std::underlying_type_t<nano::messages::telemetry_maker>> (nano::messages::telemetry_maker::nf_node));
 	ASSERT_GT (data_a.timestamp, std::chrono::system_clock::now () - std::chrono::seconds (100));
 	ASSERT_EQ (data_a.active_difficulty, data_b.active_difficulty);
 	ASSERT_EQ (data_a.unknown_data, std::vector<uint8_t>{});
@@ -31,7 +31,7 @@ void compare_telemetry_data_impl (const nano::telemetry_data & data_a, const nan
 }
 }
 
-bool nano::test::compare_telemetry_data (const nano::telemetry_data & data_a, const nano::telemetry_data & data_b)
+bool nano::test::compare_telemetry_data (const nano::messages::telemetry_data & data_a, const nano::messages::telemetry_data & data_b)
 {
 	bool result = false;
 	compare_telemetry_data_impl (data_a, data_b, result);
@@ -40,13 +40,13 @@ bool nano::test::compare_telemetry_data (const nano::telemetry_data & data_a, co
 
 namespace
 {
-void compare_telemetry_impl (const nano::telemetry_data & data, nano::node const & node, bool & result)
+void compare_telemetry_impl (const nano::messages::telemetry_data & data, nano::node const & node, bool & result)
 {
 	ASSERT_FALSE (data.validate_signature ());
 	ASSERT_EQ (data.node_id, node.node_id.pub);
 
 	// Signature should be different because uptime/timestamp will have changed.
-	nano::telemetry_data data_l = data;
+	nano::messages::telemetry_data data_l = data;
 	data_l.signature.clear ();
 	data_l.sign (node.node_id);
 	ASSERT_NE (data.signature, data_l.signature);
@@ -57,7 +57,7 @@ void compare_telemetry_impl (const nano::telemetry_data & data, nano::node const
 }
 }
 
-bool nano::test::compare_telemetry (const nano::telemetry_data & data, const nano::node & node)
+bool nano::test::compare_telemetry (const nano::messages::telemetry_data & data, const nano::node & node)
 {
 	bool result = false;
 	compare_telemetry_impl (data, node, result);

--- a/nano/test_common/telemetry.hpp
+++ b/nano/test_common/telemetry.hpp
@@ -3,6 +3,10 @@
 namespace nano
 {
 class node;
+}
+
+namespace nano::messages
+{
 class telemetry_data;
 }
 
@@ -12,11 +16,11 @@ namespace nano::test
  * Compares telemetry data without signatures
  * @return true if comparison OK
  */
-bool compare_telemetry_data (nano::telemetry_data const &, nano::telemetry_data const &);
+bool compare_telemetry_data (nano::messages::telemetry_data const &, nano::messages::telemetry_data const &);
 
 /**
  * Compares telemetry data and checks signature matches node_id
  * @return true if comparison OK
  */
-bool compare_telemetry (nano::telemetry_data const &, nano::node const &);
+bool compare_telemetry (nano::messages::telemetry_data const &, nano::node const &);
 }


### PR DESCRIPTION
The rationale for this change is to allow introducing alternative message formats (e.g., FlatBuffers) alongside the current implementation without running into name conflicts.

Does not introduce any functional changes.