### PR TITLE
Add `format-check.sh` and `format-do.sh` scripts to project root

### DIFF
--- a/format-check.sh
+++ b/format-check.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Check code formatting for C++ and CMake files
+# Usage: ./format-check.sh
+#
+# This script checks if your code is properly formatted.
+# If it fails, run ./format-do.sh to fix the formatting.
+#
+# Required tools:
+#   - clang-format version 17
+#   - cmake-format version 0.6.13
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    echo "Usage: ./format-check.sh"
+    echo ""
+    echo "Check code formatting for C++ and CMake files."
+    echo "If this fails, run ./format-do.sh to fix the formatting."
+    echo ""
+    echo "Required tools:"
+    echo "  - clang-format version 17"
+    echo "  - cmake-format version 0.6.13"
+    exit 0
+fi
+
+FAILED=0
+
+echo "Checking C++ formatting..."
+if ! "$SCRIPT_DIR/ci/clang-format-check.sh"; then
+    echo "FAILED: C++ formatting (clang-format)"
+    FAILED=1
+fi
+
+echo ""
+echo "Checking CMake formatting..."
+if ! "$SCRIPT_DIR/ci/cmake-format-check.sh"; then
+    echo "FAILED: CMake formatting (cmake-format)"
+    FAILED=1
+fi
+
+echo ""
+if [[ $FAILED -eq 1 ]]; then
+    echo "Formatting check failed. Run ./format-do.sh to fix."
+    exit 1
+else
+    echo "All formatting checks passed."
+fi

--- a/format-do.sh
+++ b/format-do.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Format C++ and CMake files
+# Usage: ./format-do.sh
+#
+# This script formats all C++ and CMake files in the project.
+# Run ./format-check.sh to verify formatting without making changes.
+#
+# Required tools:
+#   - clang-format version 17
+#   - cmake-format version 0.6.13
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ "$1" == "--help" || "$1" == "-h" ]]; then
+    echo "Usage: ./format-do.sh"
+    echo ""
+    echo "Format all C++ and CMake files in the project."
+    echo "Run ./format-check.sh to verify formatting without making changes."
+    echo ""
+    echo "Required tools:"
+    echo "  - clang-format version 17"
+    echo "  - cmake-format version 0.6.13"
+    exit 0
+fi
+
+echo "Formatting C++ files..."
+"$SCRIPT_DIR/ci/clang-format-do.sh"
+
+echo ""
+echo "Formatting CMake files..."
+"$SCRIPT_DIR/ci/cmake-format-do.sh"
+
+echo ""
+echo "Formatting complete."


### PR DESCRIPTION
These scripts in the project root make it easier to discover and use the formatting tools. All files need to be formatted properly to pass our CI.                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                          
  Usage:        
```                                                                                                                                                                                                                                                                                                                                                                                                                          
./format-check.sh  # Check if code is formatted correctly                                                                                                                                                                                                                                                                                                                                                                               
./format-do.sh     # Format all code   
```