### PR TITLE
Keep io_context alive in socket_base via shared_ptr to prevent premature destruction

### DIFF
--- a/nano/core_test/ipc.cpp
+++ b/nano/core_test/ipc.cpp
@@ -24,7 +24,7 @@ TEST (ipc, asynchronous)
 	system.nodes[0]->config.ipc_config.transport_tcp.port = system.get_available_port ();
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc (*system.nodes[0], node_rpc_config);
-	nano::ipc::ipc_client client (system.nodes[0]->io_ctx);
+	nano::ipc::ipc_client client (system.nodes[0]->io_ctx_shared);
 
 	auto req (nano::ipc::prepare_request (nano::ipc::payload_encoding::json_v1, std::string (R"({"action": "block_count"})")));
 	auto res (std::make_shared<std::vector<uint8_t>> ());
@@ -64,7 +64,7 @@ TEST (ipc, synchronous)
 	system.nodes[0]->config.ipc_config.transport_tcp.port = system.get_available_port ();
 	nano::node_rpc_config node_rpc_config;
 	nano::ipc::ipc_server ipc (*system.nodes[0], node_rpc_config);
-	nano::ipc::ipc_client client (system.nodes[0]->io_ctx);
+	nano::ipc::ipc_client client (system.nodes[0]->io_ctx_shared);
 
 	// Start blocking IPC client in a separate thread
 	std::atomic<bool> call_completed{ false };
@@ -196,7 +196,7 @@ TEST (ipc, invalid_endpoint)
 	system.nodes[0]->config.ipc_config.transport_tcp.enabled = true;
 	system.nodes[0]->config.ipc_config.transport_tcp.port = system.get_available_port ();
 	nano::node_rpc_config node_rpc_config;
-	nano::ipc::ipc_client client (system.nodes[0]->io_ctx);
+	nano::ipc::ipc_client client (system.nodes[0]->io_ctx_shared);
 
 	std::atomic<bool> call_completed{ false };
 	client.async_connect ("::-1", 24077, [&client, &call_completed] (nano::error err) {

--- a/nano/ipc_flatbuffers_test/entry.cpp
+++ b/nano/ipc_flatbuffers_test/entry.cpp
@@ -51,7 +51,7 @@ void read_message_loop (std::shared_ptr<nano::ipc::ipc_client> const & connectio
 /** A sample IPC/flatbuffers client that subscribes to confirmations from a local node */
 int main (int argc, char * const * argv)
 {
-	boost::asio::io_context io_ctx;
+	auto io_ctx = std::make_shared<boost::asio::io_context> ();
 	auto connection (std::make_shared<nano::ipc::ipc_client> (io_ctx));
 	// The client only connects to a local live node for now; the test will
 	// be improved later to handle various options, including port and address.
@@ -75,6 +75,6 @@ int main (int argc, char * const * argv)
 		}
 	});
 
-	io_ctx.run ();
+	io_ctx->run ();
 	return 0;
 }

--- a/nano/lib/ipc.cpp
+++ b/nano/lib/ipc.cpp
@@ -1,8 +1,14 @@
 #include <nano/lib/ipc.hpp>
 #include <nano/lib/utility.hpp>
 
-nano::ipc::socket_base::socket_base (boost::asio::io_context & io_ctx_a) :
-	io_timer (io_ctx_a)
+/*
+ * socket_base
+ */
+
+nano::ipc::socket_base::socket_base (std::shared_ptr<boost::asio::io_context> io_ctx_a) :
+	io_ctx{ *io_ctx_a },
+	io_ctx_shared{ std::move (io_ctx_a) },
+	io_timer{ io_ctx }
 {
 }
 
@@ -36,6 +42,10 @@ void nano::ipc::socket_base::timer_cancel ()
 	io_timer.cancel (ec);
 	debug_assert (!ec);
 }
+
+/*
+ * dsock_file_remover
+ */
 
 nano::ipc::dsock_file_remover::dsock_file_remover (std::string const & file_a) :
 	filename (file_a)

--- a/nano/lib/ipc.hpp
+++ b/nano/lib/ipc.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/boost/asio/deadline_timer.hpp>
 
+#include <memory>
 #include <string>
 
 namespace nano
@@ -29,7 +30,7 @@ namespace ipc
 	class socket_base
 	{
 	public:
-		socket_base (boost::asio::io_context & io_ctx_a);
+		explicit socket_base (std::shared_ptr<boost::asio::io_context>);
 		virtual ~socket_base ();
 
 		/** Close socket */
@@ -37,13 +38,22 @@ namespace ipc
 
 		/**
 		 * Start IO timer.
-		 * @param timeout_a Seconds to wait. To wait indefinitely, use std::chrono::seconds::max ()
+		 * @param timeout Seconds to wait. To wait indefinitely, use std::chrono::seconds::max ()
 		 */
-		void timer_start (std::chrono::seconds timeout_a);
+		void timer_start (std::chrono::seconds timeout);
 		void timer_expired ();
 		void timer_cancel ();
 
+	protected:
+		/**
+		 * IO context from node, or per-transport, depending on configuration.
+		 * Certain transports may scale better if they use a separate context.
+		 */
+		boost::asio::io_context & io_ctx;
+
 	private:
+		/** Prevent io_context destruction while this socket is alive */
+		std::shared_ptr<boost::asio::io_context> io_ctx_shared;
 		/** IO operation timer */
 		boost::asio::deadline_timer io_timer;
 	};

--- a/nano/lib/ipc_client.cpp
+++ b/nano/lib/ipc_client.cpp
@@ -45,8 +45,12 @@ template <typename SOCKET_TYPE, typename ENDPOINT_TYPE>
 class socket_client : public nano::ipc::socket_base, public channel, public std::enable_shared_from_this<socket_client<SOCKET_TYPE, ENDPOINT_TYPE>>
 {
 public:
-	socket_client (boost::asio::io_context & io_ctx_a, ENDPOINT_TYPE endpoint_a) :
-		socket_base (io_ctx_a), endpoint (std::move (endpoint_a)), socket (io_ctx_a), resolver (io_ctx_a), strand (io_ctx_a.get_executor ())
+	socket_client (std::shared_ptr<boost::asio::io_context> io_ctx_a, ENDPOINT_TYPE endpoint_a) :
+		socket_base{ io_ctx_a },
+		endpoint{ std::move (endpoint_a) },
+		socket{ io_ctx },
+		resolver{ io_ctx },
+		strand{ io_ctx.get_executor () }
 	{
 	}
 
@@ -108,7 +112,6 @@ public:
 	}
 
 	// TODO: investigate clang-tidy warning about recursive call chain
-	//
 	void write_queued_messages ()
 	{
 		auto this_l (this->shared_from_this ());
@@ -198,8 +201,8 @@ private:
 class client_impl : public nano::ipc::ipc_client_impl
 {
 public:
-	explicit client_impl (boost::asio::io_context & io_ctx_a) :
-		io_ctx (io_ctx_a)
+	explicit client_impl (std::shared_ptr<boost::asio::io_context> io_ctx_a) :
+		io_ctx{ std::move (io_ctx_a) }
 	{
 	}
 
@@ -242,7 +245,7 @@ public:
 	}
 
 private:
-	boost::asio::io_context & io_ctx;
+	std::shared_ptr<boost::asio::io_context> io_ctx;
 	std::shared_ptr<socket_client<socket_type, boost::asio::ip::tcp::endpoint>> tcp_client;
 #if defined(BOOST_ASIO_HAS_LOCAL_SOCKETS)
 	std::shared_ptr<socket_client<boost::asio::local::stream_protocol::socket, boost::asio::local::stream_protocol::endpoint>> domain_client;
@@ -250,8 +253,8 @@ private:
 };
 }
 
-nano::ipc::ipc_client::ipc_client (boost::asio::io_context & io_ctx_a) :
-	io_ctx (io_ctx_a)
+nano::ipc::ipc_client::ipc_client (std::shared_ptr<boost::asio::io_context> io_ctx_a) :
+	io_ctx{ std::move (io_ctx_a) }
 {
 }
 

--- a/nano/lib/ipc_client.hpp
+++ b/nano/lib/ipc_client.hpp
@@ -27,7 +27,7 @@ namespace ipc
 	class ipc_client
 	{
 	public:
-		ipc_client (boost::asio::io_context & io_ctx_a);
+		ipc_client (std::shared_ptr<boost::asio::io_context> io_ctx_a);
 		ipc_client (ipc_client && ipc_client) = default;
 		virtual ~ipc_client () = default;
 
@@ -57,7 +57,7 @@ namespace ipc
 		void async_read_message (std::shared_ptr<std::vector<uint8_t>> const & buffer_a, std::chrono::seconds timeout_a, std::function<void (nano::error, size_t)> callback_a);
 
 	private:
-		boost::asio::io_context & io_ctx;
+		std::shared_ptr<boost::asio::io_context> io_ctx;
 
 		// PIMPL pattern to hide implementation details
 		std::unique_ptr<ipc_client_impl> impl;

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -45,7 +45,7 @@ void run (std::filesystem::path const & data_path, std::vector<std::string> cons
 
 		try
 		{
-			nano::ipc_rpc_processor ipc_rpc_processor (*io_ctx, rpc_config);
+			nano::ipc_rpc_processor ipc_rpc_processor (io_ctx, rpc_config);
 			auto rpc = nano::get_rpc (io_ctx, rpc_config, ipc_rpc_processor);
 			rpc->start ();
 

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -540,18 +540,19 @@ public:
 
 		// Close all active sessions to cancel pending async operations
 		{
-			auto sessions_lockeded = sessions.lock ();
-			for (auto & session_weak : sessions_lockeded.get ())
+			auto sessions_locked = sessions.lock ();
+			for (auto & session_weak : sessions_locked.get ())
 			{
 				if (auto session = session_weak.lock ())
 				{
 					session->close ();
 				}
 			}
-			sessions_lockeded->clear ();
+			sessions_locked->clear ();
 		}
 
-		io_ctx->stop ();
+		// Let io_context drain naturally - don't call io_ctx->stop()
+		// The cancelled handlers need to run to release their captured shared_ptrs
 		runner->join ();
 	}
 

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -32,10 +32,10 @@ template <typename SOCKET_TYPE>
 class session final : public nano::ipc::socket_base, public std::enable_shared_from_this<session<SOCKET_TYPE>>
 {
 public:
-	session (nano::ipc::ipc_server & server_a, boost::asio::io_context & io_ctx_a, nano::ipc::ipc_config_transport & config_transport_a) :
-		socket_base (io_ctx_a),
-		server (server_a), node (server_a.node), session_id (server_a.id_dispenser.fetch_add (1)),
-		io_ctx (io_ctx_a), strand (io_ctx_a.get_executor ()), socket (io_ctx_a), config_transport (config_transport_a)
+	session (nano::ipc::ipc_server & server_a, std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::ipc::ipc_config_transport & config_transport_a) :
+		socket_base{ io_ctx_a },
+		server{ server_a }, node{ server_a.node }, session_id{ server_a.id_dispenser.fetch_add (1) },
+		strand{ io_ctx.get_executor () }, socket{ io_ctx }, config_transport{ config_transport_a }
 	{
 		node.logger.debug (nano::log::type::ipc, "Creating session with id: {}", session_id.load ());
 	}
@@ -434,12 +434,6 @@ private:
 	/** Timer for measuring the duration of ipc calls */
 	nano::timer<std::chrono::microseconds> session_timer;
 
-	/**
-	 * IO context from node, or per-transport, depending on configuration.
-	 * Certain transports may scale better if they use a separate context.
-	 */
-	boost::asio::io_context & io_ctx;
-
 	/** IO strand for synchronizing */
 	boost::asio::strand<boost::asio::io_context::executor_type> strand;
 
@@ -495,7 +489,7 @@ public:
 	void accept ()
 	{
 		// Prepare the next session
-		auto new_session (std::make_shared<session<SOCKET_TYPE>> (server, context (), config_transport));
+		auto new_session (std::make_shared<session<SOCKET_TYPE>> (server, io_ctx, config_transport));
 
 		std::weak_ptr<nano::node> nano_weak = server.node.shared ();
 		acceptor->async_accept (new_session->get_socket (), [this, new_session, nano_weak] (boost::system::error_code const & ec) {

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <list>
 
 #include <flatbuffers/flatbuffers.h>
 
@@ -34,13 +35,17 @@ class session final : public nano::ipc::socket_base, public std::enable_shared_f
 public:
 	session (nano::ipc::ipc_server & server_a, std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::ipc::ipc_config_transport & config_transport_a) :
 		socket_base{ io_ctx_a },
-		server{ server_a }, node{ server_a.node }, session_id{ server_a.id_dispenser.fetch_add (1) },
-		strand{ io_ctx.get_executor () }, socket{ io_ctx }, config_transport{ config_transport_a }
+		server{ server_a },
+		node{ server_a.node },
+		session_id{ server_a.id_dispenser.fetch_add (1) },
+		strand{ io_ctx.get_executor () },
+		socket{ io_ctx },
+		config_transport{ config_transport_a }
 	{
 		node.logger.debug (nano::log::type::ipc, "Creating session with id: {}", session_id.load ());
 	}
 
-	~session ()
+	~session () override
 	{
 		close ();
 	}
@@ -491,6 +496,13 @@ public:
 		// Prepare the next session
 		auto new_session (std::make_shared<session<SOCKET_TYPE>> (server, io_ctx, config_transport));
 
+		// Track session immediately so it can be closed on shutdown
+		{
+			auto sessions_locked = sessions.lock ();
+			sessions_locked->remove_if ([] (auto const & ws) { return ws.expired (); });
+			sessions_locked->push_back (new_session);
+		}
+
 		std::weak_ptr<nano::node> nano_weak = server.node.shared ();
 		acceptor->async_accept (new_session->get_socket (), [this, new_session, nano_weak] (boost::system::error_code const & ec) {
 			auto node = nano_weak.lock ();
@@ -525,6 +537,20 @@ public:
 		release_assert (runner);
 
 		acceptor->close ();
+
+		// Close all active sessions to cancel pending async operations
+		{
+			auto sessions_lockeded = sessions.lock ();
+			for (auto & session_weak : sessions_lockeded.get ())
+			{
+				if (auto session = session_weak.lock ())
+				{
+					session->close ();
+				}
+			}
+			sessions_lockeded->clear ();
+		}
+
 		io_ctx->stop ();
 		runner->join ();
 	}
@@ -537,6 +563,7 @@ private:
 	std::unique_ptr<nano::thread_runner> runner;
 	std::shared_ptr<boost::asio::io_context> io_ctx;
 	std::unique_ptr<ACCEPTOR_TYPE> acceptor;
+	nano::locked<std::list<std::weak_ptr<session<SOCKET_TYPE>>>> sessions;
 };
 
 using tcp_socket_transport = socket_transport<boost::asio::ip::tcp::acceptor, boost::asio::ip::tcp::socket, boost::asio::ip::tcp::endpoint>;

--- a/nano/node/ipc/ipc_server.hpp
+++ b/nano/node/ipc/ipc_server.hpp
@@ -41,8 +41,8 @@ namespace ipc
 		nano::logger logger{ "ipc_server" };
 
 	private:
-		void
-		setup_callbacks ();
+		void setup_callbacks ();
+
 		std::shared_ptr<nano::ipc::broker> broker;
 		nano::ipc::access access;
 		std::unique_ptr<dsock_file_remover> file_remover;

--- a/nano/rpc/rpc_request_processor.cpp
+++ b/nano/rpc/rpc_request_processor.cpp
@@ -5,13 +5,13 @@
 
 #include <boost/endian/conversion.hpp>
 
-nano::rpc_request_processor::rpc_request_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a) :
-	ipc_address (rpc_config.rpc_process.ipc_address),
-	ipc_port (ipc_port_a),
-	thread ([this] () {
+nano::rpc_request_processor::rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a) :
+	ipc_address{ rpc_config.rpc_process.ipc_address },
+	ipc_port{ ipc_port_a },
+	thread{ [this] () {
 		nano::thread_role::set (nano::thread_role::name::rpc_request_processor);
 		this->run ();
-	})
+	} }
 {
 	nano::lock_guard<nano::mutex> lk{ this->request_mutex };
 	this->connections.reserve (rpc_config.rpc_process.num_ipc_connections);
@@ -27,8 +27,8 @@ nano::rpc_request_processor::rpc_request_processor (boost::asio::io_context & io
 	}
 }
 
-nano::rpc_request_processor::rpc_request_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config) :
-	rpc_request_processor (io_ctx, rpc_config, rpc_config.rpc_process.ipc_port)
+nano::rpc_request_processor::rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config) :
+	rpc_request_processor (std::move (io_ctx), rpc_config, rpc_config.rpc_process.ipc_port)
 {
 }
 

--- a/nano/rpc/rpc_request_processor.hpp
+++ b/nano/rpc/rpc_request_processor.hpp
@@ -47,8 +47,8 @@ struct rpc_request
 class rpc_request_processor
 {
 public:
-	rpc_request_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config);
-	rpc_request_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a);
+	rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config);
+	rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a);
 	~rpc_request_processor ();
 	void stop ();
 	void add (std::shared_ptr<rpc_request> const & request);
@@ -74,12 +74,12 @@ private:
 class ipc_rpc_processor final : public nano::rpc_handler_interface
 {
 public:
-	ipc_rpc_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config) :
-		rpc_request_processor (io_ctx, rpc_config)
+	ipc_rpc_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config) :
+		rpc_request_processor (std::move (io_ctx), rpc_config)
 	{
 	}
-	ipc_rpc_processor (boost::asio::io_context & io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a) :
-		rpc_request_processor (io_ctx, rpc_config, ipc_port_a)
+	ipc_rpc_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a) :
+		rpc_request_processor (std::move (io_ctx), rpc_config, ipc_port_a)
 	{
 	}
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6085,7 +6085,7 @@ TEST (rpc, simultaneous_calls)
 	const auto ipc_tcp_port = ipc_server.listening_tcp_port ();
 	ASSERT_TRUE (ipc_tcp_port.has_value ());
 	rpc_config.rpc_process.num_ipc_connections = 8;
-	nano::ipc_rpc_processor ipc_rpc_processor (*system.io_ctx, rpc_config, ipc_tcp_port.value ());
+	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config, ipc_tcp_port.value ());
 	auto rpc = std::make_shared<nano::rpc> (system.io_ctx, rpc_config, ipc_rpc_processor);
 	nano::test::start_stop_guard stop_guard{ *rpc };
 

--- a/nano/rpc_test/rpc_context.cpp
+++ b/nano/rpc_test/rpc_context.cpp
@@ -48,7 +48,7 @@ nano::test::rpc_context nano::test::add_rpc (nano::test::system & system, std::s
 	nano::rpc_config rpc_config (node_a->network_params.network, system.get_available_port (), true);
 	const auto ipc_tcp_port = ipc_server->listening_tcp_port ();
 	debug_assert (ipc_tcp_port.has_value ());
-	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (*system.io_ctx, rpc_config, ipc_tcp_port.value ()));
+	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (system.io_ctx, rpc_config, ipc_tcp_port.value ()));
 	auto rpc (std::make_shared<nano::rpc> (system.io_ctx, rpc_config, *ipc_rpc_processor));
 	rpc->start ();
 

--- a/nano/slow_test/bootstrap.cpp
+++ b/nano/slow_test/bootstrap.cpp
@@ -34,7 +34,7 @@ public:
 		node_rpc_config{},
 		rpc_config{ node.network_params.network, port, true },
 		ipc{ node, node_rpc_config },
-		ipc_rpc_processor{ *system.io_ctx, rpc_config },
+		ipc_rpc_processor{ system.io_ctx, rpc_config },
 		rpc{ system.io_ctx, rpc_config, ipc_rpc_processor }
 	{
 	}


### PR DESCRIPTION
Should fix sanitizer error in rpc_test where deadline_timer accesses destroyed io_context:
```
Report: sanitizer_report.rpc_test.71093
  /Users/runner/work/nano-node/nano-node/submodules/boost/libs/asio/include/boost/asio/basic_deadline_timer.hpp:548:41: runtime error: member call on address 0x6000004715e0 which does not point to an object of type 'boost::asio::detail::deadline_timer_service<boost::asio::time_traits<boost::posix_time::ptime>>'
  0x6000004715e0: note: object has invalid vptr
   00 00 00 00  e0 15 bb 31 5f 00 00 00  45 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
                ^~~~~~~~~~~~~~~~~~~~~~~
                invalid vptr
```