### PR TITLE
Introduce `node_scope_guard` to ensure proper node shutdown

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3875,3 +3875,25 @@ TEST (node, super_rebroadcaster)
 	ASSERT_TIMELY (5s, node3.block_confirmed (send->hash ()));
 	ASSERT_TIMELY (5s, node4.block_confirmed (send->hash ()));
 }
+
+// Tests that when two nodes try to bind to the same port, the second node fails gracefully
+TEST (node, port_already_in_use)
+{
+	nano::test::system system;
+
+	// Start first node on the port
+	auto node1 = system.add_node ();
+	ASSERT_NE (0, node1->network.port);
+
+	// Try to start second node on the same port
+	nano::node_config config2{ node1->network.port };
+
+	// Create node in a scope so it gets destroyed if start() throws
+	auto node2 = std::make_shared<nano::node> (system.io_ctx, nano::unique_path (), config2, system.work);
+
+	// This should throw boost::system::system_error indicating port is already in use
+	ASSERT_THROW (node2->start (), boost::system::system_error);
+
+	// Exit gracefully
+	node2->stop ();
+}

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -206,6 +206,7 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 	catch (std::exception const & ex)
 	{
 		logger.critical (nano::log::type::daemon, "Error: {}", ex.what ());
+		std::exit (1);
 	}
 
 	logger.info (nano::log::type::daemon, "Stopped");

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -12,6 +12,7 @@
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/json_handler.hpp>
 #include <nano/node/node.hpp>
+#include <nano/node/node_scope_guard.hpp>
 #include <nano/node/openclwork.hpp>
 #include <nano/rpc/rpc.hpp>
 
@@ -120,7 +121,9 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 			config.node.peering_port = network_params.network.default_node_port;
 		}
 
-		auto node = std::make_shared<nano::node> (io_ctx, data_path, config.node, opencl_work, flags);
+		// Use a scope guard to ensure node->stop() is called while we still hold a shared_ptr (even in case of exceptions)
+		nano::node_scope_guard node{ std::make_shared<nano::node> (io_ctx, data_path, config.node, opencl_work, flags) };
+
 		// IO context runner should be started first and stopped last to allow asio handlers to execute during node start/stop
 		runner = std::make_unique<nano::thread_runner> (io_ctx, logger, node->config.io_threads, nano::thread_role::name::io_daemon);
 

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -15,6 +15,7 @@
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/json_handler.hpp>
 #include <nano/node/node_rpc_config.hpp>
+#include <nano/node/node_scope_guard.hpp>
 #include <nano/qt/qt.hpp>
 #include <nano/rpc/rpc.hpp>
 
@@ -117,7 +118,6 @@ public:
 
 			try
 			{
-				std::shared_ptr<nano::node> node;
 				std::shared_ptr<nano_qt::wallet> gui;
 				nano::set_application_icon (application);
 				auto opencl = nano::opencl_work::create (config.opencl_enable, config.opencl, logger, config.node.network_params.work);
@@ -129,7 +129,7 @@ public:
 					};
 				}
 				nano::work_pool work{ config.node.network_params.network, config.node.work_threads, config.node.pow_sleep_interval, opencl_work_func };
-				node = std::make_shared<nano::node> (io_ctx, data_path, config.node, work, flags);
+				nano::node_scope_guard node{ std::make_shared<nano::node> (io_ctx, data_path, config.node, work, flags) };
 				auto wallet (node->wallets.open (wallet_config.wallet));
 				if (wallet == nullptr)
 				{

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -116,6 +116,7 @@ add_library(
   node_rpc_config.cpp
   node_wrapper.hpp
   node_wrapper.cpp
+  node_scope_guard.hpp
   inactive_node.hpp
   inactive_node.cpp
   node.hpp

--- a/nano/node/node_scope_guard.hpp
+++ b/nano/node/node_scope_guard.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <nano/node/node.hpp>
+
+#include <memory>
+
+namespace nano
+{
+/**
+ * RAII guard to ensure node is properly stopped before shared_ptr destruction.
+ * This prevents bad_weak_ptr exceptions when stop() is called from the destructor
+ * (where shared_from_this() can no longer work because refcount is 0).
+ */
+class node_scope_guard
+{
+public:
+	explicit node_scope_guard (std::shared_ptr<nano::node> node_a) :
+		node{ std::move (node_a) }
+	{
+	}
+
+	~node_scope_guard ()
+	{
+		if (node)
+		{
+			node->stop ();
+		}
+	}
+
+	// Non-copyable
+	node_scope_guard (node_scope_guard const &) = delete;
+	node_scope_guard & operator= (node_scope_guard const &) = delete;
+
+	// Movable
+	node_scope_guard (node_scope_guard && other) noexcept :
+		node{ std::move (other.node) }
+	{
+	}
+
+	node_scope_guard & operator= (node_scope_guard && other) noexcept
+	{
+		if (this != &other)
+		{
+			node = std::move (other.node);
+		}
+		return *this;
+	}
+
+	nano::node & operator* () const
+	{
+		return *node;
+	}
+
+	nano::node * operator->() const
+	{
+		return node.get ();
+	}
+
+	nano::node * get () const
+	{
+		return node.get ();
+	}
+
+private:
+	std::shared_ptr<nano::node> node;
+};
+}

--- a/nano/node/transport/tcp_listener.cpp
+++ b/nano/node/transport/tcp_listener.cpp
@@ -49,7 +49,15 @@ void nano::transport::tcp_listener::start ()
 		asio::ip::tcp::endpoint target{ asio::ip::address_v6::any (), port };
 
 		acceptor.open (target.protocol ());
+
+#ifndef _WIN32
+		// On Unix, SO_REUSEADDR allows binding to a port in TIME_WAIT state,
+		// but still fails if the port is actively bound by another socket.
+		// On Windows, SO_REUSEADDR has different semantics - it allows multiple
+		// sockets to bind to the same port (port stealing), so we skip it there.
 		acceptor.set_option (asio::ip::tcp::acceptor::reuse_address (true));
+#endif
+
 		acceptor.bind (target);
 		acceptor.listen (asio::socket_base::max_listen_connections);
 

--- a/systest/bind_failure.sh
+++ b/systest/bind_failure.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -eu
+
+# Test that node exits gracefully when port is already in use.
+# Verifies:
+# - No uncaught exception (terminate called)
+# - Non-zero exit code for error
+# - Exit code is not from signal termination
+
+DATADIR1=$(mktemp -d)
+DATADIR2=$(mktemp -d)
+PORT=44999
+
+cleanup() {
+    kill $NODE1_PID 2>/dev/null || true
+    rm -rf "$DATADIR1" "$DATADIR2"
+}
+trap cleanup EXIT
+
+# Start first node
+$NANO_NODE_EXE --daemon --network dev --data_path "$DATADIR1" --config node.peering_port=$PORT &
+NODE1_PID=$!
+sleep 3
+
+# Start second node on same port - should fail gracefully
+set +e
+OUTPUT=$($NANO_NODE_EXE --daemon --network dev --data_path "$DATADIR2" --config node.peering_port=$PORT 2>&1)
+EXIT_CODE=$?
+set -e
+
+# Check for any uncaught exception causing terminate
+if echo "$OUTPUT" | grep -q "terminate called"; then
+    echo "FAIL: Node crashed with uncaught exception"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+# Check exit code is non-zero (indicates error was detected)
+if [ $EXIT_CODE -eq 0 ]; then
+    echo "FAIL: Node should exit with non-zero code on bind failure"
+    exit 1
+fi
+
+# Check exit code is not from signal (128+ indicates killed by signal)
+if [ $EXIT_CODE -ge 128 ]; then
+    echo "FAIL: Node terminated by signal (exit code $EXIT_CODE)"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+echo "PASS: Node exited gracefully with code $EXIT_CODE"


### PR DESCRIPTION
Fixes std::bad_weak_ptr crash when node startup fails (e.g., port already in use).                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
When node->start() throws, the node's shared_ptr goes out of scope and the destructor calls stop(). At this point shared_from_this() fails because refcount is 0.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         
The node_scope_guard RAII wrapper ensures stop() is called while we still hold a valid shared_ptr, preventing the crash. Applied to both daemon and wallet entry points.
```
Running: daemon_interrupt.sh
  ++ mktemp -d
  + DATADIR=/tmp/tmp.BwrO4o40ii
  + NODE_PID=605779
  + sleep 10
  + ./nano_node --daemon --network dev --data_path /tmp/tmp.BwrO4o40ii
  Config file `config-log.toml` not found, using default configuration
  Logging to file: /tmp/tmp.BwrO4o40ii/log/log_2026-01-22_00-10-09_561436176.log
  [2026-01-22 00:10:09.561] [daemon] [info] Daemon started
  [2026-01-22 00:10:09.561] [daemon] [info] Version: TAG_VERSION_STRING
  [2026-01-22 00:10:09.561] [daemon] [info] Build info: GIT_COMMIT_HASH "Clang version " "18.1.3 (1ubuntu1)" "BOOST 108600" BUILT "Jan 21 2026"
  [2026-01-22 00:10:09.561] [daemon] [info] Data path: /tmp/tmp.BwrO4o40ii
  [2026-01-22 00:10:09.561] [daemon] [info] Start time: Thu Jan 22 00:10:09 2026 UTC
  Default database backend overridden by NANO_BACKEND environment variable: rocksdb
  [2026-01-22 00:10:09.562] [daemon] [info] Starting up Nano node...
  [2026-01-22 00:10:09.562] [daemon] [info] Hardware concurrency: 4 (configured: 4)
  [2026-01-22 00:10:09.562] [daemon] [info] File descriptor limit: 65536 (hard cap: 65536)
  [2026-01-22 00:10:09.562] [init] [info] Using data directory: /tmp/tmp.BwrO4o40ii
  [2026-01-22 00:10:09.563] [init] [info] Generated new local node ID: node_3rt65a76scyzocgc6aftf1hqhsc5tbbyssnbpzby55f7s8bfy5wngfson7ai
  [2026-01-22 00:10:09.566] [ledger_store] [info] Initializing ledger store: /tmp/tmp.BwrO4o40ii/rocksdb
  [2026-01-22 00:10:09.566] [ledger_store] [info] No existing ledger found, a new database will be created.
  [2026-01-22 00:10:09.566] [ledger_store] [info] Creating new ledger database with version 24 at '/tmp/tmp.BwrO4o40ii/rocksdb'
  [2026-01-22 00:10:10.073] [ledger] [info] Loading ledger, this may take a while...
  [2026-01-22 00:10:10.073] [ledger] [info] Initializing ledger with genesis block: 04270D7F11C4B2B472F2854C5A59F2A7E84226CE9ED799DE75744BD7D85FC9D9
  [2026-01-22 00:10:10.089] [ledger] [info] Block count:              1
  [2026-01-22 00:10:10.089] [ledger] [info] Cemented count:           1
  [2026-01-22 00:10:10.089] [ledger] [info] Account count:            1
  [2026-01-22 00:10:10.089] [ledger] [info] Pruned count:             0
  [2026-01-22 00:10:10.089] [ledger] [info] Representative count:     1
  [2026-01-22 00:10:10.089] [ledger] [info] Active balance: 340,282,366 | pending: 0 | burned: 0
  [2026-01-22 00:10:10.089] [ledger] [info] Weight committed: 340,282,366 | unused: 0
  [2026-01-22 00:10:10.105] [wallet] [info] Loading wallets from: /tmp/tmp.BwrO4o40ii/wallets.ldb
  [2026-01-22 00:10:10.106] [wallet] [info] Found 0 wallet(s)
  [2026-01-22 00:10:10.107] [node] [info] Version: TAG_VERSION_STRING
  [2026-01-22 00:10:10.107] [node] [info] Build information: GIT_COMMIT_HASH "Clang version " "18.1.3 (1ubuntu1)" "BOOST 108600" BUILT "Jan 21 2026"
  [2026-01-22 00:10:10.107] [node] [info] Active network: dev
  [2026-01-22 00:10:10.107] [node] [info] Database backend: RocksDB 10.4.2
  [2026-01-22 00:10:10.107] [node] [info] Data path: /tmp/tmp.BwrO4o40ii
  [2026-01-22 00:10:10.107] [node] [info] Ledger path: /tmp/tmp.BwrO4o40ii/rocksdb
  [2026-01-22 00:10:10.107] [node] [info] Work pool threads: 1 (CPU)
  [2026-01-22 00:10:10.107] [node] [info] Work peers: 0
  [2026-01-22 00:10:10.107] [node] [info] Node ID: node_3rt65a76scyzocgc6aftf1hqhsc5tbbyssnbpzby55f7s8bfy5wngfson7ai
  [2026-01-22 00:10:10.107] [node] [info] Number of buckets: 63
  [2026-01-22 00:10:10.107] [node] [info] Genesis block: 04270D7F11C4B2B472F2854C5A59F2A7E84226CE9ED799DE75744BD7D85FC9D9
  [2026-01-22 00:10:10.107] [node] [info] Genesis account: nano_3e3j5tkog48pnny9dmfzj1r16pg8t1e76dz5tmac6iq689wyjfpiij4txtdo
  [2026-01-22 00:10:10.107] [node] [info] Outbound bandwidth limit: 10485760 bytes/s, burst ratio: 3
  [2026-01-22 00:10:10.107] [node] [info] Voting is enabled, more system resources will be used, local representatives: 0
  [2026-01-22 00:10:10.107] [tcp_listener] [critical] Error while binding for incoming TCP: Address already in use (port: 44000)
  [2026-01-22 00:10:10.107] [node] [info] Stopping...
  terminate called after throwing an instance of 'std::bad_weak_ptr'
    what():  bad_weak_ptr
  ./..//systest/daemon_interrupt.sh: line 11: 605779 Aborted                 $NANO_NODE_EXE --daemon --network dev --data_path $DATADIR
  + kill -SIGINT 605779
  ./..//systest/daemon_interrupt.sh: line 14: kill: (605779) - No such process
```