### PR TITLE
Optimize `enum_convert` to use table lookup instead of string comparison

### DIFF
--- a/nano/core_test/enums.cpp
+++ b/nano/core_test/enums.cpp
@@ -79,6 +79,8 @@ enum class test_enum
 enum class test_enum2
 {
 	one,
+	two,
+	three,
 };
 }
 
@@ -122,7 +124,9 @@ TEST (enum_util, parse)
 	ASSERT_THROW (nano::enum_parse<test_enum> ("_invalid"), std::invalid_argument);
 }
 
-TEST (enum_util, cast)
+TEST (enum_util, convert)
 {
 	ASSERT_EQ (nano::enum_convert<test_enum> (test_enum2::one), test_enum::one);
+	ASSERT_EQ (nano::enum_convert<test_enum> (test_enum2::two), test_enum::two);
+	ASSERT_EQ (nano::enum_convert<test_enum> (test_enum2::three), test_enum::three);
 }

--- a/nano/lib/enum_util.hpp
+++ b/nano/lib/enum_util.hpp
@@ -4,6 +4,7 @@
 
 #include <magic_enum.hpp>
 #include <magic_enum_containers.hpp>
+#include <magic_enum_switch.hpp>
 
 namespace nano
 {
@@ -105,13 +106,20 @@ E enum_parse (std::string_view name, bool ignore_reserved = true)
 /**
  * Converts an enum value to another enum type by matching names.
  * Validates at compile-time that all source enum values exist in target enum.
+ * Uses enum_switch to generate a switch statement instead of runtime string comparison.
  */
 template <class T, class S>
 	requires enum_convertible_to<S, T>
-T enum_convert (S value)
+constexpr T enum_convert (S value)
 {
-	auto conv = magic_enum::enum_cast<T> (nano::enum_to_string (value));
-	debug_assert (conv);
-	return conv.value_or (T{});
+	return magic_enum::enum_switch (
+	[] (auto val) -> T {
+		constexpr S src_value = decltype (val)::value;
+		constexpr auto name = magic_enum::enum_name (src_value);
+		constexpr auto conv = magic_enum::enum_cast<T> (name);
+		static_assert (conv.has_value ());
+		return *conv;
+	},
+	value, T{});
 }
 }


### PR DESCRIPTION
All name lookups and enum_cast calls now happen at compile time, allowing the compiler to generate a direct lookup table.
Verified on ARM64, release build                                                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  
Before:                                                                                                                                                                                                                                                                                                                                                                                                                                 
>   ; ~112 bytes, O(n) with loop and function call                                                                                                                                                                                                                                                                                                                                                                                          
>   cmp   w0, #0xf                                                                                                                                                                                                                                                                                                                                                                                                                          
>   ...                                                                                                                                                                                                                                                                                                                                                                                                                                     
>   ; Loop iterating through target enum entries:                                                                                                                                                                                                                                                                                                                                                                                           
>   104: ldr      x8, [x22]           ; load string length                                                                                                                                                                                                                                                                                                                                                                                  
>   108: cmp      x19, x8             ; compare lengths                                                                                                                                                                                                                                                                                                                                                                                     
>   10c: b.ne     0xf4              ; mismatch -> next iteration                                                                                                                                                                                                                                                                                                                                                                            
>   ...                                                                                                                                                                                                                                                                                                                                                                                                                                     
>   11c: bl       memcmp              ; string comparison call                                                                                                                                                                                                                                                                                                                                                                              
>   120: cbnz     w0, 0xf4          ; mismatch -> loop back

                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  

After:                                                                                                                                                                                                                                                                                                                                                                                                                                  
>   ; 32 bytes, O(1) direct table lookup                                                                                                                                                                                                                                                                                                                                                                                                    
>   90: cmp       w0, #0xf              ; bounds check                                                                                                                                                                                                                                                                                                                                                                                      
>   94: b.hi      0xac               ; out-of-bounds -> return default                                                                                                                                                                                                                                                                                                                                                                      
>   98: sxtb      x8, w0              ; sign-extend enum value                                                                                                                                                                                                                                                                                                                                                                              
>   9c: adrp      x9, table          ; load table address                                                                                                                                                                                                                                                                                                                                                                                   
>   a4: ldr       w0, [x9, x8, lsl #2] ; DIRECT TABLE LOOKUP   