### PR TITLE
Use atomic enabled flag in request_aggregator::request

### DIFF
--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -31,9 +31,15 @@ nano::request_aggregator::request_aggregator (request_aggregator_config const & 
 	queue.max_size_query = [this] (auto const & origin) {
 		return config.max_queue;
 	};
-	queue.priority_query = [this] (auto const & origin) {
+	queue.priority_query = [] (auto const & origin) {
 		return 1;
 	};
+
+	// Disable if voting is disabled
+	if (!node_config.enable_voting)
+	{
+		enabled = false;
+	}
 }
 
 nano::request_aggregator::~request_aggregator ()
@@ -45,7 +51,7 @@ void nano::request_aggregator::start ()
 {
 	debug_assert (threads.empty ());
 
-	if (!node_config.enable_voting)
+	if (!enabled)
 	{
 		return;
 	}
@@ -94,7 +100,7 @@ bool nano::request_aggregator::request (request_type const & request, std::share
 	debug_assert (!request.empty ());
 
 	// Do not accept requests if disabled
-	if (threads.empty ())
+	if (!enabled.load (std::memory_order_relaxed))
 	{
 		return false;
 	}

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -9,17 +9,11 @@
 #include <nano/node/transport/channel.hpp>
 #include <nano/node/transport/transport.hpp>
 
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/member.hpp>
-#include <boost/multi_index/ordered_index.hpp>
-#include <boost/multi_index_container.hpp>
-
+#include <atomic>
 #include <condition_variable>
 #include <thread>
 #include <unordered_map>
 #include <vector>
-
-namespace mi = boost::multi_index;
 
 namespace nano
 {
@@ -99,6 +93,7 @@ private:
 	using value_type = std::pair<request_type, std::shared_ptr<nano::transport::channel>>;
 	nano::fair_queue<value_type, nano::no_value> queue;
 
+	std::atomic<bool> enabled{ true };
 	bool stopped{ false };
 	nano::condition_variable condition;
 	mutable nano::mutex mutex{ mutex_identifier (mutexes::request_aggregator) };


### PR DESCRIPTION
Should fix:
```
WARNING: ThreadSanitizer: data race (pid=57940)
    Read of size 8 at 0x000114b008e0 by thread T1708:
      #0 std::__1::vector<std::__1::thread, std::__1::allocator<std::__1::thread>>::empty[abi:ue170006]() const vector:610 (rpc_test:arm64+0x10058ccb4)
      #1 nano::request_aggregator::request(std::__1::vector<std::__1::pair<nano::block_hash, nano::root>, std::__1::allocator<std::__1::pair<nano::block_hash, nano::root>>> const&, std::__1::shared_ptr<nano::transport::channel> const&) request_aggregator.cpp:97 (rpc_test:arm64+0x100bf8c14)
      #2 (anonymous namespace)::process_visitor::confirm_req(nano::messages::confirm_req const&) message_processor.cpp:212 (rpc_test:arm64+0x100a5601c)
      #3 nano::messages::confirm_req::visit(nano::messages::message_visitor&) const confirm.cpp:55 (rpc_test:arm64+0x10117957c)
      #4 nano::message_processor::process(nano::messages::message const&, std::__1::shared_ptr<nano::transport::channel> const&) message_processor.cpp:297 (rpc_test:arm64+0x100a4a170)
      #5 nano::node::inbound(nano::messages::message const&, std::__1::shared_ptr<nano::transport::channel> const&) node.cpp:489 (rpc_test:arm64+0x100aec338)
      #6 nano::transport::loopback_channel::send_impl(nano::messages::message const&, nano::transport::traffic_type, std::__1::function<void (boost::system::error_code const&, unsigned long)>) loopback.cpp:20 (rpc_test:arm64+0x100d2f188)
      #7 nano::transport::channel::send(nano::messages::message const&, nano::transport::traffic_type, std::__1::function<void (boost::system::error_code const&, unsigned long)>) channel.cpp:19 (rpc_test:arm64+0x100cd7688)
      #8 nano::confirmation_solicitor::flush() confirmation_solicitor.cpp:109 (rpc_test:arm64+0x1006a81e0)
      #9 nano::active_elections::tick_elections(std::__1::unique_lock<nano::mutex>&) active_elections.cpp:529 (rpc_test:arm64+0x1003f3330)
      #10 nano::active_elections::run() active_elections.cpp:549 (rpc_test:arm64+0x1003f3ba8)
      #11 nano::active_elections::start()::$_3::operator()() const active_elections.cpp:116 (rpc_test:arm64+0x1004371f0)
      #12 decltype(std::declval<nano::active_elections::start()::$_3>()()) std::__1::__invoke[abi:ue170006]<nano::active_elections::start()::$_3>(nano::active_elections::start()::$_3&&) invoke.h:340 (rpc_test:arm64+0x10043712c)
      #13 void std::__1::__thread_execute[abi:ue170006]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, nano::active_elections::start()::$_3>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, nano::active_elections::start()::$_3>&, std::__1::__tuple_indices<>) thread.h:227 (rpc_test:arm64+0x1004370d8)
      #14 void* std::__1::__thread_proxy[abi:ue170006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, nano::active_elections::start()::$_3>>(void*) thread.h:238 (rpc_test:arm64+0x100436b6c)
  
    Previous write of size 8 at 0x000114b008e0 by thread T1740:
      #0 std::__1::vector<std::__1::thread, std::__1::allocator<std::__1::thread>>::__base_destruct_at_end[abi:ue170006](std::__1::thread*) vector:945 (rpc_test:arm64+0x100598130)
      #1 std::__1::vector<std::__1::thread, std::__1::allocator<std::__1::thread>>::__clear[abi:ue170006]() vector:938 (rpc_test:arm64+0x100597e70)
      #2 std::__1::vector<std::__1::thread, std::__1::allocator<std::__1::thread>>::clear[abi:ue170006]() vector:723 (rpc_test:arm64+0x10058d328)
      #3 nano::request_aggregator::stop() request_aggregator.cpp:76 (rpc_test:arm64+0x100bf87e0)
      #4 nano::node::stop() node.cpp:618 (rpc_test:arm64+0x100aeb980)
      #5 nano::test::system::stop_node(nano::node&)::$_2::operator()() const system.cpp:211 (rpc_test:arm64+0x100395a44)
      #6 decltype(std::declval<nano::test::system::stop_node(nano::node&)::$_2>()()) std::__1::__invoke[abi:ue170006]<nano::test::system::stop_node(nano::node&)::$_2>(nano::test::system::stop_node(nano::node&)::$_2&&) invoke.h:340 (rpc_test:arm64+0x100395998)
      #7 void std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>::__execute[abi:ue170006]<>(std::__1::__tuple_indices<>) future:2195 (rpc_test:arm64+0x100395944)
      #8 std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>::operator()[abi:ue170006]() future:2188 (rpc_test:arm64+0x1003958ec)
      #9 std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>::__execute() future:1020 (rpc_test:arm64+0x10039565c)
      #10 decltype(*std::declval<std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>*>().*std::declval<void (std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>::*)()>()()) std::__1::__invoke[abi:ue170006]<void (std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>*, void>(void (std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>::*&&)(), std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>*&&) invoke.h:308 (rpc_test:arm64+0x1003966f4)
      #11 void std::__1::__thread_execute[abi:ue170006]<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>*, 2ul>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>*>&, std::__1::__tuple_indices<2ul>) thread.h:227 (rpc_test:arm64+0x100396614)
      #12 void* std::__1::__thread_proxy[abi:ue170006]<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct>>, void (std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>::*)(), std::__1::__async_assoc_state<void, std::__1::__async_func<nano::test::system::stop_node(nano::node&)::$_2>>*>>(void*) thread.h:238 (rpc_test:arm64+0x100395fac)
```