### PR TITLE
Add Docker-based CI testing

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -145,3 +145,38 @@ jobs:
         working-directory: build
         shell: bash
         continue-on-error: true # FIXME: Investigate why this fails on Windows
+
+  docker_test:
+    name: Docker [${{ matrix.BACKEND }}]
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        BACKEND: [lmdb, rocksdb]
+    runs-on: ubuntu-24.04
+    env:
+      NANO_BACKEND: ${{ matrix.BACKEND }}
+      TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}
+      DEADLINE_SCALE_FACTOR: ${{ matrix.BACKEND == 'rocksdb' && '2' || '1' }}
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+
+      - name: Build Docker Test Image
+        id: build
+        run: ci/build-docker-tests.sh
+
+      - name: Core Tests
+        if: steps.build.outcome == 'success' && (success() || failure())
+        run: ci/tests/run-docker-tests.sh core
+
+      - name: RPC Tests
+        if: steps.build.outcome == 'success' && (success() || failure())
+        run: ci/tests/run-docker-tests.sh rpc
+
+      - name: System Tests
+        if: steps.build.outcome == 'success' && (success() || failure())
+        run: ci/tests/run-docker-tests.sh system

--- a/ci/build-docker-tests.sh
+++ b/ci/build-docker-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euox pipefail
+
+COMPILER=${COMPILER:-gcc}
+
+echo "Building Docker test image with COMPILER=${COMPILER}"
+
+docker build \
+    --build-arg COMPILER=${COMPILER} \
+    -f docker/tests/Dockerfile-tests \
+    -t nano-test:latest \
+    .

--- a/ci/tests/run-docker-tests.sh
+++ b/ci/tests/run-docker-tests.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+TEST_TYPE=${1:-}
+if [ -z "${TEST_TYPE}" ]; then
+    echo "Usage: $0 <test-type>"
+    echo "  test-type: core, rpc, system"
+    exit 1
+fi
+
+echo "Running ${TEST_TYPE} tests in Docker"
+
+# Run tests inside the pre-built Docker image
+# --privileged: Required for core dump generation (writing to /proc/sys/kernel/core_pattern)
+# --tmpfs: Provides fast RAM-based storage for test data (required by tests via NANO_APP_PATH)
+# --network=host: Use host networking for IPC tests that connect to localhost
+docker run --rm \
+    --privileged \
+    --network=host \
+    --tmpfs /tmp:exec,size=4G \
+    -e NANO_APP_PATH="/tmp" \
+    -e NANO_BACKEND \
+    -e TEST_USE_ROCKSDB \
+    -e DEADLINE_SCALE_FACTOR \
+    nano-test:latest \
+    bash -c "cd build && ../ci/tests/run-${TEST_TYPE}-tests.sh"

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -48,4 +48,4 @@ ENTRYPOINT ["/usr/bin/entry.sh"]
 CMD ["daemon"]
 
 ARG REPOSITORY=nanocurrency/nano-node
-LABEL org.opencontainers.image.source https://github.com/$REPOSITORY
+LABEL org.opencontainers.image.source=https://github.com/$REPOSITORY

--- a/docker/tests/Dockerfile-tests
+++ b/docker/tests/Dockerfile-tests
@@ -1,0 +1,23 @@
+FROM ubuntu:22.04
+
+ARG COMPILER=gcc
+ENV COMPILER=${COMPILER}
+
+# Install build dependencies (same as node Dockerfile)
+COPY ./ci/prepare/linux /tmp/prepare
+RUN /tmp/prepare/prepare.sh
+
+# Install test-specific dependencies
+RUN apt-get install -yqq sudo jq netcat-openbsd
+
+# Copy source code
+COPY ./ /workspace
+WORKDIR /workspace
+
+# Build tests
+RUN ci/build-tests.sh
+
+CMD ["docker/tests/docker-test-entrypoint.sh"]
+
+ARG REPOSITORY=nanocurrency/nano-node
+LABEL org.opencontainers.image.source=https://github.com/$REPOSITORY

--- a/docker/tests/docker-test-entrypoint.sh
+++ b/docker/tests/docker-test-entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -uo pipefail
+
+# Default entrypoint for running all tests locally
+# For CI, individual tests are run via ci/tests/run-docker-tests.sh <test-type>
+
+exit_code=0
+
+cd build
+
+echo "=== Running Core Tests ==="
+if ../ci/tests/run-core-tests.sh; then
+    echo "Core tests: PASSED"
+else
+    echo "Core tests: FAILED"
+    exit_code=1
+fi
+
+echo "=== Running RPC Tests ==="
+if ../ci/tests/run-rpc-tests.sh; then
+    echo "RPC tests: PASSED"
+else
+    echo "RPC tests: FAILED"
+    exit_code=1
+fi
+
+echo "=== Running System Tests ==="
+if ../ci/tests/run-system-tests.sh; then
+    echo "System tests: PASSED"
+else
+    echo "System tests: FAILED"
+    exit_code=1
+fi
+
+echo "=== Test Summary ==="
+if [ $exit_code -eq 0 ]; then
+    echo "All tests passed"
+else
+    echo "Some tests failed"
+fi
+
+exit $exit_code


### PR DESCRIPTION
Code may compile on bare metal but fail in Docker due to environment differences (Ubuntu 22.04 in Docker vs Ubuntu 24.04 in CI). Currently no CI job validates that the codebase builds and tests pass inside Docker containers.