### PR TITLE
Refactor `wallet` methods to be self-contained with internal transactions

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -410,10 +410,7 @@ TEST (network, receive_weight_change)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key2;
 	system.wallet (1)->insert_adhoc (key2.prv);
-	{
-		auto transaction (system.nodes[1]->wallets.tx_begin_write ());
-		system.wallet (1)->store.representative_set (transaction, key2.pub);
-	}
+	system.wallet (1)->set_representative (key2.pub);
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
 	ASSERT_TIMELY (10s, std::all_of (system.nodes.begin (), system.nodes.end (), [&] (std::shared_ptr<nano::node> const & node_a) { return node_a->weight (key2.pub) == system.nodes[0]->config.receive_minimum.number (); }));
 }

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -374,10 +374,7 @@ TEST (node, search_receivable_confirmed)
 	ASSERT_NE (nullptr, send2);
 	ASSERT_TIMELY (5s, nano::test::confirmed (*node, { send2 }));
 
-	{
-		auto transaction (node->wallets.tx_begin_write ());
-		system.wallet (0)->store.erase (transaction, nano::dev::genesis_key.pub);
-	}
+	system.wallet (0)->remove_account (nano::dev::genesis_key.pub);
 
 	system.wallet (0)->insert_adhoc (key2.prv);
 	ASSERT_FALSE (system.wallet (0)->search_receivable ());
@@ -408,7 +405,7 @@ TEST (node, search_receivable_pruned)
 	ASSERT_TIMELY (10s, node1->active.empty () && node2->active.empty ());
 	ASSERT_TIMELY (5s, node1->ledger.confirmed.block_exists_or_pruned (node1->ledger.tx_begin_read (), send2->hash ()));
 	ASSERT_TIMELY_EQ (5s, node2->ledger.cemented_count (), 3);
-	system.wallet (0)->store.erase (node1->wallets.tx_begin_write (), nano::dev::genesis_key.pub);
+	system.wallet (0)->remove_account (nano::dev::genesis_key.pub);
 
 	// Pruning
 	{
@@ -430,10 +427,7 @@ TEST (node, unlock_search)
 	auto node (system.nodes[0]);
 	nano::keypair key2;
 	nano::uint128_t balance (node->balance (nano::dev::genesis_key.pub));
-	{
-		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
-		system.wallet (0)->store.rekey (transaction, "");
-	}
+	system.wallet (0)->rekey ("");
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	ASSERT_TIMELY (10s, node->balance (nano::dev::genesis_key.pub) != balance);
@@ -1067,10 +1061,7 @@ TEST (node, fork_no_vote_quorum)
 	auto key4 (system.wallet (0)->deterministic_insert ());
 	system.wallet (0)->send_action (nano::dev::genesis_key.pub, key4, nano::dev::constants.genesis_amount / 4);
 	auto key1 (system.wallet (1)->deterministic_insert ());
-	{
-		auto transaction (system.wallet (1)->wallets.tx_begin_write ());
-		system.wallet (1)->store.representative_set (transaction, key1);
-	}
+	system.wallet (1)->set_representative (key1);
 	auto block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1, node1.config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, block);
 	ASSERT_TIMELY (30s, node3.balance (key1) == node1.config.receive_minimum.number () && node2.balance (key1) == node1.config.receive_minimum.number () && node1.balance (key1) == node1.config.receive_minimum.number ());
@@ -1100,8 +1091,7 @@ TEST (node, fork_no_vote_quorum)
 				 .work (*system.work.generate (block->hash ()))
 				 .build ();
 	nano::raw_key key3;
-	auto transaction (system.wallet (1)->wallets.tx_begin_read ());
-	ASSERT_FALSE (system.wallet (1)->store.fetch (transaction, key1, key3));
+	ASSERT_FALSE (system.wallet (1)->fetch_prv (key1, key3));
 	auto vote = std::make_shared<nano::vote> (key1, key3, 0, 0, std::vector<nano::block_hash>{ send2->hash () });
 	nano::messages::confirm_ack confirm{ nano::dev::network_params.network, vote };
 	auto channel = node2.network.find_node_id (node3.node_id.pub);
@@ -1138,16 +1128,10 @@ TEST (node, DISABLED_fork_pre_confirm)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key1;
 	system.wallet (1)->insert_adhoc (key1.prv);
-	{
-		auto transaction (system.wallet (1)->wallets.tx_begin_write ());
-		system.wallet (1)->store.representative_set (transaction, key1.pub);
-	}
+	system.wallet (1)->set_representative (key1.pub);
 	nano::keypair key2;
 	system.wallet (2)->insert_adhoc (key2.prv);
-	{
-		auto transaction (system.wallet (2)->wallets.tx_begin_write ());
-		system.wallet (2)->store.representative_set (transaction, key2.pub);
-	}
+	system.wallet (2)->set_representative (key2.pub);
 	auto block0 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1.pub, nano::dev::constants.genesis_amount / 3));
 	ASSERT_NE (nullptr, block0);
 	ASSERT_TIMELY (30s, node0.balance (key1.pub) != 0);
@@ -2795,10 +2779,7 @@ TEST (node, bidirectional_tcp)
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	// Test block propagation & confirmation from node 2 (remove representative from node 1)
-	{
-		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
-		system.wallet (0)->store.erase (transaction, nano::dev::genesis_key.pub);
-	}
+	system.wallet (0)->remove_account (nano::dev::genesis_key.pub);
 	/* Test block propagation from node 2
 	Node 2 has only ephemeral TCP port open. Node 1 cannot establish connection to node 2 listening port */
 	auto send2 = builder.make_block ()

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -323,7 +323,7 @@ TEST (node, search_receivable)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	system.wallet (0)->insert_adhoc (key2.prv);
-	ASSERT_FALSE (system.wallet (0)->search_receivable (system.wallet (0)->wallets.tx_begin_read ()));
+	ASSERT_FALSE (system.wallet (0)->search_receivable ());
 	ASSERT_TIMELY (10s, !node->balance (key2.pub).is_zero ());
 }
 
@@ -336,7 +336,7 @@ TEST (node, search_receivable_same)
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	system.wallet (0)->insert_adhoc (key2.prv);
-	ASSERT_FALSE (system.wallet (0)->search_receivable (system.wallet (0)->wallets.tx_begin_read ()));
+	ASSERT_FALSE (system.wallet (0)->search_receivable ());
 	ASSERT_TIMELY_EQ (10s, node->balance (key2.pub), 2 * node->config.receive_minimum.number ());
 }
 
@@ -353,7 +353,7 @@ TEST (node, search_receivable_multiple)
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, node->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, system.wallet (0)->send_action (key3.pub, key2.pub, node->config.receive_minimum.number ()));
 	system.wallet (0)->insert_adhoc (key2.prv);
-	ASSERT_FALSE (system.wallet (0)->search_receivable (system.wallet (0)->wallets.tx_begin_read ()));
+	ASSERT_FALSE (system.wallet (0)->search_receivable ());
 	ASSERT_TIMELY_EQ (10s, node->balance (key2.pub), 2 * node->config.receive_minimum.number ());
 }
 
@@ -380,7 +380,7 @@ TEST (node, search_receivable_confirmed)
 	}
 
 	system.wallet (0)->insert_adhoc (key2.prv);
-	ASSERT_FALSE (system.wallet (0)->search_receivable (system.wallet (0)->wallets.tx_begin_read ()));
+	ASSERT_FALSE (system.wallet (0)->search_receivable ());
 	ASSERT_TIMELY (5s, !node->vote_router.active (send1->hash ()));
 	ASSERT_TIMELY (5s, !node->vote_router.active (send2->hash ()));
 	ASSERT_TIMELY_EQ (5s, node->balance (key2.pub), 2 * node->config.receive_minimum.number ());
@@ -420,7 +420,7 @@ TEST (node, search_receivable_pruned)
 
 	// Receive pruned block
 	system.wallet (1)->insert_adhoc (key2.prv);
-	ASSERT_FALSE (system.wallet (1)->search_receivable (system.wallet (1)->wallets.tx_begin_read ()));
+	ASSERT_FALSE (system.wallet (1)->search_receivable ());
 	ASSERT_TIMELY_EQ (10s, node2->balance (key2.pub), 2 * node2->config.receive_minimum.number ());
 }
 
@@ -444,8 +444,7 @@ TEST (node, unlock_search)
 		system.wallet (0)->store.password.value_set (nano::keypair ().prv);
 	}
 	{
-		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
-		ASSERT_FALSE (system.wallet (0)->enter_password (transaction, ""));
+		ASSERT_FALSE (system.wallet (0)->enter_password (""));
 	}
 	ASSERT_TIMELY (10s, !node->balance (key2.pub).is_zero ());
 }
@@ -460,8 +459,7 @@ TEST (node, confirm_locked)
 {
 	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-	system.wallet (0)->enter_password (transaction, "1");
+	system.wallet (0)->enter_password ("1");
 	auto block = nano::send_block_builder ()
 				 .previous (0)
 				 .destination (0)

--- a/nano/core_test/system.cpp
+++ b/nano/core_test/system.cpp
@@ -125,20 +125,15 @@ TEST (system, DISABLED_generate_send_new)
 	system.generate_send_new (node1, accounts);
 	nano::account new_account{};
 	{
-		auto transaction (node1.wallets.tx_begin_read ());
-		auto iterator2 (system.wallet (0)->store.begin (transaction));
-		if (iterator2->first != nano::dev::genesis_key.pub)
+		auto wallet_accounts = system.wallet (0)->accounts ();
+		ASSERT_EQ (2, wallet_accounts.size ());
+		for (auto const & acc : wallet_accounts)
 		{
-			new_account = iterator2->first;
+			if (acc != nano::dev::genesis_key.pub)
+			{
+				new_account = acc;
+			}
 		}
-		++iterator2;
-		ASSERT_NE (system.wallet (0)->store.end (transaction), iterator2);
-		if (iterator2->first != nano::dev::genesis_key.pub)
-		{
-			new_account = iterator2->first;
-		}
-		++iterator2;
-		ASSERT_EQ (system.wallet (0)->store.end (transaction), iterator2);
 		ASSERT_FALSE (new_account.is_zero ());
 	}
 	ASSERT_TIMELY (10s, node1.balance (new_account) != 0);

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -127,9 +127,9 @@ TEST (vote_processor, weights)
 	system.wallet (1)->insert_adhoc (key0.prv);
 	system.wallet (2)->insert_adhoc (key1.prv);
 	system.wallet (3)->insert_adhoc (key2.prv);
-	system.wallet (1)->store.representative_set (system.nodes[1]->wallets.tx_begin_write (), key0.pub);
-	system.wallet (2)->store.representative_set (system.nodes[2]->wallets.tx_begin_write (), key1.pub);
-	system.wallet (3)->store.representative_set (system.nodes[3]->wallets.tx_begin_write (), key2.pub);
+	system.wallet (1)->set_representative (key0.pub);
+	system.wallet (2)->set_representative (key1.pub);
+	system.wallet (3)->set_representative (key2.pub);
 	system.wallet (0)->send_sync (nano::dev::genesis_key.pub, key0.pub, level0);
 	system.wallet (0)->send_sync (nano::dev::genesis_key.pub, key1.pub, level1);
 	system.wallet (0)->send_sync (nano::dev::genesis_key.pub, key2.pub, level2);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -568,9 +568,8 @@ TEST (wallet, work)
 	system.deadline_set (20s);
 	while (!done)
 	{
-		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 		uint64_t work (0);
-		if (!wallet->store.work_get (transaction, nano::dev::genesis_key.pub, work))
+		if (!wallet->get_work (nano::dev::genesis_key.pub, work))
 		{
 			done = nano::dev::network_params.work.difficulty (nano::dev::genesis->work_version (), nano::dev::genesis->hash (), work) >= system.nodes[0]->default_difficulty (nano::dev::genesis->work_version ());
 		}
@@ -586,11 +585,7 @@ TEST (wallet, work_generate)
 	nano::uint128_t amount1 (node1.balance (nano::dev::genesis_key.pub));
 	uint64_t work1;
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
-	nano::account account1;
-	{
-		auto transaction = node1.wallets.tx_begin_read ();
-		account1 = system.account (transaction, 0);
-	}
+	nano::account account1 = system.wallet (0)->accounts ().front ();
 	nano::keypair key;
 	auto block (wallet->send_action (nano::dev::genesis_key.pub, key.pub, 100));
 	ASSERT_TIMELY (10s, node1.ledger.any.account_balance (node1.ledger.tx_begin_read (), nano::dev::genesis_key.pub) != amount1);
@@ -600,8 +595,7 @@ TEST (wallet, work_generate)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 		auto block_transaction = node1.ledger.tx_begin_read ();
-		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-		again = wallet->store.work_get (transaction, account1, work1) || nano::dev::network_params.work.difficulty (block->work_version (), node1.ledger.latest_root (block_transaction, account1), work1) < node1.default_difficulty (block->work_version ());
+		again = wallet->get_work (account1, work1) || nano::dev::network_params.work.difficulty (block->work_version (), node1.ledger.latest_root (block_transaction, account1), work1) < node1.default_difficulty (block->work_version ());
 	}
 }
 
@@ -612,11 +606,7 @@ TEST (wallet, work_cache_delayed)
 	auto wallet (system.wallet (0));
 	uint64_t work1;
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
-	nano::account account1;
-	{
-		auto transaction = node1.wallets.tx_begin_read ();
-		account1 = system.account (transaction, 0);
-	}
+	nano::account account1 = system.wallet (0)->accounts ().front ();
 	nano::keypair key;
 	auto block1 (wallet->send_action (nano::dev::genesis_key.pub, key.pub, 100));
 	ASSERT_EQ (block1->hash (), node1.latest (nano::dev::genesis_key.pub));
@@ -629,7 +619,7 @@ TEST (wallet, work_cache_delayed)
 	while (again)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		if (!wallet->store.work_get (node1.wallets.tx_begin_read (), account1, work1))
+		if (!wallet->get_work (account1, work1))
 		{
 			again = nano::dev::network_params.work.difficulty (nano::work_version::work_1, block2->hash (), work1) < threshold;
 		}
@@ -744,9 +734,8 @@ TEST (wallet, no_work)
 	ASSERT_NE (nullptr, block);
 	ASSERT_NE (0, block->block_work ());
 	ASSERT_GE (nano::dev::network_params.work.difficulty (*block), nano::dev::network_params.work.threshold (block->work_version (), block->sideband ().details));
-	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
 	uint64_t cached_work (0);
-	system.wallet (0)->store.work_get (transaction, nano::dev::genesis_key.pub, cached_work);
+	system.wallet (0)->get_work (nano::dev::genesis_key.pub, cached_work);
 	ASSERT_EQ (0, cached_work);
 }
 
@@ -770,15 +759,13 @@ TEST (wallet, password_race)
 	std::thread thread ([&wallet] () {
 		for (int i = 0; i < 100; i++)
 		{
-			auto transaction (wallet->wallets.tx_begin_write ());
-			wallet->store.rekey (transaction, std::to_string (i));
+			wallet->rekey (std::to_string (i));
 		}
 	});
 	for (int i = 0; i < 100; i++)
 	{
-		auto transaction (wallet->wallets.tx_begin_read ());
 		// Password should always be valid, the rekey operation should be atomic.
-		bool ok = wallet->store.valid_password (transaction);
+		bool ok = !wallet->is_locked ();
 		EXPECT_TRUE (ok);
 		if (!ok)
 		{
@@ -797,10 +784,9 @@ TEST (wallet, password_race_corrupt_seed)
 	auto wallet = system.wallet (0);
 	nano::raw_key seed;
 	{
-		auto transaction (wallet->wallets.tx_begin_write ());
-		ASSERT_FALSE (wallet->store.rekey (transaction, "4567"));
-		wallet->store.seed (seed, transaction);
-		ASSERT_FALSE (wallet->store.attempt_password (transaction, "4567"));
+		ASSERT_FALSE (wallet->rekey ("4567"));
+		wallet->get_seed (seed);
+		ASSERT_FALSE (wallet->enter_password ("4567"));
 	}
 	std::vector<std::thread> threads;
 	for (int i = 0; i < 100; i++)
@@ -808,22 +794,19 @@ TEST (wallet, password_race_corrupt_seed)
 		threads.emplace_back ([&wallet] () {
 			for (int i = 0; i < 10; i++)
 			{
-				auto transaction (wallet->wallets.tx_begin_write ());
-				wallet->store.rekey (transaction, "0000");
+				wallet->rekey ("0000");
 			}
 		});
 		threads.emplace_back ([&wallet] () {
 			for (int i = 0; i < 10; i++)
 			{
-				auto transaction (wallet->wallets.tx_begin_write ());
-				wallet->store.rekey (transaction, "1234");
+				wallet->rekey ("1234");
 			}
 		});
 		threads.emplace_back ([&wallet] () {
 			for (int i = 0; i < 10; i++)
 			{
-				auto transaction (wallet->wallets.tx_begin_read ());
-				wallet->store.attempt_password (transaction, "1234");
+				wallet->enter_password ("1234");
 			}
 		});
 	}
@@ -834,23 +817,22 @@ TEST (wallet, password_race_corrupt_seed)
 	system.stop ();
 	runner.join ();
 	{
-		auto transaction (wallet->wallets.tx_begin_write ());
-		if (!wallet->store.attempt_password (transaction, "1234"))
+		if (!wallet->enter_password ("1234"))
 		{
 			nano::raw_key seed_now;
-			wallet->store.seed (seed_now, transaction);
+			wallet->get_seed (seed_now);
 			ASSERT_EQ (seed_now, seed);
 		}
-		else if (!wallet->store.attempt_password (transaction, "0000"))
+		else if (!wallet->enter_password ("0000"))
 		{
 			nano::raw_key seed_now;
-			wallet->store.seed (seed_now, transaction);
+			wallet->get_seed (seed_now);
 			ASSERT_EQ (seed_now, seed);
 		}
-		else if (!wallet->store.attempt_password (transaction, "4567"))
+		else if (!wallet->enter_password ("4567"))
 		{
 			nano::raw_key seed_now;
-			wallet->store.seed (seed_now, transaction);
+			wallet->get_seed (seed_now);
 			ASSERT_EQ (seed_now, seed);
 		}
 		else
@@ -880,8 +862,7 @@ TEST (wallet, change_seed)
 		nano::raw_key seed2;
 		wallet->get_seed (seed2);
 		ASSERT_EQ (seed1, seed2);
-		auto transaction (wallet->wallets.tx_begin_read ());
-		ASSERT_EQ (index + 1, wallet->store.deterministic_index_get (transaction));
+		ASSERT_EQ (index + 1, wallet->get_deterministic_index ());
 	}
 	ASSERT_TRUE (wallet->exists (pub));
 }
@@ -900,8 +881,7 @@ TEST (wallet, deterministic_restore)
 		nano::raw_key seed2;
 		wallet->get_seed (seed2);
 		ASSERT_EQ (seed1, seed2);
-		auto transaction (wallet->wallets.tx_begin_read ());
-		ASSERT_EQ (1, wallet->store.deterministic_index_get (transaction));
+		ASSERT_EQ (1, wallet->get_deterministic_index ());
 		auto prv = nano::deterministic_key (seed1, index);
 		pub = nano::pub_key (prv);
 	}
@@ -911,8 +891,7 @@ TEST (wallet, deterministic_restore)
 	ASSERT_TIMELY (5s, nano::test::exists (*system.nodes[0], { block }));
 	{
 		wallet->deterministic_restore ();
-		auto transaction (wallet->wallets.tx_begin_read ());
-		ASSERT_EQ (index + 1, wallet->store.deterministic_index_get (transaction));
+		ASSERT_EQ (index + 1, wallet->get_deterministic_index ());
 	}
 	ASSERT_TRUE (wallet->exists (pub));
 }
@@ -1112,7 +1091,7 @@ TEST (wallet, search_receivable)
 	ASSERT_TIMELY (5s, election = node.active.election (send->qualified_root ()));
 
 	// Erase the key so the confirmation does not trigger an automatic receive
-	wallet.store.erase (node.wallets.tx_begin_write (), nano::dev::genesis_key.pub);
+	wallet.remove_account (nano::dev::genesis_key.pub);
 
 	// Now confirm the election
 	election->force_confirm ();

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -527,7 +527,7 @@ TEST (wallet_store, import)
 	nano::keypair key1;
 	wallet1->insert_adhoc (key1.prv);
 	std::string json;
-	wallet1->serialize (json);
+	wallet1->serialize_json (json);
 	ASSERT_FALSE (wallet2->exists (key1.pub));
 	auto error (wallet2->import (json, ""));
 	ASSERT_FALSE (error);
@@ -542,7 +542,7 @@ TEST (wallet_store, fail_import_bad_password)
 	nano::keypair key1;
 	wallet1->insert_adhoc (key1.prv);
 	std::string json;
-	wallet1->serialize (json);
+	wallet1->serialize_json (json);
 	ASSERT_FALSE (wallet2->exists (key1.pub));
 	auto error (wallet2->import (json, "1"));
 	ASSERT_TRUE (error);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -642,13 +642,11 @@ TEST (wallet, insert_locked)
 	nano::test::system system (1);
 	auto wallet (system.wallet (0));
 	{
-		auto transaction (wallet->wallets.tx_begin_write ());
-		wallet->store.rekey (transaction, "1");
-		ASSERT_TRUE (wallet->store.valid_password (transaction));
-		wallet->enter_password (transaction, "");
+		wallet->rekey ("1");
+		ASSERT_FALSE (wallet->is_locked ());
+		wallet->enter_password ("");
 	}
-	auto transaction (wallet->wallets.tx_begin_read ());
-	ASSERT_FALSE (wallet->store.valid_password (transaction));
+	ASSERT_TRUE (wallet->is_locked ());
 	ASSERT_TRUE (wallet->insert_adhoc (nano::keypair ().prv).is_zero ());
 }
 
@@ -730,12 +728,11 @@ TEST (wallet, insert_deterministic_locked)
 {
 	nano::test::system system (1);
 	auto wallet (system.wallet (0));
-	auto transaction (wallet->wallets.tx_begin_write ());
-	wallet->store.rekey (transaction, "1");
-	ASSERT_TRUE (wallet->store.valid_password (transaction));
-	wallet->enter_password (transaction, "");
-	ASSERT_FALSE (wallet->store.valid_password (transaction));
-	ASSERT_TRUE (wallet->deterministic_insert (transaction).is_zero ());
+	wallet->rekey ("1");
+	ASSERT_FALSE (wallet->is_locked ());
+	wallet->enter_password ("");
+	ASSERT_TRUE (wallet->is_locked ());
+	ASSERT_TRUE (wallet->deterministic_insert ().is_zero ());
 }
 
 TEST (wallet, no_work)
@@ -879,11 +876,11 @@ TEST (wallet, change_seed)
 	ASSERT_NE (nullptr, block);
 	ASSERT_TIMELY (5s, nano::test::exists (*system.nodes[0], { block }));
 	{
-		auto transaction (wallet->wallets.tx_begin_write ());
-		wallet->change_seed (transaction, seed1);
+		wallet->change_seed (seed1);
 		nano::raw_key seed2;
-		wallet->store.seed (seed2, transaction);
+		wallet->get_seed (seed2);
 		ASSERT_EQ (seed1, seed2);
+		auto transaction (wallet->wallets.tx_begin_read ());
 		ASSERT_EQ (index + 1, wallet->store.deterministic_index_get (transaction));
 	}
 	ASSERT_TRUE (wallet->exists (pub));
@@ -899,11 +896,11 @@ TEST (wallet, deterministic_restore)
 	nano::public_key pub;
 	uint32_t index (4);
 	{
-		auto transaction (wallet->wallets.tx_begin_write ());
-		wallet->change_seed (transaction, seed1);
+		wallet->change_seed (seed1);
 		nano::raw_key seed2;
-		wallet->store.seed (seed2, transaction);
+		wallet->get_seed (seed2);
 		ASSERT_EQ (seed1, seed2);
+		auto transaction (wallet->wallets.tx_begin_read ());
 		ASSERT_EQ (1, wallet->store.deterministic_index_get (transaction));
 		auto prv = nano::deterministic_key (seed1, index);
 		pub = nano::pub_key (prv);
@@ -913,8 +910,8 @@ TEST (wallet, deterministic_restore)
 	ASSERT_NE (nullptr, block);
 	ASSERT_TIMELY (5s, nano::test::exists (*system.nodes[0], { block }));
 	{
-		auto transaction (wallet->wallets.tx_begin_write ());
-		wallet->deterministic_restore (transaction);
+		wallet->deterministic_restore ();
+		auto transaction (wallet->wallets.tx_begin_read ());
 		ASSERT_EQ (index + 1, wallet->store.deterministic_index_get (transaction));
 	}
 	ASSERT_TRUE (wallet->exists (pub));
@@ -1110,7 +1107,7 @@ TEST (wallet, search_receivable)
 
 	// Pending search should start an election
 	ASSERT_TRUE (node.active.empty ());
-	ASSERT_FALSE (wallet.search_receivable (wallet.wallets.tx_begin_read ()));
+	ASSERT_FALSE (wallet.search_receivable ());
 	std::shared_ptr<nano::election> election;
 	ASSERT_TIMELY (5s, election = node.active.election (send->qualified_root ()));
 
@@ -1127,7 +1124,7 @@ TEST (wallet, search_receivable)
 
 	// Pending search should create the receive block
 	ASSERT_EQ (2, node.ledger.block_count ());
-	ASSERT_FALSE (wallet.search_receivable (wallet.wallets.tx_begin_read ()));
+	ASSERT_FALSE (wallet.search_receivable ());
 	ASSERT_TIMELY_EQ (3s, node.balance (nano::dev::genesis_key.pub), nano::dev::constants.genesis_amount);
 	auto receive_hash = node.ledger.any.account_head (node.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
 	auto receive = node.block (receive_hash);

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -96,7 +96,7 @@ TEST (wallets, create_from_json)
 		auto wallet = wallets.create (id);
 		ASSERT_NE (nullptr, wallet);
 		account = wallet->deterministic_insert ();
-		wallet->serialize (json);
+		wallet->serialize_json (json);
 		ASSERT_FALSE (json.empty ());
 		wallets.destroy (id);
 		ASSERT_EQ (nullptr, wallets.open (id));

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -193,7 +193,7 @@ TEST (wallets, search_receivable)
 		auto & node (*system.add_node (config, flags));
 
 		nano::unique_lock<nano::mutex> lk (node.wallets.mutex);
-		auto wallets = node.wallets.get_wallets ();
+		auto wallets = node.wallets.all_wallets ();
 		lk.unlock ();
 		ASSERT_EQ (1, wallets.size ());
 		auto wallet_id = wallets.begin ()->first;

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -83,6 +83,39 @@ TEST (wallets, remove)
 	}
 }
 
+TEST (wallets, create_from_json)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+	node.wallets.stop (); // Stop node wallets to avoid race condition with local wallets sharing same LMDB environment
+	nano::wallet_id id (1);
+	std::string json;
+	nano::public_key account;
+	{
+		auto wallets = make_wallets (node);
+		auto wallet = wallets.create (id);
+		ASSERT_NE (nullptr, wallet);
+		account = wallet->deterministic_insert ();
+		wallet->serialize (json);
+		ASSERT_FALSE (json.empty ());
+		wallets.destroy (id);
+		ASSERT_EQ (nullptr, wallets.open (id));
+	}
+	{
+		auto wallets = make_wallets (node);
+		// Invalid JSON should return nullptr
+		auto bad_wallet = wallets.create_from_json (id, "not valid json");
+		ASSERT_EQ (nullptr, bad_wallet);
+		ASSERT_EQ (nullptr, wallets.open (id));
+		// Create wallet from exported JSON
+		auto wallet = wallets.create_from_json (id, json);
+		ASSERT_NE (nullptr, wallet);
+		ASSERT_NE (nullptr, wallets.open (id));
+		// Verify the account was restored
+		ASSERT_TRUE (wallet->exists (account));
+	}
+}
+
 // Opening multiple environments using the same file within the same process is not supported.
 // http://www.lmdb.tech/doc/starting.html
 TEST (wallets, DISABLED_reload)
@@ -192,9 +225,7 @@ TEST (wallets, search_receivable)
 		flags.disable_search_pending = true;
 		auto & node (*system.add_node (config, flags));
 
-		nano::unique_lock<nano::mutex> lk (node.wallets.mutex);
 		auto wallets = node.wallets.all_wallets ();
-		lk.unlock ();
 		ASSERT_EQ (1, wallets.size ());
 		auto wallet_id = wallets.begin ()->first;
 		auto wallet = wallets.begin ()->second;
@@ -226,7 +257,7 @@ TEST (wallets, search_receivable)
 		ASSERT_TIMELY (5s, election = node.active.election (send->qualified_root ()));
 
 		// Erase the key so the confirmation does not trigger an automatic receive
-		wallet->store.erase (node.wallets.tx_begin_write (), nano::dev::genesis_key.pub);
+		wallet->remove_account (nano::dev::genesis_key.pub);
 
 		// Now confirm the election
 		election->force_confirm ();

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -146,15 +146,14 @@ public:
 				}
 				if (wallet_config.account.is_zero () || !wallet->exists (wallet_config.account))
 				{
-					auto transaction (wallet->wallets.tx_begin_write ());
-					auto existing (wallet->store.begin (transaction));
-					if (existing != wallet->store.end (transaction))
+					auto wallet_accounts = wallet->accounts ();
+					if (!wallet_accounts.empty ())
 					{
-						wallet_config.account = existing->first;
+						wallet_config.account = wallet_accounts.front ();
 					}
 					else
 					{
-						wallet_config.account = wallet->deterministic_insert (transaction);
+						wallet_config.account = wallet->deterministic_insert ();
 					}
 				}
 

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -306,10 +306,9 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				auto wallet (inactive_node->node->wallets.open (wallet_id));
 				if (wallet != nullptr)
 				{
-					auto transaction (wallet->wallets.tx_begin_write ());
-					if (!wallet->enter_password (transaction, password))
+					if (!wallet->enter_password (password))
 					{
-						auto pub (wallet->store.deterministic_insert (transaction));
+						auto pub (wallet->deterministic_insert ());
 						std::cout << boost::str (boost::format ("Account: %1%\n") % pub.to_account ());
 					}
 					else
@@ -891,13 +890,12 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				auto wallet (inactive_node->node->wallets.open (wallet_id));
 				if (wallet != nullptr)
 				{
-					auto transaction (wallet->wallets.tx_begin_write ());
-					if (!wallet->enter_password (transaction, password))
+					if (!wallet->enter_password (password))
 					{
 						nano::raw_key key;
 						if (!key.decode_hex (vm["key"].as<std::string> ()))
 						{
-							wallet->store.insert_adhoc (transaction, key);
+							wallet->insert_adhoc (key);
 						}
 						else
 						{
@@ -945,8 +943,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				auto wallet (inactive_node->node->wallets.open (wallet_id));
 				if (wallet != nullptr)
 				{
-					auto transaction (wallet->wallets.tx_begin_write ());
-					if (!wallet->enter_password (transaction, password))
+					if (!wallet->enter_password (password))
 					{
 						nano::raw_key seed;
 						if (vm.count ("seed"))
@@ -965,7 +962,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 						if (!ec)
 						{
 							std::cout << "Changing seed and caching work. Please wait..." << std::endl;
-							wallet->change_seed (transaction, seed);
+							wallet->change_seed (seed);
 						}
 					}
 					else
@@ -1041,8 +1038,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				}
 				if (vm.count ("seed") || vm.count ("key"))
 				{
-					auto transaction (wallet->wallets.tx_begin_write ());
-					wallet->change_seed (transaction, seed_key);
+					wallet->change_seed (seed_key);
 				}
 				std::cout << wallet_key.to_string () << std::endl;
 			}
@@ -1070,17 +1066,15 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				auto existing (inactive_node->node->wallets.items.find (wallet_id));
 				if (existing != inactive_node->node->wallets.items.end ())
 				{
-					auto transaction (existing->second->wallets.tx_begin_write ());
-					if (!existing->second->enter_password (transaction, password))
+					if (!existing->second->enter_password (password))
 					{
 						nano::raw_key seed;
-						existing->second->store.seed (seed, transaction);
+						existing->second->get_seed (seed);
 						std::cout << boost::str (boost::format ("Seed: %1%\n") % seed.to_string ());
-						for (auto i (existing->second->store.begin (transaction)), m (existing->second->store.end (transaction)); i != m; ++i)
+						for (auto const & account : existing->second->accounts ())
 						{
-							nano::account const & account (i->first);
 							nano::raw_key key;
-							auto error (existing->second->store.fetch (transaction, account, key));
+							auto error (existing->second->fetch_prv (account, key));
 							(void)error;
 							debug_assert (!error);
 							std::cout << boost::str (boost::format ("Pub: %1% Prv: %2%\n") % account.to_account () % key.to_string ());
@@ -1176,14 +1170,10 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 						auto existing (node->wallets.items.find (wallet_id));
 						if (existing != node->wallets.items.end ())
 						{
-							bool valid (false);
+							bool valid (!existing->second->is_locked ());
+							if (!valid)
 							{
-								auto transaction (node->wallets.tx_begin_write ());
-								valid = existing->second->store.valid_password (transaction);
-								if (!valid)
-								{
-									valid = !existing->second->enter_password (transaction, password);
-								}
+								valid = !existing->second->enter_password (password);
 							}
 							if (valid)
 							{

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -1201,22 +1201,14 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 							}
 							else
 							{
-								bool error (true);
-								{
-									nano::lock_guard<nano::mutex> lock{ node->wallets.mutex };
-									auto transaction (node->wallets.tx_begin_write ());
-									nano::wallet wallet (error, transaction, node->wallets, wallet_id.to_string (), contents.str ());
-								}
-								if (error)
+								auto wallet = node->wallets.create_from_json (wallet_id, contents.str ());
+								if (!wallet)
 								{
 									std::cerr << "Unable to import wallet\n";
 									ec = nano::error_cli::invalid_arguments;
 								}
 								else
 								{
-									node->wallets.reload ();
-									nano::lock_guard<nano::mutex> lock{ node->wallets.mutex };
-									release_assert (node->wallets.items.find (wallet_id) != node->wallets.items.end ());
 									std::cout << "Import completed\n";
 								}
 							}

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -1028,8 +1028,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				if (vm.count ("password") > 0)
 				{
 					std::string password (vm["password"].as<std::string> ());
-					auto transaction (wallet->wallets.tx_begin_write ());
-					auto error (wallet->store.rekey (transaction, password));
+					auto error (wallet->rekey (password));
 					if (error)
 					{
 						std::cerr << "Password change error\n";
@@ -1251,13 +1250,12 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 	{
 		auto inactive_node = nano::default_inactive_node (data_path, vm);
 		auto node = inactive_node->node;
-		for (auto i (node->wallets.items.begin ()), n (node->wallets.items.end ()); i != n; ++i)
+		for (auto const & [id, wallet] : node->wallets.all_wallets ())
 		{
-			std::cout << boost::str (boost::format ("Wallet ID: %1%\n") % i->first.to_string ());
-			auto transaction (i->second->wallets.tx_begin_read ());
-			for (auto j (i->second->store.begin (transaction)), m (i->second->store.end (transaction)); j != m; ++j)
+			std::cout << boost::str (boost::format ("Wallet ID: %1%\n") % id.to_string ());
+			for (auto const & account : wallet->accounts ())
 			{
-				std::cout << nano::account (j->first).to_account () << '\n';
+				std::cout << account.to_account () << '\n';
 			}
 		}
 	}
@@ -1276,11 +1274,9 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 					nano::account account_id;
 					if (!account_id.decode_account (vm["account"].as<std::string> ()))
 					{
-						auto transaction (wallet->second->wallets.tx_begin_write ());
-						auto account (wallet->second->store.find (transaction, account_id));
-						if (account != wallet->second->store.end (transaction))
+						if (wallet->second->exists (account_id))
 						{
-							wallet->second->store.erase (transaction, account_id);
+							wallet->second->remove_account (account_id);
 						}
 						else
 						{
@@ -1324,8 +1320,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				auto wallet (node->wallets.items.find (wallet_id));
 				if (wallet != node->wallets.items.end ())
 				{
-					auto transaction (wallet->second->wallets.tx_begin_read ());
-					auto representative (wallet->second->store.representative (transaction));
+					auto representative (wallet->second->get_representative ());
 					std::cout << boost::str (boost::format ("Representative: %1%\n") % representative.to_account ());
 				}
 				else
@@ -1363,8 +1358,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 						auto wallet (node->wallets.items.find (wallet_id));
 						if (wallet != node->wallets.items.end ())
 						{
-							auto transaction (wallet->second->wallets.tx_begin_write ());
-							wallet->second->store.representative_set (transaction, account);
+							wallet->second->set_representative (account);
 						}
 						else
 						{

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -47,6 +47,7 @@ class vote_processor;
 class vote_rebroadcaster;
 class vote_router;
 class vote_spacing;
+class wallet;
 class wallets;
 
 enum class block_source;

--- a/nano/node/ipc/ipc_broker.cpp
+++ b/nano/node/ipc/ipc_broker.cpp
@@ -143,7 +143,6 @@ void nano::ipc::broker::broadcast (std::shared_ptr<nanoapi::EventConfirmationT> 
 				{
 					if (itr->topic->options->all_local_accounts)
 					{
-						auto transaction_l (this->node.wallets.tx_begin_read ());
 						nano::account source_l{};
 						nano::account destination_l{};
 						auto decode_source_ok_l (!source_l.decode_account (state->account));
@@ -151,7 +150,7 @@ void nano::ipc::broker::broadcast (std::shared_ptr<nanoapi::EventConfirmationT> 
 						(void)decode_source_ok_l;
 						(void)decode_destination_ok_l;
 						debug_assert (decode_source_ok_l && decode_destination_ok_l);
-						if (this->node.wallets.exists (transaction_l, source_l) || this->node.wallets.exists (transaction_l, destination_l))
+						if (this->node.wallets.exists_any (source_l, destination_l))
 						{
 							should_filter_account_l = false;
 						}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4611,7 +4611,7 @@ void nano::json_handler::wallet_export ()
 	if (!ec)
 	{
 		std::string json;
-		wallet->serialize (json);
+		wallet->serialize_json (json);
 		response_l.put ("json", json);
 	}
 	response_errors ();

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -17,6 +17,7 @@
 #include <nano/node/node_rpc_config.hpp>
 #include <nano/node/online_reps.hpp>
 #include <nano/node/telemetry.hpp>
+#include <nano/node/wallet.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_confirmed.hpp>

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -197,12 +197,12 @@ std::shared_ptr<nano::wallet> nano::json_handler::wallet_impl ()
 	return nullptr;
 }
 
-bool nano::json_handler::wallet_locked_impl (store::transaction const & transaction_a, std::shared_ptr<nano::wallet> const & wallet_a)
+bool nano::json_handler::wallet_locked_impl (std::shared_ptr<nano::wallet> const & wallet_a)
 {
 	bool result (false);
 	if (!ec)
 	{
-		if (!wallet_a->store.valid_password (transaction_a))
+		if (wallet_a->is_locked ())
 		{
 			ec = nano::error_common::wallet_locked;
 			result = true;
@@ -211,12 +211,12 @@ bool nano::json_handler::wallet_locked_impl (store::transaction const & transact
 	return result;
 }
 
-bool nano::json_handler::wallet_account_impl (store::transaction const & transaction_a, std::shared_ptr<nano::wallet> const & wallet_a, nano::account const & account_a)
+bool nano::json_handler::wallet_account_impl (std::shared_ptr<nano::wallet> const & wallet_a, nano::account const & account_a)
 {
 	bool result (false);
 	if (!ec)
 	{
-		if (wallet_a->store.find (transaction_a, account_a) != wallet_a->store.end (transaction_a))
+		if (wallet_a->exists (account_a))
 		{
 			result = true;
 		}
@@ -723,11 +723,10 @@ void nano::json_handler::account_list ()
 	if (!ec)
 	{
 		boost::property_tree::ptree accounts;
-		auto transaction (node.wallets.tx_begin_read ());
-		for (auto i (wallet->store.begin (transaction)), j (wallet->store.end (transaction)); i != j; ++i)
+		for (auto const & account : wallet->accounts ())
 		{
 			boost::property_tree::ptree entry;
-			entry.put ("", nano::account (i->first).to_account ());
+			entry.put ("", account.to_account ());
 			accounts.push_back (std::make_pair ("", entry));
 		}
 		response_l.add_child ("accounts", accounts);
@@ -749,15 +748,14 @@ void nano::json_handler::account_move ()
 				auto existing (rpc_l->node.wallets.items.find (source));
 				if (existing != rpc_l->node.wallets.items.end ())
 				{
-					auto source (existing->second);
+					auto source_wallet (existing->second);
 					std::vector<nano::public_key> accounts;
 					for (auto i (accounts_text.begin ()), n (accounts_text.end ()); i != n; ++i)
 					{
 						auto account (rpc_l->account_impl (i->second.get<std::string> ("")));
 						accounts.push_back (account);
 					}
-					auto transaction (rpc_l->node.wallets.tx_begin_write ());
-					auto error (wallet->store.move (transaction, source->store, accounts));
+					auto error (wallet->move_accounts (*source_wallet, accounts));
 					rpc_l->response_l.put ("moved", error ? "0" : "1");
 				}
 				else
@@ -781,12 +779,11 @@ void nano::json_handler::account_remove ()
 		auto account (rpc_l->account_impl ());
 		if (!rpc_l->ec)
 		{
-			auto transaction = rpc_l->node.wallets.tx_begin_write ();
-			rpc_l->wallet_locked_impl (transaction, wallet);
-			rpc_l->wallet_account_impl (transaction, wallet, account);
+			rpc_l->wallet_locked_impl (wallet);
+			rpc_l->wallet_account_impl (wallet, account);
 			if (!rpc_l->ec)
 			{
-				wallet->store.erase (transaction, account);
+				wallet->remove_account (account);
 				rpc_l->response_l.put ("removed", "1");
 			}
 		}
@@ -821,9 +818,8 @@ void nano::json_handler::account_representative_set ()
 			auto work (rpc_l->work_optional_impl ());
 			if (!rpc_l->ec && work)
 			{
-				auto transaction = rpc_l->node.wallets.tx_begin_write ();
-				rpc_l->wallet_locked_impl (transaction, wallet);
-				rpc_l->wallet_account_impl (transaction, wallet, account);
+				rpc_l->wallet_locked_impl (wallet);
+				rpc_l->wallet_account_impl (wallet, account);
 				if (!rpc_l->ec)
 				{
 					auto block_transaction = rpc_l->node.ledger.tx_begin_read ();
@@ -1535,13 +1531,12 @@ void nano::json_handler::block_create ()
 		auto existing (node.wallets.items.find (wallet));
 		if (existing != node.wallets.items.end ())
 		{
-			auto transaction = node.wallets.tx_begin_read ();
-			auto block_transaction = node.ledger.tx_begin_read ();
-			wallet_locked_impl (transaction, existing->second);
-			wallet_account_impl (transaction, existing->second, account);
+			wallet_locked_impl (existing->second);
+			wallet_account_impl (existing->second, account);
 			if (!ec)
 			{
-				existing->second->store.fetch (transaction, account, prv);
+				existing->second->fetch_prv (account, prv);
+				auto block_transaction = node.ledger.tx_begin_read ();
 				previous = node.ledger.any.account_head (block_transaction, account);
 				balance = node.ledger.any.account_balance (block_transaction, account).value_or (0);
 			}
@@ -2975,12 +2970,11 @@ void nano::json_handler::password_change ()
 		auto wallet (rpc_l->wallet_impl ());
 		if (!rpc_l->ec)
 		{
-			auto transaction (rpc_l->node.wallets.tx_begin_write ());
-			rpc_l->wallet_locked_impl (transaction, wallet);
+			rpc_l->wallet_locked_impl (wallet);
 			if (!rpc_l->ec)
 			{
 				std::string password_text (rpc_l->request.get<std::string> ("password"));
-				bool error (wallet->store.rekey (transaction, password_text));
+				bool error (wallet->rekey (password_text));
 				rpc_l->response_l.put ("changed", error ? "0" : "1");
 				if (!error)
 				{
@@ -3434,9 +3428,8 @@ void nano::json_handler::receive ()
 	auto hash (hash_impl ("block"));
 	if (!ec)
 	{
-		auto wallet_transaction (node.wallets.tx_begin_read ());
-		wallet_locked_impl (wallet_transaction, wallet);
-		wallet_account_impl (wallet_transaction, wallet, account);
+		wallet_locked_impl (wallet);
+		wallet_account_impl (wallet, account);
 		if (!ec)
 		{
 			auto block_transaction = node.ledger.tx_begin_read ();
@@ -3478,7 +3471,7 @@ void nano::json_handler::receive ()
 					{
 						// Representative is only used by receive_action when opening accounts
 						// Set a wallet default representative for new accounts
-						nano::account representative (wallet->store.representative (wallet_transaction));
+						nano::account representative (wallet->get_representative ());
 						bool generate_work (work == 0); // Disable work generation if "work" option is provided
 						auto response_a (response);
 						wallet->receive_async (
@@ -3806,10 +3799,9 @@ void nano::json_handler::send ()
 		}
 		if (!ec)
 		{
-			auto transaction (node.wallets.tx_begin_read ());
+			wallet_locked_impl (wallet);
+			wallet_account_impl (wallet, source);
 			auto block_transaction = node.ledger.tx_begin_read ();
-			wallet_locked_impl (transaction, wallet);
-			wallet_account_impl (transaction, wallet, source);
 			auto info (account_info_impl (block_transaction, source));
 			if (!ec)
 			{
@@ -3917,12 +3909,11 @@ void nano::json_handler::sign ()
 				auto wallet (wallet_impl ());
 				if (!ec)
 				{
-					auto transaction (node.wallets.tx_begin_read ());
-					wallet_locked_impl (transaction, wallet);
-					wallet_account_impl (transaction, wallet, account);
+					wallet_locked_impl (wallet);
+					wallet_account_impl (wallet, account);
 					if (!ec)
 					{
-						wallet->store.fetch (transaction, account, prv);
+						wallet->fetch_prv (account, prv);
 					}
 				}
 			}
@@ -4435,12 +4426,9 @@ void nano::json_handler::wallet_info ()
 		uint64_t cemented_block_count (0);
 		uint64_t deterministic_count (0);
 		uint64_t adhoc_count (0);
-		auto transaction (node.wallets.tx_begin_read ());
 		auto block_transaction = node.ledger.tx_begin_read ();
-		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end (transaction)); i != n; ++i)
+		for (auto const & account : wallet->accounts ())
 		{
-			nano::account const & account (i->first);
-
 			auto account_info = node.ledger.any.account_get (block_transaction, account);
 			if (account_info)
 			{
@@ -4456,12 +4444,12 @@ void nano::json_handler::wallet_info ()
 
 			receivable += node.ledger.account_receivable (block_transaction, account);
 
-			nano::key_type key_type (wallet->store.key_type (i->second));
-			if (key_type == nano::key_type::deterministic)
+			nano::key_type key_type_l (wallet->key_type (account));
+			if (key_type_l == nano::key_type::deterministic)
 			{
 				deterministic_count++;
 			}
-			else if (key_type == nano::key_type::adhoc)
+			else if (key_type_l == nano::key_type::adhoc)
 			{
 				adhoc_count++;
 			}
@@ -4469,7 +4457,7 @@ void nano::json_handler::wallet_info ()
 			++count;
 		}
 
-		uint32_t deterministic_index (wallet->store.deterministic_index_get (transaction));
+		uint32_t deterministic_index (wallet->get_deterministic_index ());
 		response_l.put ("balance", balance.convert_to<std::string> ());
 		response_l.put ("pending", receivable.convert_to<std::string> ());
 		response_l.put ("receivable", receivable.convert_to<std::string> ());
@@ -4491,11 +4479,9 @@ void nano::json_handler::wallet_balances ()
 	if (!ec)
 	{
 		boost::property_tree::ptree balances;
-		auto transaction (node.wallets.tx_begin_read ());
 		auto block_transaction = node.ledger.tx_begin_read ();
-		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end (transaction)); i != n; ++i)
+		for (auto const & account : wallet->accounts ())
 		{
-			nano::account const & account (i->first);
 			nano::uint128_t balance = node.ledger.any.account_balance (block_transaction, account).value_or (0).number ();
 			if (balance >= threshold.number ())
 			{
@@ -4528,8 +4514,7 @@ void nano::json_handler::wallet_change_seed ()
 					nano::public_key account (wallet->change_seed (seed, count));
 					rpc_l->response_l.put ("success", "");
 					rpc_l->response_l.put ("last_restored_account", account.to_account ());
-					auto transaction (rpc_l->node.wallets.tx_begin_read ());
-					auto index (wallet->store.deterministic_index_get (transaction));
+					auto index (wallet->get_deterministic_index ());
 					debug_assert (index > 0);
 					rpc_l->response_l.put ("restored_count", std::to_string (index));
 				}
@@ -4584,8 +4569,7 @@ void nano::json_handler::wallet_create ()
 			{
 				nano::public_key account (wallet->change_seed (seed));
 				rpc_l->response_l.put ("last_restored_account", account.to_account ());
-				auto transaction (rpc_l->node.wallets.tx_begin_read ());
-				auto index (wallet->store.deterministic_index_get (transaction));
+				auto index (wallet->get_deterministic_index ());
 				debug_assert (index > 0);
 				rpc_l->response_l.put ("restored_count", std::to_string (index));
 			}
@@ -4626,9 +4610,8 @@ void nano::json_handler::wallet_export ()
 	auto wallet (wallet_impl ());
 	if (!ec)
 	{
-		auto transaction (node.wallets.tx_begin_read ());
 		std::string json;
-		wallet->store.serialize_json (transaction, json);
+		wallet->serialize (json);
 		response_l.put ("json", json);
 	}
 	response_errors ();
@@ -4640,11 +4623,9 @@ void nano::json_handler::wallet_frontiers ()
 	if (!ec)
 	{
 		boost::property_tree::ptree frontiers;
-		auto transaction (node.wallets.tx_begin_read ());
 		auto block_transaction = node.ledger.tx_begin_read ();
-		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end (transaction)); i != n; ++i)
+		for (auto const & account : wallet->accounts ())
 		{
-			nano::account const & account (i->first);
 			auto latest (node.ledger.any.account_head (block_transaction, account));
 			if (!latest.is_zero ())
 			{
@@ -4671,11 +4652,9 @@ void nano::json_handler::wallet_history ()
 	if (!ec)
 	{
 		std::multimap<uint64_t, boost::property_tree::ptree, std::greater<uint64_t>> entries;
-		auto transaction (node.wallets.tx_begin_read ());
 		auto block_transaction = node.ledger.tx_begin_read ();
-		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end (transaction)); i != n; ++i)
+		for (auto const & account : wallet->accounts ())
 		{
-			nano::account const & account (i->first);
 			auto info = node.ledger.any.account_get (block_transaction, account);
 			if (info)
 			{
@@ -4722,8 +4701,7 @@ void nano::json_handler::wallet_key_valid ()
 	auto wallet (wallet_impl ());
 	if (!ec)
 	{
-		auto transaction (node.wallets.tx_begin_read ());
-		auto valid (wallet->store.valid_password (transaction));
+		auto valid (!wallet->is_locked ());
 		response_l.put ("valid", valid ? "1" : "0");
 	}
 	response_errors ();
@@ -4745,11 +4723,9 @@ void nano::json_handler::wallet_ledger ()
 	if (!ec)
 	{
 		boost::property_tree::ptree accounts;
-		auto transaction (node.wallets.tx_begin_read ());
 		auto block_transaction = node.ledger.tx_begin_read ();
-		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end (transaction)); i != n; ++i)
+		for (auto const & account : wallet->accounts ())
 		{
-			nano::account const & account (i->first);
 			auto info = node.ledger.any.account_get (block_transaction, account);
 			if (info)
 			{
@@ -4820,11 +4796,9 @@ void nano::json_handler::wallet_receivable ()
 	if (!ec)
 	{
 		boost::property_tree::ptree pending;
-		auto transaction (node.wallets.tx_begin_read ());
 		auto block_transaction = node.ledger.tx_begin_read ();
-		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end (transaction)); i != n; ++i)
+		for (auto const & account : wallet->accounts ())
 		{
-			nano::account const & account (i->first);
 			boost::property_tree::ptree peers_l;
 			for (auto ii (node.store.pending.begin (block_transaction, nano::pending_key (account, 0))), nn (node.store.pending.end (block_transaction)); ii != nn && nano::pending_key (ii->first).account == account && peers_l.size () < count; ++ii)
 			{
@@ -4939,11 +4913,9 @@ void nano::json_handler::wallet_republish ()
 	{
 		boost::property_tree::ptree blocks;
 		std::deque<std::shared_ptr<nano::block>> republish_bundle;
-		auto transaction (node.wallets.tx_begin_read ());
 		auto block_transaction = node.ledger.tx_begin_read ();
-		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end (transaction)); i != n; ++i)
+		for (auto const & account : wallet->accounts ())
 		{
-			nano::account const & account (i->first);
 			auto latest (node.ledger.any.account_head (block_transaction, account));
 			std::shared_ptr<nano::block> block;
 			std::vector<nano::block_hash> hashes;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2999,8 +2999,7 @@ void nano::json_handler::password_enter ()
 		if (!rpc_l->ec)
 		{
 			std::string password_text (rpc_l->request.get<std::string> ("password"));
-			auto transaction (wallet->wallets.tx_begin_write ());
-			auto error (wallet->enter_password (transaction, password_text));
+			auto error (wallet->enter_password (password_text));
 			rpc_l->response_l.put ("valid", error ? "0" : "1");
 		}
 		rpc_l->response_errors ();
@@ -3012,8 +3011,7 @@ void nano::json_handler::password_valid (bool wallet_locked)
 	auto wallet (wallet_impl ());
 	if (!ec)
 	{
-		auto transaction (node.wallets.tx_begin_read ());
-		auto valid (wallet->store.valid_password (transaction));
+		auto valid (!wallet->is_locked ());
 		if (!wallet_locked)
 		{
 			response_l.put ("valid", valid ? "1" : "0");
@@ -3763,7 +3761,7 @@ void nano::json_handler::search_receivable ()
 	auto wallet (wallet_impl ());
 	if (!ec)
 	{
-		auto error (wallet->search_receivable (wallet->wallets.tx_begin_read ()));
+		auto error (wallet->search_receivable ());
 		response_l.put ("started", !error);
 	}
 	response_errors ();
@@ -4398,15 +4396,14 @@ void nano::json_handler::wallet_add_watch ()
 		auto wallet (rpc_l->wallet_impl ());
 		if (!rpc_l->ec)
 		{
-			auto transaction (rpc_l->node.wallets.tx_begin_write ());
-			if (wallet->store.valid_password (transaction))
+			if (!wallet->is_locked ())
 			{
 				for (auto & accounts : rpc_l->request.get_child ("accounts"))
 				{
 					auto account (rpc_l->account_impl (accounts.second.data ()));
 					if (!rpc_l->ec)
 					{
-						if (wallet->insert_watch (transaction, account))
+						if (wallet->insert_watch (account))
 						{
 							rpc_l->ec = nano::error_common::bad_public_key;
 						}
@@ -4526,12 +4523,12 @@ void nano::json_handler::wallet_change_seed ()
 			if (!seed.decode_hex (seed_text))
 			{
 				auto count (static_cast<uint32_t> (rpc_l->count_optional_impl (0)));
-				auto transaction (rpc_l->node.wallets.tx_begin_write ());
-				if (wallet->store.valid_password (transaction))
+				if (!wallet->is_locked ())
 				{
-					nano::public_key account (wallet->change_seed (transaction, seed, count));
+					nano::public_key account (wallet->change_seed (seed, count));
 					rpc_l->response_l.put ("success", "");
 					rpc_l->response_l.put ("last_restored_account", account.to_account ());
+					auto transaction (rpc_l->node.wallets.tx_begin_read ());
 					auto index (wallet->store.deterministic_index_get (transaction));
 					debug_assert (index > 0);
 					rpc_l->response_l.put ("restored_count", std::to_string (index));
@@ -4556,9 +4553,7 @@ void nano::json_handler::wallet_contains ()
 	auto wallet (wallet_impl ());
 	if (!ec)
 	{
-		auto transaction (node.wallets.tx_begin_read ());
-		auto exists (wallet->store.find (transaction, account) != wallet->store.end (transaction));
-		response_l.put ("exists", exists ? "1" : "0");
+		response_l.put ("exists", wallet->exists (account) ? "1" : "0");
 	}
 	response_errors ();
 }
@@ -4587,9 +4582,9 @@ void nano::json_handler::wallet_create ()
 			}
 			if (!rpc_l->ec && seed_text.is_initialized ())
 			{
-				auto transaction (rpc_l->node.wallets.tx_begin_write ());
-				nano::public_key account (wallet->change_seed (transaction, seed));
+				nano::public_key account (wallet->change_seed (seed));
 				rpc_l->response_l.put ("last_restored_account", account.to_account ());
+				auto transaction (rpc_l->node.wallets.tx_begin_read ());
 				auto index (wallet->store.deterministic_index_get (transaction));
 				debug_assert (index > 0);
 				rpc_l->response_l.put ("restored_count", std::to_string (index));
@@ -4884,8 +4879,7 @@ void nano::json_handler::wallet_representative ()
 	auto wallet (wallet_impl ());
 	if (!ec)
 	{
-		auto transaction (node.wallets.tx_begin_read ());
-		response_l.put ("representative", wallet->store.representative (transaction).to_account ());
+		response_l.put ("representative", wallet->get_representative ().to_account ());
 	}
 	response_errors ();
 }
@@ -4899,28 +4893,23 @@ void nano::json_handler::wallet_representative_set ()
 		if (!rpc_l->ec)
 		{
 			bool update_existing_accounts (rpc_l->request.get<bool> ("update_existing_accounts", false));
+			if (update_existing_accounts && wallet->is_locked ())
 			{
-				auto transaction (rpc_l->node.wallets.tx_begin_write ());
-				if (wallet->store.valid_password (transaction) || !update_existing_accounts)
-				{
-					wallet->store.representative_set (transaction, representative);
-					rpc_l->response_l.put ("set", "1");
-				}
-				else
-				{
-					rpc_l->ec = nano::error_common::wallet_locked;
-				}
+				rpc_l->ec = nano::error_common::wallet_locked;
+			}
+			else
+			{
+				wallet->set_representative (representative);
+				rpc_l->response_l.put ("set", "1");
 			}
 			// Change representative for all wallet accounts
 			if (!rpc_l->ec && update_existing_accounts)
 			{
 				std::vector<nano::account> accounts;
 				{
-					auto transaction (rpc_l->node.wallets.tx_begin_read ());
 					auto block_transaction = rpc_l->node.ledger.tx_begin_read ();
-					for (auto i (wallet->store.begin (transaction)), n (wallet->store.end (transaction)); i != n; ++i)
+					for (auto const & account : wallet->accounts ())
 					{
-						nano::account const & account (i->first);
 						auto info = rpc_l->node.ledger.any.account_get (block_transaction, account);
 						if (info)
 						{
@@ -4992,11 +4981,9 @@ void nano::json_handler::wallet_seed ()
 	auto wallet (wallet_impl ());
 	if (!ec)
 	{
-		auto transaction (node.wallets.tx_begin_read ());
-		if (wallet->store.valid_password (transaction))
+		nano::raw_key seed;
+		if (!wallet->get_seed (seed))
 		{
-			nano::raw_key seed;
-			wallet->store.seed (seed, transaction);
 			response_l.put ("seed", seed.to_string ());
 		}
 		else
@@ -5013,12 +5000,10 @@ void nano::json_handler::wallet_work_get ()
 	if (!ec)
 	{
 		boost::property_tree::ptree works;
-		auto transaction (node.wallets.tx_begin_read ());
-		for (auto i (wallet->store.begin (transaction)), n (wallet->store.end (transaction)); i != n; ++i)
+		for (auto const & account : wallet->accounts ())
 		{
-			nano::account const & account (i->first);
 			uint64_t work (0);
-			auto error_work (wallet->store.work_get (transaction, account, work));
+			auto error_work (wallet->get_work (account, work));
 			(void)error_work;
 			works.put (account.to_account (), nano::to_string_hex (work));
 		}
@@ -5164,12 +5149,14 @@ void nano::json_handler::work_get ()
 	auto account (account_impl ());
 	if (!ec)
 	{
-		auto transaction (node.wallets.tx_begin_read ());
-		wallet_account_impl (transaction, wallet, account);
-		if (!ec)
+		if (!wallet->exists (account))
+		{
+			ec = nano::error_common::account_not_found_wallet;
+		}
+		else
 		{
 			uint64_t work (0);
-			auto error_work (wallet->store.work_get (transaction, account, work));
+			auto error_work (wallet->get_work (account, work));
 			(void)error_work;
 			response_l.put ("work", nano::to_string_hex (work));
 		}
@@ -5185,11 +5172,13 @@ void nano::json_handler::work_set ()
 		auto work (rpc_l->work_optional_impl ());
 		if (!rpc_l->ec)
 		{
-			auto transaction (rpc_l->node.wallets.tx_begin_write ());
-			rpc_l->wallet_account_impl (transaction, wallet, account);
-			if (!rpc_l->ec)
+			if (!wallet->exists (account))
 			{
-				wallet->store.work_put (transaction, account, work);
+				rpc_l->ec = nano::error_common::account_not_found_wallet;
+			}
+			else
+			{
+				wallet->set_work (account, work);
 				rpc_l->response_l.put ("success", "");
 			}
 		}

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
 #include <nano/lib/numbers.hpp>
+#include <nano/node/fwd.hpp>
 #include <nano/node/ipc/flatbuffers_handler.hpp>
-#include <nano/node/wallet.hpp>
 #include <nano/rpc/rpc.hpp>
 
 #include <boost/property_tree/ptree.hpp>

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -159,8 +159,8 @@ public:
 	std::string action;
 	boost::property_tree::ptree response_l;
 	std::shared_ptr<nano::wallet> wallet_impl ();
-	bool wallet_locked_impl (store::transaction const &, std::shared_ptr<nano::wallet> const &);
-	bool wallet_account_impl (store::transaction const &, std::shared_ptr<nano::wallet> const &, nano::account const &);
+	bool wallet_locked_impl (std::shared_ptr<nano::wallet> const &);
+	bool wallet_account_impl (std::shared_ptr<nano::wallet> const &, nano::account const &);
 	nano::account account_impl (std::string = "", std::error_code = nano::error_common::bad_account_number);
 	nano::account_info account_info_impl (secure::transaction const &, nano::account const &);
 	nano::amount amount_impl ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -48,6 +48,7 @@
 #include <nano/node/vote_processor.hpp>
 #include <nano/node/vote_rebroadcaster.hpp>
 #include <nano/node/vote_router.hpp>
+#include <nano/node/wallet.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -707,15 +707,14 @@ nano::uint128_t nano::node::minimum_principal_weight ()
 
 void nano::node::backup_wallet ()
 {
-	auto transaction (wallets.tx_begin_read ());
-	for (auto i (wallets.items.begin ()), n (wallets.items.end ()); i != n; ++i)
+	for (auto const & [id, wallet] : wallets.all_wallets ())
 	{
 		boost::system::error_code error_chmod;
 		auto backup_path (application_path / "backup");
 
 		std::filesystem::create_directories (backup_path);
 		nano::set_secure_perm_directory (backup_path, error_chmod);
-		i->second->store.write_backup (transaction, backup_path / (i->first.to_string () + ".json"));
+		wallet->write_backup (backup_path / (id.to_string () + ".json"));
 	}
 	auto this_l (shared ());
 	workers.post_delayed (network_params.node.backup_interval, [this_l] () {

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -19,7 +19,6 @@
 #include <nano/node/transport/tcp_server.hpp>
 #include <nano/node/unchecked_map.hpp>
 #include <nano/node/vote_cache.hpp>
-#include <nano/node/wallet.hpp>
 #include <nano/node/websocket.hpp>
 #include <nano/weights/bootstrap_weights.hpp>
 

--- a/nano/node/vote_generator.hpp
+++ b/nano/node/vote_generator.hpp
@@ -7,7 +7,6 @@
 #include <nano/lib/processing_queue.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/fwd.hpp>
-#include <nano/node/wallet.hpp>
 #include <nano/secure/common.hpp>
 
 #include <boost/multi_index/hashed_index.hpp>

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1752,6 +1752,27 @@ std::shared_ptr<nano::wallet> nano::wallets::create (nano::wallet_id const & id_
 	return result;
 }
 
+std::shared_ptr<nano::wallet> nano::wallets::create_from_json (nano::wallet_id const & id_a, std::string const & json_a)
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	debug_assert (items.find (id_a) == items.end ());
+	std::shared_ptr<nano::wallet> result;
+	bool error;
+	{
+		auto transaction (tx_begin_write ());
+		result = std::make_shared<nano::wallet> (error, transaction, *this, id_a.to_string (), json_a);
+	}
+	if (!error)
+	{
+		items[id_a] = result;
+	}
+	else
+	{
+		result = nullptr;
+	}
+	return result;
+}
+
 bool nano::wallets::search_receivable (nano::wallet_id const & wallet_a)
 {
 	auto result (false);
@@ -1764,9 +1785,7 @@ bool nano::wallets::search_receivable (nano::wallet_id const & wallet_a)
 
 void nano::wallets::search_receivable_all ()
 {
-	nano::unique_lock<nano::mutex> lk{ mutex };
 	auto wallets_l = all_wallets ();
-	lk.unlock ();
 	for (auto const & [id, wallet] : wallets_l)
 	{
 		wallet->search_receivable ();
@@ -2045,10 +2064,8 @@ void nano::wallets::run_receivable_scan ()
 
 void nano::wallets::receive_confirmed (nano::block_hash const & hash_a, nano::account const & destination_a)
 {
-	nano::unique_lock<nano::mutex> lk{ mutex };
 	auto wallets_l = all_wallets ();
 	auto wallet_transaction = tx_begin_read ();
-	lk.unlock ();
 	for ([[maybe_unused]] auto const & [id, wallet] : wallets_l)
 	{
 		if (wallet->store.exists (wallet_transaction, destination_a))
@@ -2079,7 +2096,7 @@ void nano::wallets::receive_confirmed (nano::block_hash const & hash_a, nano::ac
 
 std::unordered_map<nano::wallet_id, std::shared_ptr<nano::wallet>> nano::wallets::all_wallets ()
 {
-	debug_assert (!mutex.try_lock ());
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	return items;
 }
 

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -886,7 +886,7 @@ bool nano::wallet::import (std::string const & json_a, std::string const & passw
 	return error;
 }
 
-void nano::wallet::serialize (std::string & json_a)
+void nano::wallet::serialize_json (std::string & json_a)
 {
 	auto transaction (wallets.tx_begin_read ());
 	store.serialize_json (transaction, json_a);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -29,19 +29,19 @@
 
 template class nano::store::typed_iterator<nano::account, nano::wallet_value>;
 
-nano::uint256_union nano::wallet_store::check (nano::store::transaction const & transaction_a)
+nano::uint256_union nano::wallet_store::check (nano::store::transaction const & transaction_a) const
 {
 	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::check_special));
 	return value.key;
 }
 
-nano::uint256_union nano::wallet_store::salt (nano::store::transaction const & transaction_a)
+nano::uint256_union nano::wallet_store::salt (nano::store::transaction const & transaction_a) const
 {
 	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::salt_special));
 	return value.key;
 }
 
-void nano::wallet_store::wallet_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a)
+void nano::wallet_store::wallet_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a) const
 {
 	nano::lock_guard<std::recursive_mutex> lock{ mutex };
 	nano::raw_key wallet_l;
@@ -51,7 +51,7 @@ void nano::wallet_store::wallet_key (nano::raw_key & prv_a, nano::store::transac
 	prv_a.decrypt (wallet_l, password_l, salt (transaction_a).owords[0]);
 }
 
-void nano::wallet_store::seed (nano::raw_key & prv_a, nano::store::transaction const & transaction_a)
+void nano::wallet_store::seed (nano::raw_key & prv_a, nano::store::transaction const & transaction_a) const
 {
 	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::seed_special));
 	nano::raw_key password_l;
@@ -100,7 +100,7 @@ nano::public_key nano::wallet_store::deterministic_insert (nano::store::write_tr
 	return result;
 }
 
-nano::raw_key nano::wallet_store::deterministic_key (nano::store::transaction const & transaction_a, uint32_t index_a)
+nano::raw_key nano::wallet_store::deterministic_key (nano::store::transaction const & transaction_a, uint32_t index_a) const
 {
 	debug_assert (valid_password (transaction_a));
 	nano::raw_key seed_l;
@@ -108,7 +108,7 @@ nano::raw_key nano::wallet_store::deterministic_key (nano::store::transaction co
 	return nano::deterministic_key (seed_l, index_a);
 }
 
-uint32_t nano::wallet_store::deterministic_index_get (nano::store::transaction const & transaction_a)
+uint32_t nano::wallet_store::deterministic_index_get (nano::store::transaction const & transaction_a) const
 {
 	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::deterministic_index_special));
 	return static_cast<uint32_t> (value.key.number () & static_cast<uint32_t> (-1));
@@ -145,7 +145,7 @@ void nano::wallet_store::deterministic_clear (nano::store::write_transaction con
 	deterministic_index_set (transaction_a, 0);
 }
 
-bool nano::wallet_store::valid_password (nano::store::transaction const & transaction_a)
+bool nano::wallet_store::valid_password (nano::store::transaction const & transaction_a) const
 {
 	nano::raw_key zero;
 	zero.clear ();
@@ -207,7 +207,7 @@ bool nano::wallet_store::rekey (nano::store::write_transaction const & transacti
 	return result;
 }
 
-void nano::wallet_store::derive_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a, std::string const & password_a)
+void nano::wallet_store::derive_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a, std::string const & password_a) const
 {
 	auto salt_l (salt (transaction_a));
 	kdf.phs (prv_a, password_a, salt_l);
@@ -226,13 +226,13 @@ nano::fan::fan (nano::raw_key const & key, std::size_t count_a)
 	values.push_back (std::move (first));
 }
 
-void nano::fan::value (nano::raw_key & prv_a)
+void nano::fan::value (nano::raw_key & prv_a) const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	value_get (prv_a);
 }
 
-void nano::fan::value_get (nano::raw_key & prv_a)
+void nano::fan::value_get (nano::raw_key & prv_a) const
 {
 	debug_assert (!mutex.try_lock ());
 	prv_a.clear ();
@@ -394,7 +394,7 @@ nano::wallet_store::wallet_store (bool & init_a, nano::kdf & kdf_a, nano::store:
 	wallet_key_mem.value_set (key);
 }
 
-std::vector<nano::account> nano::wallet_store::accounts (nano::store::transaction const & transaction_a)
+std::vector<nano::account> nano::wallet_store::accounts (nano::store::transaction const & transaction_a) const
 {
 	std::vector<nano::account> result;
 	for (auto i (begin (transaction_a)), n (end (transaction_a)); i != n; ++i)
@@ -415,7 +415,7 @@ void nano::wallet_store::initialize (nano::store::write_transaction const & tran
 	init_a = error != 0;
 }
 
-bool nano::wallet_store::is_representative (nano::store::transaction const & transaction_a)
+bool nano::wallet_store::is_representative (nano::store::transaction const & transaction_a) const
 {
 	return exists (transaction_a, representative (transaction_a));
 }
@@ -427,7 +427,7 @@ void nano::wallet_store::representative_set (nano::store::write_transaction cons
 	entry_put_raw (transaction_a, nano::wallet_store::representative_special, nano::wallet_value (rep, 0));
 }
 
-nano::account nano::wallet_store::representative (nano::store::transaction const & transaction_a)
+nano::account nano::wallet_store::representative (nano::store::transaction const & transaction_a) const
 {
 	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::representative_special));
 	return reinterpret_cast<nano::account const &> (value.key);
@@ -463,7 +463,7 @@ void nano::wallet_store::erase (nano::store::write_transaction const & transacti
 	release_assert (nano::store::lmdb::success (status), nano::store::lmdb::error_string (status));
 }
 
-nano::wallet_value nano::wallet_store::entry_get_raw (nano::store::transaction const & transaction_a, nano::account const & pub_a)
+nano::wallet_value nano::wallet_store::entry_get_raw (nano::store::transaction const & transaction_a, nano::account const & pub_a) const
 {
 	nano::wallet_value result;
 	nano::store::lmdb::db_val value;
@@ -494,7 +494,7 @@ void nano::wallet_store::entry_put_raw (nano::store::write_transaction const & t
 	release_assert (nano::store::lmdb::success (status), nano::store::lmdb::error_string (status));
 }
 
-nano::key_type nano::wallet_store::key_type (nano::wallet_value const & value_a)
+nano::key_type nano::wallet_store::key_type (nano::wallet_value const & value_a) const
 {
 	auto number (value_a.key.number ());
 	nano::key_type result;
@@ -517,7 +517,7 @@ nano::key_type nano::wallet_store::key_type (nano::wallet_value const & value_a)
 	return result;
 }
 
-bool nano::wallet_store::fetch (nano::store::transaction const & transaction_a, nano::account const & pub, nano::raw_key & prv)
+bool nano::wallet_store::fetch (nano::store::transaction const & transaction_a, nano::account const & pub, nano::raw_key & prv) const
 {
 	auto result (false);
 	if (valid_password (transaction_a))
@@ -570,17 +570,17 @@ bool nano::wallet_store::fetch (nano::store::transaction const & transaction_a, 
 	return result;
 }
 
-bool nano::wallet_store::valid_public_key (nano::public_key const & pub)
+bool nano::wallet_store::valid_public_key (nano::public_key const & pub) const
 {
 	return pub.number () >= special_count;
 }
 
-bool nano::wallet_store::exists (nano::store::transaction const & transaction_a, nano::public_key const & pub)
+bool nano::wallet_store::exists (nano::store::transaction const & transaction_a, nano::public_key const & pub) const
 {
 	return valid_public_key (pub) && find (transaction_a, pub) != end (transaction_a);
 }
 
-void nano::wallet_store::serialize_json (nano::store::transaction const & transaction_a, std::string & string_a)
+void nano::wallet_store::serialize_json (nano::store::transaction const & transaction_a, std::string & string_a) const
 {
 	boost::property_tree::ptree tree;
 	using iterator = store::typed_iterator<nano::uint256_union, nano::wallet_value>;
@@ -593,7 +593,7 @@ void nano::wallet_store::serialize_json (nano::store::transaction const & transa
 	string_a = ostream.str ();
 }
 
-void nano::wallet_store::write_backup (nano::store::transaction const & transaction_a, std::filesystem::path const & path_a)
+void nano::wallet_store::write_backup (nano::store::transaction const & transaction_a, std::filesystem::path const & path_a) const
 {
 	std::ofstream backup_file;
 	backup_file.open (path_a.string ());
@@ -654,7 +654,7 @@ bool nano::wallet_store::import (nano::store::write_transaction const & transact
 	return result;
 }
 
-bool nano::wallet_store::work_get (nano::store::transaction const & transaction_a, nano::public_key const & pub_a, uint64_t & work_a)
+bool nano::wallet_store::work_get (nano::store::transaction const & transaction_a, nano::public_key const & pub_a, uint64_t & work_a) const
 {
 	auto result (false);
 	auto entry (entry_get_raw (transaction_a, pub_a));
@@ -677,7 +677,7 @@ void nano::wallet_store::work_put (nano::store::write_transaction const & transa
 	entry_put_raw (transaction_a, pub_a, entry);
 }
 
-unsigned nano::wallet_store::version (nano::store::transaction const & transaction_a)
+unsigned nano::wallet_store::version (nano::store::transaction const & transaction_a) const
 {
 	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::version_special));
 	auto entry (value.key);
@@ -736,12 +736,18 @@ void nano::wallet::enter_initial_password ()
 		}
 		else
 		{
-			enter_password (transaction, "");
+			enter_password_impl (transaction, "");
 		}
 	}
 }
 
-bool nano::wallet::enter_password (nano::store::transaction const & transaction_a, std::string const & password_a)
+bool nano::wallet::enter_password (std::string const & password_a)
+{
+	auto transaction = wallets.tx_begin_write ();
+	return enter_password_impl (transaction, password_a);
+}
+
+bool nano::wallet::enter_password_impl (nano::store::transaction const & transaction_a, std::string const & password_a)
 {
 	auto result (store.attempt_password (transaction_a, password_a));
 	if (!result)
@@ -751,7 +757,7 @@ bool nano::wallet::enter_password (nano::store::transaction const & transaction_
 		auto this_l = shared_from_this ();
 		wallets.queue_wallet_action (nano::wallets::high_priority, this_l, [this_l] (nano::wallet & wallet) {
 			// Wallets must survive node lifetime
-			this_l->search_receivable (this_l->wallets.tx_begin_read ());
+			this_l->search_receivable ();
 		});
 	}
 	else
@@ -762,7 +768,7 @@ bool nano::wallet::enter_password (nano::store::transaction const & transaction_
 	return result;
 }
 
-nano::public_key nano::wallet::deterministic_insert (nano::store::write_transaction const & transaction_a, bool generate_work_a)
+nano::public_key nano::wallet::deterministic_insert_impl (nano::store::write_transaction const & transaction_a, bool generate_work_a)
 {
 	nano::public_key key{};
 	if (store.valid_password (transaction_a))
@@ -806,7 +812,7 @@ nano::public_key nano::wallet::deterministic_insert (uint32_t const index, bool 
 nano::public_key nano::wallet::deterministic_insert (bool generate_work_a)
 {
 	auto transaction (wallets.tx_begin_write ());
-	auto result (deterministic_insert (transaction, generate_work_a));
+	auto result (deterministic_insert_impl (transaction, generate_work_a));
 	return result;
 }
 
@@ -839,7 +845,13 @@ nano::public_key nano::wallet::insert_adhoc (nano::raw_key const & key_a, bool g
 	return key;
 }
 
-bool nano::wallet::insert_watch (nano::store::write_transaction const & transaction_a, nano::public_key const & pub_a)
+bool nano::wallet::insert_watch (nano::public_key const & pub_a)
+{
+	auto transaction = wallets.tx_begin_write ();
+	return insert_watch_impl (transaction, pub_a);
+}
+
+bool nano::wallet::insert_watch_impl (nano::store::write_transaction const & transaction_a, nano::public_key const & pub_a)
 {
 	return store.insert_watch (transaction_a, pub_a);
 }
@@ -1235,7 +1247,7 @@ void nano::wallet::send_async (nano::account const & source_a, nano::account con
 }
 
 // Update work for account if latest root is root_a
-void nano::wallet::work_update (nano::store::write_transaction const & transaction_a, nano::account const & account_a, nano::root const & root_a, uint64_t work_a)
+void nano::wallet::work_update_impl (nano::store::write_transaction const & transaction_a, nano::account const & account_a, nano::root const & root_a, uint64_t work_a)
 {
 	debug_assert (!wallets.network_params.work.validate_entry (nano::work_version::work_1, root_a, work_a));
 	debug_assert (store.exists (transaction_a, account_a));
@@ -1275,7 +1287,13 @@ void nano::wallet::work_ensure (nano::account const & account_a, nano::root cons
 	});
 }
 
-bool nano::wallet::search_receivable (nano::store::transaction const & wallet_transaction_a)
+bool nano::wallet::search_receivable ()
+{
+	auto transaction = wallets.tx_begin_read ();
+	return search_receivable_impl (transaction);
+}
+
+bool nano::wallet::search_receivable_impl (nano::store::transaction const & wallet_transaction_a)
 {
 	auto result (!store.valid_password (wallet_transaction_a));
 	if (!result)
@@ -1334,7 +1352,7 @@ bool nano::wallet::search_receivable (nano::store::transaction const & wallet_tr
 	return result;
 }
 
-void nano::wallet::init_free_accounts (nano::store::transaction const & transaction_a)
+void nano::wallet::init_free_accounts_impl (nano::store::transaction const & transaction_a)
 {
 	free_accounts.clear ();
 	for (auto i (store.begin (transaction_a)), n (store.end (transaction_a)); i != n; ++i)
@@ -1343,7 +1361,13 @@ void nano::wallet::init_free_accounts (nano::store::transaction const & transact
 	}
 }
 
-uint32_t nano::wallet::deterministic_check (nano::store::transaction const & transaction_a, uint32_t index)
+uint32_t nano::wallet::deterministic_check (uint32_t index)
+{
+	auto transaction = wallets.tx_begin_read ();
+	return deterministic_check_impl (transaction, index);
+}
+
+uint32_t nano::wallet::deterministic_check_impl (nano::store::transaction const & transaction_a, uint32_t index)
 {
 	auto ledger_txn = wallets.ledger.tx_begin_read ();
 	for (uint32_t i (index + 1), n (index + 64); i < n; ++i)
@@ -1373,21 +1397,27 @@ uint32_t nano::wallet::deterministic_check (nano::store::transaction const & tra
 	return index;
 }
 
-nano::public_key nano::wallet::change_seed (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv_a, uint32_t count)
+nano::public_key nano::wallet::change_seed (nano::raw_key const & prv_a, uint32_t count)
+{
+	auto transaction = wallets.tx_begin_write ();
+	return change_seed_impl (transaction, prv_a, count);
+}
+
+nano::public_key nano::wallet::change_seed_impl (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv_a, uint32_t count)
 {
 	logger.info (nano::log::type::wallet, "Changing wallet seed");
 
 	store.seed_set (transaction_a, prv_a);
-	auto account = deterministic_insert (transaction_a);
+	auto account = deterministic_insert_impl (transaction_a);
 	if (count == 0)
 	{
-		count = deterministic_check (transaction_a, 0);
+		count = deterministic_check_impl (transaction_a, 0);
 		logger.info (nano::log::type::wallet, "Auto-detected {} accounts to generate from seed", count);
 	}
 	for (uint32_t i (0); i < count; ++i)
 	{
 		// Disable work generation to prevent weak CPU nodes stuck
-		account = deterministic_insert (transaction_a, false);
+		account = deterministic_insert_impl (transaction_a, false);
 	}
 
 	logger.info (nano::log::type::wallet, "Completed changing wallet seed and generating accounts");
@@ -1395,15 +1425,86 @@ nano::public_key nano::wallet::change_seed (nano::store::write_transaction const
 	return account;
 }
 
-void nano::wallet::deterministic_restore (nano::store::write_transaction const & transaction_a)
+void nano::wallet::deterministic_restore ()
+{
+	auto transaction = wallets.tx_begin_write ();
+	deterministic_restore_impl (transaction);
+}
+
+void nano::wallet::deterministic_restore_impl (nano::store::write_transaction const & transaction_a)
 {
 	auto index (store.deterministic_index_get (transaction_a));
-	auto new_index (deterministic_check (transaction_a, index));
+	auto new_index (deterministic_check_impl (transaction_a, index));
 	for (uint32_t i (index); i <= new_index && index != new_index; ++i)
 	{
 		// Disable work generation to prevent weak CPU nodes stuck
-		deterministic_insert (transaction_a, false);
+		deterministic_insert_impl (transaction_a, false);
 	}
+}
+
+bool nano::wallet::rekey (std::string const & password_a)
+{
+	auto transaction = wallets.tx_begin_write ();
+	return store.rekey (transaction, password_a);
+}
+
+bool nano::wallet::is_locked () const
+{
+	auto transaction = wallets.tx_begin_read ();
+	return !store.valid_password (transaction);
+}
+
+void nano::wallet::remove_account (nano::account const & account_a)
+{
+	auto transaction = wallets.tx_begin_write ();
+	store.erase (transaction, account_a);
+}
+
+std::vector<nano::account> nano::wallet::accounts () const
+{
+	auto transaction = wallets.tx_begin_read ();
+	return store.accounts (transaction);
+}
+
+void nano::wallet::set_representative (nano::account const & rep_a)
+{
+	auto transaction = wallets.tx_begin_write ();
+	store.representative_set (transaction, rep_a);
+}
+
+nano::account nano::wallet::get_representative () const
+{
+	auto transaction = wallets.tx_begin_read ();
+	return store.representative (transaction);
+}
+
+bool nano::wallet::get_seed (nano::raw_key & seed_a) const
+{
+	auto transaction = wallets.tx_begin_read ();
+	if (!store.valid_password (transaction))
+	{
+		return true; // error: wallet locked
+	}
+	store.seed (seed_a, transaction);
+	return false;
+}
+
+bool nano::wallet::get_work (nano::public_key const & pub_a, uint64_t & work_a) const
+{
+	auto transaction = wallets.tx_begin_read ();
+	return store.work_get (transaction, pub_a, work_a);
+}
+
+void nano::wallet::set_work (nano::public_key const & pub_a, uint64_t work_a)
+{
+	auto transaction = wallets.tx_begin_write ();
+	store.work_put (transaction, pub_a, work_a);
+}
+
+bool nano::wallet::fetch_prv (nano::account const & pub_a, nano::raw_key & prv_a) const
+{
+	auto transaction = wallets.tx_begin_read ();
+	return store.fetch (transaction, pub_a, prv_a);
 }
 
 bool nano::wallet::live ()
@@ -1427,7 +1528,7 @@ void nano::wallet::work_cache_blocking (nano::account const & account_a, nano::r
 			auto transaction_l (wallets.tx_begin_write ());
 			if (live () && store.exists (transaction_l, account_a))
 			{
-				work_update (transaction_l, account_a, root_a, opt_work_l.value ());
+				work_update_impl (transaction_l, account_a, root_a, opt_work_l.value ());
 			}
 		}
 		else if (!wallets.node.stopped)
@@ -1624,7 +1725,7 @@ bool nano::wallets::search_receivable (nano::wallet_id const & wallet_a)
 	auto result (false);
 	if (auto wallet = open (wallet_a); wallet != nullptr)
 	{
-		result = wallet->search_receivable (tx_begin_read ());
+		result = wallet->search_receivable ();
 	}
 	return result;
 }
@@ -1632,12 +1733,11 @@ bool nano::wallets::search_receivable (nano::wallet_id const & wallet_a)
 void nano::wallets::search_receivable_all ()
 {
 	nano::unique_lock<nano::mutex> lk{ mutex };
-	auto wallets_l = get_wallets ();
-	auto wallet_transaction (tx_begin_read ());
+	auto wallets_l = all_wallets ();
 	lk.unlock ();
 	for (auto const & [id, wallet] : wallets_l)
 	{
-		wallet->search_receivable (wallet_transaction);
+		wallet->search_receivable ();
 	}
 }
 
@@ -1760,7 +1860,7 @@ void nano::wallets::foreach_representative (std::function<void (nano::public_key
 	}
 }
 
-bool nano::wallets::exists (nano::store::transaction const & transaction_a, nano::account const & account_a)
+bool nano::wallets::exists_impl (nano::store::transaction const & transaction_a, nano::account const & account_a)
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto result (false);
@@ -1774,7 +1874,13 @@ bool nano::wallets::exists (nano::store::transaction const & transaction_a, nano
 bool nano::wallets::exists (nano::account const & account_a)
 {
 	auto transaction (tx_begin_read ());
-	return exists (transaction, account_a);
+	return exists_impl (transaction, account_a);
+}
+
+bool nano::wallets::exists_any (nano::account const & account1, nano::account const & account2)
+{
+	auto transaction (tx_begin_read ());
+	return exists_impl (transaction, account1) || exists_impl (transaction, account2);
 }
 
 nano::store::write_transaction nano::wallets::tx_begin_write ()
@@ -1908,7 +2014,7 @@ void nano::wallets::run_receivable_scan ()
 void nano::wallets::receive_confirmed (nano::block_hash const & hash_a, nano::account const & destination_a)
 {
 	nano::unique_lock<nano::mutex> lk{ mutex };
-	auto wallets_l = get_wallets ();
+	auto wallets_l = all_wallets ();
 	auto wallet_transaction = tx_begin_read ();
 	lk.unlock ();
 	for ([[maybe_unused]] auto const & [id, wallet] : wallets_l)
@@ -1939,7 +2045,7 @@ void nano::wallets::receive_confirmed (nano::block_hash const & hash_a, nano::ac
 	}
 }
 
-std::unordered_map<nano::wallet_id, std::shared_ptr<nano::wallet>> nano::wallets::get_wallets ()
+std::unordered_map<nano::wallet_id, std::shared_ptr<nano::wallet>> nano::wallets::all_wallets ()
 {
 	debug_assert (!mutex.try_lock ());
 	return items;
@@ -1979,19 +2085,19 @@ void nano::wallets::do_wallet_actions ()
 nano::uint128_t const nano::wallets::generate_priority = std::numeric_limits<nano::uint128_t>::max ();
 nano::uint128_t const nano::wallets::high_priority = std::numeric_limits<nano::uint128_t>::max () - 1;
 
-auto nano::wallet_store::begin (nano::store::transaction const & transaction_a) -> iterator
+auto nano::wallet_store::begin (nano::store::transaction const & transaction_a) const -> iterator
 {
 	nano::account account{ special_count };
 	return iterator{ store::iterator{ store::lmdb::iterator::lower_bound (env.tx (transaction_a), handle, store::lmdb::to_mdb_val (account)) } };
 }
 
-auto nano::wallet_store::begin (nano::store::transaction const & transaction_a, nano::account const & key) -> iterator
+auto nano::wallet_store::begin (nano::store::transaction const & transaction_a, nano::account const & key) const -> iterator
 {
 	nano::account account (key);
 	return iterator{ store::iterator{ store::lmdb::iterator::lower_bound (env.tx (transaction_a), handle, store::lmdb::to_mdb_val (account)) } };
 }
 
-auto nano::wallet_store::find (nano::store::transaction const & transaction_a, nano::account const & key) -> iterator
+auto nano::wallet_store::find (nano::store::transaction const & transaction_a, nano::account const & key) const -> iterator
 {
 	auto result = begin (transaction_a, key);
 	auto end = this->end (transaction_a);
@@ -2013,7 +2119,7 @@ auto nano::wallet_store::find (nano::store::transaction const & transaction_a, n
 	return result;
 }
 
-auto nano::wallet_store::end (nano::store::transaction const & transaction_a) -> iterator
+auto nano::wallet_store::end (nano::store::transaction const & transaction_a) const -> iterator
 {
 	return iterator{ store::iterator{ store::lmdb::iterator::end (env.tx (transaction_a), handle) } };
 }

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -892,6 +892,12 @@ void nano::wallet::serialize (std::string & json_a)
 	store.serialize_json (transaction, json_a);
 }
 
+void nano::wallet::write_backup (std::filesystem::path const & path_a)
+{
+	auto transaction (wallets.tx_begin_read ());
+	store.write_backup (transaction, path_a);
+}
+
 void nano::wallet_store::destroy (nano::store::write_transaction const & transaction_a)
 {
 	auto status (mdb_drop (env.tx (transaction_a), handle, 1));
@@ -1454,6 +1460,13 @@ bool nano::wallet::is_locked () const
 	return !store.valid_password (transaction);
 }
 
+void nano::wallet::lock ()
+{
+	nano::raw_key empty;
+	empty.clear ();
+	store.password.value_set (empty);
+}
+
 void nano::wallet::remove_account (nano::account const & account_a)
 {
 	auto transaction = wallets.tx_begin_write ();
@@ -1464,6 +1477,19 @@ std::vector<nano::account> nano::wallet::accounts () const
 {
 	auto transaction = wallets.tx_begin_read ();
 	return store.accounts (transaction);
+}
+
+bool nano::wallet::move_accounts (wallet & source, std::vector<nano::public_key> const & accounts_a)
+{
+	auto transaction = wallets.tx_begin_write ();
+	return store.move (transaction, source.store, accounts_a);
+}
+
+nano::key_type nano::wallet::key_type (nano::account const & account_a) const
+{
+	auto transaction = wallets.tx_begin_read ();
+	auto value = store.entry_get_raw (transaction, account_a);
+	return store.key_type (value);
 }
 
 void nano::wallet::set_representative (nano::account const & rep_a)
@@ -1487,6 +1513,12 @@ bool nano::wallet::get_seed (nano::raw_key & seed_a) const
 	}
 	store.seed (seed_a, transaction);
 	return false;
+}
+
+uint32_t nano::wallet::get_deterministic_index () const
+{
+	auto transaction = wallets.tx_begin_read ();
+	return store.deterministic_index_get (transaction);
 }
 
 bool nano::wallet::get_work (nano::public_key const & pub_a, uint64_t & work_a) const

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -29,14 +29,14 @@ class wallets;
 class fan final
 {
 public:
-	fan (nano::raw_key const &, std::size_t);
-	void value (nano::raw_key &);
-	void value_set (nano::raw_key const &);
+	fan (nano::raw_key const & key, std::size_t count);
+	void value (nano::raw_key & result) const;
+	void value_set (nano::raw_key const & value);
 	std::vector<std::unique_ptr<nano::raw_key>> values;
 
 private:
-	nano::mutex mutex;
-	void value_get (nano::raw_key &);
+	mutable nano::mutex mutex;
+	void value_get (nano::raw_key & result) const;
 };
 
 class kdf final
@@ -46,7 +46,7 @@ public:
 		kdf_work{ kdf_work }
 	{
 	}
-	void phs (nano::raw_key &, std::string const &, nano::uint256_union const &);
+	void phs (nano::raw_key & result, std::string const & password, nano::uint256_union const & salt);
 	nano::mutex mutex;
 	unsigned const & kdf_work;
 };
@@ -65,57 +65,57 @@ public:
 	using iterator = store::typed_iterator<nano::account, nano::wallet_value>;
 
 public:
-	wallet_store (bool &, nano::kdf &, nano::store::write_transaction &, store::lmdb::env &, nano::account, unsigned, std::string const &);
-	wallet_store (bool &, nano::kdf &, nano::store::write_transaction &, store::lmdb::env &, nano::account, unsigned, std::string const &, std::string const &);
-	void initialize (nano::store::write_transaction const &, bool &, std::string const &);
-	std::vector<nano::account> accounts (nano::store::transaction const &);
-	nano::uint256_union check (nano::store::transaction const &);
-	bool rekey (nano::store::write_transaction const &, std::string const &);
-	bool valid_password (nano::store::transaction const &);
-	bool valid_public_key (nano::public_key const &);
-	bool attempt_password (nano::store::transaction const &, std::string const &);
-	void wallet_key (nano::raw_key &, nano::store::transaction const &);
-	void seed (nano::raw_key &, nano::store::transaction const &);
-	void seed_set (nano::store::write_transaction const &, nano::raw_key const &);
-	nano::key_type key_type (nano::wallet_value const &);
+	wallet_store (bool & error, nano::kdf &, nano::store::write_transaction &, store::lmdb::env &, nano::account representative, unsigned fanout, std::string const & wallet_path);
+	wallet_store (bool & error, nano::kdf &, nano::store::write_transaction &, store::lmdb::env &, nano::account representative, unsigned fanout, std::string const & wallet_path, std::string const & json);
+	void initialize (nano::store::write_transaction const &, bool & error, std::string const & path);
+	std::vector<nano::account> accounts (nano::store::transaction const &) const;
+	nano::uint256_union check (nano::store::transaction const &) const;
+	bool rekey (nano::store::write_transaction const &, std::string const & password);
+	bool valid_password (nano::store::transaction const &) const;
+	bool valid_public_key (nano::public_key const &) const;
+	bool attempt_password (nano::store::transaction const &, std::string const & password);
+	void wallet_key (nano::raw_key & result, nano::store::transaction const &) const;
+	void seed (nano::raw_key & result, nano::store::transaction const &) const;
+	void seed_set (nano::store::write_transaction const &, nano::raw_key const & seed);
+	nano::key_type key_type (nano::wallet_value const &) const;
 	nano::public_key deterministic_insert (nano::store::write_transaction const &);
-	nano::public_key deterministic_insert (nano::store::write_transaction const &, uint32_t const);
-	nano::raw_key deterministic_key (nano::store::transaction const &, uint32_t);
-	uint32_t deterministic_index_get (nano::store::transaction const &);
-	void deterministic_index_set (nano::store::write_transaction const &, uint32_t);
+	nano::public_key deterministic_insert (nano::store::write_transaction const &, uint32_t index);
+	nano::raw_key deterministic_key (nano::store::transaction const &, uint32_t index) const;
+	uint32_t deterministic_index_get (nano::store::transaction const &) const;
+	void deterministic_index_set (nano::store::write_transaction const &, uint32_t index);
 	void deterministic_clear (nano::store::write_transaction const &);
-	nano::uint256_union salt (nano::store::transaction const &);
-	bool is_representative (nano::store::transaction const &);
-	nano::account representative (nano::store::transaction const &);
-	void representative_set (nano::store::write_transaction const &, nano::account const &);
-	nano::public_key insert_adhoc (nano::store::write_transaction const &, nano::raw_key const &);
-	bool insert_watch (nano::store::write_transaction const &, nano::account const &);
-	void erase (nano::store::write_transaction const &, nano::account const &);
-	nano::wallet_value entry_get_raw (nano::store::transaction const &, nano::account const &);
-	void entry_put_raw (nano::store::write_transaction const &, nano::account const &, nano::wallet_value const &);
-	bool fetch (nano::store::transaction const &, nano::account const &, nano::raw_key &);
-	bool exists (nano::store::transaction const &, nano::account const &);
+	nano::uint256_union salt (nano::store::transaction const &) const;
+	bool is_representative (nano::store::transaction const &) const;
+	nano::account representative (nano::store::transaction const &) const;
+	void representative_set (nano::store::write_transaction const &, nano::account const & rep);
+	nano::public_key insert_adhoc (nano::store::write_transaction const &, nano::raw_key const & prv);
+	bool insert_watch (nano::store::write_transaction const &, nano::account const & pub);
+	void erase (nano::store::write_transaction const &, nano::account const & pub);
+	nano::wallet_value entry_get_raw (nano::store::transaction const &, nano::account const & pub) const;
+	void entry_put_raw (nano::store::write_transaction const &, nano::account const & pub, nano::wallet_value const & entry);
+	bool fetch (nano::store::transaction const &, nano::account const & pub, nano::raw_key & result) const;
+	bool exists (nano::store::transaction const &, nano::account const & pub) const;
 	void destroy (nano::store::write_transaction const &);
-	iterator find (nano::store::transaction const &, nano::account const &);
-	iterator begin (nano::store::transaction const &, nano::account const &);
-	iterator begin (nano::store::transaction const &);
-	iterator end (nano::store::transaction const &);
-	void derive_key (nano::raw_key &, nano::store::transaction const &, std::string const &);
-	void serialize_json (nano::store::transaction const &, std::string &);
-	void write_backup (nano::store::transaction const &, std::filesystem::path const &);
-	bool move (nano::store::write_transaction const &, nano::wallet_store &, std::vector<nano::public_key> const &);
-	bool import (nano::store::write_transaction const &, nano::wallet_store &);
-	bool work_get (nano::store::transaction const &, nano::public_key const &, uint64_t &);
-	void work_put (nano::store::write_transaction const &, nano::public_key const &, uint64_t);
-	unsigned version (nano::store::transaction const &);
-	void version_put (nano::store::write_transaction const &, unsigned);
+	iterator find (nano::store::transaction const &, nano::account const & key) const;
+	iterator begin (nano::store::transaction const &, nano::account const & key) const;
+	iterator begin (nano::store::transaction const &) const;
+	iterator end (nano::store::transaction const &) const;
+	void derive_key (nano::raw_key & result, nano::store::transaction const &, std::string const & password) const;
+	void serialize_json (nano::store::transaction const &, std::string & json) const;
+	void write_backup (nano::store::transaction const &, std::filesystem::path const & path) const;
+	bool move (nano::store::write_transaction const &, nano::wallet_store & source, std::vector<nano::public_key> const & keys);
+	bool import (nano::store::write_transaction const &, nano::wallet_store & source);
+	bool work_get (nano::store::transaction const &, nano::public_key const & pub, uint64_t & work) const;
+	void work_put (nano::store::write_transaction const &, nano::public_key const & pub, uint64_t work);
+	unsigned version (nano::store::transaction const &) const;
+	void version_put (nano::store::write_transaction const &, unsigned version);
 
 public:
 	nano::fan password;
 	nano::fan wallet_key_mem;
 	nano::kdf & kdf;
 	std::atomic<MDB_dbi> handle{ 0 };
-	std::recursive_mutex mutex;
+	mutable std::recursive_mutex mutex;
 
 private:
 	nano::store::lmdb::env & env;
@@ -142,40 +142,69 @@ public:
 class wallet final : public std::enable_shared_from_this<nano::wallet>
 {
 public:
-	std::shared_ptr<nano::block> change_action (nano::account const &, nano::account const &, uint64_t = 0, bool = true);
-	std::shared_ptr<nano::block> receive_action (nano::block_hash const &, nano::account const &, nano::uint128_union const &, nano::account const &, uint64_t = 0, bool = true);
-	std::shared_ptr<nano::block> send_action (nano::account const &, nano::account const &, nano::uint128_t const &, uint64_t = 0, bool = true, boost::optional<std::string> = {});
-	bool action_complete (std::shared_ptr<nano::block> const &, nano::account const &, bool const, nano::block_details const &);
-	wallet (bool &, nano::store::write_transaction &, nano::wallets &, std::string const &);
-	wallet (bool &, nano::store::write_transaction &, nano::wallets &, std::string const &, std::string const &);
+	wallet (bool & error, nano::store::write_transaction &, nano::wallets &, std::string const & wallet_path);
+	wallet (bool & error, nano::store::write_transaction &, nano::wallets &, std::string const & wallet_path, std::string const & json);
+
+	// Password and lock management
 	void enter_initial_password ();
-	bool enter_password (nano::store::transaction const &, std::string const &);
-	nano::public_key insert_adhoc (nano::raw_key const &, bool = true);
-	bool insert_watch (nano::store::write_transaction const &, nano::public_key const &);
-	nano::public_key deterministic_insert (nano::store::write_transaction const &, bool = true);
-	nano::public_key deterministic_insert (uint32_t, bool = true);
-	nano::public_key deterministic_insert (bool = true);
-	bool exists (nano::public_key const &);
-	bool import (std::string const &, std::string const &);
-	void serialize (std::string &);
-	bool change_sync (nano::account const &, nano::account const &);
-	void change_async (nano::account const &, nano::account const &, std::function<void (std::shared_ptr<nano::block> const &)> const &, uint64_t = 0, bool = true);
-	bool receive_sync (std::shared_ptr<nano::block> const &, nano::account const &, nano::uint128_t const &);
-	void receive_async (nano::block_hash const &, nano::account const &, nano::uint128_t const &, nano::account const &, std::function<void (std::shared_ptr<nano::block> const &)> const &, uint64_t = 0, bool = true);
-	nano::block_hash send_sync (nano::account const &, nano::account const &, nano::uint128_t const &);
-	void send_async (nano::account const &, nano::account const &, nano::uint128_t const &, std::function<void (std::shared_ptr<nano::block> const &)> const &, uint64_t = 0, bool = true, boost::optional<std::string> = {});
-	void work_cache_blocking (nano::account const &, nano::root const &);
-	void work_update (nano::store::write_transaction const &, nano::account const &, nano::root const &, uint64_t);
-	// Schedule work generation after a few seconds
-	void work_ensure (nano::account const &, nano::root const &);
-	bool search_receivable (nano::store::transaction const &);
-	void init_free_accounts (nano::store::transaction const &);
-	uint32_t deterministic_check (nano::store::transaction const &, uint32_t index);
-	/** Changes the wallet seed and returns the first account */
-	nano::public_key change_seed (nano::store::write_transaction const &, nano::raw_key const & prv, uint32_t count = 0);
-	void deterministic_restore (nano::store::write_transaction const &);
-	bool live ();
+	bool enter_password (std::string const & password);
+	bool rekey (std::string const & password);
+	bool is_locked () const;
+
+	// Account management
+	nano::public_key insert_adhoc (nano::raw_key const & prv, bool generate_work = true);
+	nano::public_key deterministic_insert (uint32_t index, bool generate_work = true);
+	nano::public_key deterministic_insert (bool generate_work = true);
+	bool insert_watch (nano::public_key const & pub);
+	void remove_account (nano::account const & account);
+	std::vector<nano::account> accounts () const;
+	bool exists (nano::public_key const & pub);
+
+	// Seed management
+	bool get_seed (nano::raw_key & result) const;
+	nano::public_key change_seed (nano::raw_key const & seed, uint32_t count = 0);
+	void deterministic_restore ();
+	uint32_t deterministic_check (uint32_t index);
+
+	// Representative management
+	void set_representative (nano::account const & rep);
+	nano::account get_representative () const;
+
+	// Local wallet representatives
 	std::unordered_set<nano::account> reps () const;
+
+	// Key retrieval
+	bool fetch_prv (nano::account const & pub, nano::raw_key & result) const;
+
+	// Block actions
+	std::shared_ptr<nano::block> change_action (nano::account const & source, nano::account const & representative, uint64_t work = 0, bool generate_work = true);
+	std::shared_ptr<nano::block> receive_action (nano::block_hash const & send_hash, nano::account const & representative, nano::uint128_union const & amount, nano::account const & account, uint64_t work = 0, bool generate_work = true);
+	std::shared_ptr<nano::block> send_action (nano::account const & source, nano::account const & destination, nano::uint128_t const & amount, uint64_t work = 0, bool generate_work = true, boost::optional<std::string> id = {});
+	bool action_complete (std::shared_ptr<nano::block> const & block, nano::account const & account, bool generate_work, nano::block_details const & details);
+
+	// Sync/async block operations
+	bool change_sync (nano::account const & source, nano::account const & representative);
+	void change_async (nano::account const & source, nano::account const & representative, std::function<void (std::shared_ptr<nano::block> const &)> const & action, uint64_t work = 0, bool generate_work = true);
+	bool receive_sync (std::shared_ptr<nano::block> const & block, nano::account const & representative, nano::uint128_t const & amount);
+	void receive_async (nano::block_hash const & hash, nano::account const & representative, nano::uint128_t const & amount, nano::account const & account, std::function<void (std::shared_ptr<nano::block> const &)> const & action, uint64_t work = 0, bool generate_work = true);
+	nano::block_hash send_sync (nano::account const & source, nano::account const & destination, nano::uint128_t const & amount);
+	void send_async (nano::account const & source, nano::account const & destination, nano::uint128_t const & amount, std::function<void (std::shared_ptr<nano::block> const &)> const & action, uint64_t work = 0, bool generate_work = true, boost::optional<std::string> id = {});
+
+	// Work cache
+	void work_cache_blocking (nano::account const & account, nano::root const & root);
+	void work_ensure (nano::account const & account, nano::root const & root);
+	bool get_work (nano::public_key const & pub, uint64_t & work) const;
+	void set_work (nano::public_key const & pub, uint64_t work);
+
+	// Receivable
+	bool search_receivable ();
+
+	// Import/export
+	bool import (std::string const & json, std::string const & password);
+	void serialize (std::string & json);
+
+	// Status
+	bool live ();
 
 public:
 	std::unordered_set<nano::account> free_accounts;
@@ -183,6 +212,18 @@ public:
 	nano::wallet_store store;
 	nano::wallets & wallets;
 	nano::logger & logger;
+
+private:
+	// Internal implementation methods (accept transactions for batching scenarios)
+	bool enter_password_impl (nano::store::transaction const &, std::string const & password);
+	bool insert_watch_impl (nano::store::write_transaction const &, nano::public_key const & pub);
+	nano::public_key deterministic_insert_impl (nano::store::write_transaction const &, bool generate_work = true);
+	void work_update_impl (nano::store::write_transaction const &, nano::account const & account, nano::root const & root, uint64_t work);
+	bool search_receivable_impl (nano::store::transaction const &);
+	void init_free_accounts_impl (nano::store::transaction const &);
+	uint32_t deterministic_check_impl (nano::store::transaction const &, uint32_t index);
+	nano::public_key change_seed_impl (nano::store::write_transaction const &, nano::raw_key const & seed, uint32_t count = 0);
+	void deterministic_restore_impl (nano::store::write_transaction const &);
 
 private:
 	nano::locked<std::unordered_set<nano::account>> representatives;
@@ -249,32 +290,38 @@ public:
 	void start ();
 	void stop ();
 
+	// Wallet management
 	std::shared_ptr<nano::wallet> open (nano::wallet_id const &);
 	std::shared_ptr<nano::wallet> create (nano::wallet_id const &);
-	bool search_receivable (nano::wallet_id const &);
-	void search_receivable_all ();
 	void destroy (nano::wallet_id const &);
 	void reload ();
-	void do_wallet_actions ();
-	void queue_wallet_action (nano::uint128_t const &, std::shared_ptr<nano::wallet> const &, std::function<void (nano::wallet &)>);
-	void foreach_representative (std::function<void (nano::public_key const &, nano::raw_key const &)> const &);
-	bool exists (nano::store::transaction const &, nano::account const &);
-	bool exists (nano::account const &);
 	void clear_send_ids ();
-	nano::wallet_representatives reps () const;
+
+	// Account lookup
+	std::unordered_map<nano::wallet_id, std::shared_ptr<nano::wallet>> all_wallets ();
+	bool exists (nano::account const &);
+	bool exists_any (nano::account const &, nano::account const &);
+
+	// Receivable
+	bool search_receivable (nano::wallet_id const &);
+	void search_receivable_all ();
+	void receive_confirmed (nano::block_hash const & hash, nano::account const & destination);
+
+	// Wallet actions queue
+	void do_wallet_actions ();
+	void queue_wallet_action (nano::uint128_t const & priority, std::shared_ptr<nano::wallet> const &, std::function<void (nano::wallet &)> action);
+
+	// Representatives
+	void foreach_representative (std::function<void (nano::public_key const &, nano::raw_key const &)> const & action);
 	bool check_rep (nano::account const &);
 	void compute_reps ();
-	void receive_confirmed (nano::block_hash const & hash, nano::account const & destination);
-	std::unordered_map<nano::wallet_id, std::shared_ptr<nano::wallet>> get_wallets ();
+	nano::wallet_representatives reps () const;
+
 	nano::container_info container_info () const;
 
+	// Transaction
 	nano::store::write_transaction tx_begin_write ();
 	nano::store::read_transaction tx_begin_read ();
-
-private:
-	void run_reps_scan ();
-	void run_receivable_scan ();
-	bool check_rep_impl (wallet_representatives &, nano::account const &, nano::uint128_t const & half_principal_weight);
 
 public: // Dependencies
 	nano::node & node;
@@ -314,6 +361,12 @@ public:
 
 	static nano::uint128_t const generate_priority;
 	static nano::uint128_t const high_priority;
+
+private:
+	void run_reps_scan ();
+	void run_receivable_scan ();
+	bool check_rep_impl (wallet_representatives &, nano::account const &, nano::uint128_t const & half_principal_weight);
+	bool exists_impl (nano::store::transaction const &, nano::account const &);
 
 private:
 	mutable nano::locked<nano::wallet_representatives> representatives;

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -298,6 +298,7 @@ public:
 	// Wallet management
 	std::shared_ptr<nano::wallet> open (nano::wallet_id const &);
 	std::shared_ptr<nano::wallet> create (nano::wallet_id const &);
+	std::shared_ptr<nano::wallet> create_from_json (nano::wallet_id const &, std::string const & json);
 	void destroy (nano::wallet_id const &);
 	void reload ();
 	void clear_send_ids ();
@@ -324,7 +325,7 @@ public:
 
 	nano::container_info container_info () const;
 
-	// Transaction
+private: // Transactions
 	nano::store::write_transaction tx_begin_write ();
 	nano::store::read_transaction tx_begin_read ();
 
@@ -375,5 +376,7 @@ private:
 
 private:
 	mutable nano::locked<nano::wallet_representatives> representatives;
+
+	friend class wallet;
 };
 }

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -205,7 +205,7 @@ public:
 
 	// Import/export
 	bool import (std::string const & json, std::string const & password);
-	void serialize (std::string & json);
+	void serialize_json (std::string & json);
 	void write_backup (std::filesystem::path const & path);
 
 	// Status

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -150,6 +150,7 @@ public:
 	bool enter_password (std::string const & password);
 	bool rekey (std::string const & password);
 	bool is_locked () const;
+	void lock ();
 
 	// Account management
 	nano::public_key insert_adhoc (nano::raw_key const & prv, bool generate_work = true);
@@ -159,12 +160,15 @@ public:
 	void remove_account (nano::account const & account);
 	std::vector<nano::account> accounts () const;
 	bool exists (nano::public_key const & pub);
+	bool move_accounts (wallet & source, std::vector<nano::public_key> const & accounts);
+	nano::key_type key_type (nano::account const & account) const;
 
 	// Seed management
 	bool get_seed (nano::raw_key & result) const;
 	nano::public_key change_seed (nano::raw_key const & seed, uint32_t count = 0);
 	void deterministic_restore ();
 	uint32_t deterministic_check (uint32_t index);
+	uint32_t get_deterministic_index () const;
 
 	// Representative management
 	void set_representative (nano::account const & rep);
@@ -202,6 +206,7 @@ public:
 	// Import/export
 	bool import (std::string const & json, std::string const & password);
 	void serialize (std::string & json);
+	void write_backup (std::filesystem::path const & path);
 
 	// Status
 	bool live ();

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -134,7 +134,6 @@ bool nano::websocket::confirmation_options::should_filter (nano::websocket::mess
 		auto source_text_l (message_a.contents.get<std::string> ("message.account"));
 		if (all_local_accounts)
 		{
-			auto transaction_l (wallets.tx_begin_read ());
 			nano::account source_l{};
 			nano::account destination_l{};
 			auto decode_source_ok_l (!source_l.decode_account (source_text_l));
@@ -142,7 +141,7 @@ bool nano::websocket::confirmation_options::should_filter (nano::websocket::mess
 			(void)decode_source_ok_l;
 			(void)decode_destination_ok_l;
 			debug_assert (decode_source_ok_l && decode_destination_ok_l);
-			if (wallets.exists (transaction_l, source_l) || wallets.exists (transaction_l, destination_l))
+			if (wallets.exists_any (source_l, destination_l))
 			{
 				should_filter_account = false;
 			}

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -234,10 +234,9 @@ nano_qt::accounts::accounts (nano_qt::wallet & wallet_a) :
 	});
 	QObject::connect (backup_seed, &QPushButton::released, [this] () {
 		nano::raw_key seed;
-		auto transaction (this->wallet.wallet_m->wallets.tx_begin_read ());
-		if (this->wallet.wallet_m->store.valid_password (transaction))
+		if (!this->wallet.wallet_m->is_locked ())
 		{
-			this->wallet.wallet_m->store.seed (seed, transaction);
+			this->wallet.wallet_m->get_seed (seed);
 			this->wallet.application.clipboard ()->setText (QString (seed.to_string ().c_str ()));
 			show_button_success (*backup_seed);
 			backup_seed->setText ("Seed was copied to clipboard");
@@ -271,13 +270,11 @@ nano_qt::accounts::accounts (nano_qt::wallet & wallet_a) :
 
 void nano_qt::accounts::refresh_wallet_balance ()
 {
-	auto transaction (this->wallet.wallet_m->wallets.tx_begin_read ());
 	auto block_transaction = this->wallet.node.ledger.tx_begin_read ();
 	nano::uint128_t balance (0);
 	nano::uint128_t pending (0);
-	for (auto i (this->wallet.wallet_m->store.begin (transaction)), j (this->wallet.wallet_m->store.end (transaction)); i != j; ++i)
+	for (auto const & key : this->wallet.wallet_m->accounts ())
 	{
-		nano::public_key const & key (i->first);
 		balance = balance + this->wallet.node.ledger.any.account_balance (block_transaction, key).value_or (0).number ();
 		pending = pending + (this->wallet.node.ledger.account_receivable (block_transaction, key));
 	}
@@ -297,15 +294,13 @@ void nano_qt::accounts::refresh_wallet_balance ()
 void nano_qt::accounts::refresh ()
 {
 	model->removeRows (0, model->rowCount ());
-	auto transaction (wallet.wallet_m->wallets.tx_begin_read ());
 	auto block_transaction = this->wallet.node.ledger.tx_begin_read ();
 	QBrush brush;
-	for (auto i (wallet.wallet_m->store.begin (transaction)), j (wallet.wallet_m->store.end (transaction)); i != j; ++i)
+	for (auto const & key : wallet.wallet_m->accounts ())
 	{
-		nano::public_key key (i->first);
 		auto balance_amount = wallet.node.ledger.any.account_balance (block_transaction, key).value_or (0).number ();
 		bool display (true);
-		switch (wallet.wallet_m->store.key_type (i->second))
+		switch (wallet.wallet_m->key_type (key))
 		{
 			case nano::key_type::adhoc:
 			{
@@ -1240,8 +1235,7 @@ void nano_qt::wallet::start ()
 					auto balance (this_l->node.balance (this_l->account));
 					if (actual <= balance)
 					{
-						auto transaction (this_l->wallet_m->wallets.tx_begin_read ());
-						if (this_l->wallet_m->store.valid_password (transaction))
+						if (!this_l->wallet_m->is_locked ())
 						{
 							this_l->send_blocks_send->setEnabled (false);
 							this_l->node.workers.post ([this_w, account_l, actual] () {
@@ -1458,10 +1452,7 @@ void nano_qt::wallet::start ()
 
 void nano_qt::wallet::refresh ()
 {
-	{
-		auto transaction (wallet_m->wallets.tx_begin_read ());
-		debug_assert (wallet_m->store.exists (transaction, account));
-	}
+	debug_assert (wallet_m->exists (account));
 	self.account_text->setText (QString (account.to_account ().c_str ()));
 	needs_balance_refresh = true;
 	accounts.refresh ();
@@ -1565,8 +1556,7 @@ nano_qt::settings::settings (nano_qt::wallet & wallet_a) :
 	layout->addWidget (back);
 	window->setLayout (layout);
 	QObject::connect (change, &QPushButton::released, [this] () {
-		auto transaction (this->wallet.wallet_m->wallets.tx_begin_write ());
-		if (this->wallet.wallet_m->store.valid_password (transaction))
+		if (!this->wallet.wallet_m->is_locked ())
 		{
 			if (new_password->text ().isEmpty ())
 			{
@@ -1579,7 +1569,7 @@ nano_qt::settings::settings (nano_qt::wallet & wallet_a) :
 			{
 				if (new_password->text () == retype_password->text ())
 				{
-					this->wallet.wallet_m->store.rekey (transaction, std::string (new_password->text ().toLocal8Bit ()));
+					this->wallet.wallet_m->rekey (std::string (new_password->text ().toLocal8Bit ()));
 					new_password->clear ();
 					retype_password->clear ();
 					retype_password->setPlaceholderText ("Retype password");
@@ -1617,14 +1607,10 @@ nano_qt::settings::settings (nano_qt::wallet & wallet_a) :
 		nano::account representative_l;
 		if (!representative_l.decode_account (new_representative->text ().toStdString ()))
 		{
-			auto transaction (this->wallet.wallet_m->wallets.tx_begin_read ());
-			if (this->wallet.wallet_m->store.valid_password (transaction))
+			if (!this->wallet.wallet_m->is_locked ())
 			{
 				change_rep->setEnabled (false);
-				{
-					auto transaction_l (this->wallet.wallet_m->wallets.tx_begin_write ());
-					this->wallet.wallet_m->store.representative_set (transaction_l, representative_l);
-				}
+				this->wallet.wallet_m->set_representative (representative_l);
 				this->wallet.wallet_m->change_sync (this->wallet.account, representative_l);
 				change_rep->setEnabled (true);
 				show_button_success (*change_rep);
@@ -1700,8 +1686,7 @@ nano_qt::settings::settings (nano_qt::wallet & wallet_a) :
 						show_button_ok (*lock_toggle);
 
 						// if wallet is still not unlocked by now, change button text
-						auto transaction (this->wallet.wallet_m->wallets.tx_begin_write ());
-						if (!this->wallet.wallet_m->store.valid_password (transaction))
+						if (this->wallet.wallet_m->is_locked ())
 						{
 							lock_toggle->setText ("Unlock");
 						}
@@ -1717,8 +1702,7 @@ nano_qt::settings::settings (nano_qt::wallet & wallet_a) :
 	});
 
 	// initial state for lock toggle button
-	auto transaction (this->wallet.wallet_m->wallets.tx_begin_write ());
-	if (this->wallet.wallet_m->store.valid_password (transaction))
+	if (!this->wallet.wallet_m->is_locked ())
 	{
 		lock_toggle->setText ("Lock");
 		password->setDisabled (1);
@@ -1739,8 +1723,7 @@ void nano_qt::settings::refresh_representative ()
 	}
 	else
 	{
-		auto wallet_transaction (this->wallet.wallet_m->wallets.tx_begin_read ());
-		current_representative->setText (this->wallet.wallet_m->store.representative (wallet_transaction).to_account ().c_str ());
+		current_representative->setText (this->wallet.wallet_m->get_representative ().to_account ().c_str ());
 	}
 }
 
@@ -2240,10 +2223,9 @@ void nano_qt::block_creation::create_send ()
 			error = destination_l.decode_account (destination->text ().toStdString ());
 			if (!error)
 			{
-				auto transaction (wallet.node.wallets.tx_begin_read ());
 				auto block_transaction = wallet.node.ledger.tx_begin_read ();
 				nano::raw_key key;
-				if (!wallet.wallet_m->store.fetch (transaction, account_l, key))
+				if (!wallet.wallet_m->fetch_prv (account_l, key))
 				{
 					auto balance = wallet.node.ledger.any.account_balance (block_transaction, account_l).value_or (0).number ();
 					if (amount_l.number () <= balance)
@@ -2316,7 +2298,6 @@ void nano_qt::block_creation::create_receive ()
 	auto error (source_l.decode_hex (source->text ().toStdString ()));
 	if (!error)
 	{
-		auto transaction (wallet.node.wallets.tx_begin_read ());
 		auto block_transaction = wallet.node.ledger.tx_begin_read ();
 		auto block_l (wallet.node.ledger.any.block_get (block_transaction, source_l));
 		if (block_l != nullptr)
@@ -2332,7 +2313,7 @@ void nano_qt::block_creation::create_receive ()
 					if (!error)
 					{
 						nano::raw_key key;
-						auto error (wallet.wallet_m->store.fetch (transaction, pending_key.account, key));
+						auto error (wallet.wallet_m->fetch_prv (pending_key.account, key));
 						if (!error)
 						{
 							nano::state_block receive (pending_key.account, info.head, info.representative, info.balance.number () + pending.value ().amount.number (), source_l, key, pending_key.account, 0);
@@ -2409,14 +2390,13 @@ void nano_qt::block_creation::create_change ()
 		error = representative_l.decode_account (representative->text ().toStdString ());
 		if (!error)
 		{
-			auto transaction (wallet.node.wallets.tx_begin_read ());
 			auto block_transaction (wallet.node.store.tx_begin_read ());
 			nano::account_info info;
 			auto error (wallet.node.store.account.get (block_transaction, account_l, info));
 			if (!error)
 			{
 				nano::raw_key key;
-				auto error (wallet.wallet_m->store.fetch (transaction, account_l, key));
+				auto error (wallet.wallet_m->fetch_prv (account_l, key));
 				if (!error)
 				{
 					nano::state_block change (account_l, info.head, representative_l, info.balance, 0, key, account_l, 0);
@@ -2480,7 +2460,6 @@ void nano_qt::block_creation::create_open ()
 		error = representative_l.decode_account (representative->text ().toStdString ());
 		if (!error)
 		{
-			auto transaction (wallet.node.wallets.tx_begin_read ());
 			auto block_transaction = wallet.node.ledger.tx_begin_read ();
 			auto block_l (wallet.node.ledger.any.block_get (block_transaction, source_l));
 			if (block_l != nullptr)
@@ -2496,7 +2475,7 @@ void nano_qt::block_creation::create_open ()
 						if (error)
 						{
 							nano::raw_key key;
-							auto error (wallet.wallet_m->store.fetch (transaction, pending_key.account, key));
+							auto error (wallet.wallet_m->fetch_prv (pending_key.account, key));
 							if (!error)
 							{
 								nano::state_block open (pending_key.account, 0, representative_l, pending.value ().amount, source_l, key, pending_key.account, 0);

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -203,10 +203,9 @@ nano_qt::accounts::accounts (nano_qt::wallet & wallet_a) :
 	});
 	QObject::connect (create_account, &QPushButton::released, [this] () {
 		{
-			auto transaction (this->wallet.wallet_m->wallets.tx_begin_write ());
-			if (this->wallet.wallet_m->store.valid_password (transaction))
+			if (!this->wallet.wallet_m->is_locked ())
 			{
-				this->wallet.wallet_m->deterministic_insert (transaction);
+				this->wallet.wallet_m->deterministic_insert ();
 				show_button_success (*create_account);
 				create_account->setText ("New account was created");
 				this->wallet.node.workers.post_delayed (std::chrono::seconds (5), [this] () {
@@ -402,10 +401,9 @@ nano_qt::import::import (nano_qt::wallet & wallet_a) :
 			{
 				bool successful (false);
 				{
-					auto transaction (this->wallet.wallet_m->wallets.tx_begin_write ());
-					if (this->wallet.wallet_m->store.valid_password (transaction))
+					if (!this->wallet.wallet_m->is_locked ())
 					{
-						this->wallet.account = this->wallet.wallet_m->change_seed (transaction, seed_l);
+						this->wallet.account = this->wallet.wallet_m->change_seed (seed_l);
 						successful = true;
 					}
 					else
@@ -1487,8 +1485,7 @@ void nano_qt::wallet::update_connected ()
 void nano_qt::wallet::empty_password ()
 {
 	this->node.workers.post_delayed (std::chrono::seconds (3), [this] () {
-		auto transaction (wallet_m->wallets.tx_begin_write ());
-		wallet_m->enter_password (transaction, std::string (""));
+		wallet_m->enter_password (std::string (""));
 	});
 }
 
@@ -1672,8 +1669,7 @@ nano_qt::settings::settings (nano_qt::wallet & wallet_a) :
 		this->wallet.pop_main_stack ();
 	});
 	QObject::connect (lock_toggle, &QPushButton::released, [this] () {
-		auto transaction (this->wallet.wallet_m->wallets.tx_begin_write ());
-		if (this->wallet.wallet_m->store.valid_password (transaction))
+		if (!this->wallet.wallet_m->is_locked ())
 		{
 			// lock wallet
 			nano::raw_key empty;
@@ -1687,7 +1683,7 @@ nano_qt::settings::settings (nano_qt::wallet & wallet_a) :
 		else
 		{
 			// try to unlock wallet
-			if (!this->wallet.wallet_m->enter_password (transaction, std::string (password->text ().toLocal8Bit ())))
+			if (!this->wallet.wallet_m->enter_password (std::string (password->text ().toLocal8Bit ())))
 			{
 				password->clear ();
 				lock_toggle->setText ("Lock");
@@ -1917,7 +1913,7 @@ nano_qt::advanced_actions::advanced_actions (nano_qt::wallet & wallet_a) :
 		this->wallet.pop_main_stack ();
 	});
 	QObject::connect (search_for_receivables, &QPushButton::released, [this] () {
-		std::thread ([this] { this->wallet.wallet_m->search_receivable (this->wallet.wallet_m->wallets.tx_begin_read ()); }).detach ();
+		std::thread ([this] { this->wallet.wallet_m->search_receivable (); }).detach ();
 	});
 	QObject::connect (bootstrap, &QPushButton::released, [this] () {
 	});

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -175,34 +175,20 @@ TEST (wallet, password_change)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	nano::account account;
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		account = system.account (transaction, 0);
-	}
+	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	QTest::mouseClick (wallet->settings_button, Qt::LeftButton);
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		nano::raw_key password1;
-		nano::raw_key password2;
-		system.wallet (0)->store.derive_key (password1, transaction, "1");
-		system.wallet (0)->store.password.value (password2);
-		ASSERT_NE (password1, password2);
-	}
+	// Password "1" should not match current empty password
+	ASSERT_TRUE (system.wallet (0)->enter_password ("1"));
+	// Unlock wallet with correct (empty) password before changing
+	ASSERT_FALSE (system.wallet (0)->enter_password (""));
 	QTest::keyClicks (wallet->settings.new_password, "1");
 	QTest::keyClicks (wallet->settings.retype_password, "1");
 	QTest::mouseClick (wallet->settings.change, Qt::LeftButton);
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		nano::raw_key password1;
-		nano::raw_key password2;
-		system.wallet (0)->store.derive_key (password1, transaction, "1");
-		system.wallet (0)->store.password.value (password2);
-		ASSERT_EQ (password1, password2);
-	}
+	// After password change, password "1" should work
+	ASSERT_FALSE (system.wallet (0)->enter_password ("1"));
 	ASSERT_EQ ("", wallet->settings.new_password->text ());
 	ASSERT_EQ ("", wallet->settings.retype_password->text ());
 }
@@ -211,42 +197,21 @@ TEST (client, password_nochange)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	nano::account account;
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		account = system.account (transaction, 0);
-	}
+	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	QTest::mouseClick (wallet->settings_button, Qt::LeftButton);
-	nano::raw_key password;
-	password.clear ();
-	system.deadline_set (10s);
-	while (password == 0)
-	{
-		ASSERT_NO_ERROR (system.poll ());
-		system.wallet (0)->store.password.value (password);
-	}
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		nano::raw_key password1;
-		system.wallet (0)->store.derive_key (password1, transaction, "");
-		nano::raw_key password2;
-		system.wallet (0)->store.password.value (password2);
-		ASSERT_EQ (password1, password2);
-	}
+	// Wait for wallet to be initialized (password should work with empty string)
+	ASSERT_TIMELY (10s, !system.wallet (0)->enter_password (""));
+	// Verify empty password works
+	ASSERT_FALSE (system.wallet (0)->enter_password (""));
+	// Try to change password with mismatched retype
 	QTest::keyClicks (wallet->settings.new_password, "1");
 	QTest::keyClicks (wallet->settings.retype_password, "2");
 	QTest::mouseClick (wallet->settings.change, Qt::LeftButton);
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		nano::raw_key password1;
-		system.wallet (0)->store.derive_key (password1, transaction, "");
-		nano::raw_key password2;
-		system.wallet (0)->store.password.value (password2);
-		ASSERT_EQ (password1, password2);
-	}
+	// Password should still be empty after failed change
+	ASSERT_FALSE (system.wallet (0)->enter_password (""));
 	ASSERT_EQ ("1", wallet->settings.new_password->text ());
 	ASSERT_EQ ("", wallet->settings.retype_password->text ());
 }
@@ -255,12 +220,8 @@ TEST (wallet, enter_password)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (2);
-	nano::account account;
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		account = system.account (transaction, 0);
-	}
+	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	ASSERT_NE (-1, wallet->settings.layout->indexOf (wallet->settings.password));
@@ -272,10 +233,7 @@ TEST (wallet, enter_password)
 	QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents ();
 	ASSERT_NE (wallet->status->text ().toStdString ().rfind ("Status: Wallet password empty", 0), std::string::npos);
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_write ());
-		ASSERT_FALSE (system.wallet (0)->store.rekey (transaction, "abc"));
-	}
+	ASSERT_FALSE (system.wallet (0)->rekey ("abc"));
 	QTest::mouseClick (wallet->settings_button, Qt::LeftButton);
 	QTest::mouseClick (wallet->settings.lock_toggle, Qt::LeftButton);
 	test_application->processEvents ();
@@ -355,13 +313,9 @@ TEST (wallet, DISABLED_process_block)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	nano::account account;
 	nano::block_hash latest (system.nodes[0]->latest (nano::dev::genesis_key.pub));
 	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		account = system.account (transaction, 0);
-	}
+	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	ASSERT_EQ ("Process", wallet->block_entry.process->text ());
@@ -505,11 +459,7 @@ TEST (history, short_text)
 	nano::keypair key;
 	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (key.prv);
-	nano::account account;
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		account = system.account (transaction, 0);
-	}
+	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	nano::logger logger;
 	nano::stats stats{ logger };
@@ -543,11 +493,7 @@ TEST (history, pruned_source)
 	nano::keypair key;
 	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (key.prv);
-	nano::account account;
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		account = system.account (transaction, 0);
-	}
+	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	nano::logger logger;
 	nano::stats stats{ logger };
@@ -740,19 +686,12 @@ TEST (wallet, startup_work)
 	nano::keypair key;
 	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (key.prv);
-	nano::account account;
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		account = system.account (transaction, 0);
-	}
+	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
 	uint64_t work1;
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		ASSERT_TRUE (wallet->wallet_m->store.work_get (transaction, nano::dev::genesis_key.pub, work1));
-	}
+	ASSERT_TRUE (wallet->wallet_m->get_work (nano::dev::genesis_key.pub, work1));
 	QTest::mouseClick (wallet->accounts_button, Qt::LeftButton);
 	QTest::keyClicks (wallet->accounts.account_key_line, "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E58A380BC10474BB039CE4");
 	QTest::mouseClick (wallet->accounts.account_key_button, Qt::LeftButton);
@@ -761,8 +700,7 @@ TEST (wallet, startup_work)
 	while (again)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		again = wallet->wallet_m->store.work_get (transaction, nano::dev::genesis_key.pub, work1);
+		again = wallet->wallet_m->get_work (nano::dev::genesis_key.pub, work1);
 	}
 }
 
@@ -772,11 +710,7 @@ TEST (wallet, block_viewer)
 	nano::keypair key;
 	nano::test::system system (1);
 	system.wallet (0)->insert_adhoc (key.prv);
-	nano::account account;
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		account = system.account (transaction, 0);
-	}
+	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
@@ -799,10 +733,7 @@ TEST (wallet, import)
 	nano::keypair key1;
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (key1.prv);
-	{
-		auto transaction (system.nodes[0]->wallets.tx_begin_read ());
-		system.wallet (0)->store.serialize_json (transaction, json);
-	}
+	system.wallet (0)->serialize (json);
 	system.wallet (1)->insert_adhoc (key2.prv);
 	auto path{ nano::unique_path () / "wallet.json" };
 	{
@@ -906,10 +837,7 @@ TEST (wallet, change_seed)
 	auto key1 (system.wallet (0)->deterministic_insert ());
 	system.wallet (0)->deterministic_insert ();
 	nano::raw_key seed3;
-	{
-		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-		system.wallet (0)->store.seed (seed3, transaction);
-	}
+	system.wallet (0)->get_seed (seed3);
 	auto wallet_key (key1);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), wallet_key));
 	wallet->start ();
@@ -923,10 +851,7 @@ TEST (wallet, change_seed)
 	seed.clear ();
 	QTest::keyClicks (wallet->import.seed, seed.to_string ().c_str ());
 	nano::raw_key seed1;
-	{
-		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-		system.wallet (0)->store.seed (seed1, transaction);
-	}
+	system.wallet (0)->get_seed (seed1);
 	ASSERT_NE (seed, seed1);
 	ASSERT_TRUE (system.wallet (0)->exists (key1));
 	ASSERT_EQ (2, wallet->accounts.model->rowCount ());
@@ -937,8 +862,7 @@ TEST (wallet, change_seed)
 	ASSERT_EQ (1, wallet->accounts.model->rowCount ());
 	ASSERT_TRUE (wallet->import.clear_line->text ().toStdString ().empty ());
 	nano::raw_key seed2;
-	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-	system.wallet (0)->store.seed (seed2, transaction);
+	system.wallet (0)->get_seed (seed2);
 	ASSERT_EQ (seed, seed2);
 	ASSERT_FALSE (system.wallet (0)->exists (key1));
 	ASSERT_NE (key1, wallet->account);
@@ -976,8 +900,7 @@ TEST (wallet, seed_work_generation)
 	while (work == 0)
 	{
 		auto ec = system.poll ();
-		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-		system.wallet (0)->store.work_get (transaction, pub, work);
+		system.wallet (0)->get_work (pub, work);
 		ASSERT_NO_ERROR (ec);
 	}
 	auto transaction = system.nodes[0]->ledger.tx_begin_read ();
@@ -997,8 +920,7 @@ TEST (wallet, backup_seed)
 	ASSERT_EQ (wallet->accounts.window, wallet->main_stack->currentWidget ());
 	QTest::mouseClick (wallet->accounts.backup_seed, Qt::LeftButton);
 	nano::raw_key seed;
-	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-	system.wallet (0)->store.seed (seed, transaction);
+	system.wallet (0)->get_seed (seed);
 	ASSERT_EQ (seed.to_string (), test_application->clipboard ()->text ().toStdString ());
 }
 
@@ -1007,10 +929,7 @@ TEST (wallet, import_locked)
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
 	auto key1 (system.wallet (0)->deterministic_insert ());
-	{
-		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
-		system.wallet (0)->store.rekey (transaction, "1");
-	}
+	system.wallet (0)->rekey ("1");
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), key1));
 	wallet->start ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -733,7 +733,7 @@ TEST (wallet, import)
 	nano::keypair key1;
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (key1.prv);
-	system.wallet (0)->serialize (json);
+	system.wallet (0)->serialize_json (json);
 	system.wallet (1)->insert_adhoc (key2.prv);
 	auto path{ nano::unique_path () / "wallet.json" };
 	{

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -331,8 +331,7 @@ TEST (wallet, send_locked)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key1;
 	{
-		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
-		system.wallet (0)->enter_password (transaction, "0");
+		system.wallet (0)->enter_password ("0");
 	}
 	auto account (nano::dev::genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
@@ -1023,21 +1022,18 @@ TEST (wallet, import_locked)
 	QTest::keyClicks (wallet->import.seed, seed1.to_string ().c_str ());
 	QTest::keyClicks (wallet->import.clear_line, "clear keys");
 	{
-		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
-		system.wallet (0)->enter_password (transaction, "");
+		system.wallet (0)->enter_password ("");
 	}
 	QTest::mouseClick (wallet->import.import_seed, Qt::LeftButton);
 	nano::raw_key seed2;
 	{
-		auto transaction (system.wallet (0)->wallets.tx_begin_write ());
-		system.wallet (0)->store.seed (seed2, transaction);
+		system.wallet (0)->get_seed (seed2);
 		ASSERT_NE (seed1, seed2);
-		system.wallet (0)->enter_password (transaction, "1");
+		system.wallet (0)->enter_password ("1");
 	}
 	QTest::mouseClick (wallet->import.import_seed, Qt::LeftButton);
 	nano::raw_key seed3;
-	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-	system.wallet (0)->store.seed (seed3, transaction);
+	system.wallet (0)->get_seed (seed3);
 	ASSERT_EQ (seed1, seed3);
 }
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -474,12 +474,11 @@ TEST (rpc, wallet_password_change)
 	auto response (wait_response (system, rpc_ctx, request));
 	std::string account_text1 (response.get<std::string> ("changed"));
 	ASSERT_EQ (account_text1, "1");
-	auto transaction (system.wallet (0)->wallets.tx_begin_write ());
-	ASSERT_TRUE (system.wallet (0)->store.valid_password (transaction));
-	ASSERT_TRUE (system.wallet (0)->enter_password (transaction, ""));
-	ASSERT_FALSE (system.wallet (0)->store.valid_password (transaction));
-	ASSERT_FALSE (system.wallet (0)->enter_password (transaction, "test"));
-	ASSERT_TRUE (system.wallet (0)->store.valid_password (transaction));
+	ASSERT_FALSE (system.wallet (0)->is_locked ());
+	ASSERT_TRUE (system.wallet (0)->enter_password (""));
+	ASSERT_TRUE (system.wallet (0)->is_locked ());
+	ASSERT_FALSE (system.wallet (0)->enter_password ("test"));
+	ASSERT_FALSE (system.wallet (0)->is_locked ());
 }
 
 TEST (rpc, wallet_password_enter)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -530,8 +530,7 @@ TEST (rpc, wallet_representative_set)
 	request.put ("action", "wallet_representative_set");
 	request.put ("representative", key.pub.to_account ());
 	auto response (wait_response (system, rpc_ctx, request));
-	auto transaction (node->wallets.tx_begin_read ());
-	ASSERT_EQ (key.pub, node->wallets.items.begin ()->second->store.representative (transaction));
+	ASSERT_EQ (key.pub, node->wallets.items.begin ()->second->get_representative ());
 }
 
 TEST (rpc, wallet_representative_set_force)
@@ -548,10 +547,7 @@ TEST (rpc, wallet_representative_set_force)
 	request.put ("representative", key.pub.to_account ());
 	request.put ("update_existing_accounts", true);
 	auto response (wait_response (system, rpc_ctx, request));
-	{
-		auto transaction (node->wallets.tx_begin_read ());
-		ASSERT_EQ (key.pub, node->wallets.items.begin ()->second->store.representative (transaction));
-	}
+	ASSERT_EQ (key.pub, node->wallets.items.begin ()->second->get_representative ());
 	nano::account representative{};
 	while (representative != key.pub)
 	{
@@ -642,9 +638,8 @@ TEST (rpc, wallet_create_seed)
 	auto existing (node->wallets.items.find (wallet_id));
 	ASSERT_NE (node->wallets.items.end (), existing);
 	{
-		auto transaction (node->wallets.tx_begin_read ());
 		nano::raw_key seed0;
-		existing->second->store.seed (seed0, transaction);
+		existing->second->get_seed (seed0);
 		ASSERT_EQ (seed, seed0);
 	}
 	auto account_text (response.get<std::string> ("last_restored_account"));
@@ -666,12 +661,11 @@ TEST (rpc, wallet_export)
 	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
 	std::string wallet_json (response.get<std::string> ("json"));
-	bool error (false);
-	auto transaction (node->wallets.tx_begin_write ());
-	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store store (error, kdf, transaction, node->wallets.env, nano::dev::genesis_key.pub, 1, "0", wallet_json);
-	ASSERT_FALSE (error);
-	ASSERT_TRUE (store.exists (transaction, nano::dev::genesis_key.pub));
+	// Verify exported JSON is valid by importing it into a new wallet
+	auto new_wallet = node->wallets.create (nano::random_wallet_id ());
+	ASSERT_NE (nullptr, new_wallet);
+	ASSERT_FALSE (new_wallet->import (wallet_json, ""));
+	ASSERT_TRUE (new_wallet->exists (nano::dev::genesis_key.pub));
 }
 
 TEST (rpc, wallet_destroy)
@@ -713,8 +707,7 @@ TEST (rpc, account_move)
 	ASSERT_EQ ("1", response.get<std::string> ("moved"));
 	ASSERT_TRUE (destination->exists (key.pub));
 	ASSERT_TRUE (destination->exists (nano::dev::genesis_key.pub));
-	auto transaction (node->wallets.tx_begin_read ());
-	ASSERT_EQ (source->store.end (transaction), source->store.begin (transaction));
+	ASSERT_TRUE (source->accounts ().empty ());
 }
 
 TEST (rpc, block)
@@ -2539,10 +2532,7 @@ TEST (rpc, wallet_seed)
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	nano::raw_key seed;
-	{
-		auto transaction (node->wallets.tx_begin_read ());
-		system.wallet (0)->store.seed (seed, transaction);
-	}
+	system.wallet (0)->get_seed (seed);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_seed");
 	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
@@ -2561,10 +2551,8 @@ TEST (rpc, wallet_change_seed)
 	nano::raw_key seed;
 	nano::random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
 	{
-		auto transaction (node->wallets.tx_begin_read ());
 		nano::raw_key seed0;
-		nano::random_pool::generate_block (seed0.bytes.data (), seed0.bytes.size ());
-		system0.wallet (0)->store.seed (seed0, transaction);
+		system0.wallet (0)->get_seed (seed0);
 		ASSERT_NE (seed, seed0);
 	}
 	auto prv = nano::deterministic_key (seed, 0);
@@ -2575,9 +2563,8 @@ TEST (rpc, wallet_change_seed)
 	request.put ("seed", seed.to_string ());
 	auto response (wait_response (system0, rpc_ctx, request));
 	{
-		auto transaction (node->wallets.tx_begin_read ());
 		nano::raw_key seed0;
-		system0.wallet (0)->store.seed (seed0, transaction);
+		system0.wallet (0)->get_seed (seed0);
 		ASSERT_EQ (seed, seed0);
 	}
 	auto account_text (response.get<std::string> ("last_restored_account"));
@@ -2844,10 +2831,7 @@ TEST (rpc, deterministic_key)
 	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
 	nano::raw_key seed;
-	{
-		auto transaction (system0.nodes[0]->wallets.tx_begin_read ());
-		system0.wallet (0)->store.seed (seed, transaction);
-	}
+	system0.wallet (0)->get_seed (seed);
 	nano::account account0 (system0.wallet (0)->deterministic_insert ());
 	nano::account account1 (system0.wallet (0)->deterministic_insert ());
 	nano::account account2 (system0.wallet (0)->deterministic_insert ());
@@ -3198,10 +3182,7 @@ TEST (rpc, wallet_info)
 	ASSERT_TIMELY (5s, node->block_confirmed (send2->hash ()));
 
 	nano::account account (system.wallet (0)->deterministic_insert ());
-	{
-		auto transaction (node->wallets.tx_begin_write ());
-		system.wallet (0)->store.erase (transaction, account);
-	}
+	system.wallet (0)->remove_account (account);
 	account = system.wallet (0)->deterministic_insert ();
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
@@ -3444,8 +3425,7 @@ TEST (rpc, work_get)
 	auto response (wait_response (system, rpc_ctx, request));
 	std::string work_text (response.get<std::string> ("work"));
 	uint64_t work (1);
-	auto transaction (node->wallets.tx_begin_read ());
-	node->wallets.items.begin ()->second->store.work_get (transaction, nano::dev::genesis_key.pub, work);
+	node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub, work);
 	ASSERT_EQ (nano::to_string_hex (work), work_text);
 }
 
@@ -3460,14 +3440,13 @@ TEST (rpc, wallet_work_get)
 	request.put ("action", "wallet_work_get");
 	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
-	auto transaction (node->wallets.tx_begin_read ());
 	for (auto & works : response.get_child ("works"))
 	{
 		std::string account_text (works.first);
 		ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), account_text);
 		std::string work_text (works.second.get<std::string> (""));
 		uint64_t work (1);
-		node->wallets.items.begin ()->second->store.work_get (transaction, nano::dev::genesis_key.pub, work);
+		node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub, work);
 		ASSERT_EQ (nano::to_string_hex (work), work_text);
 	}
 }
@@ -3488,8 +3467,7 @@ TEST (rpc, work_set)
 	std::string success (response.get<std::string> ("success"));
 	ASSERT_TRUE (success.empty ());
 	uint64_t work1 (1);
-	auto transaction (node->wallets.tx_begin_read ());
-	node->wallets.items.begin ()->second->store.work_get (transaction, nano::dev::genesis_key.pub, work1);
+	node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub, work1);
 	ASSERT_EQ (work1, work0);
 }
 
@@ -5005,17 +4983,13 @@ TEST (rpc, wallet_lock)
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	std::string wallet = node->wallets.items.begin ()->first.to_string ();
-	{
-		auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-		ASSERT_TRUE (system.wallet (0)->store.valid_password (transaction));
-	}
+	ASSERT_FALSE (system.wallet (0)->is_locked ());
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_lock");
 	auto response (wait_response (system, rpc_ctx, request));
 	std::string account_text1 (response.get<std::string> ("locked"));
 	ASSERT_EQ (account_text1, "1");
-	auto transaction (system.wallet (0)->wallets.tx_begin_read ());
-	ASSERT_FALSE (system.wallet (0)->store.valid_password (transaction));
+	ASSERT_TRUE (system.wallet (0)->is_locked ());
 }
 
 TEST (rpc, wallet_locked)
@@ -6567,7 +6541,7 @@ TEST (rpc, receive_unopened)
 	ASSERT_FALSE (node->store.account.exists (node->ledger.tx_begin_read (), key2.pub));
 	ASSERT_TRUE (node->ledger.any.block_exists (node->ledger.tx_begin_read (), send2->hash ()));
 	nano::public_key rep;
-	wallet->store.representative_set (node->wallets.tx_begin_write (), rep);
+	wallet->set_representative (rep);
 	wallet->insert_adhoc (key2.prv); // should not auto receive, amount sent was lower than minimum
 	request.put ("account", key2.pub.to_account ());
 	request.put ("block", send2->hash ().to_string ());

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1926,7 +1926,7 @@ TEST (node, aggressive_flooding)
 	for (auto & node_wallet : nodes_wallets)
 	{
 		nano::keypair keypair;
-		node_wallet.second->store.representative_set (node_wallet.first->wallets.tx_begin_write (), keypair.pub);
+		node_wallet.second->set_representative (keypair.pub);
 		node_wallet.second->insert_adhoc (keypair.prv);
 		auto block (wallet1.send_action (nano::dev::genesis_key.pub, keypair.pub, large_amount));
 		ASSERT_NE (nullptr, block);
@@ -1951,7 +1951,7 @@ TEST (node, aggressive_flooding)
 	// Wait until all genesis blocks are received
 	auto all_received = [&nodes_wallets] () {
 		return std::all_of (nodes_wallets.begin (), nodes_wallets.end (), [] (auto const & node_wallet) {
-			auto local_representative (node_wallet.second->store.representative (node_wallet.first->wallets.tx_begin_read ()));
+			auto local_representative (node_wallet.second->get_representative ());
 			return node_wallet.first->ledger.any.account_balance (node_wallet.first->ledger.tx_begin_read (), local_representative) > 0;
 		});
 	};

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -599,10 +599,9 @@ TEST (wallets, rep_scan)
 	auto & node (*system.nodes[0]);
 	auto wallet (system.wallet (0));
 	{
-		auto transaction (node.wallets.tx_begin_write ());
 		for (auto i (0); i < 10000; ++i)
 		{
-			wallet->deterministic_insert (transaction);
+			wallet->deterministic_insert ();
 		}
 	}
 	auto begin (std::chrono::steady_clock::now ());

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -256,16 +256,6 @@ std::shared_ptr<nano::wallet> nano::test::system::wallet (size_t index_a)
 	return nodes[index_a]->wallets.items.begin ()->second;
 }
 
-nano::account nano::test::system::account (store::transaction const & transaction_a, size_t index_a)
-{
-	auto wallet_l (wallet (index_a));
-	auto keys (wallet_l->store.begin (transaction_a));
-	debug_assert (keys != wallet_l->store.end (transaction_a));
-	auto result (keys->first);
-	debug_assert (++keys == wallet_l->store.end (transaction_a));
-	return nano::account (result);
-}
-
 uint64_t nano::test::system::work_generate_limited (nano::block_hash const & root_a, uint64_t min_a, uint64_t max_a)
 {
 	debug_assert (min_a > 0);

--- a/nano/test_common/system.hpp
+++ b/nano/test_common/system.hpp
@@ -45,7 +45,6 @@ namespace test
 		void generate_send_existing (nano::node &, std::vector<nano::account> &);
 		std::shared_ptr<nano::state_block> upgrade_genesis_epoch (nano::node &, nano::epoch const);
 		std::shared_ptr<nano::wallet> wallet (size_t);
-		nano::account account (store::transaction const &, size_t);
 		/** Generate work with difficulty between \p min_difficulty_a (inclusive) and \p max_difficulty_a (exclusive) */
 		uint64_t work_generate_limited (nano::block_hash const & root_a, uint64_t min_difficulty_a, uint64_t max_difficulty_a);
 		/**


### PR DESCRIPTION
Refactor wallet and wallets methods to be self-contained by managing transactions internally rather than requiring callers to pass them in. This simplifies the wallet API by hiding transaction management from callers and makes further refactoring easier.