### PR TITLE
Gracefully stop `rpc` on failure

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4013,7 +4013,14 @@ void nano::json_handler::stop ()
 	response_errors ();
 	if (!ec)
 	{
-		stop_callback ();
+		try
+		{
+			stop_callback ();
+		}
+		catch (std::exception const & ex)
+		{
+			release_assert (false, "unexpected exception in stop callback", ex.what ());
+		}
 	}
 }
 

--- a/nano/rpc/rpc.cpp
+++ b/nano/rpc/rpc.cpp
@@ -79,7 +79,11 @@ void nano::rpc::stop ()
 {
 	stopped = true;
 	boost::system::error_code ec;
-	acceptor.close (ec); // Best effort to close, ignore errors during shutdown
+	acceptor.close (ec);
+	if (ec)
+	{
+		logger.error (nano::log::type::rpc, "Error while closing RPC acceptor during shutdown: {}", ec.message ());
+	}
 }
 
 std::shared_ptr<nano::rpc> nano::get_rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a)

--- a/nano/rpc/rpc.cpp
+++ b/nano/rpc/rpc.cpp
@@ -78,7 +78,8 @@ void nano::rpc::accept ()
 void nano::rpc::stop ()
 {
 	stopped = true;
-	acceptor.close ();
+	boost::system::error_code ec;
+	acceptor.close (ec); // Best effort to close, ignore errors during shutdown
 }
 
 std::shared_ptr<nano::rpc> nano::get_rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a)


### PR DESCRIPTION
This is an attempt to fix the following error:
```
 Assertion `false && "RPC already responded and should only respond once"` failed
  /home/runner/work/nano-node/nano-node/nano/rpc/rpc_connection.cpp:54 [void nano::rpc_connection::write_result(std::string, unsigned int, boost::beast::http::status)]'
   0# nano::generate_stacktrace[abi:cxx11]() at /home/runner/work/nano-node/nano-node/nano/lib/stacktrace.cpp:13
   1# assert_internal(char const*, char const*, char const*, unsigned int, bool, std::basic_string_view<char, std::char_traits<char> >) at /home/runner/work/nano-node/nano-node/nano/lib/assert.cpp:28
   2# nano::rpc_connection::write_result(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned int, boost::beast::http::status) at /home/runner/work/nano-node/nano-node/nano/rpc/rpc_connection.cpp:56
   3# nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}::operator()() const::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#1}::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const at /home/runner/work/nano-node/nano-node/nano/rpc/rpc_connection.cpp:120
   4# void std::__invoke_impl<void, nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}::operator()() const::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#1}&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(std::__invoke_other, nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}::operator()() const::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#1}&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /usr/include/c++/13/bits/invoke.h:61
   5# std::enable_if<is_invocable_r_v<void, nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}::operator()() const::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#1}&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>, void>::type std::__invoke_r<void, nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}::operator()() const::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#1}&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}::operator()() const::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#1}&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /usr/include/c++/13/bits/invoke.h:117
   6# std::_Function_handler<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}::operator()() const::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)#1}>::_M_invoke(std::_Any_data const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /usr/include/c++/13/bits/std_function.h:291
   7# std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const at /usr/include/c++/13/bits/std_function.h:591
   8# nano::json_error_response(std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) at /home/runner/work/nano-node/nano-node/nano/lib/json_error_response.hpp:14
   9# nano::json_handler::process_request(bool) at /home/runner/work/nano-node/nano-node/nano/node/json_handler.cpp:143
  10# nano::inprocess_rpc_handler::process_request(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>) at /home/runner/work/nano-node/nano-node/nano/node/json_handler.cpp:5276
  11# nano::rpc_handler::process_request(nano::rpc_handler_request_params const&) at /home/runner/work/nano-node/nano-node/nano/rpc/rpc_handler.cpp:114
  12# nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}::operator()() const at /home/runner/work/nano-node/nano-node/nano/rpc/rpc_connection.cpp:146
  13# void boost::asio::detail::handler_work<nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul>, void>::complete<nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}>(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}&) at /home/runner/work/nano-node/nano-node/submodules/boost/libs/asio/include/boost/asio/detail/handler_work.hpp:476
  14# boost::asio::detail::completion_handler<nano::rpc_connection::parse_request<boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> > >(boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >&, std::shared_ptr<boost::beast::http::parser<true, boost::beast::http::empty_body, std::allocator<char> > > const&)::{lambda(boost::system::error_code const&, unsigned long)#1}::operator()(boost::system::error_code const&, unsigned long) const::{lambda()#1}, boost::asio::io_context::basic_executor_type<std::allocator<void>, 0ul> >::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) at /home/runner/work/nano-node/nano-node/submodules/boost/libs/asio/include/boost/asio/detail/completion_handler.hpp:76
  15# boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) at /home/runner/work/nano-node/nano-node/submodules/boost/libs/asio/include/boost/asio/detail/scheduler_operation.hpp:41
  16# boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) at /home/runner/work/nano-node/nano-node/submodules/boost/libs/asio/include/boost/asio/detail/impl/scheduler.ipp:494
  17# boost::asio::detail::scheduler::run(boost::system::error_code&) at /home/runner/work/nano-node/nano-node/submodules/boost/libs/asio/include/boost/asio/detail/impl/scheduler.ipp:210
  18# boost::asio::io_context::run() at /home/runner/work/nano-node/nano-node/submodules/boost/libs/asio/include/boost/asio/impl/io_context.ipp:64
  19# nano::thread_runner::run() at /home/runner/work/nano-node/nano-node/nano/lib/thread_runner.cpp:109
  20# nano::thread_runner::start()::{lambda()#1}::operator()() const at /home/runner/work/nano-node/nano-node/nano/lib/thread_runner.cpp:55
  21# boost::detail::thread_data<nano::thread_runner::start()::{lambda()#1}>::run() at /home/runner/work/nano-node/nano-node/submodules/boost/libs/thread/include/boost/thread/detail/thread.hpp:121
  22# thread_proxy at /home/runner/work/nano-node/nano-node/submodules/boost/libs/thread/src/pthread/thread.cpp:194
  23# start_thread at ./nptl/pthread_create.c:447
  24# clone3 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:80
```