### PR TITLE
Super rebroadcaster mode

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1114,7 +1114,8 @@ TEST (network, flood_vote)
 	ASSERT_TIMELY_EQ (5s, node.rep_crawler.representative_count (), 1);
 
 	auto vote = nano::test::make_vote (nano::dev::genesis_key, { nano::dev::genesis->hash () });
-	ASSERT_EQ (3, node.network.flood_vote_rebroadcasted (vote, 999.0f));
+	ASSERT_EQ (2, node.network.flood_vote (vote, nano::transport::traffic_type::test));
+	ASSERT_EQ (3, node.network.flood_vote_all (vote, nano::transport::traffic_type::test));
 	ASSERT_EQ (2, node.network.flood_vote_non_pr (vote, 999.0f));
 	ASSERT_EQ (1, node.network.flood_vote_pr (vote));
 }

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2232,11 +2232,11 @@ TEST (node, DISABLED_fork_invalid_block_signature)
 	node1.process_active (send1);
 	ASSERT_TIMELY (5s, node1.block (send1->hash ()));
 	// Send the vote with the corrupt block signature
-	ASSERT_TRUE (node2.network.flood_vote_rebroadcasted (vote_corrupt, 1.0f));
+	ASSERT_TRUE (node2.network.flood_vote_all (vote_corrupt, nano::transport::traffic_type::test));
 	// Wait for the rollback
 	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::rollback));
 	// Send the vote with the correct block
-	ASSERT_TRUE (node2.network.flood_vote_rebroadcasted (vote, 1.0f));
+	ASSERT_TRUE (node2.network.flood_vote_all (vote, nano::transport::traffic_type::test));
 	ASSERT_TIMELY (10s, !node1.block (send1->hash ()));
 	ASSERT_TIMELY (10s, node1.block (send2->hash ()));
 	ASSERT_EQ (node1.block (send2->hash ())->block_signature (), send2->block_signature ());
@@ -3805,4 +3805,73 @@ TEST (node, bootstrap_poison)
 	ASSERT_FALSE (node.store.account.get (node.store.tx_begin_read (), key1.pub, account_info));
 	ASSERT_EQ (account_info.head, open_correct->hash ());
 	ASSERT_EQ (account_info.representative, key1.pub); // Correct representative
+}
+
+TEST (node, super_rebroadcaster)
+{
+	nano::test::system system;
+
+	// Node 1: Super rebroadcaster mode
+	nano::node_config config = system.default_config ();
+	config.bootstrap.enable = false;
+	config.local_block_broadcaster.enable = false;
+	nano::node_flags flags;
+	flags.super_rebroadcaster = true;
+	auto & node1 = *system.add_node (config, flags);
+
+	// Nodes 2, 3, 4: Normal peer nodes
+	nano::node_config peer_config = system.default_config ();
+	peer_config.block_rebroadcaster.enable = false;
+	peer_config.vote_rebroadcaster.enable = false;
+	peer_config.local_block_broadcaster.enable = false;
+	auto & node2 = *system.add_node (peer_config);
+	auto & node3 = *system.add_node (peer_config);
+	auto & node4 = *system.add_node (peer_config);
+
+	// Verify all nodes connected
+	ASSERT_TIMELY_EQ (5s, node1.network.size (), 3);
+
+	// Create a block
+	auto send = nano::state_block_builder ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Knano_ratio)
+				.link (nano::dev::genesis_key.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
+
+	// Process block as if received from the live network (triggers rebroadcasting)
+	node1.process_active (send);
+
+	// Verify block rebroadcasting uses super mode
+	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::block_rebroadcaster, nano::stat::detail::broadcast_super) >= 1);
+	ASSERT_EQ (0, node1.stats.count (nano::stat::type::block_rebroadcaster, nano::stat::detail::broadcast));
+
+	// Verify ALL peers received the block (super mode floods to all)
+	ASSERT_TIMELY (5s, node2.block (send->hash ()));
+	ASSERT_TIMELY (5s, node3.block (send->hash ()));
+	ASSERT_TIMELY (5s, node4.block (send->hash ()));
+
+	// Verify vote rebroadcasting uses super mode
+	// Create a final vote for the block (final vote will confirm the block)
+	auto vote = nano::test::make_final_vote (nano::dev::genesis_key, { send });
+
+	// Process vote as if received from the live network (triggers rebroadcasting)
+	node1.process_active (vote);
+
+	// Verify super mode stat is used for vote rebroadcasting
+	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::vote_rebroadcaster, nano::stat::detail::broadcast_super) >= 1);
+	ASSERT_EQ (0, node1.stats.count (nano::stat::type::vote_rebroadcaster, nano::stat::detail::broadcast));
+
+	// Verify peers received votes with rebroadcasted flag set
+	ASSERT_TIMELY (5s, node2.stats.count (nano::stat::type::vote_processor_source, nano::stat::detail::rebroadcast) >= 1);
+	ASSERT_TIMELY (5s, node3.stats.count (nano::stat::type::vote_processor_source, nano::stat::detail::rebroadcast) >= 1);
+	ASSERT_TIMELY (5s, node4.stats.count (nano::stat::type::vote_processor_source, nano::stat::detail::rebroadcast) >= 1);
+
+	// Verify all peers confirmed the block (final vote triggers confirmation)
+	ASSERT_TIMELY (5s, node2.block_confirmed (send->hash ()));
+	ASSERT_TIMELY (5s, node3.block_confirmed (send->hash ()));
+	ASSERT_TIMELY (5s, node4.block_confirmed (send->hash ()));
 }

--- a/nano/lib/rate_limiting.cpp
+++ b/nano/lib/rate_limiting.cpp
@@ -73,7 +73,9 @@ std::size_t nano::rate::token_bucket::size () const
  */
 
 nano::rate_limiter::rate_limiter (std::size_t limit_a, double burst_ratio_a) :
-	bucket (static_cast<std::size_t> (limit_a * burst_ratio_a), limit_a)
+	bucket (static_cast<std::size_t> (limit_a * burst_ratio_a), limit_a),
+	limit{ limit_a },
+	burst_ratio{ burst_ratio_a }
 {
 }
 
@@ -87,10 +89,18 @@ void nano::rate_limiter::reset (std::size_t limit_a, double burst_ratio_a)
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	bucket.reset (static_cast<std::size_t> (limit_a * burst_ratio_a), limit_a);
+	limit = limit_a;
+	burst_ratio = burst_ratio_a;
 }
 
 std::size_t nano::rate_limiter::size () const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	return bucket.size ();
+}
+
+std::pair<std::size_t, double> nano::rate_limiter::get_limit () const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return { limit, burst_ratio };
 }

--- a/nano/lib/rate_limiting.hpp
+++ b/nano/lib/rate_limiting.hpp
@@ -73,9 +73,12 @@ public:
 	void reset (std::size_t limit, double burst_ratio = 1.0);
 
 	std::size_t size () const;
+	std::pair<std::size_t, double> get_limit () const;
 
 private:
 	nano::rate::token_bucket bucket;
+	std::size_t limit;
+	double burst_ratio;
 	mutable nano::mutex mutex;
 };
 }

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -25,6 +25,7 @@ enum class type
 	vote_processor,
 	vote_processor_tier,
 	vote_processor_overfill,
+	vote_processor_source,
 	vote_rebroadcaster,
 	vote_rebroadcaster_tier,
 	election,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -626,6 +626,7 @@ enum class detail
 	// block broadcaster
 	broadcast_normal,
 	broadcast_aggressive,
+	broadcast_super,
 	erase_old,
 	erase_confirmed,
 

--- a/nano/node/bandwidth_limiter.cpp
+++ b/nano/node/bandwidth_limiter.cpp
@@ -24,6 +24,17 @@ nano::rate_limiter & nano::bandwidth_limiter::select_limiter (nano::transport::t
 	}
 }
 
+nano::rate_limiter const & nano::bandwidth_limiter::select_limiter (nano::transport::traffic_type type) const
+{
+	switch (type)
+	{
+		case nano::transport::traffic_type::bootstrap_server:
+			return limiter_bootstrap;
+		default:
+			return limiter_generic;
+	}
+}
+
 bool nano::bandwidth_limiter::should_pass (std::size_t buffer_size, nano::transport::traffic_type type)
 {
 	auto & limiter = select_limiter (type);
@@ -42,6 +53,11 @@ nano::container_info nano::bandwidth_limiter::container_info () const
 	info.put ("generic", limiter_generic.size ());
 	info.put ("bootstrap", limiter_bootstrap.size ());
 	return info;
+}
+
+std::pair<std::size_t, double> nano::bandwidth_limiter::get_limit (nano::transport::traffic_type type) const
+{
+	return select_limiter (type).get_limit ();
 }
 
 /*

--- a/nano/node/bandwidth_limiter.cpp
+++ b/nano/node/bandwidth_limiter.cpp
@@ -6,9 +6,10 @@
  * bandwidth_limiter
  */
 
-nano::bandwidth_limiter::bandwidth_limiter (nano::node_config const & node_config_a) :
-	config{ node_config_a },
-	limiter_generic{ config.generic_limit, config.generic_burst_ratio },
+nano::bandwidth_limiter::bandwidth_limiter (nano::node_config const & node_config, nano::node_flags const & flags) :
+	config{ node_config },
+	// In super_rebroadcaster mode, use unlimited bandwidth (0 = no limit)
+	limiter_generic{ flags.super_rebroadcaster ? 0 : config.generic_limit, config.generic_burst_ratio },
 	limiter_bootstrap{ config.bootstrap_limit, config.bootstrap_burst_ratio }
 {
 }

--- a/nano/node/bandwidth_limiter.hpp
+++ b/nano/node/bandwidth_limiter.hpp
@@ -39,11 +39,14 @@ public:
 
 	nano::container_info container_info () const;
 
+	std::pair<std::size_t, double> get_limit (nano::transport::traffic_type type = nano::transport::traffic_type::generic) const;
+
 private:
 	/**
 	 * Returns reference to limiter corresponding to the limit type
 	 */
 	nano::rate_limiter & select_limiter (nano::transport::traffic_type type);
+	nano::rate_limiter const & select_limiter (nano::transport::traffic_type type) const;
 
 private:
 	bandwidth_limiter_config const config;

--- a/nano/node/bandwidth_limiter.hpp
+++ b/nano/node/bandwidth_limiter.hpp
@@ -25,7 +25,7 @@ public:
 class bandwidth_limiter final
 {
 public:
-	explicit bandwidth_limiter (nano::node_config const &);
+	bandwidth_limiter (nano::node_config const &, nano::node_flags const &);
 
 	/**
 	 * Check whether packet falls withing bandwidth limits and should be allowed

--- a/nano/node/block_rebroadcaster.cpp
+++ b/nano/node/block_rebroadcaster.cpp
@@ -5,13 +5,15 @@
 #include <nano/node/block_rebroadcaster.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/network.hpp>
+#include <nano/node/nodeconfig.hpp>
 
 /*
  * block_rebroadcaster
  */
 
-nano::block_rebroadcaster::block_rebroadcaster (nano::block_rebroadcaster_config const & config_a, nano::active_elections & active_a, nano::network & network_a, nano::stats & stats_a, nano::logger & logger_a) :
+nano::block_rebroadcaster::block_rebroadcaster (nano::block_rebroadcaster_config const & config_a, nano::node_flags const & flags_a, nano::active_elections & active_a, nano::network & network_a, nano::stats & stats_a, nano::logger & logger_a) :
 	config{ config_a },
+	flags{ flags_a },
 	active{ active_a },
 	network{ network_a },
 	stats{ stats_a },
@@ -140,12 +142,16 @@ void nano::block_rebroadcaster::run ()
 			lock.lock ();
 		}
 
-		float constexpr network_fanout_scale = 1.0f;
-
 		// Wait for spare capacity if our network traffic is too high
-		if (!network.check_capacity (nano::transport::traffic_type::block_rebroadcast, network_fanout_scale))
+		if (!check_capacity ())
 		{
 			stats.inc (nano::stat::type::block_rebroadcaster, nano::stat::detail::cooldown);
+
+			if (!queue.empty () && capacity_warning_interval.elapse (5s))
+			{
+				logger.warn (nano::log::type::block_rebroadcaster, "Network capacity for block rebroadcasting unavailable, {} blocks waiting in queue", queue.size ());
+			}
+
 			lock.unlock ();
 			std::this_thread::sleep_for (100ms);
 			lock.lock ();
@@ -171,7 +177,7 @@ void nano::block_rebroadcaster::run ()
 			{
 				stats.inc (nano::stat::type::block_rebroadcaster, nano::stat::detail::rebroadcast);
 
-				auto sent = network.flood_block (block, nano::transport::traffic_type::block_rebroadcast);
+				auto sent = broadcast (block);
 				stats.add (nano::stat::type::block_rebroadcaster, nano::stat::detail::sent, sent);
 			}
 			else
@@ -181,6 +187,32 @@ void nano::block_rebroadcaster::run ()
 
 			lock.lock ();
 		}
+	}
+}
+
+size_t nano::block_rebroadcaster::broadcast (std::shared_ptr<nano::block> const & block)
+{
+	if (flags.super_rebroadcaster)
+	{
+		stats.inc (nano::stat::type::block_rebroadcaster, nano::stat::detail::broadcast_super);
+		return network.flood_block_all (block, nano::transport::traffic_type::block_rebroadcast);
+	}
+	else
+	{
+		stats.inc (nano::stat::type::block_rebroadcaster, nano::stat::detail::broadcast);
+		return network.flood_block (block, nano::transport::traffic_type::block_rebroadcast);
+	}
+}
+
+bool nano::block_rebroadcaster::check_capacity () const
+{
+	if (flags.super_rebroadcaster)
+	{
+		return network.check_capacity_ratio (nano::transport::traffic_type::block_rebroadcast, 0.5f);
+	}
+	else
+	{
+		return network.check_capacity_fanout (nano::transport::traffic_type::block_rebroadcast);
 	}
 }
 

--- a/nano/node/block_rebroadcaster.hpp
+++ b/nano/node/block_rebroadcaster.hpp
@@ -80,7 +80,7 @@ private:
 class block_rebroadcaster final
 {
 public:
-	block_rebroadcaster (block_rebroadcaster_config const &, nano::active_elections &, nano::network &, nano::stats &, nano::logger &);
+	block_rebroadcaster (block_rebroadcaster_config const &, nano::node_flags const &, nano::active_elections &, nano::network &, nano::stats &, nano::logger &);
 	~block_rebroadcaster ();
 
 	void start ();
@@ -92,6 +92,7 @@ public:
 
 public: // Dependencies
 	block_rebroadcaster_config const & config;
+	nano::node_flags const & flags;
 	nano::active_elections & active;
 	nano::network & network;
 	nano::stats & stats;
@@ -101,6 +102,8 @@ private:
 	void run ();
 	std::shared_ptr<nano::block> next ();
 	void cleanup ();
+	size_t broadcast (std::shared_ptr<nano::block> const &);
+	bool check_capacity () const;
 
 private:
 	// Simple FIFO queue of blocks to rebroadcast
@@ -117,5 +120,6 @@ private:
 
 	nano::interval cleanup_interval;
 	nano::interval log_interval;
+	nano::interval capacity_warning_interval;
 };
 }

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -122,6 +122,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_search_pending", "Disables the periodic search for pending transactions")
 		("enable_pruning", "Enable experimental ledger pruning")
 		("enable_voting", "Enable voting")
+		("super_rebroadcaster", "Broadcast all blocks and votes to all peers (high bandwidth usage)")
 		("allow_bootstrap_peers_duplicates", "Allow multiple connections to same peer in bootstrap attempts")
 		("fast_bootstrap", "Increase bootstrap speed for high end nodes with higher limits")
 		("block_processor_batch_size", boost::program_options::value<std::size_t>(), "Increase block processor transaction batch write size, default 0 (limited by config block_processor_batch_max_time), 256k for fast_bootstrap")
@@ -160,6 +161,7 @@ void nano::update_flags (nano::node_flags & flags_a, boost::program_options::var
 	flags_a.disable_block_processor_unchecked_deletion = (vm.count ("disable_block_processor_unchecked_deletion") > 0);
 	flags_a.enable_pruning = (vm.count ("enable_pruning") > 0);
 	flags_a.enable_voting = (vm.count ("enable_voting") > 0);
+	flags_a.super_rebroadcaster = (vm.count ("super_rebroadcaster") > 0);
 	flags_a.allow_bootstrap_peers_duplicates = (vm.count ("allow_bootstrap_peers_duplicates") > 0);
 	flags_a.fast_bootstrap = (vm.count ("fast_bootstrap") > 0);
 	if (flags_a.fast_bootstrap)

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -247,13 +247,27 @@ void nano::network::send_keepalive_self (std::shared_ptr<nano::transport::channe
 	channel->send (message, nano::transport::traffic_type::keepalive);
 }
 
-bool nano::network::check_capacity (nano::transport::traffic_type type, float scale) const
+bool nano::network::check_capacity (nano::transport::traffic_type type, size_t target_count) const
 {
-	auto const target_count = fanout (scale);
+	if (target_count == 0)
+	{
+		return true;
+	}
 	auto channels = list (target_count, [type] (auto const & channel) {
 		return !channel->max (type); // Only use channels that are not full for this traffic type
 	});
 	return !channels.empty () && channels.size () >= target_count / 2; // We need to have at least half of the target capacity available
+}
+
+bool nano::network::check_capacity_fanout (nano::transport::traffic_type type, float scale) const
+{
+	return check_capacity (type, fanout (scale));
+}
+
+bool nano::network::check_capacity_ratio (nano::transport::traffic_type type, float ratio) const
+{
+	auto const target_count = static_cast<size_t> (std::ceil (size () * ratio));
+	return check_capacity (type, target_count);
 }
 
 size_t nano::network::flood_message (nano::messages::message const & message, nano::transport::traffic_type type, float scale) const
@@ -264,8 +278,24 @@ size_t nano::network::flood_message (nano::messages::message const & message, na
 	size_t result = 0;
 	for (auto const & channel : channels)
 	{
+		// TODO: Serialize message only once
 		bool sent = channel->send (message, type);
 		result += sent;
+	}
+	return result;
+}
+
+size_t nano::network::flood_message_all (nano::messages::message const & message, nano::transport::traffic_type type) const
+{
+	auto channels = list (); // Get all peers
+	size_t result = 0;
+	for (auto const & channel : channels)
+	{
+		if (!channel->max (type))
+		{
+			// TODO: Serialize message only once
+			result += channel->send (message, type);
+		}
 	}
 	return result;
 }
@@ -284,47 +314,16 @@ size_t nano::network::flood_keepalive_self (float scale) const
 	return flood_message (message, nano::transport::traffic_type::keepalive, scale);
 }
 
-size_t nano::network::flood_block (std::shared_ptr<nano::block> const & block, nano::transport::traffic_type type) const
+size_t nano::network::flood_vote (std::shared_ptr<nano::vote> const & vote, nano::transport::traffic_type type, bool rebroadcasted) const
 {
-	nano::messages::publish message{ node.network_params.network, block };
+	nano::messages::confirm_ack message{ node.network_params.network, vote, rebroadcasted };
 	return flood_message (message, type);
 }
 
-size_t nano::network::flood_block_initial (std::shared_ptr<nano::block> const & block) const
+size_t nano::network::flood_vote_all (std::shared_ptr<nano::vote> const & vote, nano::transport::traffic_type type, bool rebroadcasted) const
 {
-	nano::messages::publish message{ node.network_params.network, block, /* is_originator */ true };
-
-	size_t result = 0;
-	for (auto const & rep : node.rep_crawler.principal_representatives ())
-	{
-		bool sent = rep.channel->send (message, nano::transport::traffic_type::block_broadcast_initial);
-		result += sent;
-	}
-	for (auto & peer : list_non_pr (fanout (1.0)))
-	{
-		bool sent = peer->send (message, nano::transport::traffic_type::block_broadcast_initial);
-		result += sent;
-	}
-	return result;
-}
-
-size_t nano::network::flood_vote_rebroadcasted (std::shared_ptr<nano::vote> const & vote, float scale) const
-{
-	nano::messages::confirm_ack message{ node.network_params.network, vote, /* rebroadcasted */ true };
-
-	auto const type = nano::transport::traffic_type::vote_rebroadcast;
-
-	auto channels = list (fanout (scale), [type] (auto const & channel) {
-		return !channel->max (type); // Only use channels that are not full for this traffic type
-	});
-
-	size_t result = 0;
-	for (auto & channel : channels)
-	{
-		bool sent = channel->send (message, type);
-		result += sent;
-	}
-	return result;
+	nano::messages::confirm_ack message{ node.network_params.network, vote, rebroadcasted };
+	return flood_message_all (message, type);
 }
 
 size_t nano::network::flood_vote_non_pr (std::shared_ptr<nano::vote> const & vote, float scale) const
@@ -359,6 +358,36 @@ size_t nano::network::flood_vote_pr (std::shared_ptr<nano::vote> const & vote) c
 		result += sent;
 	}
 	return result;
+}
+
+size_t nano::network::flood_block (std::shared_ptr<nano::block> const & block, nano::transport::traffic_type type) const
+{
+	nano::messages::publish message{ node.network_params.network, block };
+	return flood_message (message, type);
+}
+
+size_t nano::network::flood_block_initial (std::shared_ptr<nano::block> const & block) const
+{
+	nano::messages::publish message{ node.network_params.network, block, /* is_originator */ true };
+
+	size_t result = 0;
+	for (auto const & rep : node.rep_crawler.principal_representatives ())
+	{
+		bool sent = rep.channel->send (message, nano::transport::traffic_type::block_broadcast_initial);
+		result += sent;
+	}
+	for (auto & peer : list_non_pr (fanout (1.0)))
+	{
+		bool sent = peer->send (message, nano::transport::traffic_type::block_broadcast_initial);
+		result += sent;
+	}
+	return result;
+}
+
+size_t nano::network::flood_block_all (std::shared_ptr<nano::block> const & block, nano::transport::traffic_type type) const
+{
+	nano::messages::publish message{ node.network_params.network, block };
+	return flood_message_all (message, type);
 }
 
 void nano::network::flood_block_many (std::deque<std::shared_ptr<nano::block>> blocks, nano::transport::traffic_type type, std::chrono::milliseconds delay, std::function<void ()> callback) const

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -96,18 +96,29 @@ public:
 	nano::endpoint endpoint () const;
 
 	// Checks if we have enough channel capacity for the given traffic type
-	bool check_capacity (nano::transport::traffic_type, float scale = 1.0f) const;
+	// Returns true if at least half of target peers have spare capacity
+	bool check_capacity (nano::transport::traffic_type, size_t target_count) const;
+	// Computes target from fanout(scale)
+	bool check_capacity_fanout (nano::transport::traffic_type, float scale = 1.0f) const;
+	// Computes target as ratio of all peers (e.g., 0.5 = 50%)
+	bool check_capacity_ratio (nano::transport::traffic_type, float ratio) const;
 
 	size_t flood_message (nano::messages::message const &, nano::transport::traffic_type, float scale = 1.0f) const;
+	size_t flood_message_all (nano::messages::message const &, nano::transport::traffic_type) const;
+
 	size_t flood_keepalive (float scale = 1.0f) const;
 	size_t flood_keepalive_self (float scale = 0.5f) const;
+
+	size_t flood_vote (std::shared_ptr<nano::vote> const &, nano::transport::traffic_type, bool rebroadcasted = false) const;
+	size_t flood_vote_all (std::shared_ptr<nano::vote> const &, nano::transport::traffic_type, bool rebroadcasted = false) const;
 	size_t flood_vote_pr (std::shared_ptr<nano::vote> const &) const;
 	size_t flood_vote_non_pr (std::shared_ptr<nano::vote> const &, float scale) const;
-	size_t flood_vote_rebroadcasted (std::shared_ptr<nano::vote> const &, float scale) const;
-	// Flood block to all PRs and a random selection of non-PRs
-	size_t flood_block_initial (std::shared_ptr<nano::block> const &) const;
+
 	// Flood block to a random selection of peers
 	size_t flood_block (std::shared_ptr<nano::block> const &, nano::transport::traffic_type) const;
+	size_t flood_block_all (std::shared_ptr<nano::block> const &, nano::transport::traffic_type) const;
+	// Flood block to all PRs and a random selection of non-PRs
+	size_t flood_block_initial (std::shared_ptr<nano::block> const &) const;
 	void flood_block_many (std::deque<std::shared_ptr<nano::block>>, nano::transport::traffic_type, std::chrono::milliseconds delay = 10ms, std::function<void ()> callback = nullptr) const;
 
 	void send_keepalive (std::shared_ptr<nano::transport::channel> const &) const;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -329,9 +329,12 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 		logger.warn (nano::log::type::node, "Work generation is disabled");
 	}
 
-	logger.info (nano::log::type::node, "Outbound bandwidth limit: {} bytes/s, burst ratio: {}",
-	config.bandwidth_limit,
-	config.bandwidth_limit_burst_ratio);
+	{
+		auto [limit, burst_ratio] = outbound_limiter.get_limit ();
+		logger.info (nano::log::type::node, "Outbound bandwidth limit: {}, burst ratio: {}",
+		limit == 0 ? "unlimited" : std::to_string (limit) + " bytes/s",
+		burst_ratio);
+	}
 
 	if (!block_or_pruned_exists (config.network_params.ledger.genesis->hash ()))
 	{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -120,7 +120,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	unchecked{ *unchecked_impl },
 	ledger_notifications_impl{ std::make_unique<nano::ledger_notifications> (config, stats, logger) },
 	ledger_notifications{ *ledger_notifications_impl },
-	outbound_limiter_impl{ std::make_unique<nano::bandwidth_limiter> (config) },
+	outbound_limiter_impl{ std::make_unique<nano::bandwidth_limiter> (config, flags) },
 	outbound_limiter{ *outbound_limiter_impl },
 	message_processor_impl{ std::make_unique<nano::message_processor> (config.message_processor, *this) },
 	message_processor{ *message_processor_impl },
@@ -203,9 +203,9 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	http_callbacks{ *http_callbacks_impl },
 	pruning_impl{ std::make_unique<nano::pruning> (config, flags, ledger, stats, logger) },
 	pruning{ *pruning_impl },
-	vote_rebroadcaster_impl{ std::make_unique<nano::vote_rebroadcaster> (config.vote_rebroadcaster, ledger, vote_router, network, wallets, rep_tiers, stats, logger) },
+	vote_rebroadcaster_impl{ std::make_unique<nano::vote_rebroadcaster> (config.vote_rebroadcaster, flags, ledger, vote_router, network, wallets, rep_tiers, stats, logger) },
 	vote_rebroadcaster{ *vote_rebroadcaster_impl },
-	block_rebroadcaster_impl{ std::make_unique<nano::block_rebroadcaster> (config.block_rebroadcaster, active, network, stats, logger) },
+	block_rebroadcaster_impl{ std::make_unique<nano::block_rebroadcaster> (config.block_rebroadcaster, flags, active, network, stats, logger) },
 	block_rebroadcaster{ *block_rebroadcaster_impl },
 	startup_time{ std::chrono::steady_clock::now () },
 	node_seq{ seq }
@@ -377,6 +377,11 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 		logger.warn (nano::log::type::node, "Found local representatives in wallets, but voting is disabled. To enable voting, set `[node] enable_voting=true` in the `config-node.toml` file or use `--enable_voting` command line argument");
 	}
 
+	if (flags.super_rebroadcaster)
+	{
+		logger.warn (nano::log::type::node, "Super rebroadcaster mode enabled - broadcasting to all peers (expect high bandwidth usage)");
+	}
+
 	if ((network_params.network.is_live_network () || network_params.network.is_beta_network ()) && !flags.inactive_node)
 	{
 		ledger.bootstrap_weights = get_bootstrap_weights ();
@@ -486,6 +491,11 @@ void nano::node::inbound (const nano::messages::message & message, const std::sh
 void nano::node::process_active (std::shared_ptr<nano::block> const & incoming)
 {
 	block_processor.add (incoming);
+}
+
+void nano::node::process_active (std::shared_ptr<nano::vote> const & vote)
+{
+	vote_processor.vote (vote, loopback_channel, nano::vote_source::live);
 }
 
 [[nodiscard]] nano::block_status nano::node::process (secure::write_transaction const & transaction, std::shared_ptr<nano::block> block)

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -50,6 +50,7 @@ public:
 	int store_version ();
 	void inbound (nano::messages::message const &, std::shared_ptr<nano::transport::channel> const &);
 	void process_active (std::shared_ptr<nano::block> const &);
+	void process_active (std::shared_ptr<nano::vote> const &);
 	std::optional<nano::block_status> process_local (std::shared_ptr<nano::block> const &);
 	void process_local_async (std::shared_ptr<nano::block> const &);
 	void keepalive_preconfigured ();

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -190,6 +190,7 @@ public:
 	bool disable_search_pending{ false }; // For testing only
 	bool enable_pruning{ false };
 	bool enable_voting{ false };
+	bool super_rebroadcaster{ false }; // Broadcast all blocks and votes to all peers
 	bool fast_bootstrap{ false };
 	bool read_only{ false };
 	bool disable_connection_cleanup{ false };

--- a/nano/node/vote_processor.cpp
+++ b/nano/node/vote_processor.cpp
@@ -116,6 +116,7 @@ bool nano::vote_processor::vote (std::shared_ptr<nano::vote> const & vote, std::
 	{
 		stats.inc (nano::stat::type::vote_processor, nano::stat::detail::process);
 		stats.inc (nano::stat::type::vote_processor_tier, to_stat_detail (tier));
+		stats.inc (nano::stat::type::vote_processor_source, to_stat_detail (source));
 
 		condition.notify_one ();
 	}

--- a/nano/node/vote_rebroadcaster.cpp
+++ b/nano/node/vote_rebroadcaster.cpp
@@ -4,6 +4,7 @@
 #include <nano/lib/thread_roles.hpp>
 #include <nano/lib/vote.hpp>
 #include <nano/node/network.hpp>
+#include <nano/node/nodeconfig.hpp>
 #include <nano/node/rep_tiers.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/node/vote_rebroadcaster.hpp>
@@ -11,8 +12,9 @@
 #include <nano/node/wallet.hpp>
 #include <nano/secure/ledger.hpp>
 
-nano::vote_rebroadcaster::vote_rebroadcaster (nano::vote_rebroadcaster_config const & config_a, nano::ledger & ledger_a, nano::vote_router & vote_router_a, nano::network & network_a, nano::wallets & wallets_a, nano::rep_tiers & rep_tiers_a, nano::stats & stats_a, nano::logger & logger_a) :
+nano::vote_rebroadcaster::vote_rebroadcaster (nano::vote_rebroadcaster_config const & config_a, nano::node_flags const & flags_a, nano::ledger & ledger_a, nano::vote_router & vote_router_a, nano::network & network_a, nano::wallets & wallets_a, nano::rep_tiers & rep_tiers_a, nano::stats & stats_a, nano::logger & logger_a) :
 	config{ config_a },
+	flags{ flags_a },
 	ledger{ ledger_a },
 	vote_router{ vote_router_a },
 	network{ network_a },
@@ -72,9 +74,9 @@ nano::vote_rebroadcaster::vote_rebroadcaster (nano::vote_rebroadcaster_config co
 			return false;
 		});
 
-		// Enable vote rebroadcasting only if the node does not host a representative
+		// Enable vote rebroadcasting only if the node does not host a representative (or super_rebroadcaster mode)
 		// Do not rebroadcast votes from non-principal representatives
-		if (should_rebroadcast && non_principal)
+		if (should_rebroadcast && (!has_principal || flags.super_rebroadcaster))
 		{
 			auto tier = rep_tiers.tier (vote->account);
 			if (tier != nano::rep_tier::none)
@@ -180,8 +182,9 @@ void nano::vote_rebroadcaster::run ()
 		{
 			stats.inc (nano::stat::type::vote_rebroadcaster, nano::stat::detail::refresh);
 
+			// Check if node has a principal representative (rebroadcasting is disabled when true)
 			reps = wallets.reps ();
-			non_principal = !reps.have_half_rep (); // Disable vote rebroadcasting if the node has a principal representative (or close to)
+			has_principal = reps.have_half_rep ();
 		}
 
 		// Cleanup expired representatives from rebroadcasts
@@ -192,12 +195,16 @@ void nano::vote_rebroadcaster::run ()
 			lock.lock ();
 		}
 
-		float constexpr network_fanout_scale = 1.0f;
-
 		// Wait for spare capacity if our network traffic is too high
-		if (!network.check_capacity (nano::transport::traffic_type::vote_rebroadcast, network_fanout_scale))
+		if (!check_capacity ())
 		{
 			stats.inc (nano::stat::type::vote_rebroadcaster, nano::stat::detail::cooldown);
+
+			if (!queue.empty () && capacity_warning_interval.elapse (5s))
+			{
+				logger.warn (nano::log::type::vote_rebroadcaster, "Network capacity for vote rebroadcasting unavailable, {} votes waiting in queue", queue.size ());
+			}
+
 			lock.unlock ();
 			std::this_thread::sleep_for (100ms);
 			lock.lock ();
@@ -227,12 +234,38 @@ void nano::vote_rebroadcaster::run ()
 				stats.add (nano::stat::type::vote_rebroadcaster, nano::stat::detail::rebroadcast_hashes, vote->hashes.size ());
 				stats.inc (nano::stat::type::vote_rebroadcaster_tier, to_stat_detail (tier));
 
-				auto sent = network.flood_vote_rebroadcasted (vote, network_fanout_scale);
+				auto sent = broadcast (vote);
 				stats.add (nano::stat::type::vote_rebroadcaster, nano::stat::detail::sent, sent);
 			}
 
 			lock.lock ();
 		}
+	}
+}
+
+size_t nano::vote_rebroadcaster::broadcast (std::shared_ptr<nano::vote> const & vote)
+{
+	if (flags.super_rebroadcaster)
+	{
+		stats.inc (nano::stat::type::vote_rebroadcaster, nano::stat::detail::broadcast_super);
+		return network.flood_vote_all (vote, nano::transport::traffic_type::vote_rebroadcast, true /* rebroadcasted */);
+	}
+	else
+	{
+		stats.inc (nano::stat::type::vote_rebroadcaster, nano::stat::detail::broadcast);
+		return network.flood_vote (vote, nano::transport::traffic_type::vote_rebroadcast, true /* rebroadcasted */);
+	}
+}
+
+bool nano::vote_rebroadcaster::check_capacity () const
+{
+	if (flags.super_rebroadcaster)
+	{
+		return network.check_capacity_ratio (nano::transport::traffic_type::vote_rebroadcast, 0.5f);
+	}
+	else
+	{
+		return network.check_capacity_fanout (nano::transport::traffic_type::vote_rebroadcast);
 	}
 }
 

--- a/nano/node/vote_rebroadcaster.hpp
+++ b/nano/node/vote_rebroadcaster.hpp
@@ -128,7 +128,7 @@ private:
 class vote_rebroadcaster final
 {
 public:
-	vote_rebroadcaster (vote_rebroadcaster_config const &, nano::ledger &, nano::vote_router &, nano::network &, nano::wallets &, nano::rep_tiers &, nano::stats &, nano::logger &);
+	vote_rebroadcaster (vote_rebroadcaster_config const &, nano::node_flags const &, nano::ledger &, nano::vote_router &, nano::network &, nano::wallets &, nano::rep_tiers &, nano::stats &, nano::logger &);
 	~vote_rebroadcaster ();
 
 	void start ();
@@ -140,6 +140,7 @@ public:
 
 public: // Dependencies
 	vote_rebroadcaster_config const & config;
+	nano::node_flags const & flags;
 	nano::ledger & ledger;
 	nano::vote_router & vote_router;
 	nano::network & network;
@@ -153,6 +154,8 @@ private:
 	void cleanup ();
 	bool process (std::shared_ptr<nano::vote> const &);
 	std::pair<std::shared_ptr<nano::vote>, nano::rep_tier> next ();
+	size_t broadcast (std::shared_ptr<nano::vote> const &);
+	bool check_capacity () const;
 
 private:
 	// Queue of recently processed votes to potentially rebroadcast
@@ -162,7 +165,7 @@ private:
 	nano::locked<vote_rebroadcaster_index> rebroadcasts;
 
 private:
-	std::atomic<bool> non_principal{ true };
+	std::atomic<bool> has_principal{ false };
 	nano::wallet_representatives reps;
 	nano::interval refresh_interval;
 	nano::interval cleanup_interval;
@@ -173,5 +176,6 @@ private:
 	std::thread thread;
 
 	nano::interval log_interval;
+	nano::interval capacity_warning_interval;
 };
 }


### PR DESCRIPTION
Introduces a new "super rebroadcaster" node mode that broadcasts all blocks and votes to all connected peers, bypassing the logarithmic fanout limitation. This is enabled via `--super_rebroadcaster` CLI flag.

### Problem
On the live network, blocks and votes sometimes fail to propagate correctly across the network. The current fanout mechanism uses log(peer_count) to determine how many peers receive each message. This probabilistic approach can result in messages not reaching all nodes, especially during high network activity. Only representative nodes that are not behind NAT are guaranteed to receive all broadcasts.

### Workaround
This is intended as a practical solution for the medium term. Running a few super rebroadcaster nodes on the network can significantly improve message propagation reliability without requiring changes to all nodes.

For the longer term, we plan to introduce proper network topology awareness, which would allow more intelligent message routing and reduce the need for brute-force broadcasting. However, that requires more substantial architectural changes.