### PR TITLE
Rename dependent_blocks/dependents_confirmed to block_dependencies/dependencies_confirmed

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -634,7 +634,7 @@ TEST (active_elections, cached_vote_election_start)
 	// An election is started for send6 but does not
 	ASSERT_FALSE (node.block_confirmed_or_being_confirmed (send3->hash ()));
 	// send7 cannot be voted on but an election should be started from inactive votes
-	ASSERT_FALSE (node.ledger.dependents_confirmed (node.ledger.tx_begin_read (), *send4));
+	ASSERT_FALSE (node.ledger.dependencies_confirmed (node.ledger.tx_begin_read (), *send4));
 	node.process_active (send4);
 	ASSERT_TIMELY_EQ (5s, 7, node.ledger.cemented_count ());
 }

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -4749,14 +4749,14 @@ TEST (ledger, work_validation)
 	process_block (epoch, nano::block_details (nano::epoch::epoch_1, false, false, true));
 }
 
-TEST (ledger, dependents_confirmed)
+TEST (ledger, dependencies_confirmed)
 {
 	auto ctx = nano::test::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = ledger.tx_begin_write ();
 	nano::block_builder builder;
-	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *nano::dev::genesis));
+	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *nano::dev::genesis));
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	auto send1 = builder.state ()
@@ -4769,7 +4769,7 @@ TEST (ledger, dependents_confirmed)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send1));
-	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *send1));
+	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *send1));
 	auto send2 = builder.state ()
 				 .account (nano::dev::genesis_key.pub)
 				 .previous (send1->hash ())
@@ -4780,7 +4780,7 @@ TEST (ledger, dependents_confirmed)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
-	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *send2));
+	ASSERT_FALSE (ledger.dependencies_confirmed (transaction, *send2));
 	auto receive1 = builder.state ()
 					.account (key1.pub)
 					.previous (0)
@@ -4791,9 +4791,9 @@ TEST (ledger, dependents_confirmed)
 					.work (*pool.generate (key1.pub))
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive1));
-	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive1));
+	ASSERT_FALSE (ledger.dependencies_confirmed (transaction, *receive1));
 	ledger.confirm (transaction, send1->hash ());
-	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *receive1));
+	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *receive1));
 	auto receive2 = builder.state ()
 					.account (key1.pub)
 					.previous (receive1->hash ())
@@ -4804,14 +4804,14 @@ TEST (ledger, dependents_confirmed)
 					.work (*pool.generate (receive1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive2));
-	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive2));
+	ASSERT_FALSE (ledger.dependencies_confirmed (transaction, *receive2));
 	ledger.confirm (transaction, receive1->hash ());
-	ASSERT_FALSE (ledger.dependents_confirmed (transaction, *receive2));
+	ASSERT_FALSE (ledger.dependencies_confirmed (transaction, *receive2));
 	ledger.confirm (transaction, send2->hash ());
-	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *receive2));
+	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *receive2));
 }
 
-TEST (ledger, dependents_confirmed_pruning)
+TEST (ledger, dependencies_confirmed_pruning)
 {
 	nano::logger logger;
 	nano::stats stats{ logger };
@@ -4854,7 +4854,7 @@ TEST (ledger, dependents_confirmed_pruning)
 					.sign (key1.prv, key1.pub)
 					.work (*pool.generate (key1.pub))
 					.build ();
-	ASSERT_TRUE (ledger.dependents_confirmed (transaction, *receive1));
+	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *receive1));
 }
 
 TEST (ledger, block_confirmed)
@@ -5703,7 +5703,7 @@ TEST (ledger, cement_bounded)
 	ASSERT_EQ (confirmed1.size (), 3);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed1.begin (), confirmed1.end (), [&] (auto const & block) {
-		return ledger.dependents_confirmed (ledger.tx_begin_read (), *block);
+		return ledger.dependencies_confirmed (ledger.tx_begin_read (), *block);
 	}));
 
 	{
@@ -5715,7 +5715,7 @@ TEST (ledger, cement_bounded)
 	ASSERT_EQ (confirmed2.size (), 16);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed2.begin (), confirmed2.end (), [&] (auto const & block) {
-		return ledger.dependents_confirmed (ledger.tx_begin_read (), *block);
+		return ledger.dependencies_confirmed (ledger.tx_begin_read (), *block);
 	}));
 
 	{
@@ -5749,7 +5749,7 @@ TEST (ledger, cement_bounded_diamond)
 	ASSERT_EQ (confirmed1.size (), 3);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed1.begin (), confirmed1.end (), [&] (auto const & block) {
-		return ledger.dependents_confirmed (ledger.tx_begin_read (), *block);
+		return ledger.dependencies_confirmed (ledger.tx_begin_read (), *block);
 	}));
 
 	{
@@ -5761,7 +5761,7 @@ TEST (ledger, cement_bounded_diamond)
 	ASSERT_EQ (confirmed2.size (), 16);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed2.begin (), confirmed2.end (), [&] (auto const & block) {
-		return ledger.dependents_confirmed (ledger.tx_begin_read (), *block);
+		return ledger.dependencies_confirmed (ledger.tx_begin_read (), *block);
 	}));
 
 	{
@@ -5773,7 +5773,7 @@ TEST (ledger, cement_bounded_diamond)
 	ASSERT_EQ (confirmed3.size (), 64);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed2.begin (), confirmed2.end (), [&] (auto const & block) {
-		return ledger.dependents_confirmed (ledger.tx_begin_read (), *block);
+		return ledger.dependencies_confirmed (ledger.tx_begin_read (), *block);
 	}));
 
 	{

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3447,12 +3447,12 @@ TEST (node, deferred_dependent_elections)
 	auto election_send2 = node.active.election (send2->qualified_root ());
 	ASSERT_NE (nullptr, election_open);
 
-	// Confirm one of the dependents of the receive but not the other, to ensure both have to be confirmed to start an election on processing
+	// Confirm one of the dependencies of the receive but not the other, to ensure both have to be confirmed to start an election on processing
 	ASSERT_EQ (nano::block_status::progress, node.process (receive));
 	ASSERT_FALSE (node.active.active (receive->qualified_root ()));
 	election_open->force_confirm ();
 	ASSERT_TIMELY (5s, node.block_confirmed (open->hash ()));
-	ASSERT_FALSE (node.ledger.dependents_confirmed (node.ledger.tx_begin_read (), *receive));
+	ASSERT_FALSE (node.ledger.dependencies_confirmed (node.ledger.tx_begin_read (), *receive));
 	ASSERT_NEVER (0.5s, node.active.active (receive->qualified_root ()));
 	ASSERT_FALSE (node.ledger.rollback (node.ledger.tx_begin_write (), receive->hash ()));
 	ASSERT_FALSE (node.block (receive->hash ()));

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -422,7 +422,7 @@ TEST (request_aggregator, cannot_vote)
 	ASSERT_EQ (nano::block_status::progress, node.process (send1));
 	ASSERT_EQ (nano::block_status::progress, node.process (send2));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	ASSERT_FALSE (node.ledger.dependents_confirmed (node.ledger.tx_begin_read (), *send2));
+	ASSERT_FALSE (node.ledger.dependencies_confirmed (node.ledger.tx_begin_read (), *send2));
 
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	// Correct hash, correct root

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -497,11 +497,11 @@ enum class detail
 
 	// hinting
 	missing_block,
-	dependent_unconfirmed,
+	dependency_unconfirmed,
 	already_confirmed,
 	activate,
 	activate_immediate,
-	dependent_activated,
+	dependency_activated,
 
 	// bootstrap server
 	response,

--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -67,7 +67,7 @@ bool nano::scheduler::hinted::predicate () const
 	return active.vacancy (nano::election_behavior::hinted) > 0;
 }
 
-void nano::scheduler::hinted::activate (secure::read_transaction & transaction, nano::block_hash const & hash, bool check_dependents)
+void nano::scheduler::hinted::activate (secure::read_transaction & transaction, nano::block_hash const & hash, bool check_dependencies)
 {
 	const int max_iterations = 64;
 
@@ -94,18 +94,18 @@ void nano::scheduler::hinted::activate (secure::read_transaction & transaction, 
 				continue; // Move on to the next item in the stack
 			}
 
-			if (check_dependents)
+			if (check_dependencies)
 			{
 				// Perform a depth-first search of the dependency graph
-				if (!node.ledger.dependents_confirmed (transaction, *block))
+				if (!node.ledger.dependencies_confirmed (transaction, *block))
 				{
-					stats.inc (nano::stat::type::hinting, nano::stat::detail::dependent_unconfirmed);
-					auto dependents = node.ledger.dependent_blocks (transaction, *block);
-					for (const auto & dependent_hash : dependents)
+					stats.inc (nano::stat::type::hinting, nano::stat::detail::dependency_unconfirmed);
+					auto dependencies = node.ledger.block_dependencies (transaction, *block);
+					for (const auto & dependency_hash : dependencies)
 					{
-						if (!dependent_hash.is_zero () && visited.insert (dependent_hash).second) // Avoid visiting the same block twice
+						if (!dependency_hash.is_zero () && visited.insert (dependency_hash).second) // Avoid visiting the same block twice
 						{
-							stack.push (dependent_hash); // Add dependent block to the stack
+							stack.push (dependency_hash); // Add dependency block to the stack
 						}
 					}
 					continue; // Move on to the next item in the stack
@@ -152,12 +152,12 @@ void nano::scheduler::hinted::run_iterative ()
 			continue;
 		}
 
-		// Check dependents only if cached tally is lower than quorum
+		// Check dependencies only if cached tally is lower than quorum
 		if (entry.final_tally < minimum_final_tally)
 		{
-			// Ensure all dependent blocks are already confirmed before activating
+			// Ensure all dependency blocks are already confirmed before activating
 			stats.inc (nano::stat::type::hinting, nano::stat::detail::activate);
-			activate (transaction, entry.hash, /* activate dependents */ true);
+			activate (transaction, entry.hash, /* check dependencies */ true);
 		}
 		else
 		{

--- a/nano/node/scheduler/hinted.hpp
+++ b/nano/node/scheduler/hinted.hpp
@@ -58,7 +58,7 @@ private:
 	bool predicate () const;
 	void run ();
 	void run_iterative ();
-	void activate (secure::read_transaction &, nano::block_hash const & hash, bool check_dependents);
+	void activate (secure::read_transaction &, nano::block_hash const & hash, bool check_dependencies);
 
 	nano::uint128_t tally_threshold () const;
 	nano::uint128_t final_tally_threshold () const;

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -132,7 +132,7 @@ bool nano::scheduler::priority::activate (secure::transaction const & transactio
 		return false; // Not activated
 	}
 
-	if (ledger.dependents_confirmed (transaction, *block))
+	if (ledger.dependencies_confirmed (transaction, *block))
 	{
 		auto const [priority_balance, priority_timestamp] = ledger.block_priority (transaction, *block);
 		auto const bucket_index = bucketing.bucket_index (priority_balance);

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -54,7 +54,7 @@ bool nano::vote_generator::should_vote (transaction_variant_t const & transactio
 		auto const & transaction = std::get<nano::secure::write_transaction> (transaction_variant);
 
 		block = ledger.any.block_get (transaction, hash_a);
-		should_vote = block != nullptr && ledger.dependents_confirmed (transaction, *block) && ledger.store.final_vote.put (transaction, block->qualified_root (), hash_a);
+		should_vote = block != nullptr && ledger.dependencies_confirmed (transaction, *block) && ledger.store.final_vote.put (transaction, block->qualified_root (), hash_a);
 		debug_assert (block == nullptr || root_a == block->root ());
 	}
 	else
@@ -63,7 +63,7 @@ bool nano::vote_generator::should_vote (transaction_variant_t const & transactio
 		auto const & transaction = std::get<nano::secure::read_transaction> (transaction_variant);
 
 		block = ledger.any.block_get (transaction, hash_a);
-		should_vote = block != nullptr && ledger.dependents_confirmed (transaction, *block);
+		should_vote = block != nullptr && ledger.dependencies_confirmed (transaction, *block);
 	}
 
 	logger.trace (log_type (), nano::log::detail::should_vote,
@@ -154,13 +154,13 @@ std::size_t nano::vote_generator::generate (std::vector<std::shared_ptr<nano::bl
 	request_t::first_type req_candidates;
 	{
 		auto transaction = ledger.tx_begin_read ();
-		auto dependents_confirmed = [&transaction, this] (auto const & block_a) {
-			return this->ledger.dependents_confirmed (transaction, *block_a);
+		auto dependencies_confirmed = [&transaction, this] (auto const & block_a) {
+			return this->ledger.dependencies_confirmed (transaction, *block_a);
 		};
 		auto as_candidate = [] (auto const & block_a) {
 			return candidate_t{ block_a->root (), block_a->hash () };
 		};
-		nano::transform_if (blocks_a.begin (), blocks_a.end (), std::back_inserter (req_candidates), dependents_confirmed, as_candidate);
+		nano::transform_if (blocks_a.begin (), blocks_a.end (), std::back_inserter (req_candidates), dependencies_confirmed, as_candidate);
 	}
 	auto const result = req_candidates.size ();
 	nano::lock_guard<nano::mutex> guard{ mutex };

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -297,14 +297,14 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_tr
 		auto block = any.block_get (transaction, hash);
 		release_assert (block);
 
-		auto dependents = dependent_blocks (transaction, *block);
-		for (auto const & dependent : dependents)
+		auto dependencies = block_dependencies (transaction, *block);
+		for (auto const & dependency : dependencies)
 		{
-			if (!dependent.is_zero () && !confirmed.block_exists_or_pruned (transaction, dependent))
+			if (!dependency.is_zero () && !confirmed.block_exists_or_pruned (transaction, dependency))
 			{
-				stats.inc (nano::stat::type::confirmation_height, nano::stat::detail::dependent_unconfirmed);
+				stats.inc (nano::stat::type::confirmation_height, nano::stat::detail::dependency_unconfirmed);
 
-				stack.push_back (dependent);
+				stack.push_back (dependency);
 
 				// Limit the stack size to avoid excessive memory usage
 				// This will forget the bottom of the dependency tree
@@ -321,7 +321,7 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_tr
 			if (!confirmed.block_exists_or_pruned (transaction, hash))
 			{
 				// We must only confirm blocks that have their dependencies confirmed
-				debug_assert (dependents_confirmed (transaction, *block));
+				debug_assert (dependencies_confirmed (transaction, *block));
 				confirm_one (transaction, *block);
 				result.push_back (block);
 			}
@@ -573,9 +573,9 @@ nano::root nano::ledger::latest_root (secure::transaction const & transaction_a,
 	}
 }
 
-bool nano::ledger::dependents_confirmed (secure::transaction const & transaction_a, nano::block const & block_a) const
+bool nano::ledger::dependencies_confirmed (secure::transaction const & transaction_a, nano::block const & block_a) const
 {
-	auto dependencies (dependent_blocks (transaction_a, block_a));
+	auto dependencies (block_dependencies (transaction_a, block_a));
 	return std::all_of (dependencies.begin (), dependencies.end (), [this, &transaction_a] (nano::block_hash const & hash_a) {
 		auto result (hash_a.is_zero ());
 		if (!result)
@@ -593,12 +593,12 @@ bool nano::ledger::is_epoch_link (nano::link const & link_a) const
 
 namespace
 {
-class dependent_block_visitor final : public nano::block_visitor
+class dependency_block_visitor final : public nano::block_visitor
 {
 public:
-	dependent_block_visitor (nano::secure::transaction const & transaction, nano::ledger const & ledger) :
-		transaction{ transaction },
-		ledger{ ledger }
+	dependency_block_visitor (nano::secure::transaction const & transaction, nano::ledger const & ledger) :
+		ledger{ ledger },
+		transaction{ transaction }
 	{
 	}
 
@@ -655,9 +655,9 @@ public:
 };
 }
 
-std::array<nano::block_hash, 2> nano::ledger::dependent_blocks (secure::transaction const & transaction, nano::block const & block) const
+std::array<nano::block_hash, 2> nano::ledger::block_dependencies (secure::transaction const & transaction, nano::block const & block) const
 {
-	dependent_block_visitor visitor{ transaction, *this };
+	dependency_block_visitor visitor{ transaction, *this };
 	block.visit (visitor);
 	return visitor.result;
 }
@@ -797,6 +797,9 @@ uint64_t nano::ledger::pruning_action (secure::write_transaction & transaction_a
 	return pruned_count;
 }
 
+// Balance uses the maximum of current and previous block balance to avoid deprioritizing full sends
+// Timestamp uses the previous block's timestamp for least-recently-used ordering within a bucket,
+// falling back to the current block's sideband timestamp when there is no previous block (e.g. open blocks)
 auto nano::ledger::block_priority (nano::secure::transaction const & transaction, nano::block const & block) const -> block_priority_result
 {
 	auto const balance = block.balance ();

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -71,9 +71,7 @@ public:
 	bool rollback (secure::write_transaction const &, nano::block_hash const &);
 	void update_account (secure::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);
 	uint64_t pruning_action (secure::write_transaction &, nano::block_hash const &, uint64_t const);
-	bool dependents_confirmed (secure::transaction const &, nano::block const &) const;
 	bool is_epoch_link (nano::link const &) const;
-	std::array<nano::block_hash, 2> dependent_blocks (secure::transaction const &, nano::block const &) const;
 	std::shared_ptr<nano::block> find_receive_block_by_send_hash (secure::transaction const &, nano::account const & destination, nano::block_hash const & send_block_hash);
 	std::optional<nano::account> linked_account (secure::transaction const &, nano::block const &);
 	nano::account const & epoch_signer (nano::link const &) const;
@@ -84,17 +82,29 @@ public:
 	static nano::epoch version (nano::block const & block);
 	nano::epoch version (secure::transaction const &, nano::block_hash const & hash) const;
 
+	/**
+	 * Returns the blocks that this block depends on (previous block and/or source/link block)
+	 * Up to 2 dependency hashes, unused slots are zero
+	 */
+	std::array<nano::block_hash, 2> block_dependencies (secure::transaction const &, nano::block const &) const;
+
+	/**
+	 * Checks if all blocks that this block depends on are confirmed (or pruned)
+	 */
+	bool dependencies_confirmed (secure::transaction const &, nano::block const &) const;
+
+	/**
+	 * Computes the priority balance and timestamp for bucket-based prioritization
+	 */
+	using block_priority_result = std::pair<nano::amount, nano::priority_timestamp>;
+	block_priority_result block_priority (secure::transaction const &, nano::block const &) const;
+
 	uint64_t cemented_count () const;
 	uint64_t block_count () const;
 	uint64_t account_count () const;
 	uint64_t pruned_count () const;
 	uint64_t backlog_size () const;
 	uint64_t max_backlog () const;
-
-	// Returned priority balance is maximum of block balance and previous block balance to handle full account balance send cases
-	// Returned timestamp is the previous block timestamp or the current timestamp if there's no previous block
-	using block_priority_result = std::pair<nano::amount, nano::priority_timestamp>;
-	block_priority_result block_priority (secure::transaction const &, nano::block const &) const;
 
 	void verify_consistency (secure::transaction const &) const;
 


### PR DESCRIPTION
Both functions use "dependent" when they should use "dependency".