### PR TITLE
Cancel deadline timer in socket_base destructor

### DIFF
--- a/nano/lib/ipc.cpp
+++ b/nano/lib/ipc.cpp
@@ -6,6 +6,11 @@ nano::ipc::socket_base::socket_base (boost::asio::io_context & io_ctx_a) :
 {
 }
 
+nano::ipc::socket_base::~socket_base ()
+{
+	timer_cancel ();
+}
+
 void nano::ipc::socket_base::timer_start (std::chrono::seconds timeout_a)
 {
 	if (timeout_a < std::chrono::seconds::max ())

--- a/nano/lib/ipc.hpp
+++ b/nano/lib/ipc.hpp
@@ -30,7 +30,7 @@ namespace ipc
 	{
 	public:
 		socket_base (boost::asio::io_context & io_ctx_a);
-		virtual ~socket_base () = default;
+		virtual ~socket_base ();
 
 		/** Close socket */
 		virtual void close () = 0;


### PR DESCRIPTION
This is an attempt to fix an issue with deadline timer we're having when running rpc tests:
```
/Users/runner/work/nano-node/nano-node/submodules/boost/libs/asio/include/boost/asio/basic_deadline_timer.hpp:548:41: runtime error: member call on address 0x600003c68c40 which does not point to an object of type 'boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost::posix_time::ptime>>'
  0x600003c68c40: note: object has invalid vptr
   00 00 00 00  40 8c c6 c0 c2 bf 00 00  11 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
                ^~~~~~~~~~~~~~~~~~~~~~~
                invalid vptr
```