### PR TITLE
Remove racy debug_assert in request_aggregator::request

### DIFF
--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -749,3 +749,19 @@ TEST (request_aggregator, cemented_no_spacing)
 	ASSERT_TRUE (voted_hashes.find (send2->hash ()) != voted_hashes.end ());
 	ASSERT_TRUE (voted_hashes.find (send3->hash ()) != voted_hashes.end ());
 }
+
+TEST (request_aggregator, disabled)
+{
+	nano::test::system system;
+	nano::node_config config = system.default_config ();
+	config.enable_voting = false;
+	auto & node = *system.add_node (config);
+
+	std::vector<std::pair<nano::block_hash, nano::root>> request;
+	request.emplace_back (nano::dev::genesis->hash (), nano::dev::genesis->root ());
+
+	auto channel = nano::test::fake_channel (node);
+
+	// Request should return false when aggregator is disabled
+	ASSERT_FALSE (node.aggregator.request (request, channel));
+}

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -85,15 +85,12 @@ bool nano::request_aggregator::empty () const
 bool nano::request_aggregator::request (request_type const & request, std::shared_ptr<nano::transport::channel> const & channel)
 {
 	release_assert (channel != nullptr);
-
-	// This should be checked before calling request
-	debug_assert (wallets.reps ().voting > 0);
 	debug_assert (!request.empty ());
 
 	bool added = false;
 	{
 		nano::lock_guard<nano::mutex> guard{ mutex };
-		added = queue.push ({ request, channel }, { nano::no_value{}, channel });
+		added = queue.push ({ request, channel }, { nano::no_value{ }, channel });
 	}
 	if (added)
 	{

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -17,6 +17,7 @@
 
 nano::request_aggregator::request_aggregator (request_aggregator_config const & config_a, nano::node & node_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_router & vote_router_a) :
 	config{ config_a },
+	node_config{ node_a.config },
 	network_constants{ node_a.network_params.network },
 	local_votes (history_a),
 	ledger (ledger_a),
@@ -43,6 +44,11 @@ nano::request_aggregator::~request_aggregator ()
 void nano::request_aggregator::start ()
 {
 	debug_assert (threads.empty ());
+
+	if (!node_config.enable_voting)
+	{
+		return;
+	}
 
 	for (auto i = 0; i < config.threads; ++i)
 	{
@@ -87,10 +93,16 @@ bool nano::request_aggregator::request (request_type const & request, std::share
 	release_assert (channel != nullptr);
 	debug_assert (!request.empty ());
 
+	// Do not accept requests if disabled
+	if (threads.empty ())
+	{
+		return false;
+	}
+
 	bool added = false;
 	{
 		nano::lock_guard<nano::mutex> guard{ mutex };
-		added = queue.push ({ request, channel }, { nano::no_value{ }, channel });
+		added = queue.push ({ request, channel }, { nano::no_value{}, channel });
 	}
 	if (added)
 	{

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -84,6 +84,7 @@ private:
 
 private: // Dependencies
 	request_aggregator_config const & config;
+	nano::node_config const & node_config;
 	nano::network_constants const & network_constants;
 	nano::local_vote_history & local_votes;
 	nano::ledger & ledger;


### PR DESCRIPTION
Should fix:
```
[ RUN      ] node.bidirectional_tcp
Assertion `wallets.reps ().voting > 0` failed
/workspace/nano/node/request_aggregator.cpp:90 [bool nano::request_aggregator::request(const request_type&, const std::shared_ptr<nano::transport::channel>&)]'
 0# nano::generate_stacktrace[abi:cxx11]() at /workspace/nano/lib/stacktrace.cpp:13
 1# assert_internal(char const*, char const*, char const*, unsigned int, bool, std::basic_string_view<char, std::char_traits<char> >) at /workspace/nano/lib/assert.cpp:28
 2# nano::request_aggregator::request(std::vector<std::pair<nano::block_hash, nano::root>, std::allocator<std::pair<nano::block_hash, nano::root> > > const&, std::shared_ptr<nano::transport::channel> const&) at /workspace/nano/node/request_aggregator.cpp:90
 3# (anonymous namespace)::process_visitor::confirm_req(nano::messages::confirm_req const&) at /workspace/nano/node/message_processor.cpp:215
 4# nano::messages::confirm_req::visit(nano::messages::message_visitor&) const at /workspace/nano/messages/confirm.cpp:56
 5# nano::message_processor::process(nano::messages::message const&, std::shared_ptr<nano::transport::channel> const&) at /workspace/nano/node/message_processor.cpp:298
 6# nano::message_processor::run_batch(std::unique_lock<nano::mutex>&) at /workspace/nano/node/message_processor.cpp:151
 7# nano::message_processor::run() at /workspace/nano/node/message_processor.cpp:125
 8# nano::message_processor::start()::{lambda()#1}::operator()() const at /workspace/nano/node/message_processor.cpp:60
 9# void std::__invoke_impl<void, nano::message_processor::start()::{lambda()#1}>(std::__invoke_other, nano::message_processor::start()::{lambda()#1}&&) at /usr/include/c++/11/bits/invoke.h:61
10# std::__invoke_result<nano::message_processor::start()::{lambda()#1}>::type std::__invoke<nano::message_processor::start()::{lambda()#1}>(nano::message_processor::start()::{lambda()#1}&&) at /usr/include/c++/11/bits/invoke.h:97
11# void std::thread::_Invoker<std::tuple<nano::message_processor::start()::{lambda()#1}> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) at /usr/include/c++/11/bits/std_thread.h:259
12# std::thread::_Invoker<std::tuple<nano::message_processor::start()::{lambda()#1}> >::operator()() at /usr/include/c++/11/bits/std_thread.h:266
13# std::thread::_State_impl<std::thread::_Invoker<std::tuple<nano::message_processor::start()::{lambda()#1}> > >::_M_run() at /usr/include/c++/11/bits/std_thread.h:211
14# execute_native_thread_routine in ./core_test
15# start_thread at ./nptl/pthread_create.c:442
16# 0x00007F25621238C0 at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:83

../ci/tests/run-tests.sh: line 52:    20 Aborted                 (core dumped) "${executable}" "$@"
```