### PR TITLE
Fix missed notification race condition in priority scheduler

### DIFF
--- a/nano/core_test/priority_scheduler.cpp
+++ b/nano/core_test/priority_scheduler.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/blocks.hpp>
+#include <nano/lib/thread_pool.hpp>
 #include <nano/node/active_elections.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/scheduler/component.hpp>
@@ -535,4 +536,60 @@ TEST (priority_scheduler, activate_successors)
 	// Assert on stable, observable end-state: both successors become active elections
 	ASSERT_TIMELY (5s, node.active.election (open_destination->qualified_root ()) != nullptr);
 	ASSERT_TIMELY (5s, node.active.election (next_genesis_block->qualified_root ()) != nullptr);
+}
+
+/**
+ * Stress test to verify notifications are not missed in priority scheduler.
+ * If notifications are missed, blocks get stuck and test times out.
+ */
+TEST (priority_scheduler, stress_test)
+{
+	nano::test::system system;
+
+	nano::node_config config = system.default_config ();
+	config.backlog_scan.enable = false; // Disable fallback mechanisms to avoid interference
+
+	nano::node_flags flags;
+	flags.disable_activate_successors = true; // Full control over activations
+
+	auto & node = *system.add_node (config, flags);
+
+	// Create N unconfirmed open blocks
+	// All have balance = 1 raw, so they land in the same bucket
+	constexpr size_t num_blocks = 20;
+	auto blocks = nano::test::setup_independent_blocks (system, node, num_blocks);
+
+	// Worker pool for async activation - decouples notification from activation
+	nano::thread_pool workers{ 1, nano::thread_role::name::unknown };
+	nano::test::start_stop_guard guard{ workers };
+
+	// Track activations via batch_activated callback
+	std::atomic<size_t> activated_count{ 0 };
+	std::atomic<size_t> next_to_activate{ 1 }; // Start from 1 since we activate 0 manually
+
+	node.scheduler.priority.batch_activated.add ([&] (auto const & batch) {
+		activated_count += batch.size ();
+
+		workers.post ([&] () {
+			std::this_thread::yield (); // Increase timing variability
+
+			// Activate the next account
+			auto idx = next_to_activate.fetch_add (1);
+			if (idx < blocks.size ())
+			{
+				auto txn = node.ledger.tx_begin_read ();
+				EXPECT_TRUE (node.scheduler.priority.activate (txn, blocks[idx]->account ()));
+			}
+		});
+	});
+
+	// Kick off the chain by activating the first block
+	ASSERT_TRUE (node.scheduler.priority.activate (node.ledger.tx_begin_read (), blocks[0]->account ()));
+
+	// All blocks should eventually be activated
+	// If race occurs, some activations sit in pool and never get processed → timeout
+	ASSERT_TIMELY (15s, activated_count >= num_blocks);
+
+	// Verify pool is empty (all blocks were activated)
+	ASSERT_TRUE (node.scheduler.priority.empty ());
 }

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -139,7 +139,8 @@ bool nano::scheduler::priority::activate (secure::transaction const & transactio
 
 		bool added = false;
 		{
-			added = pool.lock ()->push (block, bucket_index, priority_timestamp);
+			nano::lock_guard<nano::mutex> guard{ mutex };
+			added = pool.push (block, bucket_index, priority_timestamp);
 		}
 		if (added)
 		{
@@ -171,45 +172,58 @@ bool nano::scheduler::priority::activate (secure::transaction const & transactio
 
 bool nano::scheduler::priority::push (std::shared_ptr<nano::block> const & block, nano::bucket_index bucket, nano::priority_timestamp priority)
 {
-	bool result = pool.lock ()->push (block, bucket, priority);
+	{
+		nano::lock_guard<nano::mutex> guard{ mutex };
+		if (!pool.push (block, bucket, priority))
+		{
+			return false;
+		}
+	}
 	condition.notify_all ();
-	return result;
+	return true;
 }
 
 bool nano::scheduler::priority::activate_successors (secure::transaction const & transaction, nano::block const & block)
 {
 	bool result = activate (transaction, block.account ());
+
 	// Start or vote for the next unconfirmed block in the destination account
 	if (block.is_send () && !block.destination ().is_zero () && block.destination () != block.account ())
 	{
 		result |= activate (transaction, block.destination ());
 	}
+
 	return result;
 }
 
 bool nano::scheduler::priority::contains (nano::block_hash const & hash) const
 {
-	return pool.lock ()->contains (hash);
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return pool.contains (hash);
 }
 
 std::size_t nano::scheduler::priority::size () const
 {
-	return pool.lock ()->size ();
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return pool.size ();
 }
 
 bool nano::scheduler::priority::empty () const
 {
-	return pool.lock ()->empty ();
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return pool.empty ();
 }
 
 size_t nano::scheduler::priority::pool_size () const
 {
-	return pool.lock ()->size ();
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return pool.size ();
 }
 
 size_t nano::scheduler::priority::pool_size (nano::bucket_index bucket) const
 {
-	return pool.lock ()->size (bucket);
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return pool.size (bucket);
 }
 
 size_t nano::scheduler::priority::election_count (nano::bucket_index bucket) const
@@ -220,7 +234,8 @@ size_t nano::scheduler::priority::election_count (nano::bucket_index bucket) con
 
 bool nano::scheduler::priority::predicate () const
 {
-	auto tops = pool.lock ()->top_all ();
+	debug_assert (!mutex.try_lock ());
+	auto tops = pool.top_all ();
 	return std::any_of (buckets.begin (), buckets.end (), [&tops] (auto const & bucket) {
 		return bucket.second->available (find_or_default (tops, bucket.first));
 	});
@@ -244,10 +259,10 @@ void nano::scheduler::priority::run ()
 
 		stats.inc (nano::stat::type::election_scheduler, nano::stat::detail::loop);
 
-		lock.unlock ();
-
 		// Get the top blocks for each bucket
-		auto tops = pool.lock ()->top_all ();
+		auto tops = pool.top_all ();
+
+		lock.unlock ();
 
 		std::deque<nano::block_hash> activated;
 
@@ -262,14 +277,15 @@ void nano::scheduler::priority::run ()
 			}
 		}
 
+		batch_activated.notify (activated); // Notify without the lock held
+
+		lock.lock ();
+
 		// Erase activated blocks from the pool
 		if (!activated.empty ())
 		{
-			pool.lock ()->erase_all (activated);
-			batch_activated.notify (activated); // Notify without the lock held
+			pool.erase_all (activated);
 		}
-
-		lock.lock ();
 	}
 }
 
@@ -316,9 +332,11 @@ nano::container_info nano::scheduler::priority::container_info () const
 		return info;
 	};
 
+	nano::lock_guard<nano::mutex> guard{ mutex };
+
 	nano::container_info info;
 	info.add ("elections", collect_elections ());
-	info.add ("pool", pool.lock ()->container_info ());
+	info.add ("pool", pool.container_info ());
 	return info;
 }
 

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -266,6 +266,7 @@ void nano::scheduler::priority::run ()
 		if (!activated.empty ())
 		{
 			pool.lock ()->erase_all (activated);
+			batch_activated.notify (activated); // Notify without the lock held
 		}
 
 		lock.lock ();

--- a/nano/node/scheduler/priority.hpp
+++ b/nano/node/scheduler/priority.hpp
@@ -4,6 +4,7 @@
 #include <nano/lib/observer_set.hpp>
 #include <nano/node/fwd.hpp>
 #include <nano/node/scheduler/bucket.hpp>
+#include <nano/node/scheduler/priority_pool.hpp>
 
 #include <condition_variable>
 #include <deque>
@@ -44,7 +45,7 @@ public:
 	void stop ();
 
 	/**
-	 * Activates the first unconfirmed block of \p account_a
+	 * Activates the first unconfirmed block of \p account
 	 * @return true if account was activated
 	 */
 	bool activate (nano::secure::transaction const &, nano::account const &);
@@ -87,7 +88,7 @@ private:
 
 private:
 	std::map<nano::bucket_index, std::unique_ptr<scheduler::bucket>> buckets;
-	nano::locked<priority_pool> pool;
+	priority_pool pool;
 
 	bool stopped{ false };
 	nano::condition_variable condition;

--- a/nano/node/scheduler/priority.hpp
+++ b/nano/node/scheduler/priority.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/numbers.hpp>
+#include <nano/lib/observer_set.hpp>
 #include <nano/node/fwd.hpp>
 #include <nano/node/scheduler/bucket.hpp>
 
@@ -63,6 +64,10 @@ public:
 
 public: // Testing
 	bool push (std::shared_ptr<nano::block> const & block, nano::bucket_index, nano::priority_timestamp);
+
+public: // Events
+	// Triggered when blocks are activated (elections started) in the scheduler run loop
+	nano::observer_set<std::deque<nano::block_hash>> batch_activated;
 
 private: // Dependencies
 	priority_config const & config;


### PR DESCRIPTION
Fixes a race condition where notifications could be missed in the priority scheduler, causing blocks to get stuck in the pool indefinitely.