### PR TITLE
Add `--runtime_info_file` flag for ephemeral port discovery

### DIFF
--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -106,6 +106,8 @@ add_library(
   rpc_handler_interface.hpp
   rpcconfig.hpp
   rpcconfig.cpp
+  runtime_files.hpp
+  runtime_files.cpp
   signal_manager.hpp
   signal_manager.cpp
   stacktrace.hpp

--- a/nano/lib/runtime_files.cpp
+++ b/nano/lib/runtime_files.cpp
@@ -1,11 +1,15 @@
 #include <nano/boost/process/process.hpp>
 #include <nano/lib/runtime_files.hpp>
 
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
 #include <mutex>
 #include <set>
+#include <sstream>
 #include <stdexcept>
 
 namespace
@@ -79,4 +83,22 @@ void nano::runtime_files::create_pid_file (std::filesystem::path const & path)
 {
 	auto pid = boost::this_process::get_id ();
 	nano::runtime_files::create (path, std::to_string (pid));
+}
+
+void nano::runtime_files::create_runtime_info (std::filesystem::path const & path, runtime_info const & info)
+{
+	boost::property_tree::ptree tree;
+	tree.put ("peering_port", info.peering_port);
+	if (info.rpc_port != 0)
+	{
+		tree.put ("rpc_port", info.rpc_port);
+	}
+	if (!info.node_id.empty ())
+	{
+		tree.put ("node_id", info.node_id);
+	}
+
+	std::ostringstream oss;
+	boost::property_tree::write_json (oss, tree);
+	nano::runtime_files::create (path, oss.str ());
 }

--- a/nano/lib/runtime_files.cpp
+++ b/nano/lib/runtime_files.cpp
@@ -1,0 +1,82 @@
+#include <nano/boost/process/process.hpp>
+#include <nano/lib/runtime_files.hpp>
+
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <set>
+#include <stdexcept>
+
+namespace
+{
+std::mutex mutex;
+std::set<std::filesystem::path> registered_files;
+bool atexit_registered = false;
+
+void atexit_handler ()
+{
+	nano::runtime_files::cleanup ();
+}
+}
+
+void nano::runtime_files::create (std::filesystem::path const & path, std::string const & contents)
+{
+	// Create parent directories
+	std::error_code ec;
+	std::filesystem::create_directories (path.parent_path (), ec);
+	if (ec)
+	{
+		throw std::runtime_error ("Unable to create runtime file directory: " + ec.message ());
+	}
+
+	// Write file
+	std::ofstream out (path, std::ios::out | std::ios::trunc);
+	if (!out)
+	{
+		throw std::runtime_error ("Unable to open runtime file: " + path.string ());
+	}
+	out << contents;
+	out.close ();
+	if (out.fail ())
+	{
+		throw std::runtime_error ("Unable to write runtime file: " + path.string ());
+	}
+
+	// Register for cleanup
+	std::lock_guard<std::mutex> lock (mutex);
+
+	if (!atexit_registered)
+	{
+		std::atexit (atexit_handler);
+		atexit_registered = true;
+	}
+
+	registered_files.insert (path);
+}
+
+void nano::runtime_files::cleanup ()
+{
+	std::set<std::filesystem::path> files_to_remove;
+	{
+		std::lock_guard<std::mutex> lock (mutex);
+		files_to_remove = std::move (registered_files);
+		registered_files.clear ();
+	}
+
+	for (auto const & path : files_to_remove)
+	{
+		std::error_code ec;
+		std::filesystem::remove (path, ec);
+		if (ec)
+		{
+			std::cerr << "WARNING: Unable to remove runtime file " << path << ": " << ec.message () << "\n";
+		}
+	}
+}
+
+void nano::runtime_files::create_pid_file (std::filesystem::path const & path)
+{
+	auto pid = boost::this_process::get_id ();
+	nano::runtime_files::create (path, std::to_string (pid));
+}

--- a/nano/lib/runtime_files.hpp
+++ b/nano/lib/runtime_files.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+
+/**
+ * Global registry for runtime files that should be cleaned up on process exit.
+ * Files are automatically removed when the process exits, even via std::exit().
+ */
+namespace nano::runtime_files
+{
+/**
+ * Creates a file with the given contents and registers it for cleanup on exit.
+ * Creates parent directories if they don't exist.
+ * @throws std::runtime_error if file creation fails
+ */
+void create (std::filesystem::path const & path, std::string const & contents);
+
+/**
+ * Removes all registered files. Called automatically on process exit.
+ * Can also be called manually for testing.
+ */
+void cleanup ();
+
+/**
+ * Creates a PID file with the current process ID and registers it for cleanup on exit.
+ * @throws std::runtime_error if file creation fails
+ */
+void create_pid_file (std::filesystem::path const & path);
+}

--- a/nano/lib/runtime_files.hpp
+++ b/nano/lib/runtime_files.hpp
@@ -27,4 +27,16 @@ void cleanup ();
  * @throws std::runtime_error if file creation fails
  */
 void create_pid_file (std::filesystem::path const & path);
+
+/**
+ * Creates a runtime info JSON file and registers it for cleanup on exit.
+ * @throws std::runtime_error if file creation fails
+ */
+struct runtime_info
+{
+	uint16_t peering_port{ 0 };
+	uint16_t rpc_port{ 0 }; // 0 if RPC is disabled
+	std::string node_id;
+};
+void create_runtime_info (std::filesystem::path const & path, runtime_info const & info);
 }

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -1,5 +1,6 @@
 #include <nano/boost/process/child.hpp>
 #include <nano/lib/files.hpp>
+#include <nano/lib/runtime_files.hpp>
 #include <nano/lib/signal_manager.hpp>
 #include <nano/lib/stacktrace.hpp>
 #include <nano/lib/thread_runner.hpp>
@@ -173,6 +174,21 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 				rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path.string (), "--network", network);
 			}
 			debug_assert (rpc || rpc_process);
+		}
+
+		// Write runtime info file with actual bound ports (if requested)
+		if (flags.runtime_info_file)
+		{
+			nano::runtime_files::runtime_info info;
+			info.peering_port = node->network.endpoint ().port ();
+			info.node_id = node->get_node_id ().to_node_id ();
+			// Only set if rpc is enabled
+			if (rpc)
+			{
+				info.rpc_port = rpc->listening_port ();
+			}
+			nano::runtime_files::create_runtime_info (*flags.runtime_info_file, info);
+			std::cerr << "Runtime info file created: " << *flags.runtime_info_file << std::endl;
 		}
 
 		auto signal_handler = [this, &stopped] (int signum) {

--- a/nano/nano_node/daemon.hpp
+++ b/nano/nano_node/daemon.hpp
@@ -9,6 +9,6 @@ class daemon
 	nano::logger logger{ "daemon" };
 
 public:
-	void run (std::filesystem::path const &, nano::node_flags const & flags);
+	void run (std::filesystem::path const & data_path, nano::node_flags const &);
 };
 }

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -5,6 +5,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/cli.hpp>
 #include <nano/lib/files.hpp>
+#include <nano/lib/runtime_files.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/lib/version.hpp>
@@ -66,38 +67,6 @@ public:
 	bool operator< (const address_library_pair & other) const;
 	bool operator== (const address_library_pair & other) const;
 };
-std::filesystem::path pid_file;
-void remove_pid_file ()
-{
-	std::error_code ec;
-	std::filesystem::remove (pid_file, ec);
-	if (ec)
-	{
-		std::cerr << "Unable to remove pid file: " << ec.message ();
-	}
-}
-void register_pid_file ()
-{
-	std::error_code ec;
-	auto pid = boost::this_process::get_id ();
-	std::filesystem::create_directories (pid_file.parent_path (), ec);
-	if (ec)
-	{
-		std::cerr << "Unable to access PID file path" << std::endl;
-		return;
-	}
-	std::ofstream pid_file_stream (pid_file, std::ios::out | std::ios::trunc);
-	if (pid_file_stream.is_open ())
-	{
-		pid_file_stream << std::to_string (pid) << std::endl;
-		pid_file_stream.close ();
-		std::atexit (remove_pid_file);
-	}
-	else
-	{
-		std::cerr << "Unable to open PID file for writing." << std::endl;
-	}
-}
 }
 
 int main (int argc, char * const * argv)
@@ -164,7 +133,7 @@ int main (int argc, char * const * argv)
 		("pow_sleep_interval", boost::program_options::value<std::string> (), "Defines the amount to sleep inbetween each pow calculation attempt")
 		("address_column", boost::program_options::value<std::string> (), "Defines which column the addresses are located, 0 indexed (check --debug_output_last_backtrace_dump output)")
 		("silent", "Silent command execution")
-		("pid_file", boost::program_options::value<std::string> (), "If present, node will write its process id to the specified file and delete the file upon exit");
+		("pid_file", boost::program_options::value<std::string> ()->implicit_value ("nano_node.pid"), "Write process ID to file. Optional path argument, defaults to nano_node.pid in current directory");
 	// clang-format on
 	nano::add_node_options (description);
 	nano::add_node_flag_options (description);
@@ -195,8 +164,9 @@ int main (int argc, char * const * argv)
 
 	if (auto existing = vm.find ("pid_file"); existing != vm.end ())
 	{
-		pid_file = existing->second.as<std::string> ();
-		register_pid_file ();
+		auto pid_filepath = std::filesystem::path (existing->second.as<std::string> ());
+		nano::runtime_files::create_pid_file (pid_filepath);
+		std::cerr << "PID file created: " << pid_filepath << std::endl;
 	}
 
 	nano::network_params network_params{ nano::get_active_network () };

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -133,7 +133,8 @@ int main (int argc, char * const * argv)
 		("pow_sleep_interval", boost::program_options::value<std::string> (), "Defines the amount to sleep inbetween each pow calculation attempt")
 		("address_column", boost::program_options::value<std::string> (), "Defines which column the addresses are located, 0 indexed (check --debug_output_last_backtrace_dump output)")
 		("silent", "Silent command execution")
-		("pid_file", boost::program_options::value<std::string> ()->implicit_value ("nano_node.pid"), "Write process ID to file. Optional path argument, defaults to nano_node.pid in current directory");
+		("pid_file", boost::program_options::value<std::string> ()->implicit_value ("nano_node.pid"), "Write process ID to file. Optional path argument, defaults to nano_node.pid in current directory")
+		("runtime_info_file", boost::program_options::value<std::string> ()->implicit_value ("runtime_info.json"), "Write runtime info JSON with ports to file. Optional path argument, defaults to runtime_info.json in current directory");
 	// clang-format on
 	nano::add_node_options (description);
 	nano::add_node_flag_options (description);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -131,8 +131,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("inactive_votes_cache_size", boost::program_options::value<std::size_t>(), "Increase cached votes without active elections size, default 16384")
 		("vote_processor_capacity", boost::program_options::value<std::size_t>(), "Vote processor queue size before dropping votes, default 144k")
 		("disable_large_votes", boost::program_options::value<bool>(), "Disable large votes")
-		("skip_consistency_check", "Skip ledger consistency check on startup, this is not recommended and should only be used for testing or recovery purposes")
-		;
+		("skip_consistency_check", "Skip ledger consistency check on startup, this is not recommended and should only be used for testing or recovery purposes");
 	// clang-format on
 }
 
@@ -211,6 +210,10 @@ void nano::update_flags (nano::node_flags & flags_a, boost::program_options::var
 	if (rpcconfig != vm.end ())
 	{
 		flags_a.rpc_config_overrides = nano::config_overrides (rpcconfig->second.as<std::vector<nano::config_key_value_pair>> ());
+	}
+	if (auto it = vm.find ("runtime_info_file"); it != vm.end ())
+	{
+		flags_a.runtime_info_file = it->second.as<std::string> ();
 	}
 }
 

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -587,7 +587,7 @@ std::shared_ptr<nano::transport::channel> nano::network::find_node_id (nano::acc
 
 nano::endpoint nano::network::endpoint () const
 {
-	return nano::endpoint (boost::asio::ip::address_v6::loopback (), port);
+	return nano::endpoint{ boost::asio::ip::address_v6::loopback (), port };
 }
 
 void nano::network::cleanup (std::chrono::steady_clock::time_point const & cutoff)

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -40,6 +40,7 @@
 #include <nano/store/txn_tracking.hpp>
 
 #include <chrono>
+#include <filesystem>
 #include <optional>
 #include <vector>
 
@@ -193,6 +194,7 @@ public:
 	bool enable_voting{ false };
 	bool super_rebroadcaster{ false }; // Broadcast all blocks and votes to all peers
 	bool fast_bootstrap{ false };
+	std::optional<std::filesystem::path> runtime_info_file; // Write runtime_info.json with ports
 	bool read_only{ false };
 	bool disable_connection_cleanup{ false };
 	nano::generate_cache_flags generate_cache;

--- a/systest/bind_failure.sh
+++ b/systest/bind_failure.sh
@@ -9,7 +9,7 @@ set -eu
 
 DATADIR1=$(mktemp -d)
 DATADIR2=$(mktemp -d)
-PORT=44999
+RUNTIME_INFO="$DATADIR1/runtime_info.json"
 
 cleanup() {
     kill $NODE1_PID 2>/dev/null || true
@@ -17,10 +17,25 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Start first node
-$NANO_NODE_EXE --daemon --network dev --data_path "$DATADIR1" --config node.peering_port=$PORT &
+# Start first node with ephemeral port
+$NANO_NODE_EXE --daemon --network dev --data_path "$DATADIR1" \
+    --runtime_info_file "$RUNTIME_INFO" \
+    --config node.peering_port=0 &
 NODE1_PID=$!
-sleep 3
+
+# Wait for runtime_info.json to appear (indicates node is ready)
+for i in {1..30}; do
+    if [ -f "$RUNTIME_INFO" ]; then
+        break
+    fi
+    sleep 1
+done
+
+[ -f "$RUNTIME_INFO" ] || { echo "FAIL: runtime_info.json not created"; exit 1; }
+
+# Get the peering port from runtime info
+PORT=$(jq -r '.peering_port' "$RUNTIME_INFO")
+[ "$PORT" != "0" ] && [ -n "$PORT" ] && [ "$PORT" != "null" ] || { echo "FAIL: invalid peering_port"; exit 1; }
 
 # Start second node on same port - should fail gracefully
 set +e

--- a/systest/daemon_interrupt.sh
+++ b/systest/daemon_interrupt.sh
@@ -1,14 +1,32 @@
 #!/bin/bash
 set -eux
 
-DATADIR=$(mktemp -d)
+# Test that the daemon handles SIGINT gracefully
 
-# Start the node in daemon mode in the background
-$NANO_NODE_EXE --daemon --network dev --data_path $DATADIR &
+DATADIR=$(mktemp -d)
+RUNTIME_INFO="$DATADIR/runtime_info.json"
+
+cleanup() {
+    kill $NODE_PID 2>/dev/null || true
+    rm -rf "$DATADIR"
+}
+trap cleanup EXIT
+
+# Start the node in daemon mode with ephemeral port
+$NANO_NODE_EXE --daemon --network dev --data_path "$DATADIR" \
+    --runtime_info_file "$RUNTIME_INFO" \
+    --config node.peering_port=0 &
 NODE_PID=$!
 
-# Allow some time for the node to start up completely
-sleep 10
+# Wait for runtime_info.json to appear (indicates node is ready)
+for i in {1..30}; do
+    if [ -f "$RUNTIME_INFO" ]; then
+        break
+    fi
+    sleep 1
+done
+
+[ -f "$RUNTIME_INFO" ] || { echo "FAIL: runtime_info.json not created"; exit 1; }
 
 # Send an interrupt signal to the node process
 kill -SIGINT $NODE_PID

--- a/systest/rpc_stop.sh
+++ b/systest/rpc_stop.sh
@@ -1,17 +1,42 @@
 #!/bin/bash
 set -eux
 
-DATADIR=$(mktemp -d)
+# Test that the RPC stop command gracefully shuts down the node
 
-# Start the node in daemon mode in the background
-$NANO_NODE_EXE --daemon --network dev --data_path $DATADIR --config rpc.enable=true --rpcconfig enable_control=true &
+DATADIR=$(mktemp -d)
+RUNTIME_INFO="$DATADIR/runtime_info.json"
+
+cleanup() {
+    kill $NODE_PID 2>/dev/null || true
+    rm -rf "$DATADIR"
+}
+trap cleanup EXIT
+
+# Start the node in daemon mode with ephemeral ports
+$NANO_NODE_EXE --daemon --network dev --data_path "$DATADIR" \
+    --runtime_info_file "$RUNTIME_INFO" \
+    --config node.peering_port=0 \
+    --config rpc.enable=true \
+    --rpcconfig port=0 \
+    --rpcconfig enable_control=true &
 NODE_PID=$!
 
-# Allow some time for the node to start up completely
-sleep 10
+# Wait for runtime_info.json to appear (indicates node is ready)
+for i in {1..30}; do
+    if [ -f "$RUNTIME_INFO" ]; then
+        break
+    fi
+    sleep 1
+done
+
+[ -f "$RUNTIME_INFO" ] || { echo "FAIL: runtime_info.json not created"; exit 1; }
+
+# Get the RPC port from runtime info
+RPC_PORT=$(jq -r '.rpc_port' "$RUNTIME_INFO")
+[ "$RPC_PORT" != "0" ] && [ -n "$RPC_PORT" ] && [ "$RPC_PORT" != "null" ] || { echo "FAIL: invalid rpc_port"; exit 1; }
 
 # Send the stop rpc command
-curl -g -d '{ "action": "stop" }' '[::1]:45000'
+curl -g -d '{ "action": "stop" }' "[::1]:$RPC_PORT"
 
 # Check if the process has stopped using a timeout to avoid infinite waiting
 if wait $NODE_PID; then

--- a/systest/runtime_files.sh
+++ b/systest/runtime_files.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -eux
+
+# Test runtime files: PID file and runtime info file
+# Both files should be created on startup and cleaned up on exit
+
+DATADIR=$(mktemp -d)
+PID_FILE="$DATADIR/node.pid"
+RUNTIME_INFO="$DATADIR/runtime_info.json"
+
+cleanup() {
+    kill $NODE_PID 2>/dev/null || true
+    rm -rf "$DATADIR"
+}
+trap cleanup EXIT
+
+# Start the node with both --pid_file and --runtime_info_file using ephemeral ports
+$NANO_NODE_EXE --daemon --network dev --data_path "$DATADIR" \
+    --pid_file "$PID_FILE" \
+    --runtime_info_file "$RUNTIME_INFO" \
+    --config node.peering_port=0 \
+    --config rpc.enable=true \
+    --rpcconfig port=0 \
+    --rpcconfig enable_control=true &
+NODE_PID=$!
+
+# Wait for runtime_info.json to appear (indicates node is ready)
+for i in {1..30}; do
+    if [ -f "$RUNTIME_INFO" ]; then
+        break
+    fi
+    sleep 1
+done
+
+# Verify PID file exists and contains correct PID
+[ -f "$PID_FILE" ] || { echo "FAIL: PID file not created"; exit 1; }
+
+FILE_PID=$(cat "$PID_FILE" | tr -d '\n')
+[ "$FILE_PID" = "$NODE_PID" ] || { echo "FAIL: PID mismatch (expected $NODE_PID, got $FILE_PID)"; exit 1; }
+
+# Verify runtime_info.json exists and contains required fields
+[ -f "$RUNTIME_INFO" ] || { echo "FAIL: runtime_info.json not created"; exit 1; }
+
+PEERING_PORT=$(jq -r '.peering_port' "$RUNTIME_INFO")
+RPC_PORT=$(jq -r '.rpc_port' "$RUNTIME_INFO")
+NODE_ID=$(jq -r '.node_id' "$RUNTIME_INFO")
+
+# Verify ephemeral ports were assigned
+[ "$PEERING_PORT" != "0" ] && [ -n "$PEERING_PORT" ] || { echo "FAIL: invalid peering_port"; exit 1; }
+[ "$RPC_PORT" != "0" ] && [ -n "$RPC_PORT" ] && [ "$RPC_PORT" != "null" ] || { echo "FAIL: invalid rpc_port"; exit 1; }
+[ -n "$NODE_ID" ] && [ "$NODE_ID" != "null" ] || { echo "FAIL: invalid node_id"; exit 1; }
+
+# Verify peering port is listening
+nc -z ::1 "$PEERING_PORT" || { echo "FAIL: Nothing listening on peering port $PEERING_PORT"; exit 1; }
+
+# Verify RPC is responding using discovered port
+curl -s -g -d '{ "action": "version" }' "[::1]:$RPC_PORT" | grep -q "node_vendor" || { echo "FAIL: RPC not responding"; exit 1; }
+
+# Stop the node via SIGINT
+kill -SIGINT $NODE_PID
+
+# Wait for clean exit
+wait $NODE_PID || { echo "FAIL: Node did not stop cleanly"; exit 1; }
+
+# Verify cleanup
+[ ! -f "$PID_FILE" ] || { echo "FAIL: PID file not cleaned up"; exit 1; }
+[ ! -f "$RUNTIME_INFO" ] || { echo "FAIL: runtime_info.json not cleaned up"; exit 1; }
+
+echo "All runtime_files tests passed"


### PR DESCRIPTION
New CLI Options                                                                                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  `--runtime_info_file [path]`                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  Writes a JSON file containing runtime information after the node starts. This is particularly useful when running with ephemeral ports (peering_port=0, rpc.port=0) where the actual bound ports are assigned by the OS.                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  Usage:                                                                                                                                                                                                                                                                                                                                                                                                                                  
```  
nano_node --daemon --runtime_info_file                     # Uses default: runtime_info.json                                                                                                                                                                                                                                                                                                                                            
nano_node --daemon --runtime_info_file /path/to/info.json  # Custom path                                                                                                                                                                                                                                                                                                                                                                
  ```                                                                                                                                                                                                                                                                                                                                                                                                                                        
  JSON output:                                                                                                                                                                                                                                                                                                                                                                                                                            
  ```
{                                                                                                                                                                                                                                                                                                                                                                                                                                       
    "peering_port": 54321,                                                                                                                                                                                                                                                                                                                                                                                                                
    "rpc_port": 54322,                                                                                                                                                                                                                                                                                                                                                                                                                    
    "node_id": "node_1abc..."                                                                                                                                                                                                                                                                                                                                                                                                             
  }
```                                                                                                                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  Notes:                                                                                                                                                                                                                                                                                                                                                                                                                                  
  - rpc_port is only included when RPC is enabled                                                                                                                                                                                                                                                                                                                                                                                         
  - File is automatically deleted on clean process exit (SIGINT/SIGTERM or RPC stop)                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                          
 ``` --pid_file [path] (improved)```                                                                                                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  Now uses the same automatic cleanup infrastructure. File is automatically deleted on process exit.                                                                                                                                                                                                                                                                                                                                      
  ```                                                                                                                                                                                                                                                                                                                                                                                                                                        
  nano_node --daemon --pid_file                    # Uses default: nano_node.pid                                                                                                                                                                                                                                                                                                                                                          
  nano_node --daemon --pid_file /path/to/node.pid  # Custom path
```

This should fix system test flakiness.