### PR TITLE
Refactor wallet API to use nano::result (boost outcome) and direct return values

### DIFF
--- a/nano/boost/outcome.hpp
+++ b/nano/boost/outcome.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+// Disable [[nodiscard]] for outcome results
+#define BOOST_OUTCOME_NODISCARD
+
 #include <boost/outcome.hpp>
 
 namespace outcome = BOOST_OUTCOME_V2_NAMESPACE;

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1090,9 +1090,9 @@ TEST (node, fork_no_vote_quorum)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*system.work.generate (block->hash ()))
 				 .build ();
-	nano::raw_key key3;
-	ASSERT_FALSE (system.wallet (1)->fetch_prv (key1, key3));
-	auto vote = std::make_shared<nano::vote> (key1, key3, 0, 0, std::vector<nano::block_hash>{ send2->hash () });
+	auto key3_result = system.wallet (1)->fetch_prv (key1);
+	ASSERT_TRUE (key3_result);
+	auto vote = std::make_shared<nano::vote> (key1, key3_result.value (), 0, 0, std::vector<nano::block_hash>{ send2->hash () });
 	nano::messages::confirm_ack confirm{ nano::dev::network_params.network, vote };
 	auto channel = node2.network.find_node_id (node3.node_id.pub);
 	ASSERT_NE (nullptr, channel);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1058,11 +1058,11 @@ TEST (node, fork_no_vote_quorum)
 	auto & node2 (*system.nodes[1]);
 	auto & node3 (*system.nodes[2]);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto key4 (system.wallet (0)->deterministic_insert ());
+	auto key4 = system.wallet (0)->deterministic_insert ().value ();
 	system.wallet (0)->send_action (nano::dev::genesis_key.pub, key4, nano::dev::constants.genesis_amount / 4);
-	auto key1 (system.wallet (1)->deterministic_insert ());
+	auto key1 = system.wallet (1)->deterministic_insert ().value ();
 	system.wallet (1)->set_representative (key1);
-	auto block (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1, node1.config.receive_minimum.number ()));
+	auto block = system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1, node1.config.receive_minimum.number ());
 	ASSERT_NE (nullptr, block);
 	ASSERT_TIMELY (30s, node3.balance (key1) == node1.config.receive_minimum.number () && node2.balance (key1) == node1.config.receive_minimum.number () && node1.balance (key1) == node1.config.receive_minimum.number ());
 	ASSERT_EQ (node1.config.receive_minimum.number (), node1.weight (key1));
@@ -1082,7 +1082,7 @@ TEST (node, fork_no_vote_quorum)
 	nano::test::process (node1, { send1 });
 	nano::test::process (node2, { send1 });
 	nano::test::process (node3, { send1 });
-	auto key2 (system.wallet (2)->deterministic_insert ());
+	auto key2 = system.wallet (2)->deterministic_insert ().value ();
 	auto send2 = nano::send_block_builder ()
 				 .previous (block->hash ())
 				 .destination (key2)

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -480,12 +480,54 @@ TEST (wallet_store, move)
 	ASSERT_TRUE (wallet2.exists (transaction, key2.pub));
 	std::vector<nano::public_key> keys;
 	keys.push_back (key2.pub);
-	ASSERT_FALSE (wallet1.move (transaction, wallet2, keys));
+	auto move_result = wallet1.move (transaction, wallet2, keys);
+	ASSERT_TRUE (move_result);
+	ASSERT_FALSE (move_result.value ());
 	ASSERT_TRUE (wallet1.exists (transaction, key2.pub));
 	ASSERT_FALSE (wallet2.exists (transaction, key2.pub));
 }
 
-TEST (wallet_store, import)
+TEST (wallet_store, move_locked)
+{
+	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
+	auto transaction (env.tx_begin_write ());
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
+	nano::wallet_store wallet1 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
+	nano::keypair key1;
+	wallet1.insert_adhoc (transaction, key1.prv);
+	nano::wallet_store wallet2 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1");
+	nano::keypair key2;
+	wallet2.insert_adhoc (transaction, key2.prv);
+	std::vector<nano::public_key> keys;
+	keys.push_back (key2.pub);
+
+	// Lock destination wallet
+	nano::raw_key bad_password;
+	bad_password = 1;
+	wallet1.password.value_set (bad_password);
+	ASSERT_FALSE (wallet1.valid_password (transaction));
+
+	auto result1 = wallet1.move (transaction, wallet2, keys);
+	ASSERT_FALSE (result1);
+	ASSERT_EQ (result1.error (), nano::error_common::wallet_locked);
+	// Key should not have been moved
+	ASSERT_FALSE (wallet1.exists (transaction, key2.pub));
+	ASSERT_TRUE (wallet2.exists (transaction, key2.pub));
+
+	// Unlock destination, lock source
+	ASSERT_FALSE (wallet1.attempt_password (transaction, ""));
+	ASSERT_TRUE (wallet1.valid_password (transaction));
+	wallet2.password.value_set (bad_password);
+	ASSERT_FALSE (wallet2.valid_password (transaction));
+
+	auto result2 = wallet1.move (transaction, wallet2, keys);
+	ASSERT_FALSE (result2);
+	ASSERT_EQ (result2.error (), nano::error_common::wallet_locked);
+	ASSERT_FALSE (wallet1.exists (transaction, key2.pub));
+	ASSERT_TRUE (wallet2.exists (transaction, key2.pub));
+}
+
+TEST (wallet_store, import_json)
 {
 	nano::test::system system (2);
 	auto wallet1 (system.wallet (0));
@@ -498,6 +540,42 @@ TEST (wallet_store, import)
 	auto error (wallet2->import (json, ""));
 	ASSERT_FALSE (error);
 	ASSERT_TRUE (wallet2->exists (key1.pub));
+}
+
+TEST (wallet_store, import_locked)
+{
+	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
+	auto transaction (env.tx_begin_write ());
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
+	nano::wallet_store wallet1 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
+	nano::wallet_store wallet2 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1");
+	nano::keypair key1;
+	wallet2.insert_adhoc (transaction, key1.prv);
+
+	// Lock destination wallet
+	nano::raw_key bad_password;
+	bad_password = 1;
+	wallet1.password.value_set (bad_password);
+	ASSERT_FALSE (wallet1.valid_password (transaction));
+
+	auto result1 = wallet1.import (transaction, wallet2);
+	ASSERT_FALSE (result1);
+	ASSERT_EQ (result1.error (), nano::error_common::wallet_locked);
+	// Key should not have been moved
+	ASSERT_FALSE (wallet1.exists (transaction, key1.pub));
+	ASSERT_TRUE (wallet2.exists (transaction, key1.pub));
+
+	// Unlock destination, lock source
+	ASSERT_FALSE (wallet1.attempt_password (transaction, ""));
+	ASSERT_TRUE (wallet1.valid_password (transaction));
+	wallet2.password.value_set (bad_password);
+	ASSERT_FALSE (wallet2.valid_password (transaction));
+
+	auto result2 = wallet1.import (transaction, wallet2);
+	ASSERT_FALSE (result2);
+	ASSERT_EQ (result2.error (), nano::error_common::wallet_locked);
+	ASSERT_FALSE (wallet1.exists (transaction, key1.pub));
+	ASSERT_TRUE (wallet2.exists (transaction, key1.pub));
 }
 
 TEST (wallet_store, fail_import_bad_password)
@@ -690,6 +768,57 @@ TEST (wallet, insert_deterministic_locked)
 	auto insert_result = wallet->deterministic_insert ();
 	ASSERT_FALSE (insert_result);
 	ASSERT_EQ (insert_result.error (), nano::error_common::wallet_locked);
+}
+
+TEST (wallet, move_accounts)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+	auto wallet1 (node.wallets.create (nano::random_wallet_id ()));
+	auto wallet2 (node.wallets.create (nano::random_wallet_id ()));
+	nano::keypair key1, key2;
+	wallet2->insert_adhoc (key1.prv);
+	wallet2->insert_adhoc (key2.prv);
+	ASSERT_FALSE (wallet1->exists (key1.pub));
+	ASSERT_FALSE (wallet1->exists (key2.pub));
+	ASSERT_TRUE (wallet2->exists (key1.pub));
+	ASSERT_TRUE (wallet2->exists (key2.pub));
+	auto result = wallet1->move_accounts (*wallet2, { key1.pub, key2.pub });
+	ASSERT_TRUE (result);
+	ASSERT_FALSE (result.value ());
+	ASSERT_TRUE (wallet1->exists (key1.pub));
+	ASSERT_TRUE (wallet1->exists (key2.pub));
+	ASSERT_FALSE (wallet2->exists (key1.pub));
+	ASSERT_FALSE (wallet2->exists (key2.pub));
+	// Verify keys are the same after move
+	auto prv1 = wallet1->fetch_prv (key1.pub);
+	ASSERT_TRUE (prv1);
+	ASSERT_EQ (key1.prv, prv1.value ());
+	auto prv2 = wallet1->fetch_prv (key2.pub);
+	ASSERT_TRUE (prv2);
+	ASSERT_EQ (key2.prv, prv2.value ());
+}
+
+TEST (wallet, move_accounts_locked)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+	auto wallet1 (node.wallets.create (nano::random_wallet_id ()));
+	auto wallet2 (node.wallets.create (nano::random_wallet_id ()));
+	nano::keypair key1;
+	wallet2->insert_adhoc (key1.prv);
+
+	// Lock destination wallet
+	wallet1->rekey ("1");
+	wallet1->enter_password ("");
+	ASSERT_TRUE (wallet1->is_locked ());
+
+	auto result = wallet1->move_accounts (*wallet2, { key1.pub });
+	ASSERT_FALSE (result);
+	ASSERT_EQ (result.error (), nano::error_common::wallet_locked);
+	// Key should not have been moved
+	ASSERT_FALSE (wallet1->exists (key1.pub));
+	ASSERT_TRUE (wallet2->exists (key1.pub));
 }
 
 TEST (wallet, no_work)

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -660,21 +660,18 @@ TEST (wallet, reseed)
 	nano::raw_key seed2;
 	seed2 = 2;
 	wallet.seed_set (transaction, seed1);
-	nano::raw_key seed3;
-	wallet.seed (seed3, transaction);
+	auto seed3 = wallet.seed (transaction);
 	ASSERT_EQ (seed1, seed3);
 	auto key1 (wallet.deterministic_insert (transaction));
 	ASSERT_EQ (1, wallet.deterministic_index_get (transaction));
 	wallet.seed_set (transaction, seed2);
 	ASSERT_EQ (0, wallet.deterministic_index_get (transaction));
-	nano::raw_key seed4;
-	wallet.seed (seed4, transaction);
+	auto seed4 = wallet.seed (transaction);
 	ASSERT_EQ (seed2, seed4);
 	auto key2 (wallet.deterministic_insert (transaction));
 	ASSERT_NE (key1, key2);
 	wallet.seed_set (transaction, seed1);
-	nano::raw_key seed5;
-	wallet.seed (seed5, transaction);
+	auto seed5 = wallet.seed (transaction);
 	ASSERT_EQ (seed1, seed5);
 	auto key3 (wallet.deterministic_insert (transaction));
 	ASSERT_EQ (key1, key3);
@@ -751,7 +748,9 @@ TEST (wallet, password_race_corrupt_seed)
 	nano::raw_key seed;
 	{
 		ASSERT_FALSE (wallet->rekey ("4567"));
-		wallet->get_seed (seed);
+		auto seed_result = wallet->get_seed ();
+		ASSERT_TRUE (seed_result);
+		seed = seed_result.value ();
 		ASSERT_FALSE (wallet->enter_password ("4567"));
 	}
 	std::vector<std::thread> threads;
@@ -785,21 +784,21 @@ TEST (wallet, password_race_corrupt_seed)
 	{
 		if (!wallet->enter_password ("1234"))
 		{
-			nano::raw_key seed_now;
-			wallet->get_seed (seed_now);
-			ASSERT_EQ (seed_now, seed);
+			auto seed_now = wallet->get_seed ();
+			ASSERT_TRUE (seed_now);
+			ASSERT_EQ (seed_now.value (), seed);
 		}
 		else if (!wallet->enter_password ("0000"))
 		{
-			nano::raw_key seed_now;
-			wallet->get_seed (seed_now);
-			ASSERT_EQ (seed_now, seed);
+			auto seed_now = wallet->get_seed ();
+			ASSERT_TRUE (seed_now);
+			ASSERT_EQ (seed_now.value (), seed);
 		}
 		else if (!wallet->enter_password ("4567"))
 		{
-			nano::raw_key seed_now;
-			wallet->get_seed (seed_now);
-			ASSERT_EQ (seed_now, seed);
+			auto seed_now = wallet->get_seed ();
+			ASSERT_TRUE (seed_now);
+			ASSERT_EQ (seed_now.value (), seed);
 		}
 		else
 		{
@@ -824,9 +823,9 @@ TEST (wallet, change_seed)
 	ASSERT_TIMELY (5s, nano::test::exists (*system.nodes[0], { block }));
 	{
 		wallet->change_seed (seed1);
-		nano::raw_key seed2;
-		wallet->get_seed (seed2);
-		ASSERT_EQ (seed1, seed2);
+		auto seed2 = wallet->get_seed ();
+		ASSERT_TRUE (seed2);
+		ASSERT_EQ (seed1, seed2.value ());
 		ASSERT_EQ (index + 1, wallet->get_deterministic_index ());
 	}
 	ASSERT_TRUE (wallet->exists (pub));
@@ -842,9 +841,9 @@ TEST (wallet, deterministic_restore)
 	uint32_t index (4);
 	{
 		wallet->change_seed (seed1);
-		nano::raw_key seed2;
-		wallet->get_seed (seed2);
-		ASSERT_EQ (seed1, seed2);
+		auto seed2 = wallet->get_seed ();
+		ASSERT_TRUE (seed2);
+		ASSERT_EQ (seed1, seed2.value ());
 		ASSERT_EQ (1, wallet->get_deterministic_index ());
 		auto prv = nano::deterministic_key (seed1, index);
 		pub = nano::pub_key (prv);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -605,7 +605,9 @@ TEST (wallet, insert_locked)
 		wallet->enter_password ("");
 	}
 	ASSERT_TRUE (wallet->is_locked ());
-	ASSERT_TRUE (wallet->insert_adhoc (nano::keypair ().prv).is_zero ());
+	auto insert_result = wallet->insert_adhoc (nano::keypair ().prv);
+	ASSERT_FALSE (insert_result);
+	ASSERT_EQ (insert_result.error (), nano::error_common::wallet_locked);
 }
 
 TEST (wallet, deterministic_keys)
@@ -685,7 +687,9 @@ TEST (wallet, insert_deterministic_locked)
 	ASSERT_FALSE (wallet->is_locked ());
 	wallet->enter_password ("");
 	ASSERT_TRUE (wallet->is_locked ());
-	ASSERT_TRUE (wallet->deterministic_insert ().is_zero ());
+	auto insert_result = wallet->deterministic_insert ();
+	ASSERT_FALSE (insert_result);
+	ASSERT_EQ (insert_result.error (), nano::error_common::wallet_locked);
 }
 
 TEST (wallet, no_work)

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -534,10 +534,10 @@ TEST (wallet, work)
 	system.deadline_set (20s);
 	while (!done)
 	{
-		uint64_t work (0);
-		if (!wallet->get_work (nano::dev::genesis_key.pub, work))
+		auto work_result = wallet->get_work (nano::dev::genesis_key.pub);
+		if (work_result)
 		{
-			done = nano::dev::network_params.work.difficulty (nano::dev::genesis->work_version (), nano::dev::genesis->hash (), work) >= system.nodes[0]->default_difficulty (nano::dev::genesis->work_version ());
+			done = nano::dev::network_params.work.difficulty (nano::dev::genesis->work_version (), nano::dev::genesis->hash (), work_result.value ()) >= system.nodes[0]->default_difficulty (nano::dev::genesis->work_version ());
 		}
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -549,19 +549,19 @@ TEST (wallet, work_generate)
 	auto & node1 (*system.nodes[0]);
 	auto wallet (system.wallet (0));
 	nano::uint128_t amount1 (node1.balance (nano::dev::genesis_key.pub));
-	uint64_t work1;
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::account account1 = system.wallet (0)->accounts ().front ();
 	nano::keypair key;
 	auto block (wallet->send_action (nano::dev::genesis_key.pub, key.pub, 100));
 	ASSERT_TIMELY (10s, node1.ledger.any.account_balance (node1.ledger.tx_begin_read (), nano::dev::genesis_key.pub) != amount1);
 	system.deadline_set (10s);
-	auto again (true);
+	auto again = true;
 	while (again)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 		auto block_transaction = node1.ledger.tx_begin_read ();
-		again = wallet->get_work (account1, work1) || nano::dev::network_params.work.difficulty (block->work_version (), node1.ledger.latest_root (block_transaction, account1), work1) < node1.default_difficulty (block->work_version ());
+		auto work_result = wallet->get_work (account1);
+		again = !work_result || nano::dev::network_params.work.difficulty (block->work_version (), node1.ledger.latest_root (block_transaction, account1), work_result.value ()) < node1.default_difficulty (block->work_version ());
 	}
 }
 
@@ -570,7 +570,6 @@ TEST (wallet, work_cache_delayed)
 	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
 	auto wallet (system.wallet (0));
-	uint64_t work1;
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::account account1 = system.wallet (0)->accounts ().front ();
 	nano::keypair key;
@@ -580,17 +579,20 @@ TEST (wallet, work_cache_delayed)
 	ASSERT_EQ (block2->hash (), node1.latest (nano::dev::genesis_key.pub));
 	ASSERT_EQ (block2->hash (), node1.wallets.delayed_work->operator[] (nano::dev::genesis_key.pub).as_block_hash ());
 	auto threshold (node1.default_difficulty (nano::work_version::work_1));
-	auto again (true);
+	nano::result<uint64_t> work_result = nano::error (nano::error_common::account_not_found_wallet);
 	system.deadline_set (10s);
+	auto again = true;
 	while (again)
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		if (!wallet->get_work (account1, work1))
+		work_result = wallet->get_work (account1);
+		if (work_result)
 		{
-			again = nano::dev::network_params.work.difficulty (nano::work_version::work_1, block2->hash (), work1) < threshold;
+			again = nano::dev::network_params.work.difficulty (nano::work_version::work_1, block2->hash (), work_result.value ()) < threshold;
 		}
 	}
-	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, block2->hash (), work1), threshold);
+	ASSERT_TRUE (work_result);
+	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, block2->hash (), work_result.value ()), threshold);
 }
 
 TEST (wallet, insert_locked)
@@ -698,9 +700,9 @@ TEST (wallet, no_work)
 	ASSERT_NE (nullptr, block);
 	ASSERT_NE (0, block->block_work ());
 	ASSERT_GE (nano::dev::network_params.work.difficulty (*block), nano::dev::network_params.work.threshold (block->work_version (), block->sideband ().details));
-	uint64_t cached_work (0);
-	system.wallet (0)->get_work (nano::dev::genesis_key.pub, cached_work);
-	ASSERT_EQ (0, cached_work);
+	auto cached_work_result = system.wallet (0)->get_work (nano::dev::genesis_key.pub);
+	ASSERT_TRUE (cached_work_result);
+	ASSERT_EQ (0, cached_work_result.value ());
 }
 
 TEST (wallet, send_race)

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -40,8 +40,9 @@ TEST (wallet, no_key)
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::keypair key1;
-	nano::raw_key prv1;
-	ASSERT_TRUE (wallet.fetch (transaction, key1.pub, prv1));
+	auto result = wallet.fetch (transaction, key1.pub);
+	ASSERT_FALSE (result);
+	ASSERT_EQ (result.error (), nano::error_common::account_not_found_wallet);
 	ASSERT_TRUE (wallet.valid_password (transaction));
 }
 
@@ -60,9 +61,12 @@ TEST (wallet, fetch_locked)
 	key3 = 1;
 	wallet.password.value_set (key3);
 	ASSERT_FALSE (wallet.valid_password (transaction));
-	nano::raw_key key4;
-	ASSERT_TRUE (wallet.fetch (transaction, key1.pub, key4));
-	ASSERT_TRUE (wallet.fetch (transaction, key2, key4));
+	auto result1 = wallet.fetch (transaction, key1.pub);
+	ASSERT_FALSE (result1);
+	ASSERT_EQ (result1.error (), nano::error_common::wallet_locked);
+	auto result2 = wallet.fetch (transaction, key2);
+	ASSERT_FALSE (result2);
+	ASSERT_EQ (result2.error (), nano::error_common::wallet_locked);
 }
 
 TEST (wallet, retrieval)
@@ -74,13 +78,14 @@ TEST (wallet, retrieval)
 	nano::keypair key1;
 	ASSERT_TRUE (wallet.valid_password (transaction));
 	wallet.insert_adhoc (transaction, key1.prv);
-	nano::raw_key prv1;
-	ASSERT_FALSE (wallet.fetch (transaction, key1.pub, prv1));
+	auto result1 = wallet.fetch (transaction, key1.pub);
+	ASSERT_TRUE (result1);
 	ASSERT_TRUE (wallet.valid_password (transaction));
-	ASSERT_EQ (key1.prv, prv1);
+	ASSERT_EQ (key1.prv, result1.value ());
 	wallet.password.values[0]->bytes[16] ^= 1;
-	nano::raw_key prv2;
-	ASSERT_TRUE (wallet.fetch (transaction, key1.pub, prv2));
+	auto result2 = wallet.fetch (transaction, key1.pub);
+	ASSERT_FALSE (result2);
+	ASSERT_EQ (result2.error (), nano::error_common::wallet_locked);
 	ASSERT_FALSE (wallet.valid_password (transaction));
 }
 
@@ -276,17 +281,17 @@ TEST (wallet, rekey)
 	ASSERT_EQ (default_password_key, password);
 	nano::keypair key1;
 	wallet.insert_adhoc (transaction, key1.prv);
-	nano::raw_key prv1;
-	wallet.fetch (transaction, key1.pub, prv1);
-	ASSERT_EQ (key1.prv, prv1);
+	auto result1 = wallet.fetch (transaction, key1.pub);
+	ASSERT_TRUE (result1);
+	ASSERT_EQ (key1.prv, result1.value ());
 	ASSERT_FALSE (wallet.rekey (transaction, "1"));
 	wallet.password.value (password);
 	nano::raw_key password1;
 	wallet.derive_key (password1, transaction, "1");
 	ASSERT_EQ (password1, password);
-	nano::raw_key prv2;
-	wallet.fetch (transaction, key1.pub, prv2);
-	ASSERT_EQ (key1.prv, prv2);
+	auto result2 = wallet.fetch (transaction, key1.pub);
+	ASSERT_TRUE (result2);
+	ASSERT_EQ (key1.prv, result2.value ());
 	*wallet.password.values[0] = 2;
 	ASSERT_TRUE (wallet.rekey (transaction, "2"));
 }
@@ -426,9 +431,9 @@ TEST (wallet, serialize_json_one)
 	ASSERT_EQ (wallet1.check (transaction), wallet2.check (transaction));
 	ASSERT_EQ (wallet1.representative (transaction), wallet2.representative (transaction));
 	ASSERT_TRUE (wallet2.exists (transaction, key.pub));
-	nano::raw_key prv;
-	wallet2.fetch (transaction, key.pub, prv);
-	ASSERT_EQ (key.prv, prv);
+	auto prv_result = wallet2.fetch (transaction, key.pub);
+	ASSERT_TRUE (prv_result);
+	ASSERT_EQ (key.prv, prv_result.value ());
 }
 
 TEST (wallet, serialize_json_password)
@@ -455,9 +460,9 @@ TEST (wallet, serialize_json_password)
 	ASSERT_EQ (wallet1.check (transaction), wallet2.check (transaction));
 	ASSERT_EQ (wallet1.representative (transaction), wallet2.representative (transaction));
 	ASSERT_TRUE (wallet2.exists (transaction, key.pub));
-	nano::raw_key prv;
-	wallet2.fetch (transaction, key.pub, prv);
-	ASSERT_EQ (key.prv, prv);
+	auto prv_result = wallet2.fetch (transaction, key.pub);
+	ASSERT_TRUE (prv_result);
+	ASSERT_EQ (key.prv, prv_result.value ());
 }
 
 TEST (wallet_store, move)
@@ -616,9 +621,9 @@ TEST (wallet, deterministic_keys)
 	wallet.deterministic_index_set (transaction, 1);
 	ASSERT_EQ (1, wallet.deterministic_index_get (transaction));
 	auto key4 (wallet.deterministic_insert (transaction));
-	nano::raw_key key5;
-	ASSERT_FALSE (wallet.fetch (transaction, key4, key5));
-	ASSERT_EQ (key3, key5);
+	auto key5_result = wallet.fetch (transaction, key4);
+	ASSERT_TRUE (key5_result);
+	ASSERT_EQ (key3, key5_result.value ());
 	ASSERT_EQ (2, wallet.deterministic_index_get (transaction));
 	wallet.deterministic_index_set (transaction, 1);
 	ASSERT_EQ (1, wallet.deterministic_index_get (transaction));
@@ -627,9 +632,9 @@ TEST (wallet, deterministic_keys)
 	auto key8 (wallet.deterministic_insert (transaction));
 	ASSERT_EQ (key4, key8);
 	auto key6 (wallet.deterministic_insert (transaction));
-	nano::raw_key key7;
-	ASSERT_FALSE (wallet.fetch (transaction, key6, key7));
-	ASSERT_NE (key5, key7);
+	auto key7_result = wallet.fetch (transaction, key6);
+	ASSERT_TRUE (key7_result);
+	ASSERT_NE (key5_result.value (), key7_result.value ());
 	ASSERT_EQ (3, wallet.deterministic_index_get (transaction));
 	nano::keypair key9;
 	ASSERT_EQ (key9.pub, wallet.insert_adhoc (transaction, key9.prv));

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -95,7 +95,9 @@ TEST (wallets, create_from_json)
 		auto wallets = make_wallets (node);
 		auto wallet = wallets.create (id);
 		ASSERT_NE (nullptr, wallet);
-		account = wallet->deterministic_insert ();
+		auto account_result = wallet->deterministic_insert ();
+		ASSERT_TRUE (account_result);
+		account = account_result.value ();
 		wallet->serialize_json (json);
 		ASSERT_FALSE (json.empty ());
 		wallets.destroy (id);
@@ -190,9 +192,9 @@ TEST (wallets, vote_minimum)
 	ASSERT_EQ (nano::block_status::progress, node1.process (open2));
 	auto wallet (node1.wallets.items.begin ()->second);
 	ASSERT_EQ (0, wallet->reps ().size ());
-	wallet->insert_adhoc (nano::dev::genesis_key.prv);
-	wallet->insert_adhoc (key1.prv);
-	wallet->insert_adhoc (key2.prv);
+	ASSERT_TRUE (wallet->insert_adhoc (nano::dev::genesis_key.prv));
+	ASSERT_TRUE (wallet->insert_adhoc (key1.prv));
+	ASSERT_TRUE (wallet->insert_adhoc (key2.prv));
 	node1.wallets.refresh_reps ();
 	ASSERT_EQ (2, wallet->reps ().size ());
 }
@@ -205,10 +207,10 @@ TEST (wallets, exists)
 	nano::keypair key2;
 	ASSERT_FALSE (node.wallets.exists (key1.pub));
 	ASSERT_FALSE (node.wallets.exists (key2.pub));
-	system.wallet (0)->insert_adhoc (key1.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (key1.prv));
 	ASSERT_TRUE (node.wallets.exists (key1.pub));
 	ASSERT_FALSE (node.wallets.exists (key2.pub));
-	system.wallet (0)->insert_adhoc (key2.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (key2.prv));
 	ASSERT_TRUE (node.wallets.exists (key1.pub));
 	ASSERT_TRUE (node.wallets.exists (key2.pub));
 }
@@ -230,7 +232,7 @@ TEST (wallets, search_receivable)
 		auto wallet_id = wallets.begin ()->first;
 		auto wallet = wallets.begin ()->second;
 
-		wallet->insert_adhoc (nano::dev::genesis_key.prv);
+		ASSERT_TRUE (wallet->insert_adhoc (nano::dev::genesis_key.prv));
 		nano::block_builder builder;
 		auto send = builder.state ()
 					.account (nano::dev::genesis_key.pub)
@@ -265,7 +267,7 @@ TEST (wallets, search_receivable)
 		ASSERT_TIMELY (5s, node.block_confirmed (send->hash ()) && node.active.empty ());
 
 		// Re-insert the key
-		wallet->insert_adhoc (nano::dev::genesis_key.prv);
+		ASSERT_TRUE (wallet->insert_adhoc (nano::dev::genesis_key.prv));
 
 		// Pending search should create the receive block
 		ASSERT_EQ (2, node.ledger.block_count ());
@@ -298,7 +300,7 @@ TEST (wallets, rep_scan)
 
 	// Insert a key that initially has no balance (not a representative)
 	nano::keypair key;
-	wallet->insert_adhoc (key.prv);
+	ASSERT_TRUE (wallet->insert_adhoc (key.prv));
 
 	// Initially the account should not be detected as a representative
 	ASSERT_EQ (0, wallet->reps ().count (key.pub));
@@ -350,7 +352,7 @@ TEST (wallets, receivable_scan)
 	auto & node = *system.add_node (config);
 
 	auto wallet = node.wallets.items.begin ()->second;
-	wallet->insert_adhoc (nano::dev::genesis_key.prv);
+	ASSERT_TRUE (wallet->insert_adhoc (nano::dev::genesis_key.prv));
 
 	// Create a send block to self (creates a receivable)
 	nano::block_builder builder;
@@ -657,6 +659,77 @@ TEST (wallets, rep_keys_cache_insert_adhoc_qualifying)
 	ASSERT_EQ (2, accounts.size ());
 	ASSERT_TRUE (accounts.count (nano::dev::genesis_key.pub));
 	ASSERT_TRUE (accounts.count (rep2.pub));
+}
+
+/*
+ * deterministic_insert with explicit index should update the rep keys cache
+ */
+TEST (wallets, rep_keys_cache_deterministic_insert_index)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+
+	// Derive the key that will be at index 0 for a known seed
+	nano::raw_key seed;
+	seed = 1;
+	auto det_prv = nano::deterministic_key (seed, 0);
+	auto det_pub = nano::pub_key (det_prv);
+
+	// Fund the deterministic account with vote_minimum weight
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - node.config.vote_minimum.number ())
+				.link (det_pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
+	ASSERT_EQ (nano::block_status::progress, node.process (send));
+
+	auto open = builder
+				.state ()
+				.account (det_pub)
+				.previous (0)
+				.representative (det_pub)
+				.balance (node.config.vote_minimum.number ())
+				.link (send->hash ())
+				.sign (det_prv, det_pub)
+				.work (*system.work.generate (det_pub))
+				.build ();
+	ASSERT_EQ (nano::block_status::progress, node.process (open));
+
+	node.wallets.refresh_reps ();
+
+	// Pre-condition: only genesis in cache
+	{
+		auto sign = node.wallets.signer ();
+		std::set<nano::account> accounts;
+		sign ([&] (nano::public_key const & pub, nano::raw_key const &) {
+			accounts.insert (pub);
+		});
+		ASSERT_EQ (1, accounts.size ());
+		ASSERT_TRUE (accounts.count (nano::dev::genesis_key.pub));
+	}
+
+	// Set the seed and insert at index 0
+	system.wallet (0)->change_seed (seed);
+	auto result = system.wallet (0)->deterministic_insert (uint32_t{ 0 });
+	ASSERT_TRUE (result);
+	ASSERT_EQ (det_pub, result.value ());
+
+	// Should immediately appear in cache
+	auto sign = node.wallets.signer ();
+	std::set<nano::account> accounts;
+	sign ([&] (nano::public_key const & pub, nano::raw_key const &) {
+		accounts.insert (pub);
+	});
+	ASSERT_TRUE (accounts.count (nano::dev::genesis_key.pub));
+	ASSERT_TRUE (accounts.count (det_pub));
 }
 
 /*

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -231,7 +231,7 @@ public:
 		return *this;
 	}
 
-	explicit operator std::error_code () const;
+	operator std::error_code () const;
 	explicit operator bool () const;
 	explicit operator std::string () const;
 	std::string get_message () const;

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -153,7 +153,9 @@ public:
 					}
 					else
 					{
-						wallet_config.account = wallet->deterministic_insert ();
+						auto insert_result = wallet->deterministic_insert ();
+						release_assert (insert_result);
+						wallet_config.account = insert_result.value ();
 					}
 				}
 

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -154,7 +154,12 @@ public:
 					else
 					{
 						auto insert_result = wallet->deterministic_insert ();
-						release_assert (insert_result);
+						if (!insert_result)
+						{
+							splash->hide ();
+							show_error ("Unable to create initial wallet account: " + insert_result.error ().get_message ());
+							std::exit (1);
+						}
 						wallet_config.account = insert_result.value ();
 					}
 				}

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -1085,24 +1085,31 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 					if (!existing->second->enter_password (password))
 					{
 						auto seed_result = existing->second->get_seed ();
-						release_assert (seed_result);
-						std::cout << boost::str (boost::format ("Seed: %1%\n") % seed_result.value ().to_string ());
-						for (auto const & account : existing->second->accounts ())
+						if (seed_result)
 						{
-							auto key_result = existing->second->fetch_prv (account);
-							debug_assert (key_result);
-							if (key_result)
+							std::cout << boost::str (boost::format ("Seed: %1%\n") % seed_result.value ().to_string ());
+							for (auto const & account : existing->second->accounts ())
 							{
-								std::cout << boost::str (boost::format ("Pub: %1% Prv: %2%\n") % account.to_account () % key_result.value ().to_string ());
-								if (nano::pub_key (key_result.value ()) != account)
+								auto key_result = existing->second->fetch_prv (account);
+								debug_assert (key_result);
+								if (key_result)
 								{
-									std::cerr << boost::str (boost::format ("Invalid private key %1%\n") % key_result.value ().to_string ());
+									std::cout << boost::str (boost::format ("Pub: %1% Prv: %2%\n") % account.to_account () % key_result.value ().to_string ());
+									if (nano::pub_key (key_result.value ()) != account)
+									{
+										std::cerr << boost::str (boost::format ("Invalid private key %1%\n") % key_result.value ().to_string ());
+									}
+								}
+								else
+								{
+									std::cerr << boost::str (boost::format ("Unable to fetch private key for account %1% (%2%)\n") % account.to_account () % key_result.error ());
 								}
 							}
-							else
-							{
-								std::cerr << boost::str (boost::format ("Unable to fetch private key for account %1% (%2%)\n") % account.to_account () % key_result.error ());
-							}
+						}
+						else
+						{
+							std::cerr << boost::str (boost::format ("Unable to retrieve seed: %1%\n") % seed_result.error ());
+							ec = seed_result.error ();
 						}
 					}
 					else

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -1071,9 +1071,9 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				{
 					if (!existing->second->enter_password (password))
 					{
-						nano::raw_key seed;
-						existing->second->get_seed (seed);
-						std::cout << boost::str (boost::format ("Seed: %1%\n") % seed.to_string ());
+						auto seed_result = existing->second->get_seed ();
+						release_assert (seed_result);
+						std::cout << boost::str (boost::format ("Seed: %1%\n") % seed_result.value ().to_string ());
 						for (auto const & account : existing->second->accounts ())
 						{
 							auto key_result = existing->second->fetch_prv (account);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -1076,14 +1076,19 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 						std::cout << boost::str (boost::format ("Seed: %1%\n") % seed.to_string ());
 						for (auto const & account : existing->second->accounts ())
 						{
-							nano::raw_key key;
-							auto error (existing->second->fetch_prv (account, key));
-							(void)error;
-							debug_assert (!error);
-							std::cout << boost::str (boost::format ("Pub: %1% Prv: %2%\n") % account.to_account () % key.to_string ());
-							if (nano::pub_key (key) != account)
+							auto key_result = existing->second->fetch_prv (account);
+							debug_assert (key_result);
+							if (key_result)
 							{
-								std::cerr << boost::str (boost::format ("Invalid private key %1%\n") % key.to_string ());
+								std::cout << boost::str (boost::format ("Pub: %1% Prv: %2%\n") % account.to_account () % key_result.value ().to_string ());
+								if (nano::pub_key (key_result.value ()) != account)
+								{
+									std::cerr << boost::str (boost::format ("Invalid private key %1%\n") % key_result.value ().to_string ());
+								}
+							}
+							else
+							{
+								std::cerr << boost::str (boost::format ("Unable to fetch private key for account %1% (%2%)\n") % account.to_account () % key_result.error ());
 							}
 						}
 					}

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -307,13 +307,21 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 					password = vm["password"].as<std::string> ();
 				}
 				auto inactive_node = nano::default_inactive_node (data_path, vm);
-				auto wallet (inactive_node->node->wallets.open (wallet_id));
+				auto wallet = inactive_node->node->wallets.open (wallet_id);
 				if (wallet != nullptr)
 				{
 					if (!wallet->enter_password (password))
 					{
-						auto pub (wallet->deterministic_insert ());
-						std::cout << boost::str (boost::format ("Account: %1%\n") % pub.to_account ());
+						auto pub_result = wallet->deterministic_insert ();
+						if (pub_result)
+						{
+							std::cout << boost::str (boost::format ("Account: %1%\n") % pub_result.value ().to_account ());
+						}
+						else
+						{
+							std::cerr << "Failed to create account\n";
+							ec = pub_result.error ();
+						}
 					}
 					else
 					{
@@ -891,7 +899,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 					password = vm["password"].as<std::string> ();
 				}
 				auto inactive_node = nano::default_inactive_node (data_path, vm);
-				auto wallet (inactive_node->node->wallets.open (wallet_id));
+				auto wallet = inactive_node->node->wallets.open (wallet_id);
 				if (wallet != nullptr)
 				{
 					if (!wallet->enter_password (password))
@@ -899,7 +907,12 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 						nano::raw_key key;
 						if (!key.decode_hex (vm["key"].as<std::string> ()))
 						{
-							wallet->insert_adhoc (key);
+							auto result = wallet->insert_adhoc (key);
+							if (!result)
+							{
+								std::cerr << "Failed to add key\n";
+								ec = result.error ();
+							}
 						}
 						else
 						{

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -553,12 +553,11 @@ void nano::json_handler::account_block_count ()
 void nano::json_handler::account_create ()
 {
 	node.workers.post (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
-		auto wallet (rpc_l->wallet_impl ());
+		auto wallet = rpc_l->wallet_impl ();
 		if (!rpc_l->ec)
 		{
 			bool const generate_work = rpc_l->request.get<bool> ("work", true);
-			nano::account new_key;
-			auto index_text (rpc_l->request.get_optional<std::string> ("index"));
+			auto index_text = rpc_l->request.get_optional<std::string> ("index");
 			if (index_text.is_initialized ())
 			{
 				uint64_t index;
@@ -568,23 +567,27 @@ void nano::json_handler::account_create ()
 				}
 				else
 				{
-					new_key = wallet->deterministic_insert (static_cast<uint32_t> (index), generate_work);
+					auto key_result = wallet->deterministic_insert (static_cast<uint32_t> (index), generate_work);
+					if (key_result)
+					{
+						rpc_l->response_l.put ("account", key_result.value ().to_account ());
+					}
+					else
+					{
+						rpc_l->ec = key_result.error ();
+					}
 				}
 			}
 			else
 			{
-				new_key = wallet->deterministic_insert (generate_work);
-			}
-
-			if (!rpc_l->ec)
-			{
-				if (!new_key.is_zero ())
+				auto key_result = wallet->deterministic_insert (generate_work);
+				if (key_result)
 				{
-					rpc_l->response_l.put ("account", new_key.to_account ());
+					rpc_l->response_l.put ("account", key_result.value ().to_account ());
 				}
 				else
 				{
-					rpc_l->ec = nano::error_common::wallet_locked;
+					rpc_l->ec = key_result.error ();
 				}
 			}
 		}
@@ -954,19 +957,19 @@ void nano::json_handler::accounts_representatives ()
 void nano::json_handler::accounts_create ()
 {
 	node.workers.post (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
-		auto wallet (rpc_l->wallet_impl ());
-		auto count (rpc_l->count_impl ());
+		auto wallet = rpc_l->wallet_impl ();
+		auto count = rpc_l->count_impl ();
 		if (!rpc_l->ec)
 		{
 			bool const generate_work = rpc_l->request.get<bool> ("work", false);
 			boost::property_tree::ptree accounts;
-			for (auto i (0); accounts.size () < count; ++i)
+			for (decltype (count) i = 0; i < count; ++i)
 			{
-				nano::account new_key (wallet->deterministic_insert (generate_work));
-				if (!new_key.is_zero ())
+				auto key_result = wallet->deterministic_insert (generate_work);
+				if (key_result)
 				{
 					boost::property_tree::ptree entry;
-					entry.put ("", new_key.to_account ());
+					entry.put ("", key_result.value ().to_account ());
 					accounts.push_back (std::make_pair ("", entry));
 				}
 			}
@@ -4335,22 +4338,22 @@ void nano::json_handler::validate_account_number ()
 void nano::json_handler::wallet_add ()
 {
 	node.workers.post (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
-		auto wallet (rpc_l->wallet_impl ());
+		auto wallet = rpc_l->wallet_impl ();
 		if (!rpc_l->ec)
 		{
-			std::string key_text (rpc_l->request.get<std::string> ("key"));
+			std::string key_text = rpc_l->request.get<std::string> ("key");
 			nano::raw_key key;
 			if (!key.decode_hex (key_text))
 			{
 				bool const generate_work = rpc_l->request.get<bool> ("work", true);
-				auto pub (wallet->insert_adhoc (key, generate_work));
-				if (!pub.is_zero ())
+				auto pub_result = wallet->insert_adhoc (key, generate_work);
+				if (pub_result)
 				{
-					rpc_l->response_l.put ("account", pub.to_account ());
+					rpc_l->response_l.put ("account", pub_result.value ().to_account ());
 				}
 				else
 				{
-					rpc_l->ec = nano::error_common::wallet_locked;
+					rpc_l->ec = pub_result.error ();
 				}
 			}
 			else

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -963,15 +963,18 @@ void nano::json_handler::accounts_create ()
 		{
 			bool const generate_work = rpc_l->request.get<bool> ("work", false);
 			boost::property_tree::ptree accounts;
+			// TODO: this should be atomic, either all accounts are created or none
 			for (decltype (count) i = 0; i < count; ++i)
 			{
 				auto key_result = wallet->deterministic_insert (generate_work);
-				if (key_result)
+				if (!key_result)
 				{
-					boost::property_tree::ptree entry;
-					entry.put ("", key_result.value ().to_account ());
-					accounts.push_back (std::make_pair ("", entry));
+					rpc_l->ec = key_result.error ();
+					break;
 				}
+				boost::property_tree::ptree entry;
+				entry.put ("", key_result.value ().to_account ());
+				accounts.push_back (std::make_pair ("", entry));
 			}
 			rpc_l->response_l.add_child ("accounts", accounts);
 		}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4953,9 +4953,8 @@ void nano::json_handler::wallet_work_get ()
 		boost::property_tree::ptree works;
 		for (auto const & account : wallet->accounts ())
 		{
-			uint64_t work (0);
-			auto error_work (wallet->get_work (account, work));
-			(void)error_work;
+			auto work_result = wallet->get_work (account);
+			auto work = work_result ? work_result.value () : 0;
 			works.put (account.to_account (), nano::to_string_hex (work));
 		}
 		response_l.add_child ("works", works);
@@ -5103,16 +5102,14 @@ void nano::json_handler::work_get ()
 	auto account (account_impl ());
 	if (!ec)
 	{
-		if (!wallet->exists (account))
+		auto work_result = wallet->get_work (account);
+		if (work_result)
 		{
-			ec = nano::error_common::account_not_found_wallet;
+			response_l.put ("work", nano::to_string_hex (work_result.value ()));
 		}
 		else
 		{
-			uint64_t work (0);
-			auto error_work (wallet->get_work (account, work));
-			(void)error_work;
-			response_l.put ("work", nano::to_string_hex (work));
+			ec = work_result.error ();
 		}
 	}
 	response_errors ();

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4929,17 +4929,17 @@ void nano::json_handler::wallet_republish ()
 
 void nano::json_handler::wallet_seed ()
 {
-	auto wallet (wallet_impl ());
+	auto wallet = wallet_impl ();
 	if (!ec)
 	{
-		nano::raw_key seed;
-		if (!wallet->get_seed (seed))
+		auto seed_result = wallet->get_seed ();
+		if (seed_result)
 		{
-			response_l.put ("seed", seed.to_string ());
+			response_l.put ("seed", seed_result.value ().to_string ());
 		}
 		else
 		{
-			ec = nano::error_common::wallet_locked;
+			ec = seed_result.error ();
 		}
 	}
 	response_errors ();

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -761,8 +761,15 @@ void nano::json_handler::account_move ()
 						auto account (rpc_l->account_impl (i->second.get<std::string> ("")));
 						accounts.push_back (account);
 					}
-					auto error (wallet->move_accounts (*source_wallet, accounts));
-					rpc_l->response_l.put ("moved", error ? "0" : "1");
+					auto result = wallet->move_accounts (*source_wallet, accounts);
+					if (result)
+					{
+						rpc_l->response_l.put ("moved", result.value () ? "0" : "1");
+					}
+					else
+					{
+						rpc_l->ec = result.error ();
+					}
 				}
 				else
 				{

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1531,17 +1531,20 @@ void nano::json_handler::block_create ()
 	}
 	if (!ec && wallet != 0 && account != 0)
 	{
-		auto existing (node.wallets.items.find (wallet));
+		auto existing = node.wallets.items.find (wallet);
 		if (existing != node.wallets.items.end ())
 		{
-			wallet_locked_impl (existing->second);
-			wallet_account_impl (existing->second, account);
-			if (!ec)
+			auto prv_result = existing->second->fetch_prv (account);
+			if (prv_result)
 			{
-				existing->second->fetch_prv (account, prv);
+				prv = prv_result.value ();
 				auto block_transaction = node.ledger.tx_begin_read ();
 				previous = node.ledger.any.account_head (block_transaction, account);
 				balance = node.ledger.any.account_balance (block_transaction, account).value_or (0);
+			}
+			else
+			{
+				ec = prv_result.error ();
 			}
 		}
 		else
@@ -3884,11 +3887,14 @@ void nano::json_handler::sign ()
 				auto wallet (wallet_impl ());
 				if (!ec)
 				{
-					wallet_locked_impl (wallet);
-					wallet_account_impl (wallet, account);
-					if (!ec)
+					auto prv_result = wallet->fetch_prv (account);
+					if (prv_result)
 					{
-						wallet->fetch_prv (account, prv);
+						prv = prv_result.value ();
+					}
+					else
+					{
+						ec = prv_result.error ();
 					}
 				}
 			}

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -332,8 +332,7 @@ nano::result<nano::raw_key> nano::wallet_store::fetch (nano::store::transaction 
 	{
 		case nano::key_type::deterministic:
 		{
-			nano::raw_key seed_l;
-			seed (seed_l, transaction);
+			auto seed_l = seed (transaction);
 			auto index = static_cast<uint32_t> (value.key.number () & static_cast<uint32_t> (-1));
 			prv = deterministic_key (transaction, index);
 			break;
@@ -499,12 +498,14 @@ void nano::wallet_store::wallet_key (nano::raw_key & prv_a, nano::store::transac
 	prv_a.decrypt (wallet_l, password_l, salt (transaction_a).owords[0]);
 }
 
-void nano::wallet_store::seed (nano::raw_key & prv_a, nano::store::transaction const & transaction_a) const
+nano::raw_key nano::wallet_store::seed (nano::store::transaction const & transaction) const
 {
-	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::seed_special));
-	nano::raw_key password_l;
-	wallet_key (password_l, transaction_a);
-	prv_a.decrypt (value.key, password_l, salt (transaction_a).owords[seed_iv_index]);
+	nano::wallet_value value (entry_get_raw (transaction, nano::wallet_store::seed_special));
+	nano::raw_key password;
+	wallet_key (password, transaction);
+	nano::raw_key result;
+	result.decrypt (value.key, password, salt (transaction).owords[seed_iv_index]);
+	return result;
 }
 
 void nano::wallet_store::seed_set (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv_a)
@@ -548,12 +549,10 @@ nano::public_key nano::wallet_store::deterministic_insert (nano::store::write_tr
 	return result;
 }
 
-nano::raw_key nano::wallet_store::deterministic_key (nano::store::transaction const & transaction_a, uint32_t index_a) const
+nano::raw_key nano::wallet_store::deterministic_key (nano::store::transaction const & transaction, uint32_t index) const
 {
-	debug_assert (valid_password (transaction_a));
-	nano::raw_key seed_l;
-	seed (seed_l, transaction_a);
-	return nano::deterministic_key (seed_l, index_a);
+	debug_assert (valid_password (transaction));
+	return nano::deterministic_key (seed (transaction), index);
 }
 
 uint32_t nano::wallet_store::deterministic_index_get (nano::store::transaction const & transaction_a) const
@@ -1534,15 +1533,14 @@ nano::account nano::wallet::get_representative () const
 	return store.representative (transaction);
 }
 
-bool nano::wallet::get_seed (nano::raw_key & seed_a) const
+nano::result<nano::raw_key> nano::wallet::get_seed () const
 {
 	auto transaction = wallets.tx_begin_read ();
 	if (!store.valid_password (transaction))
 	{
-		return true; // error: wallet locked
+		return nano::error (nano::error_common::wallet_locked);
 	}
-	store.seed (seed_a, transaction);
-	return false;
+	return store.seed (transaction);
 }
 
 uint32_t nano::wallet::get_deterministic_index () const

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -399,10 +399,12 @@ void nano::wallet_store::write_backup (nano::store::transaction const & transact
 	}
 }
 
-bool nano::wallet_store::move (nano::store::write_transaction const & transaction_a, nano::wallet_store & other_a, std::vector<nano::public_key> const & keys)
+nano::result<bool> nano::wallet_store::move (nano::store::write_transaction const & transaction_a, nano::wallet_store & other_a, std::vector<nano::public_key> const & keys)
 {
-	release_assert (valid_password (transaction_a), "wallet is locked or password is invalid");
-	release_assert (other_a.valid_password (transaction_a), "other wallet is locked or password is invalid");
+	if (!valid_password (transaction_a) || !other_a.valid_password (transaction_a))
+	{
+		return nano::error (nano::error_common::wallet_locked);
+	}
 
 	bool error = false;
 	for (auto i (keys.begin ()), n (keys.end ()); i != n; ++i)
@@ -421,10 +423,12 @@ bool nano::wallet_store::move (nano::store::write_transaction const & transactio
 	return error;
 }
 
-bool nano::wallet_store::import (nano::store::write_transaction const & transaction_a, nano::wallet_store & other_a)
+nano::result<bool> nano::wallet_store::import (nano::store::write_transaction const & transaction_a, nano::wallet_store & other_a)
 {
-	release_assert (valid_password (transaction_a), "wallet is locked or password is invalid");
-	release_assert (other_a.valid_password (transaction_a), "other wallet is locked or password is invalid");
+	if (!valid_password (transaction_a) || !other_a.valid_password (transaction_a))
+	{
+		return nano::error (nano::error_common::wallet_locked);
+	}
 
 	bool error = false;
 	for (auto i (other_a.begin (transaction_a)), n (other_a.end (transaction_a)); i != n; ++i)
@@ -904,7 +908,8 @@ bool nano::wallet::import (std::string const & json_a, std::string const & passw
 		auto temp = std::make_unique<nano::wallet_store> (wallets.kdf, transaction, wallets.env, 1, id.to_string (), json_a);
 		if (!temp->attempt_password (transaction, password_a))
 		{
-			error = store.import (transaction, *temp);
+			auto result = store.import (transaction, *temp);
+			error = !result || result.value ();
 		}
 		temp->destroy (transaction);
 	}
@@ -1527,15 +1532,15 @@ std::vector<nano::account> nano::wallet::accounts () const
 	return store.accounts (transaction);
 }
 
-bool nano::wallet::move_accounts (wallet & source, std::vector<nano::public_key> const & accounts_a)
+nano::result<bool> nano::wallet::move_accounts (wallet & source, std::vector<nano::public_key> const & accounts)
 {
-	bool error;
+	nano::result<bool> result{ true };
 	{
 		auto transaction = wallets.tx_begin_write ();
-		error = store.move (transaction, source.store, accounts_a);
+		result = store.move (transaction, source.store, accounts);
 	}
 	wallets.refresh_rep_keys_cache ();
-	return error;
+	return result;
 }
 
 nano::key_type nano::wallet::key_type (nano::account const & account_a) const

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -232,7 +232,7 @@ nano::account nano::wallet_store::representative (nano::store::transaction const
 
 nano::public_key nano::wallet_store::insert_adhoc (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv)
 {
-	debug_assert (valid_password (transaction_a));
+	release_assert (valid_password (transaction_a), "wallet is locked or password is invalid");
 	nano::public_key pub (nano::pub_key (prv));
 	nano::raw_key password_l;
 	wallet_key (password_l, transaction_a);
@@ -401,27 +401,31 @@ void nano::wallet_store::write_backup (nano::store::transaction const & transact
 
 bool nano::wallet_store::move (nano::store::write_transaction const & transaction_a, nano::wallet_store & other_a, std::vector<nano::public_key> const & keys)
 {
-	debug_assert (valid_password (transaction_a));
-	debug_assert (other_a.valid_password (transaction_a));
-	auto result (false);
+	release_assert (valid_password (transaction_a), "wallet is locked or password is invalid");
+	release_assert (other_a.valid_password (transaction_a), "other wallet is locked or password is invalid");
+
+	bool error = false;
 	for (auto i (keys.begin ()), n (keys.end ()); i != n; ++i)
 	{
 		auto prv_result = other_a.fetch (transaction_a, *i);
-		if (!prv_result)
+		if (prv_result)
 		{
-			result = true;
-			break;
+			insert_adhoc (transaction_a, prv_result.value ());
+			other_a.erase (transaction_a, *i);
 		}
-		insert_adhoc (transaction_a, prv_result.value ());
-		other_a.erase (transaction_a, *i);
+		else
+		{
+			error = true;
+		}
 	}
-	return result;
+	return error;
 }
 
 bool nano::wallet_store::import (nano::store::write_transaction const & transaction_a, nano::wallet_store & other_a)
 {
-	debug_assert (valid_password (transaction_a));
-	debug_assert (other_a.valid_password (transaction_a));
+	release_assert (valid_password (transaction_a), "wallet is locked or password is invalid");
+	release_assert (other_a.valid_password (transaction_a), "other wallet is locked or password is invalid");
+
 	auto result (false);
 	for (auto i (other_a.begin (transaction_a)), n (other_a.end (transaction_a)); i != n; ++i)
 	{
@@ -698,7 +702,6 @@ nano::mdb_wallets_store::mdb_wallets_store (std::filesystem::path const & path_a
 	environment (path_a, nano::store::lmdb::env::options::make ().set_config (lmdb_config_a).override_config_sync (nano::lmdb_config::sync_strategy::always).override_config_map_size (1ULL * 1024 * 1024 * 1024))
 {
 }
-
 
 /*
  * wallet

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -314,57 +314,51 @@ nano::key_type nano::wallet_store::key_type (nano::wallet_value const & value_a)
 	return result;
 }
 
-bool nano::wallet_store::fetch (nano::store::transaction const & transaction_a, nano::account const & pub, nano::raw_key & prv) const
+nano::result<nano::raw_key> nano::wallet_store::fetch (nano::store::transaction const & transaction, nano::account const & pub) const
 {
-	auto result (false);
-	if (valid_password (transaction_a))
+	if (!valid_password (transaction))
 	{
-		nano::wallet_value value (entry_get_raw (transaction_a, pub));
-		if (!value.key.is_zero ())
+		return nano::error (nano::error_common::wallet_locked);
+	}
+
+	auto value = entry_get_raw (transaction, pub);
+	if (value.key.is_zero ())
+	{
+		return nano::error (nano::error_common::account_not_found_wallet);
+	}
+
+	nano::raw_key prv;
+	switch (key_type (value))
+	{
+		case nano::key_type::deterministic:
 		{
-			switch (key_type (value))
-			{
-				case nano::key_type::deterministic:
-				{
-					nano::raw_key seed_l;
-					seed (seed_l, transaction_a);
-					uint32_t index (static_cast<uint32_t> (value.key.number () & static_cast<uint32_t> (-1)));
-					prv = deterministic_key (transaction_a, index);
-					break;
-				}
-				case nano::key_type::adhoc:
-				{
-					// Ad-hoc keys
-					nano::raw_key password_l;
-					wallet_key (password_l, transaction_a);
-					prv.decrypt (value.key, password_l, pub.owords[0].number ());
-					break;
-				}
-				default:
-				{
-					result = true;
-					break;
-				}
-			}
+			nano::raw_key seed_l;
+			seed (seed_l, transaction);
+			auto index = static_cast<uint32_t> (value.key.number () & static_cast<uint32_t> (-1));
+			prv = deterministic_key (transaction, index);
+			break;
 		}
-		else
+		case nano::key_type::adhoc:
 		{
-			result = true;
+			nano::raw_key password_l;
+			wallet_key (password_l, transaction);
+			prv.decrypt (value.key, password_l, pub.owords[0].number ());
+			break;
+		}
+		default:
+		{
+			return nano::error (nano::error_common::bad_private_key);
 		}
 	}
-	else
+
+	// Verify the key
+	nano::public_key compare = nano::pub_key (prv);
+	if (pub != compare)
 	{
-		result = true;
+		return nano::error (nano::error_common::bad_private_key);
 	}
-	if (!result)
-	{
-		nano::public_key compare (nano::pub_key (prv));
-		if (!(pub == compare))
-		{
-			result = true;
-		}
-	}
-	return result;
+
+	return prv;
 }
 
 bool nano::wallet_store::valid_public_key (nano::public_key const & pub) const
@@ -413,14 +407,14 @@ bool nano::wallet_store::move (nano::store::write_transaction const & transactio
 	auto result (false);
 	for (auto i (keys.begin ()), n (keys.end ()); i != n; ++i)
 	{
-		nano::raw_key prv;
-		auto error (other_a.fetch (transaction_a, *i, prv));
-		result = result | error;
-		if (!result)
+		auto prv_result = other_a.fetch (transaction_a, *i);
+		if (!prv_result)
 		{
-			insert_adhoc (transaction_a, prv);
-			other_a.erase (transaction_a, *i);
+			result = true;
+			break;
 		}
+		insert_adhoc (transaction_a, prv_result.value ());
+		other_a.erase (transaction_a, *i);
 	}
 	return result;
 }
@@ -432,21 +426,21 @@ bool nano::wallet_store::import (nano::store::write_transaction const & transact
 	auto result (false);
 	for (auto i (other_a.begin (transaction_a)), n (other_a.end (transaction_a)); i != n; ++i)
 	{
-		nano::raw_key prv;
-		auto error (other_a.fetch (transaction_a, i->first, prv));
-		result = result | error;
-		if (!result)
+		auto prv_result = other_a.fetch (transaction_a, i->first);
+		if (!prv_result)
 		{
-			if (!prv.is_zero ())
-			{
-				insert_adhoc (transaction_a, prv);
-			}
-			else
-			{
-				insert_watch (transaction_a, i->first);
-			}
-			other_a.erase (transaction_a, i->first);
+			result = true;
+			break;
 		}
+		if (!prv_result.value ().is_zero ())
+		{
+			insert_adhoc (transaction_a, prv_result.value ());
+		}
+		else
+		{
+			insert_watch (transaction_a, i->first);
+		}
+		other_a.erase (transaction_a, i->first);
 	}
 	return result;
 }
@@ -709,6 +703,7 @@ nano::mdb_wallets_store::mdb_wallets_store (std::filesystem::path const & path_a
 {
 }
 
+
 /*
  * wallet
  */
@@ -928,8 +923,8 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 			auto pending_info = wallets.ledger.any.pending_get (ledger_txn, nano::pending_key (account_a, send_hash_a));
 			if (pending_info)
 			{
-				nano::raw_key prv;
-				if (!store.fetch (transaction, account_a, prv))
+				auto prv_result = store.fetch (transaction, account_a);
+				if (prv_result)
 				{
 					logger.info (nano::log::type::wallet, "Receiving block: {} from account: {}, amount: {} raw",
 					send_hash_a,
@@ -943,12 +938,12 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 					auto info = wallets.ledger.any.account_get (ledger_txn, account_a);
 					if (info)
 					{
-						block = std::make_shared<nano::state_block> (account_a, info->head, info->representative, info->balance.number () + pending_info->amount.number (), send_hash_a, prv, account_a, work_a);
+						block = std::make_shared<nano::state_block> (account_a, info->head, info->representative, info->balance.number () + pending_info->amount.number (), send_hash_a, prv_result.value (), account_a, work_a);
 						details.epoch = std::max (info->epoch (), pending_info->epoch);
 					}
 					else
 					{
-						block = std::make_shared<nano::state_block> (account_a, 0, representative_a, pending_info->amount, reinterpret_cast<nano::link const &> (send_hash_a), prv, account_a, work_a);
+						block = std::make_shared<nano::state_block> (account_a, 0, representative_a, pending_info->amount, reinterpret_cast<nano::link const &> (send_hash_a), prv_result.value (), account_a, work_a);
 						details.epoch = pending_info->epoch;
 					}
 				}
@@ -1005,14 +1000,13 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 
 				auto info = wallets.ledger.any.account_get (ledger_txn, source_a);
 				release_assert (info, "could not find account info for account in wallet change_action", source_a.to_account ());
-				nano::raw_key prv;
-				auto error2 (store.fetch (transaction, source_a, prv));
-				release_assert (!error2, "failed to fetch private key for account in wallet change_action", source_a.to_account ());
+				auto prv_result = store.fetch (transaction, source_a);
+				release_assert (prv_result, "failed to fetch private key for account in wallet change_action", source_a.to_account ());
 				if (work_a == 0)
 				{
 					store.work_get (transaction, source_a, work_a);
 				}
-				block = std::make_shared<nano::state_block> (source_a, info->head, representative_a, info->balance, 0, prv, source_a, work_a);
+				block = std::make_shared<nano::state_block> (source_a, info->head, representative_a, info->balance, 0, prv_result.value (), source_a, work_a);
 				details.epoch = info->epoch ();
 			}
 			else
@@ -1100,14 +1094,13 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 
 						auto info = wallets.ledger.any.account_get (ledger_txn, source_a);
 						release_assert (info, "could not find account info for account in wallet send_action", source_a.to_account ());
-						nano::raw_key prv;
-						auto error2 (store.fetch (transaction, source_a, prv));
-						release_assert (!error2, "failed to fetch private key for account in wallet send_action", source_a.to_account ());
+						auto prv_result = store.fetch (transaction, source_a);
+						release_assert (prv_result, "failed to fetch private key for account in wallet send_action", source_a.to_account ());
 						if (work_a == 0)
 						{
 							store.work_get (transaction, source_a, work_a);
 						}
-						block = std::make_shared<nano::state_block> (source_a, info->head, info->representative, balance.value ().number () - amount_a, account_a, prv, source_a, work_a);
+						block = std::make_shared<nano::state_block> (source_a, info->head, info->representative, balance.value ().number () - amount_a, account_a, prv_result.value (), source_a, work_a);
 						details.epoch = info->epoch ();
 						if (id_mdb_val && block != nullptr)
 						{
@@ -1575,10 +1568,10 @@ void nano::wallet::set_work (nano::public_key const & pub_a, uint64_t work_a)
 	store.work_put (transaction, pub_a, work_a);
 }
 
-bool nano::wallet::fetch_prv (nano::account const & pub_a, nano::raw_key & prv_a) const
+nano::result<nano::raw_key> nano::wallet::fetch_prv (nano::account const & pub_a) const
 {
 	auto transaction = wallets.tx_begin_read ();
-	return store.fetch (transaction, pub_a, prv_a);
+	return store.fetch (transaction, pub_a);
 }
 
 bool nano::wallet::live ()
@@ -2064,12 +2057,11 @@ void nano::wallets::refresh_rep_keys_cache ()
 			{
 				if (wallet->store.valid_password (wallet_txn))
 				{
-					nano::raw_key prv;
-					auto error = wallet->store.fetch (wallet_txn, account, prv);
-					release_assert (!error, "failed to fetch private key for representative account", account.to_account ());
+					auto prv_result = wallet->store.fetch (wallet_txn, account);
+					release_assert (prv_result, "failed to fetch private key for representative account", account.to_account ());
 
 					// Store private key spread across multiple heap allocations via fan to avoid plaintext keys in memory at rest
-					new_cache.emplace_back (account, std::make_unique<nano::fan> (prv, config.password_fanout));
+					new_cache.emplace_back (account, std::make_unique<nano::fan> (prv_result.value (), config.password_fanout));
 				}
 				else
 				{

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -767,88 +767,105 @@ bool nano::wallet::enter_password_impl (nano::store::transaction const & transac
 	return result;
 }
 
-nano::public_key nano::wallet::deterministic_insert_impl (nano::store::write_transaction const & transaction_a, bool generate_work_a)
+nano::public_key nano::wallet::deterministic_insert_impl (nano::store::write_transaction const & transaction, bool generate_work)
 {
-	nano::public_key key{};
-	if (store.valid_password (transaction_a))
+	auto key = store.deterministic_insert (transaction);
+
+	logger.info (nano::log::type::wallet, "Deterministically inserted new account: {}", key.to_account ());
+
+	if (generate_work)
 	{
-		key = store.deterministic_insert (transaction_a);
-
-		logger.info (nano::log::type::wallet, "Deterministically inserted new account: {}", nano::log::as_account (key));
-
-		if (generate_work_a)
-		{
-			work_ensure (key, key);
-		}
-
-		if (wallets.check_rep (key))
-		{
-			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", nano::log::as_account (key));
-			representatives.lock ()->insert (key);
-		}
+		work_ensure (key, key);
 	}
+
+	if (wallets.check_rep (key))
+	{
+		logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", key.to_account ());
+		representatives.lock ()->insert (key);
+	}
+
 	return key;
 }
 
-nano::public_key nano::wallet::deterministic_insert (uint32_t const index, bool generate_work_a)
+nano::public_key nano::wallet::deterministic_insert_impl (nano::store::write_transaction const & transaction, uint32_t index, bool generate_work)
 {
-	auto transaction (wallets.tx_begin_write ());
-	nano::public_key key{};
-	if (store.valid_password (transaction))
+	auto key = store.deterministic_insert (transaction, index);
+
+	logger.info (nano::log::type::wallet, "Deterministically inserted new account: {} with index: {}", key.to_account (), index);
+
+	if (generate_work)
 	{
-		key = store.deterministic_insert (transaction, index);
-
-		logger.info (nano::log::type::wallet, "Deterministically inserted new account: {}", nano::log::as_account (key));
-
-		if (generate_work_a)
-		{
-			work_ensure (key, key);
-		}
+		work_ensure (key, key);
 	}
+
+	if (wallets.check_rep (key))
+	{
+		logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", key.to_account ());
+		representatives.lock ()->insert (key);
+	}
+
 	return key;
 }
 
-nano::public_key nano::wallet::deterministic_insert (bool generate_work_a)
+nano::result<nano::public_key> nano::wallet::deterministic_insert (uint32_t index, bool generate_work)
 {
-	nano::public_key result;
+	auto transaction = wallets.tx_begin_write ();
+
+	if (!store.valid_password (transaction))
 	{
-		auto transaction (wallets.tx_begin_write ());
-		result = deterministic_insert_impl (transaction, generate_work_a);
+		return nano::error (nano::error_common::wallet_locked);
 	}
-	if (!result.is_zero ())
-	{
-		wallets.refresh_rep_keys_cache ();
-	}
+
+	auto result = deterministic_insert_impl (transaction, index, generate_work);
+	transaction.commit ();
+	wallets.refresh_rep_keys_cache ();
 	return result;
 }
 
-nano::public_key nano::wallet::insert_adhoc (nano::raw_key const & key_a, bool generate_work_a)
+nano::result<nano::public_key> nano::wallet::deterministic_insert (bool generate_work)
 {
-	nano::public_key key{};
-	auto transaction (wallets.tx_begin_write ());
-	if (store.valid_password (transaction))
+	auto transaction = wallets.tx_begin_write ();
+
+	if (!store.valid_password (transaction))
 	{
-		key = store.insert_adhoc (transaction, key_a);
-
-		logger.info (nano::log::type::wallet, "Ad-hoc inserted new account: {}", nano::log::as_account (key));
-
-		auto ledger_txn = wallets.ledger.tx_begin_read ();
-		if (generate_work_a)
-		{
-			work_ensure (key, wallets.ledger.latest_root (ledger_txn, key));
-		}
-
-		// Makes sure that the representatives container will
-		// be in sync with any added keys.
-		transaction.commit ();
-
-		if (wallets.check_rep (key))
-		{
-			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", nano::log::as_account (key));
-			representatives.lock ()->insert (key);
-			wallets.refresh_rep_keys_cache ();
-		}
+		return nano::error (nano::error_common::wallet_locked);
 	}
+
+	auto result = deterministic_insert_impl (transaction, generate_work);
+	transaction.commit ();
+	wallets.refresh_rep_keys_cache ();
+	return result;
+}
+
+nano::result<nano::public_key> nano::wallet::insert_adhoc (nano::raw_key const & prv, bool generate_work)
+{
+	auto transaction = wallets.tx_begin_write ();
+
+	if (!store.valid_password (transaction))
+	{
+		return nano::error (nano::error_common::wallet_locked);
+	}
+
+	auto key = store.insert_adhoc (transaction, prv);
+
+	logger.info (nano::log::type::wallet, "Ad-hoc inserted new account: {}", key.to_account ());
+
+	if (generate_work)
+	{
+		auto ledger_txn = wallets.ledger.tx_begin_read ();
+		work_ensure (key, wallets.ledger.latest_root (ledger_txn, key));
+	}
+
+	// Makes sure that the representatives container will be in sync with any added keys
+	transaction.commit ();
+
+	if (wallets.check_rep (key))
+	{
+		logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", key.to_account ());
+		representatives.lock ()->insert (key);
+		wallets.refresh_rep_keys_cache ();
+	}
+
 	return key;
 }
 

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -500,6 +500,7 @@ void nano::wallet_store::wallet_key (nano::raw_key & prv_a, nano::store::transac
 
 nano::raw_key nano::wallet_store::seed (nano::store::transaction const & transaction) const
 {
+	release_assert (valid_password (transaction), "wallet is locked or password is invalid");
 	nano::wallet_value value (entry_get_raw (transaction, nano::wallet_store::seed_special));
 	nano::raw_key password;
 	wallet_key (password, transaction);
@@ -551,8 +552,9 @@ nano::public_key nano::wallet_store::deterministic_insert (nano::store::write_tr
 
 nano::raw_key nano::wallet_store::deterministic_key (nano::store::transaction const & transaction, uint32_t index) const
 {
-	debug_assert (valid_password (transaction));
-	return nano::deterministic_key (seed (transaction), index);
+	release_assert (valid_password (transaction), "wallet is locked or password is invalid");
+	auto wallet_seed = seed (transaction);
+	return nano::deterministic_key (wallet_seed, index);
 }
 
 uint32_t nano::wallet_store::deterministic_index_get (nano::store::transaction const & transaction_a) const

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -445,19 +445,14 @@ bool nano::wallet_store::import (nano::store::write_transaction const & transact
 	return result;
 }
 
-bool nano::wallet_store::work_get (nano::store::transaction const & transaction_a, nano::public_key const & pub_a, uint64_t & work_a) const
+std::optional<uint64_t> nano::wallet_store::work_get (nano::store::transaction const & transaction, nano::public_key const & pub) const
 {
-	auto result (false);
-	auto entry (entry_get_raw (transaction_a, pub_a));
+	auto entry = entry_get_raw (transaction, pub);
 	if (!entry.key.is_zero ())
 	{
-		work_a = entry.work;
+		return entry.work;
 	}
-	else
-	{
-		result = true;
-	}
-	return result;
+	return std::nullopt;
 }
 
 void nano::wallet_store::work_put (nano::store::write_transaction const & transaction_a, nano::public_key const & pub_a, uint64_t work_a)
@@ -933,7 +928,7 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 
 					if (work_a == 0)
 					{
-						store.work_get (transaction, account_a, work_a);
+						work_a = store.work_get (transaction, account_a).value_or (0);
 					}
 					auto info = wallets.ledger.any.account_get (ledger_txn, account_a);
 					if (info)
@@ -1004,7 +999,7 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 				release_assert (prv_result, "failed to fetch private key for account in wallet change_action", source_a.to_account ());
 				if (work_a == 0)
 				{
-					store.work_get (transaction, source_a, work_a);
+					work_a = store.work_get (transaction, source_a).value_or (0);
 				}
 				block = std::make_shared<nano::state_block> (source_a, info->head, representative_a, info->balance, 0, prv_result.value (), source_a, work_a);
 				details.epoch = info->epoch ();
@@ -1098,7 +1093,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 						release_assert (prv_result, "failed to fetch private key for account in wallet send_action", source_a.to_account ());
 						if (work_a == 0)
 						{
-							store.work_get (transaction, source_a, work_a);
+							work_a = store.work_get (transaction, source_a).value_or (0);
 						}
 						block = std::make_shared<nano::state_block> (source_a, info->head, info->representative, balance.value ().number () - amount_a, account_a, prv_result.value (), source_a, work_a);
 						details.epoch = info->epoch ();
@@ -1556,10 +1551,15 @@ uint32_t nano::wallet::get_deterministic_index () const
 	return store.deterministic_index_get (transaction);
 }
 
-bool nano::wallet::get_work (nano::public_key const & pub_a, uint64_t & work_a) const
+nano::result<uint64_t> nano::wallet::get_work (nano::public_key const & pub) const
 {
 	auto transaction = wallets.tx_begin_read ();
-	return store.work_get (transaction, pub_a, work_a);
+	auto result = store.work_get (transaction, pub);
+	if (result)
+	{
+		return *result;
+	}
+	return nano::error (nano::error_common::account_not_found_wallet);
 }
 
 void nano::wallet::set_work (nano::public_key const & pub_a, uint64_t work_a)

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -426,26 +426,28 @@ bool nano::wallet_store::import (nano::store::write_transaction const & transact
 	release_assert (valid_password (transaction_a), "wallet is locked or password is invalid");
 	release_assert (other_a.valid_password (transaction_a), "other wallet is locked or password is invalid");
 
-	auto result (false);
+	bool error = false;
 	for (auto i (other_a.begin (transaction_a)), n (other_a.end (transaction_a)); i != n; ++i)
 	{
 		auto prv_result = other_a.fetch (transaction_a, i->first);
-		if (!prv_result)
+		if (prv_result)
 		{
-			result = true;
-			break;
-		}
-		if (!prv_result.value ().is_zero ())
-		{
-			insert_adhoc (transaction_a, prv_result.value ());
+			if (!prv_result.value ().is_zero ())
+			{
+				insert_adhoc (transaction_a, prv_result.value ());
+			}
+			else
+			{
+				insert_watch (transaction_a, i->first);
+			}
+			other_a.erase (transaction_a, i->first);
 		}
 		else
 		{
-			insert_watch (transaction_a, i->first);
+			error = true;
 		}
-		other_a.erase (transaction_a, i->first);
 	}
-	return result;
+	return error;
 }
 
 std::optional<uint64_t> nano::wallet_store::work_get (nano::store::transaction const & transaction, nano::public_key const & pub) const

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -161,9 +161,9 @@ public:
 	void lock ();
 
 	// Account management
-	nano::public_key insert_adhoc (nano::raw_key const & prv, bool generate_work = true);
-	nano::public_key deterministic_insert (uint32_t index, bool generate_work = true);
-	nano::public_key deterministic_insert (bool generate_work = true);
+	nano::result<nano::public_key> insert_adhoc (nano::raw_key const & prv, bool generate_work = true);
+	nano::result<nano::public_key> deterministic_insert (uint32_t index, bool generate_work = true);
+	nano::result<nano::public_key> deterministic_insert (bool generate_work = true);
 	bool insert_watch (nano::public_key const & pub);
 	void remove_account (nano::account const & account);
 	std::vector<nano::account> accounts () const;
@@ -231,6 +231,7 @@ private:
 	bool enter_password_impl (nano::store::transaction const &, std::string const & password);
 	bool insert_watch_impl (nano::store::write_transaction const &, nano::public_key const & pub);
 	nano::public_key deterministic_insert_impl (nano::store::write_transaction const &, bool generate_work = true);
+	nano::public_key deterministic_insert_impl (nano::store::write_transaction const &, uint32_t index, bool generate_work = true);
 	void work_update_impl (nano::store::write_transaction const &, nano::account const & account, nano::root const & root, uint64_t work);
 	bool search_receivable_impl (nano::store::transaction const &);
 	void init_free_accounts_impl (nano::store::transaction const &);

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -4,6 +4,7 @@
 #include <nano/lib/locks.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/numbers_templ.hpp>
+#include <nano/lib/result.hpp>
 #include <nano/lib/thread_pool.hpp>
 #include <nano/lib/work.hpp>
 #include <nano/node/fwd.hpp>
@@ -15,6 +16,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <unordered_set>
 
@@ -96,7 +98,7 @@ public:
 	void erase (nano::store::write_transaction const &, nano::account const & pub);
 	nano::wallet_value entry_get_raw (nano::store::transaction const &, nano::account const & pub) const;
 	void entry_put_raw (nano::store::write_transaction const &, nano::account const & pub, nano::wallet_value const & entry);
-	bool fetch (nano::store::transaction const &, nano::account const & pub, nano::raw_key & result) const;
+	nano::result<nano::raw_key> fetch (nano::store::transaction const &, nano::account const & pub) const;
 	bool exists (nano::store::transaction const &, nano::account const & pub) const;
 	void destroy (nano::store::write_transaction const &);
 	iterator find (nano::store::transaction const &, nano::account const & key) const;
@@ -184,7 +186,7 @@ public:
 	std::unordered_set<nano::account> reps () const;
 
 	// Key retrieval
-	bool fetch_prv (nano::account const & pub, nano::raw_key & result) const;
+	nano::result<nano::raw_key> fetch_prv (nano::account const & pub) const;
 
 	// Block actions
 	std::shared_ptr<nano::block> change_action (nano::account const & source, nano::account const & representative, uint64_t work = 0, bool generate_work = true);

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -110,7 +110,7 @@ public:
 	void write_backup (nano::store::transaction const &, std::filesystem::path const & path) const;
 	bool move (nano::store::write_transaction const &, nano::wallet_store & source, std::vector<nano::public_key> const & keys);
 	bool import (nano::store::write_transaction const &, nano::wallet_store & source);
-	bool work_get (nano::store::transaction const &, nano::public_key const & pub, uint64_t & work) const;
+	std::optional<uint64_t> work_get (nano::store::transaction const &, nano::public_key const &) const;
 	void work_put (nano::store::write_transaction const &, nano::public_key const & pub, uint64_t work);
 	unsigned version (nano::store::transaction const &) const;
 	void version_put (nano::store::write_transaction const &, unsigned version);
@@ -205,7 +205,7 @@ public:
 	// Work cache
 	void work_cache_blocking (nano::account const & account, nano::root const & root);
 	void work_ensure (nano::account const & account, nano::root const & root);
-	bool get_work (nano::public_key const & pub, uint64_t & work) const;
+	nano::result<uint64_t> get_work (nano::public_key const &) const;
 	void set_work (nano::public_key const & pub, uint64_t work);
 
 	// Receivable

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -80,7 +80,7 @@ public:
 	bool valid_public_key (nano::public_key const &) const;
 	bool attempt_password (nano::store::transaction const &, std::string const & password);
 	void wallet_key (nano::raw_key & result, nano::store::transaction const &) const;
-	void seed (nano::raw_key & result, nano::store::transaction const &) const;
+	nano::raw_key seed (nano::store::transaction const &) const;
 	void seed_set (nano::store::write_transaction const &, nano::raw_key const & seed);
 	nano::key_type key_type (nano::wallet_value const &) const;
 	nano::public_key deterministic_insert (nano::store::write_transaction const &);
@@ -172,7 +172,7 @@ public:
 	nano::key_type key_type (nano::account const & account) const;
 
 	// Seed management
-	bool get_seed (nano::raw_key & result) const;
+	nano::result<nano::raw_key> get_seed () const;
 	nano::public_key change_seed (nano::raw_key const & seed, uint32_t count = 0);
 	void deterministic_restore ();
 	uint32_t deterministic_check (uint32_t index);

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -108,8 +108,8 @@ public:
 	void derive_key (nano::raw_key & result, nano::store::transaction const &, std::string const & password) const;
 	void serialize_json (nano::store::transaction const &, std::string & json) const;
 	void write_backup (nano::store::transaction const &, std::filesystem::path const & path) const;
-	bool move (nano::store::write_transaction const &, nano::wallet_store & source, std::vector<nano::public_key> const & keys);
-	bool import (nano::store::write_transaction const &, nano::wallet_store & source);
+	nano::result<bool> move (nano::store::write_transaction const &, nano::wallet_store & source, std::vector<nano::public_key> const & keys);
+	nano::result<bool> import (nano::store::write_transaction const &, nano::wallet_store & source);
 	std::optional<uint64_t> work_get (nano::store::transaction const &, nano::public_key const &) const;
 	void work_put (nano::store::write_transaction const &, nano::public_key const & pub, uint64_t work);
 	unsigned version (nano::store::transaction const &) const;
@@ -168,7 +168,7 @@ public:
 	void remove_account (nano::account const & account);
 	std::vector<nano::account> accounts () const;
 	bool exists (nano::public_key const & pub);
-	bool move_accounts (wallet & source, std::vector<nano::public_key> const & accounts);
+	nano::result<bool> move_accounts (wallet & source, std::vector<nano::public_key> const & accounts);
 	nano::key_type key_type (nano::account const & account) const;
 
 	// Seed management

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -2224,8 +2224,8 @@ void nano_qt::block_creation::create_send ()
 			if (!error)
 			{
 				auto block_transaction = wallet.node.ledger.tx_begin_read ();
-				nano::raw_key key;
-				if (!wallet.wallet_m->fetch_prv (account_l, key))
+				auto key_result = wallet.wallet_m->fetch_prv (account_l);
+				if (key_result)
 				{
 					auto balance = wallet.node.ledger.any.account_balance (block_transaction, account_l).value_or (0).number ();
 					if (amount_l.number () <= balance)
@@ -2234,7 +2234,7 @@ void nano_qt::block_creation::create_send ()
 						auto error (wallet.node.store.account.get (block_transaction, account_l, info));
 						(void)error;
 						debug_assert (!error);
-						nano::state_block send (account_l, info.head, info.representative, balance - amount_l.number (), destination_l, key, account_l, 0);
+						nano::state_block send (account_l, info.head, info.representative, balance - amount_l.number (), destination_l, key_result.value (), account_l, 0);
 						nano::block_details details;
 						details.is_send = true;
 						details.epoch = info.epoch ();
@@ -2312,11 +2312,10 @@ void nano_qt::block_creation::create_receive ()
 					auto error (wallet.node.store.account.get (block_transaction, pending_key.account, info));
 					if (!error)
 					{
-						nano::raw_key key;
-						auto error (wallet.wallet_m->fetch_prv (pending_key.account, key));
-						if (!error)
+						auto key_result = wallet.wallet_m->fetch_prv (pending_key.account);
+						if (key_result)
 						{
-							nano::state_block receive (pending_key.account, info.head, info.representative, info.balance.number () + pending.value ().amount.number (), source_l, key, pending_key.account, 0);
+							nano::state_block receive (pending_key.account, info.head, info.representative, info.balance.number () + pending.value ().amount.number (), source_l, key_result.value (), pending_key.account, 0);
 							nano::block_details details;
 							details.is_receive = true;
 							details.epoch = std::max (info.epoch (), pending.value ().epoch);
@@ -2395,11 +2394,10 @@ void nano_qt::block_creation::create_change ()
 			auto error (wallet.node.store.account.get (block_transaction, account_l, info));
 			if (!error)
 			{
-				nano::raw_key key;
-				auto error (wallet.wallet_m->fetch_prv (account_l, key));
-				if (!error)
+				auto key_result = wallet.wallet_m->fetch_prv (account_l);
+				if (key_result)
 				{
-					nano::state_block change (account_l, info.head, representative_l, info.balance, 0, key, account_l, 0);
+					nano::state_block change (account_l, info.head, representative_l, info.balance, 0, key_result.value (), account_l, 0);
 					nano::block_details details;
 					details.epoch = info.epoch ();
 					auto const required_difficulty{ wallet.node.network_params.work.threshold (change.work_version (), details) };
@@ -2474,11 +2472,10 @@ void nano_qt::block_creation::create_open ()
 						auto error (wallet.node.store.account.get (block_transaction, pending_key.account, info));
 						if (error)
 						{
-							nano::raw_key key;
-							auto error (wallet.wallet_m->fetch_prv (pending_key.account, key));
-							if (!error)
+							auto key_result = wallet.wallet_m->fetch_prv (pending_key.account);
+							if (key_result)
 							{
-								nano::state_block open (pending_key.account, 0, representative_l, pending.value ().amount, source_l, key, pending_key.account, 0);
+								nano::state_block open (pending_key.account, 0, representative_l, pending.value ().amount, source_l, key_result.value (), pending_key.account, 0);
 								nano::block_details details;
 								details.is_receive = true;
 								details.epoch = pending.value ().epoch;

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -238,10 +238,9 @@ nano_qt::accounts::accounts (nano_qt::wallet & wallet_a) :
 		this->wallet.push_main_stack (this->wallet.import.window);
 	});
 	QObject::connect (backup_seed, &QPushButton::released, [this] () {
-		if (!this->wallet.wallet_m->is_locked ())
+		auto seed_result = this->wallet.wallet_m->get_seed ();
+		if (seed_result)
 		{
-			auto seed_result = this->wallet.wallet_m->get_seed ();
-			release_assert (seed_result);
 			this->wallet.application.clipboard ()->setText (QString (seed_result.value ().to_string ().c_str ()));
 			show_button_success (*backup_seed);
 			backup_seed->setText ("Seed was copied to clipboard");

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -186,12 +186,19 @@ nano_qt::accounts::accounts (nano_qt::wallet & wallet_a) :
 		nano::raw_key key;
 		if (!key.decode_hex (key_text))
 		{
-			show_line_ok (*account_key_line);
-			account_key_line->clear ();
-			this->wallet.wallet_m->insert_adhoc (key);
-			this->wallet.accounts.refresh ();
-			this->wallet.accounts.refresh_wallet_balance ();
-			this->wallet.history.refresh ();
+			auto result = this->wallet.wallet_m->insert_adhoc (key);
+			if (result)
+			{
+				show_line_ok (*account_key_line);
+				account_key_line->clear ();
+				this->wallet.accounts.refresh ();
+				this->wallet.accounts.refresh_wallet_balance ();
+				this->wallet.history.refresh ();
+			}
+			else
+			{
+				show_line_error (*account_key_line);
+			}
 		}
 		else
 		{
@@ -202,30 +209,28 @@ nano_qt::accounts::accounts (nano_qt::wallet & wallet_a) :
 		this->wallet.pop_main_stack ();
 	});
 	QObject::connect (create_account, &QPushButton::released, [this] () {
+		auto result = this->wallet.wallet_m->deterministic_insert ();
+		if (result)
 		{
-			if (!this->wallet.wallet_m->is_locked ())
-			{
-				this->wallet.wallet_m->deterministic_insert ();
-				show_button_success (*create_account);
-				create_account->setText ("New account was created");
-				this->wallet.node.workers.post_delayed (std::chrono::seconds (5), [this] () {
-					this->wallet.application.postEvent (&this->wallet.processor, new eventloop_event ([this] () {
-						show_button_ok (*create_account);
-						create_account->setText ("Create account");
-					}));
-				});
-			}
-			else
-			{
-				show_button_error (*create_account);
-				create_account->setText ("Wallet is locked, unlock it to create account");
-				this->wallet.node.workers.post_delayed (std::chrono::seconds (5), [this] () {
-					this->wallet.application.postEvent (&this->wallet.processor, new eventloop_event ([this] () {
-						show_button_ok (*create_account);
-						create_account->setText ("Create account");
-					}));
-				});
-			}
+			show_button_success (*create_account);
+			create_account->setText ("New account was created");
+			this->wallet.node.workers.post_delayed (std::chrono::seconds (5), [this] () {
+				this->wallet.application.postEvent (&this->wallet.processor, new eventloop_event ([this] () {
+					show_button_ok (*create_account);
+					create_account->setText ("Create account");
+				}));
+			});
+		}
+		else
+		{
+			show_button_error (*create_account);
+			create_account->setText ("Wallet is locked, unlock it to create account");
+			this->wallet.node.workers.post_delayed (std::chrono::seconds (5), [this] () {
+				this->wallet.application.postEvent (&this->wallet.processor, new eventloop_event ([this] () {
+					show_button_ok (*create_account);
+					create_account->setText ("Create account");
+				}));
+			});
 		}
 		refresh ();
 	});

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -2274,7 +2274,7 @@ void nano_qt::block_creation::create_send ()
 				else
 				{
 					show_label_error (*status);
-					status->setText ("Account is not in wallet");
+					status->setText (key_result.error ().get_message ().c_str ());
 				}
 			}
 			else
@@ -2349,7 +2349,7 @@ void nano_qt::block_creation::create_receive ()
 						else
 						{
 							show_label_error (*status);
-							status->setText ("Account is not in wallet");
+							status->setText (key_result.error ().get_message ().c_str ());
 						}
 					}
 					else
@@ -2430,7 +2430,7 @@ void nano_qt::block_creation::create_change ()
 				else
 				{
 					show_label_error (*status);
-					status->setText ("Account is not in wallet");
+					status->setText (key_result.error ().get_message ().c_str ());
 				}
 			}
 			else
@@ -2509,7 +2509,7 @@ void nano_qt::block_creation::create_open ()
 							else
 							{
 								show_label_error (*status);
-								status->setText ("Account is not in wallet");
+								status->setText (key_result.error ().get_message ().c_str ());
 							}
 						}
 						else

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -233,11 +233,11 @@ nano_qt::accounts::accounts (nano_qt::wallet & wallet_a) :
 		this->wallet.push_main_stack (this->wallet.import.window);
 	});
 	QObject::connect (backup_seed, &QPushButton::released, [this] () {
-		nano::raw_key seed;
 		if (!this->wallet.wallet_m->is_locked ())
 		{
-			this->wallet.wallet_m->get_seed (seed);
-			this->wallet.application.clipboard ()->setText (QString (seed.to_string ().c_str ()));
+			auto seed_result = this->wallet.wallet_m->get_seed ();
+			release_assert (seed_result);
+			this->wallet.application.clipboard ()->setText (QString (seed_result.value ().to_string ().c_str ()));
 			show_button_success (*backup_seed);
 			backup_seed->setText ("Seed was copied to clipboard");
 			this->wallet.node.workers.post_delayed (std::chrono::seconds (5), [this] () {

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -690,17 +690,16 @@ TEST (wallet, startup_work)
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
-	uint64_t work1;
-	ASSERT_TRUE (wallet->wallet_m->get_work (nano::dev::genesis_key.pub, work1));
+	auto work1_result = wallet->wallet_m->get_work (nano::dev::genesis_key.pub);
+	ASSERT_TRUE (work1_result);
 	QTest::mouseClick (wallet->accounts_button, Qt::LeftButton);
 	QTest::keyClicks (wallet->accounts.account_key_line, "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E58A380BC10474BB039CE4");
 	QTest::mouseClick (wallet->accounts.account_key_button, Qt::LeftButton);
 	system.deadline_set (10s);
-	auto again (true);
-	while (again)
+	// Wait until genesis key is removed from wallet (work lookup fails)
+	while (wallet->wallet_m->get_work (nano::dev::genesis_key.pub))
 	{
 		ASSERT_NO_ERROR (system.poll ());
-		again = wallet->wallet_m->get_work (nano::dev::genesis_key.pub, work1);
 	}
 }
 
@@ -894,17 +893,17 @@ TEST (wallet, seed_work_generation)
 	auto pub (nano::pub_key (prv));
 	QTest::keyClicks (wallet->import.seed, seed.to_string ().c_str ());
 	QTest::keyClicks (wallet->import.clear_line, "clear keys");
-	uint64_t work (0);
+	nano::result<uint64_t> work_result = nano::error (nano::error_common::account_not_found_wallet);
 	QTest::mouseClick (wallet->import.import_seed, Qt::LeftButton);
 	system.deadline_set (10s);
-	while (work == 0)
+	while (!work_result || work_result.value () == 0)
 	{
 		auto ec = system.poll ();
-		system.wallet (0)->get_work (pub, work);
+		work_result = system.wallet (0)->get_work (pub);
 		ASSERT_NO_ERROR (ec);
 	}
 	auto transaction = system.nodes[0]->ledger.tx_begin_read ();
-	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, system.nodes[0]->ledger.latest_root (transaction, pub), work), system.nodes[0]->default_difficulty (nano::work_version::work_1));
+	ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, system.nodes[0]->ledger.latest_root (transaction, pub), work_result.value ()), system.nodes[0]->default_difficulty (nano::work_version::work_1));
 }
 
 TEST (wallet, backup_seed)

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -835,8 +835,8 @@ TEST (wallet, change_seed)
 	nano::test::system system (1);
 	auto key1 (system.wallet (0)->deterministic_insert ());
 	system.wallet (0)->deterministic_insert ();
-	nano::raw_key seed3;
-	system.wallet (0)->get_seed (seed3);
+	auto seed3 = system.wallet (0)->get_seed ();
+	ASSERT_TRUE (seed3);
 	auto wallet_key (key1);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), wallet_key));
 	wallet->start ();
@@ -849,9 +849,9 @@ TEST (wallet, change_seed)
 	nano::raw_key seed;
 	seed.clear ();
 	QTest::keyClicks (wallet->import.seed, seed.to_string ().c_str ());
-	nano::raw_key seed1;
-	system.wallet (0)->get_seed (seed1);
-	ASSERT_NE (seed, seed1);
+	auto seed1 = system.wallet (0)->get_seed ();
+	ASSERT_TRUE (seed1);
+	ASSERT_NE (seed, seed1.value ());
 	ASSERT_TRUE (system.wallet (0)->exists (key1));
 	ASSERT_EQ (2, wallet->accounts.model->rowCount ());
 	QTest::mouseClick (wallet->import.import_seed, Qt::LeftButton);
@@ -860,14 +860,14 @@ TEST (wallet, change_seed)
 	QTest::mouseClick (wallet->import.import_seed, Qt::LeftButton);
 	ASSERT_EQ (1, wallet->accounts.model->rowCount ());
 	ASSERT_TRUE (wallet->import.clear_line->text ().toStdString ().empty ());
-	nano::raw_key seed2;
-	system.wallet (0)->get_seed (seed2);
-	ASSERT_EQ (seed, seed2);
+	auto seed2 = system.wallet (0)->get_seed ();
+	ASSERT_TRUE (seed2);
+	ASSERT_EQ (seed, seed2.value ());
 	ASSERT_FALSE (system.wallet (0)->exists (key1));
 	ASSERT_NE (key1, wallet->account);
 	auto key2 (wallet->account);
 	ASSERT_TRUE (system.wallet (0)->exists (key2));
-	QTest::keyClicks (wallet->import.seed, seed3.to_string ().c_str ());
+	QTest::keyClicks (wallet->import.seed, seed3.value ().to_string ().c_str ());
 	QTest::keyClicks (wallet->import.clear_line, "clear keys");
 	QTest::mouseClick (wallet->import.import_seed, Qt::LeftButton);
 	ASSERT_EQ (key1, wallet->account);
@@ -918,9 +918,9 @@ TEST (wallet, backup_seed)
 	QTest::mouseClick (wallet->accounts_button, Qt::LeftButton);
 	ASSERT_EQ (wallet->accounts.window, wallet->main_stack->currentWidget ());
 	QTest::mouseClick (wallet->accounts.backup_seed, Qt::LeftButton);
-	nano::raw_key seed;
-	system.wallet (0)->get_seed (seed);
-	ASSERT_EQ (seed.to_string (), test_application->clipboard ()->text ().toStdString ());
+	auto seed = system.wallet (0)->get_seed ();
+	ASSERT_TRUE (seed);
+	ASSERT_EQ (seed.value ().to_string (), test_application->clipboard ()->text ().toStdString ());
 }
 
 TEST (wallet, import_locked)
@@ -939,20 +939,16 @@ TEST (wallet, import_locked)
 	seed1.clear ();
 	QTest::keyClicks (wallet->import.seed, seed1.to_string ().c_str ());
 	QTest::keyClicks (wallet->import.clear_line, "clear keys");
-	{
-		system.wallet (0)->enter_password ("");
-	}
+	system.wallet (0)->enter_password ("");
 	QTest::mouseClick (wallet->import.import_seed, Qt::LeftButton);
-	nano::raw_key seed2;
-	{
-		system.wallet (0)->get_seed (seed2);
-		ASSERT_NE (seed1, seed2);
-		system.wallet (0)->enter_password ("1");
-	}
+	auto seed2 = system.wallet (0)->get_seed ();
+	ASSERT_FALSE (seed2);
+	ASSERT_EQ (seed2.error (), nano::error_common::wallet_locked);
+	system.wallet (0)->enter_password ("1");
 	QTest::mouseClick (wallet->import.import_seed, Qt::LeftButton);
-	nano::raw_key seed3;
-	system.wallet (0)->get_seed (seed3);
-	ASSERT_EQ (seed1, seed3);
+	auto seed3 = system.wallet (0)->get_seed ();
+	ASSERT_TRUE (seed3);
+	ASSERT_EQ (seed1, seed3.value ());
 }
 
 TEST (wallet, epoch_2_validation)

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -24,14 +24,16 @@ TEST (wallet, construction)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
-	auto key (wallet_l->deterministic_insert ());
-	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key));
+	auto wallet_l = system.nodes[0]->wallets.create (nano::random_wallet_id ());
+	auto key_result = wallet_l->deterministic_insert ();
+	ASSERT_TRUE (key_result);
+	auto key = key_result.value ();
+	auto wallet = std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key);
 	wallet->start ();
-	std::string account (key.to_account ());
+	std::string account = key.to_account ();
 	ASSERT_EQ (account, wallet->self.account_text->text ().toStdString ());
 	ASSERT_EQ (1, wallet->accounts.model->rowCount ());
-	auto item1 (wallet->accounts.model->item (0, 1));
+	auto item1 = wallet->accounts.model->item (0, 1);
 	ASSERT_EQ (key.to_account (), item1->text ().toStdString ());
 }
 
@@ -41,10 +43,10 @@ TEST (wallet, DISABLED_status)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
+	auto wallet_l = system.nodes[0]->wallets.create (nano::random_wallet_id ());
 	nano::keypair key;
-	wallet_l->insert_adhoc (key.prv);
-	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key.pub));
+	ASSERT_TRUE (wallet_l->insert_adhoc (key.prv));
+	auto wallet = std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key.pub);
 	wallet->start ();
 	auto wallet_has = [wallet] (nano_qt::status_types status_ty) {
 		return wallet->active_status.active.find (status_ty) != wallet->active_status.active.end ();
@@ -76,7 +78,7 @@ TEST (wallet, status_with_peer)
 	nano::test::system system (2);
 	auto wallet_l = system.nodes[0]->wallets.create (nano::random_wallet_id ());
 	nano::keypair key;
-	wallet_l->insert_adhoc (key.prv);
+	ASSERT_TRUE (wallet_l->insert_adhoc (key.prv));
 	auto wallet = std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key.pub);
 	wallet->start ();
 	auto wallet_has = [wallet] (nano_qt::status_types status_ty) {
@@ -100,7 +102,7 @@ TEST (wallet, startup_balance)
 	nano::test::system system (1);
 	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
 	nano::keypair key;
-	wallet_l->insert_adhoc (key.prv);
+	ASSERT_TRUE (wallet_l->insert_adhoc (key.prv));
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key.pub));
 	wallet->needs_balance_refresh = true;
 	wallet->start ();
@@ -112,10 +114,10 @@ TEST (wallet, select_account)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
-	nano::public_key key1 (wallet_l->deterministic_insert ());
-	nano::public_key key2 (wallet_l->deterministic_insert ());
-	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key1));
+	auto wallet_l = system.nodes[0]->wallets.create (nano::random_wallet_id ());
+	auto key1 = wallet_l->deterministic_insert ().value ();
+	auto key2 = wallet_l->deterministic_insert ().value ();
+	auto wallet = std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key1);
 	wallet->start ();
 	ASSERT_EQ (key1, wallet->account);
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
@@ -146,7 +148,7 @@ TEST (wallet, main)
 	nano::test::system system (1);
 	auto wallet_l (system.nodes[0]->wallets.create (nano::random_wallet_id ()));
 	nano::keypair key;
-	wallet_l->insert_adhoc (key.prv);
+	ASSERT_TRUE (wallet_l->insert_adhoc (key.prv));
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], wallet_l, key.pub));
 	wallet->start ();
 	ASSERT_EQ (wallet->entry_window, wallet->main_stack->currentWidget ());
@@ -175,7 +177,7 @@ TEST (wallet, password_change)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::keypair ().prv));
 	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
@@ -197,7 +199,7 @@ TEST (client, password_nochange)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::keypair ().prv));
 	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
@@ -220,7 +222,7 @@ TEST (wallet, enter_password)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (2);
-	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::keypair ().prv));
 	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
@@ -253,8 +255,8 @@ TEST (wallet, send)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (2);
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	nano::public_key key1 (system.wallet (1)->insert_adhoc (nano::keypair ().prv));
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv));
+	auto key1 = system.wallet (1)->insert_adhoc (nano::keypair ().prv).value ();
 	auto account (nano::dev::genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
@@ -286,7 +288,7 @@ TEST (wallet, send_locked)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv));
 	nano::keypair key1;
 	{
 		system.wallet (0)->enter_password ("0");
@@ -314,7 +316,7 @@ TEST (wallet, DISABLED_process_block)
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
 	nano::block_hash latest (system.nodes[0]->latest (nano::dev::genesis_key.pub));
-	system.wallet (0)->insert_adhoc (nano::keypair ().prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::keypair ().prv));
 	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
@@ -351,8 +353,8 @@ TEST (wallet, create_send)
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
 	nano::test::system system (1);
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	system.wallet (0)->insert_adhoc (key.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv));
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (key.prv));
 	auto account (nano::dev::genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
@@ -381,13 +383,13 @@ TEST (wallet, create_open_receive)
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
 	nano::test::system system (1);
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv));
 	system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, 100);
 	nano::block_hash latest1 (system.nodes[0]->latest (nano::dev::genesis_key.pub));
 	system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, 100);
 	nano::block_hash latest2 (system.nodes[0]->latest (nano::dev::genesis_key.pub));
 	ASSERT_NE (latest1, latest2);
-	system.wallet (0)->insert_adhoc (key.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (key.prv));
 	auto account (nano::dev::genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
@@ -430,7 +432,7 @@ TEST (wallet, create_change)
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
 	nano::test::system system (1);
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv));
 	auto account (nano::dev::genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
@@ -458,7 +460,7 @@ TEST (history, short_text)
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
 	nano::test::system system (1);
-	system.wallet (0)->insert_adhoc (key.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (key.prv));
 	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	nano::logger logger;
@@ -492,7 +494,7 @@ TEST (history, pruned_source)
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
 	nano::test::system system (1);
-	system.wallet (0)->insert_adhoc (key.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (key.prv));
 	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	nano::logger logger;
@@ -645,7 +647,7 @@ TEST (history, pruned_source)
 	ASSERT_EQ ("0 raw", amount9->text ().toStdString ());
 	// Pruning for state blocks. Open state block
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (key2.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (key2.prv));
 	{
 		auto transaction = ledger.tx_begin_write ();
 		auto latest_key (ledger.any.account_head (transaction, key.pub));
@@ -685,22 +687,22 @@ TEST (wallet, startup_work)
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
 	nano::test::system system (1);
-	system.wallet (0)->insert_adhoc (key.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (key.prv));
 	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
 	auto work1_result = wallet->wallet_m->get_work (nano::dev::genesis_key.pub);
-	ASSERT_TRUE (work1_result);
+	ASSERT_FALSE (work1_result);
 	QTest::mouseClick (wallet->accounts_button, Qt::LeftButton);
 	QTest::keyClicks (wallet->accounts.account_key_line, "34F0A37AAD20F4A260F0A5B3CB3D7FB50673212263E58A380BC10474BB039CE4");
 	QTest::mouseClick (wallet->accounts.account_key_button, Qt::LeftButton);
-	system.deadline_set (10s);
-	// Wait until genesis key is removed from wallet (work lookup fails)
-	while (wallet->wallet_m->get_work (nano::dev::genesis_key.pub))
-	{
-		ASSERT_NO_ERROR (system.poll ());
-	}
+	// Wait until genesis key is added to wallet and usable work is generated
+	auto has_work = [&] (nano::public_key const & account) {
+		auto result = wallet->wallet_m->get_work (account);
+		return result && result.value () != 0;
+	};
+	ASSERT_TIMELY (10s, has_work (nano::dev::genesis_key.pub));
 }
 
 TEST (wallet, block_viewer)
@@ -708,7 +710,7 @@ TEST (wallet, block_viewer)
 	nano_qt::eventloop_processor processor;
 	nano::keypair key;
 	nano::test::system system (1);
-	system.wallet (0)->insert_adhoc (key.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (key.prv));
 	nano::account account = system.wallet (0)->accounts ().front ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), account));
 	wallet->start ();
@@ -731,9 +733,9 @@ TEST (wallet, import)
 	std::string json;
 	nano::keypair key1;
 	nano::keypair key2;
-	system.wallet (0)->insert_adhoc (key1.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (key1.prv));
 	system.wallet (0)->serialize_json (json);
-	system.wallet (1)->insert_adhoc (key2.prv);
+	ASSERT_TRUE (system.wallet (1)->insert_adhoc (key2.prv));
 	auto path{ nano::unique_path () / "wallet.json" };
 	{
 		std::ofstream stream;
@@ -770,7 +772,7 @@ TEST (wallet, republish)
 	auto & node1 = *system.add_node (node_config);
 	auto & node2 = *system.add_node (node_config);
 
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv));
 	nano::keypair key;
 	nano::block_hash hash;
 	{
@@ -807,7 +809,7 @@ TEST (wallet, ignore_empty_adhoc)
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
 	nano::keypair key1;
-	system.wallet (0)->insert_adhoc (key1.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (key1.prv));
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), key1.pub));
 	wallet->start ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
@@ -833,8 +835,8 @@ TEST (wallet, change_seed)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	auto key1 (system.wallet (0)->deterministic_insert ());
-	system.wallet (0)->deterministic_insert ();
+	auto key1 = system.wallet (0)->deterministic_insert ().value ();
+	ASSERT_TRUE (system.wallet (0)->deterministic_insert ());
 	auto seed3 = system.wallet (0)->get_seed ();
 	ASSERT_TRUE (seed3);
 	auto wallet_key (key1);
@@ -879,7 +881,7 @@ TEST (wallet, seed_work_generation)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	auto key1 (system.wallet (0)->deterministic_insert ());
+	auto key1 = system.wallet (0)->deterministic_insert ().value ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), key1));
 	wallet->start ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
@@ -910,7 +912,7 @@ TEST (wallet, backup_seed)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	auto key1 (system.wallet (0)->deterministic_insert ());
+	auto key1 = system.wallet (0)->deterministic_insert ().value ();
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), key1));
 	wallet->start ();
 	QTest::mouseClick (wallet->show_advanced, Qt::LeftButton);
@@ -927,7 +929,7 @@ TEST (wallet, import_locked)
 {
 	nano_qt::eventloop_processor processor;
 	nano::test::system system (1);
-	auto key1 (system.wallet (0)->deterministic_insert ());
+	auto key1 = system.wallet (0)->deterministic_insert ().value ();
 	system.wallet (0)->rekey ("1");
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *system.nodes[0], system.wallet (0), key1));
 	wallet->start ();
@@ -961,7 +963,7 @@ TEST (wallet, epoch_2_validation)
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (*node, nano::epoch::epoch_1));
 	ASSERT_NE (nullptr, system.upgrade_genesis_epoch (*node, nano::epoch::epoch_2));
 
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv));
 
 	auto account (nano::dev::genesis_key.pub);
 	auto wallet (std::make_shared<nano_qt::wallet> (*test_application, processor, *node, system.wallet (0), account));
@@ -1020,7 +1022,7 @@ TEST (wallet, epoch_2_validation)
 	while (++tries < max_tries)
 	{
 		nano::keypair key;
-		system.wallet (0)->insert_adhoc (key.prv);
+		ASSERT_TRUE (system.wallet (0)->insert_adhoc (key.prv));
 		auto send1 = do_send (key.pub);
 		do_open (send1, key.pub);
 		auto send2 = do_send (key.pub);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1126,7 +1126,7 @@ TEST (rpc, account_history)
 	}
 
 	// Test filtering
-	auto account2 (system.wallet (0)->deterministic_insert ());
+	auto account2 = system.wallet (0)->deterministic_insert ().value ();
 	auto send2 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, account2, node0->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send2);
 	auto receive2 (system.wallet (0)->receive_action (send2->hash (), account2, node0->config.receive_minimum.number (), send2->destination ()));
@@ -2527,7 +2527,7 @@ TEST (rpc, account_remove)
 {
 	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
-	auto key1 (system0.wallet (0)->deterministic_insert ());
+	auto key1 = system0.wallet (0)->deterministic_insert ().value ();
 	ASSERT_TRUE (system0.wallet (0)->exists (key1));
 	auto const rpc_ctx = add_rpc (system0, node);
 	boost::property_tree::ptree request;
@@ -2865,9 +2865,9 @@ TEST (rpc, deterministic_key)
 	auto node = add_ipc_enabled_node (system0);
 	auto seed = system0.wallet (0)->get_seed ();
 	ASSERT_TRUE (seed);
-	nano::account account0 (system0.wallet (0)->deterministic_insert ());
-	nano::account account1 (system0.wallet (0)->deterministic_insert ());
-	nano::account account2 (system0.wallet (0)->deterministic_insert ());
+	auto account0 = system0.wallet (0)->deterministic_insert ().value ();
+	auto account1 = system0.wallet (0)->deterministic_insert ().value ();
+	auto account2 = system0.wallet (0)->deterministic_insert ().value ();
 	auto const rpc_ctx = add_rpc (system0, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "deterministic_key");
@@ -3214,9 +3214,9 @@ TEST (rpc, wallet_info)
 	auto send2 (system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, 1));
 	ASSERT_TIMELY (5s, node->block_confirmed (send2->hash ()));
 
-	nano::account account (system.wallet (0)->deterministic_insert ());
+	auto account = system.wallet (0)->deterministic_insert ().value ();
 	system.wallet (0)->remove_account (account);
-	account = system.wallet (0)->deterministic_insert ();
+	account = system.wallet (0)->deterministic_insert ().value ();
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_info");
@@ -5217,7 +5217,7 @@ TEST (rpc, online_reps)
 	auto weight2 (item2->second.get<std::string> ("weight"));
 	ASSERT_EQ (node2->weight (nano::dev::genesis_key.pub).convert_to<std::string> (), weight2);
 	// Test accounts filter
-	auto new_rep (system.wallet (1)->deterministic_insert ());
+	auto new_rep = system.wallet (1)->deterministic_insert ().value ();
 	auto send (system.wallet (0)->send_action (nano::dev::genesis_key.pub, new_rep, node1->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send);
 	ASSERT_TIMELY (10s, node2->block (send->hash ()));

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -4613,6 +4613,29 @@ TEST (rpc, accounts_create)
 	ASSERT_EQ (8, accounts.size ());
 }
 
+TEST (rpc, accounts_create_locked)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto const rpc_ctx = add_rpc (system, node);
+
+	// Lock the wallet
+	system.wallet (0)->rekey ("password");
+	system.wallet (0)->enter_password ("");
+	ASSERT_TRUE (system.wallet (0)->is_locked ());
+
+	boost::property_tree::ptree request;
+	request.put ("action", "accounts_create");
+	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("count", "8");
+	auto response = wait_response (system, rpc_ctx, request);
+
+	// Should return wallet_locked error
+	auto error = response.get_optional<std::string> ("error");
+	ASSERT_TRUE (error);
+	ASSERT_EQ ("Wallet is locked", error.value ());
+}
+
 TEST (rpc, block_create)
 {
 	nano::test::system system;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -3457,9 +3457,9 @@ TEST (rpc, work_get)
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
 	auto response (wait_response (system, rpc_ctx, request));
 	std::string work_text (response.get<std::string> ("work"));
-	uint64_t work (1);
-	node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub, work);
-	ASSERT_EQ (nano::to_string_hex (work), work_text);
+	auto work_result = node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub);
+	ASSERT_TRUE (work_result);
+	ASSERT_EQ (nano::to_string_hex (work_result.value ()), work_text);
 }
 
 TEST (rpc, wallet_work_get)
@@ -3478,9 +3478,9 @@ TEST (rpc, wallet_work_get)
 		std::string account_text (works.first);
 		ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), account_text);
 		std::string work_text (works.second.get<std::string> (""));
-		uint64_t work (1);
-		node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub, work);
-		ASSERT_EQ (nano::to_string_hex (work), work_text);
+		auto work_result = node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub);
+		ASSERT_TRUE (work_result);
+		ASSERT_EQ (nano::to_string_hex (work_result.value ()), work_text);
 	}
 }
 
@@ -3499,9 +3499,9 @@ TEST (rpc, work_set)
 	auto response (wait_response (system, rpc_ctx, request));
 	std::string success (response.get<std::string> ("success"));
 	ASSERT_TRUE (success.empty ());
-	uint64_t work1 (1);
-	node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub, work1);
-	ASSERT_EQ (work1, work0);
+	auto work1_result = node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub);
+	ASSERT_TRUE (work1_result);
+	ASSERT_EQ (work1_result.value (), work0);
 }
 
 TEST (rpc, search_receivable_all)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -711,6 +711,42 @@ TEST (rpc, account_move)
 	ASSERT_TRUE (source->accounts ().empty ());
 }
 
+TEST (rpc, account_move_locked)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto wallet_id (node->wallets.items.begin ()->first);
+	auto destination (system.wallet (0));
+	nano::keypair key;
+	auto source_id = nano::random_wallet_id ();
+	auto source (node->wallets.create (source_id));
+	source->insert_adhoc (key.prv);
+
+	// Lock destination wallet
+	destination->rekey ("password");
+	destination->enter_password ("");
+	ASSERT_TRUE (destination->is_locked ());
+
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "account_move");
+	request.put ("wallet", wallet_id.to_string ());
+	request.put ("source", source_id.to_string ());
+	boost::property_tree::ptree keys;
+	boost::property_tree::ptree entry;
+	entry.put ("", key.pub.to_account ());
+	keys.push_back (std::make_pair ("", entry));
+	request.add_child ("accounts", keys);
+	auto response (wait_response (system, rpc_ctx, request));
+
+	// Should return wallet_locked error
+	auto error = response.get_optional<std::string> ("error");
+	ASSERT_TRUE (error);
+	ASSERT_EQ ("Wallet is locked", error.value ());
+	// Key should not have been moved
+	ASSERT_TRUE (source->exists (key.pub));
+}
+
 TEST (rpc, block)
 {
 	nano::test::system system;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -639,9 +639,9 @@ TEST (rpc, wallet_create_seed)
 	auto existing (node->wallets.items.find (wallet_id));
 	ASSERT_NE (node->wallets.items.end (), existing);
 	{
-		nano::raw_key seed0;
-		existing->second->get_seed (seed0);
-		ASSERT_EQ (seed, seed0);
+		auto seed0 = existing->second->get_seed ();
+		ASSERT_TRUE (seed0);
+		ASSERT_EQ (seed, seed0.value ());
 	}
 	auto account_text (response.get<std::string> ("last_restored_account"));
 	nano::account account;
@@ -2564,15 +2564,15 @@ TEST (rpc, wallet_seed)
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
-	nano::raw_key seed;
-	system.wallet (0)->get_seed (seed);
+	auto seed = system.wallet (0)->get_seed ();
+	ASSERT_TRUE (seed);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_seed");
 	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
 	{
 		std::string seed_text (response.get<std::string> ("seed"));
-		ASSERT_EQ (seed.to_string (), seed_text);
+		ASSERT_EQ (seed.value ().to_string (), seed_text);
 	}
 }
 
@@ -2584,9 +2584,9 @@ TEST (rpc, wallet_change_seed)
 	nano::raw_key seed;
 	nano::random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
 	{
-		nano::raw_key seed0;
-		system0.wallet (0)->get_seed (seed0);
-		ASSERT_NE (seed, seed0);
+		auto seed0 = system0.wallet (0)->get_seed ();
+		ASSERT_TRUE (seed0);
+		ASSERT_NE (seed, seed0.value ());
 	}
 	auto prv = nano::deterministic_key (seed, 0);
 	auto pub (nano::pub_key (prv));
@@ -2596,9 +2596,9 @@ TEST (rpc, wallet_change_seed)
 	request.put ("seed", seed.to_string ());
 	auto response (wait_response (system0, rpc_ctx, request));
 	{
-		nano::raw_key seed0;
-		system0.wallet (0)->get_seed (seed0);
-		ASSERT_EQ (seed, seed0);
+		auto seed0 = system0.wallet (0)->get_seed ();
+		ASSERT_TRUE (seed0);
+		ASSERT_EQ (seed, seed0.value ());
 	}
 	auto account_text (response.get<std::string> ("last_restored_account"));
 	nano::account account;
@@ -2863,15 +2863,15 @@ TEST (rpc, deterministic_key)
 {
 	nano::test::system system0;
 	auto node = add_ipc_enabled_node (system0);
-	nano::raw_key seed;
-	system0.wallet (0)->get_seed (seed);
+	auto seed = system0.wallet (0)->get_seed ();
+	ASSERT_TRUE (seed);
 	nano::account account0 (system0.wallet (0)->deterministic_insert ());
 	nano::account account1 (system0.wallet (0)->deterministic_insert ());
 	nano::account account2 (system0.wallet (0)->deterministic_insert ());
 	auto const rpc_ctx = add_rpc (system0, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "deterministic_key");
-	request.put ("seed", seed.to_string ());
+	request.put ("seed", seed.value ().to_string ());
 	request.put ("index", "0");
 	auto response0 (wait_response (system0, rpc_ctx, request));
 	std::string validate_text (response0.get<std::string> ("account"));

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -107,8 +107,10 @@ TEST (system, receive_while_synchronizing)
 		nano::keypair key;
 		auto node1 (std::make_shared<nano::node> (system.io_ctx, system.get_available_port (), nano::unique_path (), system.work));
 		auto wallet (node1->wallets.create (1));
-		wallet->insert_adhoc (nano::dev::genesis_key.prv); // For voting
-		ASSERT_EQ (key.pub, wallet->insert_adhoc (key.prv));
+		ASSERT_TRUE (wallet->insert_adhoc (nano::dev::genesis_key.prv)); // For voting
+		auto insert_result = wallet->insert_adhoc (key.prv);
+		ASSERT_TRUE (insert_result);
+		ASSERT_EQ (key.pub, insert_result.value ());
 		node1->start ();
 		system.nodes.push_back (node1);
 		ASSERT_NE (nullptr, nano::test::establish_tcp (system, *node1, node->network.endpoint ()));

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -128,7 +128,8 @@ std::shared_ptr<nano::node> nano::test::system::add_node (nano::node_config cons
 	auto wallet = node->wallets.create (nano::random_wallet_id ());
 	if (rep)
 	{
-		wallet->insert_adhoc (rep->prv);
+		auto result = wallet->insert_adhoc (rep->prv);
+		debug_assert (result);
 	}
 	node->start ();
 
@@ -589,9 +590,10 @@ void nano::test::system::generate_send_new (nano::node & node_a, std::vector<nan
 	}
 	if (!amount.is_zero ())
 	{
-		auto pub (node_a.wallets.items.begin ()->second->deterministic_insert ());
-		accounts_a.push_back (pub);
-		auto hash (wallet (0)->send_sync (source, pub, amount));
+		auto pub_result = node_a.wallets.items.begin ()->second->deterministic_insert ();
+		debug_assert (pub_result);
+		accounts_a.push_back (pub_result.value ());
+		auto hash = wallet (0)->send_sync (source, pub_result.value (), amount);
 		(void)hash;
 		debug_assert (!hash.is_zero ());
 	}
@@ -601,7 +603,8 @@ void nano::test::system::generate_mass_activity (uint32_t count_a, nano::node & 
 {
 	std::vector<nano::account> accounts;
 	auto dev_genesis_key = nano::dev::genesis_key;
-	wallet (0)->insert_adhoc (dev_genesis_key.prv);
+	auto insert_result = wallet (0)->insert_adhoc (dev_genesis_key.prv);
+	debug_assert (insert_result);
 	accounts.push_back (dev_genesis_key.pub);
 	auto previous (std::chrono::steady_clock::now ());
 	for (uint32_t i (0); i < count_a; ++i)


### PR DESCRIPTION
Refactors key wallet functions to improve error handling and API ergonomics:                                                                         
                                                                                                                                                       
  - Refactors `wallet::insert_adhoc` and `wallet::deterministic_insert` to return `nano::result` instead of out-parameters                             
  - Refactors `wallet::get_seed` and `wallet_store::seed` to return values directly                                                                    
  - Adds stricter runtime assertions for wallet operations                                                                                                                                                                       
  - Adds tests for wallet representative detection and locked wallet scenarios