### PR TITLE
Fix race condition in `wallets::ongoing_compute_reps`

### DIFF
--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -24,6 +24,7 @@ TEST (wallets, open_create)
 {
 	nano::test::system system (1);
 	auto & node = *system.nodes[0];
+	node.wallets.stop (); // Stop node wallets to avoid race condition with local wallets sharing same LMDB environment
 	auto wallets = make_wallets (node);
 	ASSERT_EQ (1, wallets.items.size ()); // it starts out with a default wallet
 	auto id = nano::random_wallet_id ();
@@ -37,6 +38,7 @@ TEST (wallets, open_existing)
 {
 	nano::test::system system (1);
 	auto & node = *system.nodes[0];
+	node.wallets.stop (); // Stop node wallets to avoid race condition with local wallets sharing same LMDB environment
 	auto id (nano::random_wallet_id ());
 	{
 		auto wallets = make_wallets (node);
@@ -64,6 +66,7 @@ TEST (wallets, remove)
 {
 	nano::test::system system (1);
 	auto & node = *system.nodes[0];
+	node.wallets.stop (); // Stop node wallets to avoid race condition with local wallets sharing same LMDB environment
 	nano::wallet_id one (1);
 	{
 		auto wallets = make_wallets (node);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1824,11 +1824,10 @@ void nano::wallets::compute_reps ()
 void nano::wallets::ongoing_compute_reps ()
 {
 	compute_reps ();
-	auto & node_l (node);
 	// Representation drifts quickly on the test network but very slowly on the live network
 	auto compute_delay = network_params.network.is_dev_network () ? std::chrono::milliseconds (10) : (network_params.network.is_test_network () ? std::chrono::milliseconds (nano::test_scan_wallet_reps_delay ()) : std::chrono::minutes (15));
-	workers.post_delayed (compute_delay, [&node_l] () {
-		node_l.wallets.ongoing_compute_reps ();
+	workers.post_delayed (compute_delay, [this] () {
+		ongoing_compute_reps ();
 	});
 }
 


### PR DESCRIPTION
The issue occurs because multiple wallets instances may share the same underlying wallet store. Ideally, wallets should be instantiable without requiring a full node instance.

```
[ RUN      ] wallets.remove
Assertion `success (open_status)` failed: status: 22 (Invalid argument)
D:\a\nano-node\nano-node\nano\store\lmdb\iterator.cpp:40 [__cdecl nano::store::lmdb::iterator::iterator(struct MDB_txn *,unsigned int) noexcept]'
 0# boost::stacktrace::basic_stacktrace<std::allocator<boost::stacktrace::frame> >::init at D:\a\nano-node\nano-node\submodules\boost\libs\stacktrace\include\boost\stacktrace\stacktrace.hpp:110
 1# boost::stacktrace::basic_stacktrace<std::allocator<boost::stacktrace::frame> >::basic_stacktrace<std::allocator<boost::stacktrace::frame> > at D:\a\nano-node\nano-node\submodules\boost\libs\stacktrace\include\boost\stacktrace\stacktrace.hpp:162
 2# nano::generate_stacktrace at D:\a\nano-node\nano-node\nano\lib\stacktrace.cpp:13
 3# assert_internal at D:\a\nano-node\nano-node\nano\lib\assert.cpp:27
 4# nano::store::lmdb::iterator::iterator at D:\a\nano-node\nano-node\nano\store\lmdb\iterator.cpp:40
 5# nano::store::lmdb::iterator::lower_bound at D:\a\nano-node\nano-node\nano\store\lmdb\iterator.cpp:59
 6# nano::wallet_store::begin at D:\a\nano-node\nano-node\nano\node\wallet.cpp:1912
 7# nano::wallets::compute_reps at D:\a\nano-node\nano-node\nano\node\wallet.cpp:1811
 8# nano::wallets::ongoing_compute_reps at D:\a\nano-node\nano-node\nano\node\wallet.cpp:1827
 9# `nano::wallets::ongoing_compute_reps'::`2'::<lambda_1>::operator() at D:\a\nano-node\nano-node\nano\node\wallet.cpp:1831
10# `nano::thread_pool::post<`nano::wallets::ongoing_compute_reps'::`2'::<lambda_1> >'::`5'::<lambda_1>::operator() at D:\a\nano-node\nano-node\nano\lib\thread_pool.hpp:81
11# boost::asio::detail::binder0<`nano::thread_pool::post<`nano::wallets::ongoing_compute_reps'::`2'::<lambda_1> >'::`5'::<lambda_1> >::operator() at D:\a\nano-node\nano-node\submodules\boost\libs\asio\include\boost\asio\detail\bind_handler.hpp:56
12# boost::asio::detail::executor_op<boost::asio::detail::binder0<`nano::thread_pool::post<`nano::wallets::ongoing_compute_reps'::`2'::<lambda_1> >'::`5'::<lambda_1> >,std::allocator<void>,boost::asio::detail::scheduler_operation>::do_complete at D:\a\nano-node\nano-node\submodules\boost\libs\asio\include\boost\asio\detail\executor_op.hpp:70
13# boost::asio::detail::scheduler_operation::complete at D:\a\nano-node\nano-node\submodules\boost\libs\asio\include\boost\asio\detail\scheduler_operation.hpp:40
14# boost::asio::detail::scheduler::do_run_one at D:\a\nano-node\nano-node\submodules\boost\libs\asio\include\boost\asio\detail\impl\scheduler.ipp:494
15# boost::asio::detail::scheduler::run at D:\a\nano-node\nano-node\submodules\boost\libs\asio\include\boost\asio\detail\impl\scheduler.ipp:210
16# boost::asio::thread_pool::thread_function::operator() at D:\a\nano-node\nano-node\submodules\boost\libs\asio\include\boost\asio\impl\thread_pool.ipp:39
17# boost::asio::detail::win_thread::func<boost::asio::thread_pool::thread_function>::run at D:\a\nano-node\nano-node\submodules\boost\libs\asio\include\boost\asio\detail\win_thread.hpp:122
18# boost::asio::detail::win_thread_function at D:\a\nano-node\nano-node\submodules\boost\libs\asio\include\boost\asio\detail\impl\win_thread.ipp:127
19# register_onexit_function in ucrtbased
20# BaseThreadInitThunk in KERNEL32
21# RtlUserThreadStart in ntdll
```