### PR TITLE
Fix race condition in `vote_router::disconnect (...)`

### DIFF
--- a/nano/node/vote_router.cpp
+++ b/nano/node/vote_router.cpp
@@ -23,29 +23,51 @@ nano::vote_router::~vote_router ()
 	debug_assert (!thread.joinable ());
 }
 
+void nano::vote_router::start ()
+{
+	thread = std::thread{ [this] () {
+		nano::thread_role::set (nano::thread_role::name::vote_router);
+		run ();
+	} };
+}
+
+void nano::vote_router::stop ()
+{
+	{
+		std::unique_lock lock{ mutex };
+		stopped = true;
+	}
+	condition.notify_all ();
+	if (thread.joinable ())
+	{
+		thread.join ();
+	}
+}
+
 void nano::vote_router::connect (nano::block_hash const & hash, std::weak_ptr<nano::election> election)
 {
 	std::unique_lock lock{ mutex };
 	elections.insert_or_assign (hash, election);
 }
 
-void nano::vote_router::disconnect (nano::election const & election)
+std::size_t nano::vote_router::disconnect (nano::election const & election)
 {
 	std::unique_lock lock{ mutex };
+	std::size_t erased = 0;
 	for (auto const & [hash, _] : election.blocks ())
 	{
-		elections.erase (hash);
+		erased += elections.erase (hash);
 	}
+	return erased;
 }
 
-void nano::vote_router::disconnect (nano::block_hash const & hash)
+bool nano::vote_router::disconnect (nano::block_hash const & hash)
 {
 	std::unique_lock lock{ mutex };
-	[[maybe_unused]] auto erased = elections.erase (hash);
-	debug_assert (erased == 1);
+	auto erased = elections.erase (hash);
+	return erased > 0;
 }
 
-// Validate a vote and apply it to the current election if one exists
 std::unordered_map<nano::block_hash, nano::vote_code> nano::vote_router::vote (std::shared_ptr<nano::vote> const & vote, nano::vote_source source, nano::block_hash filter)
 {
 	debug_assert (!vote->validate ()); // false => valid vote
@@ -146,31 +168,19 @@ std::shared_ptr<nano::election> nano::vote_router::election (nano::block_hash co
 	return nullptr;
 }
 
-// This is meant to be a fast check and may return false positives if weak pointers have expired, but we don't care about that here
 bool nano::vote_router::contains (nano::block_hash const & hash) const
 {
 	std::shared_lock lock{ mutex };
 	return elections.contains (hash);
 }
 
-void nano::vote_router::start ()
+nano::container_info nano::vote_router::container_info () const
 {
-	thread = std::thread{ [this] () {
-		nano::thread_role::set (nano::thread_role::name::vote_router);
-		run ();
-	} };
-}
+	std::shared_lock lock{ mutex };
 
-void nano::vote_router::stop ()
-{
-	std::unique_lock lock{ mutex };
-	stopped = true;
-	lock.unlock ();
-	condition.notify_all ();
-	if (thread.joinable ())
-	{
-		thread.join ();
-	}
+	nano::container_info info;
+	info.put ("elections", elections);
+	return info;
 }
 
 void nano::vote_router::run ()
@@ -181,15 +191,6 @@ void nano::vote_router::run ()
 		std::erase_if (elections, [] (auto const & pair) { return pair.second.lock () == nullptr; });
 		condition.wait_for (lock, 15s, [&] () { return stopped; });
 	}
-}
-
-nano::container_info nano::vote_router::container_info () const
-{
-	std::shared_lock lock{ mutex };
-
-	nano::container_info info;
-	info.put ("elections", elections);
-	return info;
 }
 
 /*

--- a/nano/node/vote_router.hpp
+++ b/nano/node/vote_router.hpp
@@ -4,6 +4,7 @@
 #include <nano/lib/numbers_templ.hpp>
 #include <nano/node/fwd.hpp>
 
+#include <condition_variable>
 #include <memory>
 #include <shared_mutex>
 #include <thread>
@@ -34,39 +35,54 @@ enum class vote_source
 nano::stat::detail to_stat_detail (vote_source);
 std::string_view to_string (vote_source);
 
-// This class routes votes to their associated election
-// This class holds a weak_ptr as this container does not own the elections
-// Routing entries are removed periodically if the weak_ptr has expired
+/**
+ * Routes votes to their associated elections.
+ * Holds weak_ptr to elections as this container does not own them.
+ * Routing entries are removed periodically if the weak_ptr has expired.
+ */
 class vote_router final
 {
 public:
-	vote_router (nano::vote_cache & cache, nano::recently_confirmed_cache & recently_confirmed);
+	vote_router (nano::vote_cache &, nano::recently_confirmed_cache &);
 	~vote_router ();
 
 	void start ();
 	void stop ();
 
-	// Add a route for 'hash' to 'election'
-	// Existing routes will be replaced
-	// Election must hold the block for the hash being passed in
+	/**
+	 * Add a route for 'hash' to 'election'.
+	 * Existing routes will be replaced.
+	 * Election must hold the block for the hash being passed in.
+	 */
 	void connect (nano::block_hash const & hash, std::weak_ptr<nano::election> election);
-	// Remove all routes to this election
-	void disconnect (nano::election const & election);
-	void disconnect (nano::block_hash const & hash);
-	// Route vote to associated elections
-	// Distinguishes replay votes, cannot be determined if the block is not in any election
+	/**
+	 * Remove all routes to this election.
+	 * @return number of routes removed
+	 */
+	std::size_t disconnect (nano::election const & election);
+	/**
+	 * Remove route for hash.
+	 * @return true if route existed and was removed
+	 */
+	bool disconnect (nano::block_hash const & hash);
 
-	// If 'filter' parameter is non-zero, only elections for the specified hash are notified.
-	// This eliminates duplicate processing when triggering votes from the vote_cache as the result of a specific election being created.
+	/**
+	 * Route vote to associated elections.
+	 * Distinguishes replay votes, cannot be determined if the block is not in any election.
+	 * If 'filter' parameter is non-zero, only elections for the specified hash are notified.
+	 * This eliminates duplicate processing when triggering votes from the vote_cache as the result of a specific election being created.
+	 */
 	std::unordered_map<nano::block_hash, nano::vote_code> vote (std::shared_ptr<nano::vote> const &, nano::vote_source = nano::vote_source::live, nano::block_hash filter = { 0 });
+
 	bool active (nano::block_hash const & hash) const;
 	std::shared_ptr<nano::election> election (nano::block_hash const & hash) const;
 	bool contains (nano::block_hash const & hash) const;
 
+	nano::container_info container_info () const;
+
+public: // Events
 	using vote_processed_event_t = nano::observer_set<std::shared_ptr<nano::vote> const &, nano::vote_source, std::unordered_map<nano::block_hash, nano::vote_code> const &>;
 	vote_processed_event_t vote_processed;
-
-	nano::container_info container_info () const;
 
 private: // Dependencies
 	nano::vote_cache & vote_cache;
@@ -75,14 +91,12 @@ private: // Dependencies
 private:
 	void run ();
 
-private:
-	// Mapping of block hashes to elections.
-	// Election already contains the associated block
+	// Mapping of block hashes to elections
 	std::unordered_map<nano::block_hash, std::weak_ptr<nano::election>> elections;
 
 	bool stopped{ false };
-	std::condition_variable_any condition;
 	mutable std::shared_mutex mutex;
+	std::condition_variable_any condition;
 	std::thread thread;
 };
 }


### PR DESCRIPTION
Fixes intermittent test error:
```
[ RUN      ] active_elections.fork_replacement_tally
Assertion `erased == 1` failed
/Users/runner/work/nano-node/nano-node/nano/node/vote_router.cpp:45 [void nano::vote_router::disconnect(const nano::block_hash &)]'
 0# nano::generate_stacktrace() in /Users/runner/work/nano-node/nano-node/build/core_test
 1# assert_internal(char const*, char const*, char const*, unsigned int, bool, std::__1::basic_string_view<char, std::__1::char_traits<char>>) in /Users/runner/work/nano-node/nano-node/build/core_test
 2# nano::vote_router::disconnect(nano::block_hash const&) in /Users/runner/work/nano-node/nano-node/build/core_test
 3# nano::election::replace_by_weight(std::__1::unique_lock<nano::mutex>&, nano::block_hash const&) in /Users/runner/work/nano-node/nano-node/build/core_test
 4# nano::election::publish(std::__1::shared_ptr<nano::block> const&) in /Users/runner/work/nano-node/nano-node/build/core_test
 5# nano::active_elections::publish(std::__1::shared_ptr<nano::block> const&) in /Users/runner/work/nano-node/nano-node/build/core_test
 6# auto nano::active_elections::active_elections(nano::node&, nano::ledger_notifications&, nano::cementing_set&)::$_1::operator()<std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>>(std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&) const in /Users/runner/work/nano-node/nano-node/build/core_test
 7# decltype(std::declval<nano::active_elections::active_elections(nano::node&, nano::ledger_notifications&, nano::cementing_set&)::$_1&>()(std::declval<std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&>())) std::__1::__invoke[abi:ue170006]<nano::active_elections::active_elections(nano::node&, nano::ledger_notifications&, nano::cementing_set&)::$_1&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&>(nano::active_elections::active_elections(nano::node&, nano::ledger_notifications&, nano::cementing_set&)::$_1&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&) in /Users/runner/work/nano-node/nano-node/build/core_test
 8# void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<nano::active_elections::active_elections(nano::node&, nano::ledger_notifications&, nano::cementing_set&)::$_1&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&>(nano::active_elections::active_elections(nano::node&, nano::ledger_notifications&, nano::cementing_set&)::$_1&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&) in /Users/runner/work/nano-node/nano-node/build/core_test
 9# std::__1::__function::__alloc_func<nano::active_elections::active_elections(nano::node&, nano::ledger_notifications&, nano::cementing_set&)::$_1, std::__1::allocator<nano::active_elections::active_elections(nano::node&, nano::ledger_notifications&, nano::cementing_set&)::$_1>, void (std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&)>::operator()[abi:ue170006](std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&) in /Users/runner/work/nano-node/nano-node/build/core_test
10# std::__1::__function::__func<nano::active_elections::active_elections(nano::node&, nano::ledger_notifications&, nano::cementing_set&)::$_1, std::__1::allocator<nano::active_elections::active_elections(nano::node&, nano::ledger_notifications&, nano::cementing_set&)::$_1>, void (std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&)>::operator()(std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&) in /Users/runner/work/nano-node/nano-node/build/core_test
11# std::__1::__function::__value_func<void (std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&)>::operator()[abi:ue170006](std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&) const in /Users/runner/work/nano-node/nano-node/build/core_test
12# std::__1::function<void (std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&)>::operator()(std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&) const in /Users/runner/work/nano-node/nano-node/build/core_test
13# nano::observer_set<std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>>::notify(std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>> const&) const in /Users/runner/work/nano-node/nano-node/build/core_test
14# nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2::operator()() in /Users/runner/work/nano-node/nano-node/build/core_test
15# nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2 auto nano::wrap_move_only<nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2>(nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2&&)::'lambda'(auto&&...)::operator()<>('lambda'(auto&&...)) const in /Users/runner/work/nano-node/nano-node/build/core_test
16# decltype(std::declval<nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2&&>()()) std::__1::__invoke[abi:ue170006]<auto nano::wrap_move_only<nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2>(nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2&&)::'lambda'(auto&&...)&>(auto, decltype(std::declval<nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2&&>()())&&...) in /Users/runner/work/nano-node/nano-node/build/core_test
17# void std::__1::__invoke_void_return_wrapper<void, true>::__call[abi:ue170006]<auto nano::wrap_move_only<nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2>(nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2&&)::'lambda'(auto&&...)&>(auto nano::wrap_move_only<nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2>(nano::ledger_notifications::notify_processed(nano::secure::write_transaction&, std::__1::deque<std::__1::pair<nano::block_status, nano::block_context>, std::__1::allocator<std::__1::pair<nano::block_status, nano::block_context>>>, std::__1::function<void ()>)::$_2&&)::'lambda'(auto&&...)) in /Users/runner/work/nano-node/nano-node/build/core_test
18# _ZNSt3__110__function12__alloc_funcIZN4nano14wrap_move_onlyIZNS2_20ledger_notifications16notify_processedERNS2_6secure17write_transactionENS_5dequeINS_4pairINS2_12block_statusENS2_13block_contextEEENS_9allocatorISC_EEEENS_8functionIFvvEEEE3$_2EEDaOT_EUlDpOT_E_NSD_ISQ_EESH_EclB8ue170006Ev in /Users/runner/work/nano-node/nano-node/build/core_test
19# _ZNSt3__110__function6__funcIZN4nano14wrap_move_onlyIZNS2_20ledger_notifications16notify_processedERNS2_6secure17write_transactionENS_5dequeINS_4pairINS2_12block_statusENS2_13block_contextEEENS_9allocatorISC_EEEENS_8functionIFvvEEEE3$_2EEDaOT_EUlDpOT_E_NSD_ISQ_EESH_EclEv in /Users/runner/work/nano-node/nano-node/build/core_test
20# std::__1::__function::__value_func<void ()>::operator()[abi:ue170006]() const in /Users/runner/work/nano-node/nano-node/build/core_test
21# std::__1::function<void ()>::operator()() const in /Users/runner/work/nano-node/nano-node/build/core_test
22# nano::ledger_notifications::run() in /Users/runner/work/nano-node/nano-node/build/core_test
23# nano::ledger_notifications::start()::$_0::operator()() const in /Users/runner/work/nano-node/nano-node/build/core_test
24# decltype(std::declval<nano::ledger_notifications::start()::$_0>()()) std::__1::__invoke[abi:ue170006]<nano::ledger_notifications::start()::$_0>(nano::ledger_notifications::start()::$_0&&) in /Users/runner/work/nano-node/nano-node/build/core_test
25# void std::__1::__thread_execute[abi:ue170006]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, nano::ledger_notifications::start()::$_0>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, nano::ledger_notifications::start()::$_0>&, std::__1::__tuple_indices<>) in /Users/runner/work/nano-node/nano-node/build/core_test
26# void* std::__1::__thread_proxy[abi:ue170006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, nano::ledger_notifications::start()::$_0>>(void*) in /Users/runner/work/nano-node/nano-node/build/core_test
27# _pthread_start in /usr/lib/system/libsystem_pthread.dylib
```

The race occurs in `election::replace_by_weight()`:

```
Thread A (replace_by_weight):                Thread B (erase_election):
├─ Holds election mutex                      │
├─ Copies last_tally to sorted vector        │
├─ UNLOCKS election mutex (line 772) ◄───────┤─ Can now proceed
├─ Computing which block to replace          │
│                                            ├─ Gets election->blocks() snapshot
│                                            ├─ Calls disconnect(election)
│                                            │  └─ Erases ALL blocks from vote_router
├─ Calls disconnect(replaced_block) ◄────────┤─ Block already erased!


 - Fix assertion failure in vote_router::disconnect(hash) caused by race condition between replace_by_weight() and erase_election()                                                                                                                                                                                                                                                                                                      
  - Return bool from disconnect(hash) indicating if route existed                                                                                                                                                                                                                                                                                                                                                                         
  - Return std::size_t from disconnect(election) with number of routes removed                                                                                                                                                                                                                                                                                                                                                            
  - Reorganize vote_router files to follow project conventions
```

Summary:
1. Thread A enters `replace_by_weight()`, unlocks the election mutex at line 772
2. Thread B calls `erase_election()`, takes a snapshot of `election->blocks()`
3. Thread B calls `vote_router.disconnect(election)` which erases all blocks including the one Thread A will try to disconnect
4. Thread A calls `vote_router.disconnect(replaced_block)` - assertion fails because `erased == 0`