### PR TITLE
Optimize `ledger::confirm (...)` database operations

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -4,10 +4,10 @@ add_executable(
   fakes/websocket_client.hpp
   fakes/work_peer.hpp
   active_elections.cpp
-  backend.cpp
   active_elections_index.cpp
   assert.cpp
   async.cpp
+  backend.cpp
   backlog.cpp
   block.cpp
   block_store.cpp
@@ -16,6 +16,7 @@ add_executable(
   bootstrap.cpp
   bootstrap_frontier_scan.cpp
   bootstrap_server.cpp
+  bounded_dfs.cpp
   bucketing.cpp
   cli.cpp
   confirmation_solicitor.cpp

--- a/nano/core_test/bounded_dfs.cpp
+++ b/nano/core_test/bounded_dfs.cpp
@@ -1,0 +1,520 @@
+#include <nano/lib/bounded_dfs.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <map>
+#include <set>
+#include <vector>
+
+namespace
+{
+// Simple graph representation for testing: node -> list of dependencies
+using graph_t = std::map<int, std::vector<int>>;
+
+// Helper that runs bounded_dfs on an int graph, tracking resolve order
+nano::bounded_dfs_result run_dfs (graph_t const & graph, int start, size_t max_depth, std::vector<int> & resolve_order)
+{
+	std::set<int> resolved;
+	return nano::bounded_dfs (
+	start, max_depth,
+	[&] (int const & node) {
+		return resolved.contains (node);
+	},
+	[&] (int const & node) -> std::vector<int> {
+		auto it = graph.find (node);
+		if (it != graph.end ())
+		{
+			return it->second;
+		}
+		return {};
+	},
+	[&] (int const & node) {
+		resolved.insert (node);
+		resolve_order.push_back (node);
+		return true;
+	});
+}
+}
+
+TEST (bounded_dfs, single_node_no_deps)
+{
+	graph_t graph = { { 1, {} } };
+	std::vector<int> order;
+	auto result = run_dfs (graph, 1, 100, order);
+	ASSERT_EQ (result.resolved, 1);
+	ASSERT_FALSE (result.overflow);
+	ASSERT_EQ (order, std::vector<int> ({ 1 }));
+}
+
+TEST (bounded_dfs, linear_chain)
+{
+	// 4 -> 3 -> 2 -> 1 (each depends on the next)
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+		{ 3, { 2 } },
+		{ 4, { 3 } },
+	};
+	std::vector<int> order;
+	auto result = run_dfs (graph, 4, 100, order);
+	ASSERT_EQ (result.resolved, 4);
+	ASSERT_FALSE (result.overflow);
+	// Must resolve in dependency order: 1, 2, 3, 4
+	ASSERT_EQ (order, std::vector<int> ({ 1, 2, 3, 4 }));
+}
+
+TEST (bounded_dfs, diamond)
+{
+	//     4
+	//    / \
+	//   2   3
+	//    \ /
+	//     1
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+		{ 3, { 1 } },
+		{ 4, { 2, 3 } },
+	};
+	std::vector<int> order;
+	auto result = run_dfs (graph, 4, 100, order);
+	ASSERT_EQ (result.resolved, 4);
+	ASSERT_FALSE (result.overflow);
+	// 1 must be first, 4 must be last
+	ASSERT_EQ (order.front (), 1);
+	ASSERT_EQ (order.back (), 4);
+	// 2 and 3 must come after 1 and before 4
+	auto pos = [&] (int v) { return std::find (order.begin (), order.end (), v) - order.begin (); };
+	ASSERT_GT (pos (2), pos (1));
+	ASSERT_GT (pos (3), pos (1));
+	ASSERT_LT (pos (2), pos (4));
+	ASSERT_LT (pos (3), pos (4));
+}
+
+TEST (bounded_dfs, already_resolved)
+{
+	graph_t graph = { { 1, {} } };
+	std::set<int> pre_resolved = { 1 };
+	std::vector<int> order;
+	auto result = nano::bounded_dfs (
+	1, 100,
+	[&] (int const & node) { return pre_resolved.contains (node); },
+	[&] (int const & node) -> std::vector<int> { return graph.at (node); },
+	[&] (int const & node) { order.push_back (node); return true; });
+	ASSERT_EQ (result.resolved, 0);
+	ASSERT_FALSE (result.overflow);
+	ASSERT_TRUE (order.empty ());
+}
+
+TEST (bounded_dfs, partially_resolved)
+{
+	// 3 -> 2 -> 1, but 1 and 2 are already resolved
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+		{ 3, { 2 } },
+	};
+	std::set<int> pre_resolved = { 1, 2 };
+	std::vector<int> order;
+	auto result = nano::bounded_dfs (
+	3, 100,
+	[&] (int const & node) { return pre_resolved.contains (node); },
+	[&] (int const & node) -> std::vector<int> { return graph.at (node); },
+	[&] (int const & node) {
+		pre_resolved.insert (node);
+		order.push_back (node);
+		return true;
+	});
+	ASSERT_EQ (result.resolved, 1);
+	ASSERT_FALSE (result.overflow);
+	ASSERT_EQ (order, std::vector<int> ({ 3 }));
+}
+
+TEST (bounded_dfs, overflow_deep_chain)
+{
+	// Chain: 5 -> 4 -> 3 -> 2 -> 1, max_depth = 3
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+		{ 3, { 2 } },
+		{ 4, { 3 } },
+		{ 5, { 4 } },
+	};
+	std::vector<int> order;
+	auto result = run_dfs (graph, 5, 3, order);
+	ASSERT_TRUE (result.overflow);
+	// Some progress should have been made (resolved nodes at bottom of chain)
+	ASSERT_EQ (result.resolved, 3);
+	ASSERT_EQ (order, std::vector<int> ({ 1, 2, 3 }));
+}
+
+TEST (bounded_dfs, overflow_multi_pass)
+{
+	// Chain: 5 -> 4 -> 3 -> 2 -> 1, max_depth = 3
+	// Run multiple passes until fully resolved
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+		{ 3, { 2 } },
+		{ 4, { 3 } },
+		{ 5, { 4 } },
+	};
+	std::set<int> resolved;
+	std::vector<int> order;
+	size_t total_resolved = 0;
+	int passes = 0;
+	while (true)
+	{
+		auto result = nano::bounded_dfs (
+		5, 3,
+		[&] (int const & node) { return resolved.contains (node); },
+		[&] (int const & node) -> std::vector<int> { return graph.at (node); },
+		[&] (int const & node) {
+			resolved.insert (node);
+			order.push_back (node);
+			return true;
+		});
+		total_resolved += result.resolved;
+		++passes;
+		if (!result.overflow)
+		{
+			break;
+		}
+		// Safety: prevent infinite loop in test
+		ASSERT_LT (passes, 10);
+	}
+	ASSERT_EQ (total_resolved, 5);
+	ASSERT_EQ (order, std::vector<int> ({ 1, 2, 3, 4, 5 }));
+	ASSERT_EQ (passes, 2);
+}
+
+TEST (bounded_dfs, wide_fan_out)
+{
+	// Node 10 depends on 1..5, each with no deps
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, {} },
+		{ 3, {} },
+		{ 4, {} },
+		{ 5, {} },
+		{ 10, { 1, 2, 3, 4, 5 } },
+	};
+	std::vector<int> order;
+	auto result = run_dfs (graph, 10, 100, order);
+	ASSERT_EQ (result.resolved, 6);
+	ASSERT_FALSE (result.overflow);
+	// 10 must be last
+	ASSERT_EQ (order.back (), 10);
+	// All deps must come before 10
+	for (int i = 1; i <= 5; ++i)
+	{
+		ASSERT_NE (std::find (order.begin (), order.end (), i), order.end ());
+	}
+}
+
+TEST (bounded_dfs, zero_deps_skipped)
+{
+	// Use 0 as "null" dependency that is_resolved returns true for
+	graph_t graph = {
+		{ 1, { 0, 0 } }, // both deps are zero/null
+	};
+	std::vector<int> order;
+	auto result = nano::bounded_dfs (
+	1, 100,
+	[&] (int const & node) { return node == 0; },
+	[&] (int const & node) -> std::vector<int> { return graph.at (node); },
+	[&] (int const & node) { order.push_back (node); return true; });
+	ASSERT_EQ (result.resolved, 1);
+	ASSERT_FALSE (result.overflow);
+	ASSERT_EQ (order, std::vector<int> ({ 1 }));
+}
+
+TEST (bounded_dfs, max_depth_one)
+{
+	// With max_depth=1, drops start to push dep, resolves only the leaf
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+	};
+	std::vector<int> order;
+	auto result = run_dfs (graph, 2, 1, order);
+	ASSERT_TRUE (result.overflow);
+	ASSERT_EQ (result.resolved, 1);
+	ASSERT_EQ (order, std::vector<int> ({ 1 }));
+}
+
+TEST (bounded_dfs, complex_dag)
+{
+	//       7
+	//      / \
+	//     5   6
+	//    / \ / \
+	//   2   3   4
+	//    \ /
+	//     1
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+		{ 3, { 1 } },
+		{ 4, {} },
+		{ 5, { 2, 3 } },
+		{ 6, { 3, 4 } },
+		{ 7, { 5, 6 } },
+	};
+	std::vector<int> order;
+	auto result = run_dfs (graph, 7, 100, order);
+	ASSERT_EQ (result.resolved, 7);
+	ASSERT_FALSE (result.overflow);
+	// Verify topological ordering: every node appears after all its deps
+	auto pos = [&] (int v) { return std::find (order.begin (), order.end (), v) - order.begin (); };
+	for (auto const & [node, deps] : graph)
+	{
+		for (auto dep : deps)
+		{
+			ASSERT_LT (pos (dep), pos (node)) << "node " << node << " should appear after dep " << dep;
+		}
+	}
+}
+
+TEST (bounded_dfs, array_deps)
+{
+	// Test with std::array return type (like nano::block::dependencies())
+	std::set<int> resolved;
+	std::vector<int> order;
+	auto result = nano::bounded_dfs (
+	3, 100,
+	[&] (int const & node) { return node == 0 || resolved.contains (node); },
+	[&] (int const & node) -> std::array<int, 2> {
+		switch (node)
+		{
+			case 1:
+				return { 0, 0 }; // no deps
+			case 2:
+				return { 1, 0 }; // depends on 1
+			case 3:
+				return { 2, 1 }; // depends on 2 and 1
+			default:
+				return { 0, 0 };
+		}
+	},
+	[&] (int const & node) {
+		resolved.insert (node);
+		order.push_back (node);
+		return true;
+	});
+	ASSERT_EQ (result.resolved, 3);
+	ASSERT_FALSE (result.overflow);
+	ASSERT_EQ (order, std::vector<int> ({ 1, 2, 3 }));
+}
+
+TEST (bounded_dfs, no_duplicate_resolves)
+{
+	// Shared dependency resolved only once despite multiple parents
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+		{ 3, { 1 } },
+		{ 4, { 2, 3 } },
+	};
+	std::vector<int> order;
+	auto result = run_dfs (graph, 4, 100, order);
+	// Node 1 appears exactly once despite being dep of both 2 and 3
+	ASSERT_EQ (std::count (order.begin (), order.end (), 1), 1);
+	ASSERT_EQ (result.resolved, 4);
+}
+
+TEST (bounded_dfs, early_return)
+{
+	// Chain: 4 -> 3 -> 2 -> 1, resolve returns false after 2 nodes
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+		{ 3, { 2 } },
+		{ 4, { 3 } },
+	};
+	std::set<int> resolved;
+	std::vector<int> order;
+	auto result = nano::bounded_dfs (
+	4, 100,
+	[&] (int const & node) { return resolved.contains (node); },
+	[&] (int const & node) -> std::vector<int> { return graph.at (node); },
+	[&] (int const & node) {
+		resolved.insert (node);
+		order.push_back (node);
+		return order.size () < 2; // Stop after resolving 2 nodes
+	});
+	ASSERT_EQ (result.resolved, 2);
+	ASSERT_TRUE (result.overflow); // Early return signals overflow so caller knows to retry
+	ASSERT_EQ (order, std::vector<int> ({ 1, 2 }));
+}
+
+TEST (bounded_dfs, early_return_multi_pass)
+{
+	// Chain: 6 -> 5 -> 4 -> 3 -> 2 -> 1, resolve returns false after 2 nodes per pass
+	// Verify that early return overflow enables multi-pass completion
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+		{ 3, { 2 } },
+		{ 4, { 3 } },
+		{ 5, { 4 } },
+		{ 6, { 5 } },
+	};
+	std::set<int> resolved;
+	std::vector<int> order;
+	size_t total_resolved = 0;
+	int passes = 0;
+	while (true)
+	{
+		size_t pass_start = order.size ();
+		auto result = nano::bounded_dfs (
+		6, 100,
+		[&] (int const & node) { return resolved.contains (node); },
+		[&] (int const & node) -> std::vector<int> { return graph.at (node); },
+		[&] (int const & node) {
+			resolved.insert (node);
+			order.push_back (node);
+			return (order.size () - pass_start) < 2; // Max 2 resolves per pass
+		});
+		total_resolved += result.resolved;
+		++passes;
+		if (!result.overflow)
+		{
+			break;
+		}
+		ASSERT_LT (passes, 10);
+	}
+	ASSERT_EQ (total_resolved, 6);
+	ASSERT_EQ (order, std::vector<int> ({ 1, 2, 3, 4, 5, 6 }));
+	// 3 productive passes (2 resolves each) + 1 final pass that finds everything resolved
+	ASSERT_EQ (passes, 4);
+}
+
+TEST (bounded_dfs, push_all_deps)
+{
+	// Verify all unresolved deps are pushed at once (LIFO: last dep processed first)
+	//   3
+	//  / \
+	// 1   2  (deps listed as {1, 2})
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, {} },
+		{ 3, { 1, 2 } },
+	};
+	std::vector<int> order;
+	auto result = run_dfs (graph, 3, 100, order);
+	ASSERT_EQ (result.resolved, 3);
+	ASSERT_FALSE (result.overflow);
+	// Push-all with LIFO means 2 (pushed last) is processed first
+	ASSERT_EQ (order, std::vector<int> ({ 2, 1, 3 }));
+}
+
+TEST (bounded_dfs, shared_dep_not_loaded_twice)
+{
+	// Diamond DAG where shared dep is pushed by both parents (push-all)
+	// Verify get_dependencies is only called once for the shared dep
+	//     4
+	//    / \
+	//   2   3
+	//    \ /
+	//     1
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+		{ 3, { 1 } },
+		{ 4, { 2, 3 } },
+	};
+	std::set<int> resolved;
+	std::map<int, int> dep_call_count;
+	std::vector<int> order;
+	nano::bounded_dfs (
+	4, 100,
+	[&] (int const & node) { return resolved.contains (node); },
+	[&] (int const & node) -> std::vector<int> {
+		dep_call_count[node]++;
+		return graph.at (node);
+	},
+	[&] (int const & node) {
+		resolved.insert (node);
+		order.push_back (node);
+		return true;
+	});
+	// With LIFO, node 3 is processed first and resolves node 1.
+	// When node 2 is visited, node 1 is already resolved and not pushed again.
+	ASSERT_EQ (dep_call_count[1], 1);
+	ASSERT_EQ (std::count (order.begin (), order.end (), 1), 1);
+}
+
+TEST (bounded_dfs, already_resolved_no_resolve)
+{
+	// Start node already resolved: get_dependencies is called but resolve is not
+	graph_t graph = { { 1, { 2 } }, { 2, {} } };
+	std::set<int> pre_resolved = { 1, 2 };
+	int dep_calls = 0;
+	int resolve_calls = 0;
+	auto result = nano::bounded_dfs (
+	1, 100,
+	[&] (int const & node) { return pre_resolved.contains (node); },
+	[&] (int const & node) -> std::vector<int> {
+		dep_calls++;
+		return graph.at (node);
+	},
+	[&] (int const & node) {
+		resolve_calls++;
+		return true;
+	});
+	ASSERT_EQ (result.resolved, 0);
+	ASSERT_FALSE (result.overflow);
+	ASSERT_EQ (dep_calls, 1); // Deps loaded for start node
+	ASSERT_EQ (resolve_calls, 0); // But resolve never called
+}
+
+TEST (bounded_dfs, callback_counts)
+{
+	// Complex DAG that exercises push-all, shared deps, and dep rescanning
+	// Exact callback counts serve as a regression guard for algorithm efficiency
+	//       7
+	//      / \
+	//     5   6
+	//    / \ / \
+	//   2   3   4
+	//    \ /
+	//     1
+	graph_t graph = {
+		{ 1, {} },
+		{ 2, { 1 } },
+		{ 3, { 1 } },
+		{ 4, {} },
+		{ 5, { 2, 3 } },
+		{ 6, { 3, 4 } },
+		{ 7, { 5, 6 } },
+	};
+	std::set<int> resolved;
+	int is_resolved_calls = 0;
+	int get_deps_calls = 0;
+	int resolve_calls = 0;
+	std::vector<int> order;
+	auto result = nano::bounded_dfs (
+	7, 100,
+	[&] (int const & node) {
+		++is_resolved_calls;
+		return resolved.contains (node);
+	},
+	[&] (int const & node) -> std::vector<int> {
+		++get_deps_calls;
+		return graph.at (node);
+	},
+	[&] (int const & node) {
+		++resolve_calls;
+		resolved.insert (node);
+		order.push_back (node);
+		return true;
+	});
+	ASSERT_EQ (result.resolved, 7);
+	ASSERT_FALSE (result.overflow);
+	ASSERT_EQ (get_deps_calls, 7); // Once per node
+	ASSERT_EQ (resolve_calls, 7); // Once per node
+	ASSERT_EQ (is_resolved_calls, 22);
+}

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
   blockbuilders.cpp
   blocks.hpp
   blocks.cpp
+  bounded_dfs.hpp
   char_traits.hpp
   cli.hpp
   cli.cpp

--- a/nano/lib/bounded_dfs.hpp
+++ b/nano/lib/bounded_dfs.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <cstddef>
+#include <deque>
+#include <type_traits>
+
+namespace nano
+{
+struct bounded_dfs_result
+{
+	size_t resolved{ 0 }; // Number of nodes newly resolved in this call
+	bool overflow{ false }; // True if stack exceeded max_depth (partial progress, needs more passes)
+};
+
+/**
+ * Bounded iterative DFS that resolves a node and all its transitive dependencies
+ *
+ * Starting from `start`, walks dependencies depth-first. For each node:
+ *   1. Call get_dependencies(node) to obtain the node's deps (called once per stack entry)
+ *   2. Push all unresolved dependencies and go deeper
+ *   3. When all deps are resolved, call resolve(node) to process the node
+ *
+ * Returns a result with the count of resolved nodes and whether the stack overflowed.
+ * On overflow, partial progress is preserved -- the caller's outer loop picks up remaining work.
+ *
+ * Precondition: The dependency graph must be acyclic
+ *
+ * Callbacks:
+ *   is_resolved(Node const &) -> bool
+ *   get_dependencies(Node const &) -> iterable of Node
+ *   resolve(Node const &) -> bool (return true to continue, false to stop early)
+ */
+template <typename Node, typename IsResolved, typename GetDeps, typename Resolve>
+bounded_dfs_result bounded_dfs (
+Node const & start,
+size_t max_depth,
+IsResolved && is_resolved,
+GetDeps && get_dependencies,
+Resolve && resolve)
+{
+	using deps_type = std::decay_t<decltype (get_dependencies (start))>;
+
+	struct entry
+	{
+		Node node;
+		deps_type deps{};
+		bool loaded{ false };
+	};
+
+	bounded_dfs_result result{};
+
+	std::deque<entry> stack;
+	stack.push_back ({ start });
+
+	while (!stack.empty ())
+	{
+		auto current = stack.back ();
+
+		if (!current.loaded)
+		{
+			current.loaded = true;
+			current.deps = get_dependencies (current.node);
+			stack.back () = current; // Persist loaded state back to stack
+		}
+
+		// Push all unresolved dependencies
+		bool pushed = false;
+		for (auto const & dep : current.deps)
+		{
+			if (!is_resolved (dep))
+			{
+				if (stack.size () >= max_depth)
+				{
+					result.overflow = true;
+					stack.pop_front ();
+				}
+				stack.push_back ({ dep });
+				pushed = true;
+			}
+		}
+
+		if (!pushed)
+		{
+			// All dependencies resolved, process the current node
+			if (!is_resolved (current.node))
+			{
+				bool keep_going = resolve (current.node);
+				++result.resolved;
+				if (!keep_going)
+				{
+					// Early return requested (needs more passes to finish)
+					result.overflow = true;
+					stack.pop_back ();
+					break;
+				}
+			}
+			stack.pop_back ();
+		}
+	}
+
+	return result;
+}
+}

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -654,6 +654,7 @@ enum class detail
 	notify_intermediate,
 	already_cemented,
 	cementing,
+	cementing_overflow,
 	cemented_hash,
 	cementing_failed,
 	deferred_failed,

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -290,20 +290,42 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_tr
 {
 	std::deque<std::shared_ptr<nano::block>> result;
 
-	auto is_resolved = [&] (nano::block_hash const & hash) {
-		return hash.is_zero () || confirmed.block_exists_or_pruned (transaction, hash);
+	auto start_block = any.block_get (transaction, target_hash);
+	release_assert (start_block, "attempting to cement a non-existent block", target_hash.to_string ());
+
+	auto is_resolved = [&] (std::shared_ptr<nano::block> const & block) {
+		if (block)
+		{
+			return confirmed.block_exists (transaction, *block);
+		}
+		return true; // Pruned, must have been cemented
 	};
 
-	auto get_dependencies = [&] (nano::block_hash const & hash) {
-		auto block = any.block_get (transaction, hash);
-		release_assert (block);
-		return block->dependencies ();
+	auto get_dependencies = [&] (std::shared_ptr<nano::block> const & block) {
+		auto dep_hashes = block->dependencies ();
+		std::array<std::shared_ptr<nano::block>, dep_hashes.size ()> deps{};
+		for (size_t i = 0; i < dep_hashes.size (); ++i)
+		{
+			auto const & dep_hash = dep_hashes[i];
+			if (!dep_hash.is_zero ())
+			{
+				auto dep_block = any.block_get (transaction, dep_hash);
+				if (dep_block)
+				{
+					deps[i] = dep_block;
+				}
+				else
+				{
+					// If the block doesn't exist, it must be pruned
+					debug_assert (any.block_pruned (transaction, dep_hash), "missing dependency block", dep_hash.to_string ());
+				}
+				// nullptr will be filtered by is_resolved
+			}
+		}
+		return deps;
 	};
 
-	auto resolve = [&] (nano::block_hash const & hash) -> bool {
-		auto block = any.block_get (transaction, hash);
-		release_assert (block);
-
+	auto resolve = [&] (std::shared_ptr<nano::block> const & block) -> bool {
 		// We must only confirm blocks that have their dependencies confirmed
 		debug_assert (dependencies_confirmed (transaction, *block));
 		confirm_one (transaction, *block);
@@ -325,7 +347,12 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_tr
 		return result.size () < max_blocks;
 	};
 
-	nano::bounded_dfs (target_hash, max_blocks, is_resolved, get_dependencies, resolve);
+	// Walk the dependency tree depth-first, cementing blocks bottom-up, newly cemented blocks are collected in result
+	auto dfs_result = nano::bounded_dfs (start_block, max_blocks, is_resolved, get_dependencies, resolve);
+	debug_assert (dfs_result.resolved == result.size ());
+
+	stats.inc (nano::stat::type::ledger, dfs_result.overflow ? nano::stat::detail::cementing_overflow : nano::stat::detail::cementing);
+	stats.inc (nano::stat::type::ledger, nano::stat::detail::cemented, dfs_result.resolved);
 
 	return result;
 }

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -1,6 +1,7 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/block_type.hpp>
 #include <nano/lib/blocks.hpp>
+#include <nano/lib/bounded_dfs.hpp>
 #include <nano/lib/files.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/numbers.hpp>
@@ -289,47 +290,25 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_tr
 {
 	std::deque<std::shared_ptr<nano::block>> result;
 
-	std::deque<nano::block_hash> stack;
-	stack.push_back (target_hash);
-	while (!stack.empty ())
-	{
-		auto hash = stack.back ();
+	auto is_resolved = [&] (nano::block_hash const & hash) {
+		return hash.is_zero () || confirmed.block_exists_or_pruned (transaction, hash);
+	};
+
+	auto get_dependencies = [&] (nano::block_hash const & hash) {
+		auto block = any.block_get (transaction, hash);
+		release_assert (block);
+		return block->dependencies ();
+	};
+
+	auto resolve = [&] (nano::block_hash const & hash) -> bool {
 		auto block = any.block_get (transaction, hash);
 		release_assert (block);
 
-		auto dependencies = block->dependencies ();
-		for (auto const & dependency : dependencies)
-		{
-			if (!dependency.is_zero () && !confirmed.block_exists_or_pruned (transaction, dependency))
-			{
-				stats.inc (nano::stat::type::confirmation_height, nano::stat::detail::dependency_unconfirmed);
+		// We must only confirm blocks that have their dependencies confirmed
+		debug_assert (dependencies_confirmed (transaction, *block));
+		confirm_one (transaction, *block);
 
-				stack.push_back (dependency);
-
-				// Limit the stack size to avoid excessive memory usage
-				// This will forget the bottom of the dependency tree
-				if (stack.size () > max_blocks)
-				{
-					stack.pop_front ();
-				}
-			}
-		}
-
-		if (stack.back () == hash)
-		{
-			stack.pop_back ();
-			if (!confirmed.block_exists_or_pruned (transaction, hash))
-			{
-				// We must only confirm blocks that have their dependencies confirmed
-				debug_assert (dependencies_confirmed (transaction, *block));
-				confirm_one (transaction, *block);
-				result.push_back (block);
-			}
-		}
-		else
-		{
-			// Unconfirmed dependencies were added
-		}
+		result.push_back (block);
 
 		// Refresh the transaction to avoid long-running transactions
 		// Ensure that the block wasn't rolled back during the refresh
@@ -338,16 +317,15 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_tr
 		{
 			if (!any.block_exists (transaction, target_hash))
 			{
-				break; // Block was rolled back during cementing
+				return false; // Block was rolled back during cementing
 			}
 		}
 
 		// Early return might leave parts of the dependency tree unconfirmed
-		if (result.size () >= max_blocks)
-		{
-			break;
-		}
-	}
+		return result.size () < max_blocks;
+	};
+
+	nano::bounded_dfs (target_hash, max_blocks, is_resolved, get_dependencies, resolve);
 
 	return result;
 }

--- a/nano/secure/ledger_set_any.cpp
+++ b/nano/secure/ledger_set_any.cpp
@@ -159,6 +159,11 @@ std::shared_ptr<nano::block> nano::ledger_set_any::block_get (secure::transactio
 	return ledger.store.block.get (transaction, hash);
 }
 
+bool nano::ledger_set_any::block_pruned (secure::transaction const & transaction, nano::block_hash const & hash) const
+{
+	return ledger.store.pruned.exists (transaction, hash);
+}
+
 uint64_t nano::ledger_set_any::block_height (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	auto block = block_get (transaction, hash);

--- a/nano/secure/ledger_set_any.hpp
+++ b/nano/secure/ledger_set_any.hpp
@@ -54,6 +54,7 @@ public: // Operations on blocks
 	bool block_exists (secure::transaction const & transaction, nano::block_hash const & hash) const;
 	bool block_exists_or_pruned (secure::transaction const & transaction, nano::block_hash const & hash) const;
 	std::shared_ptr<nano::block> block_get (secure::transaction const & transaction, nano::block_hash const & hash) const;
+	bool block_pruned (secure::transaction const & transaction, nano::block_hash const & hash) const;
 	uint64_t block_height (secure::transaction const & transaction, nano::block_hash const & hash) const;
 	std::optional<nano::block_hash> block_successor (secure::transaction const & transaction, nano::block_hash const & hash) const;
 	std::optional<nano::block_hash> block_successor (secure::transaction const & transaction, nano::qualified_root const & root) const;

--- a/nano/secure/ledger_set_confirmed.cpp
+++ b/nano/secure/ledger_set_confirmed.cpp
@@ -60,6 +60,16 @@ bool nano::ledger_set_confirmed::block_exists (secure::transaction const & trans
 	return block_get (transaction, hash) != nullptr;
 }
 
+bool nano::ledger_set_confirmed::block_exists (secure::transaction const & transaction, nano::block const & block) const
+{
+	auto info = ledger.store.confirmation_height.get (transaction, block.account ());
+	if (!info)
+	{
+		return false;
+	}
+	return block.sideband ().height <= info.value ().height;
+}
+
 bool nano::ledger_set_confirmed::block_exists_or_pruned (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	if (hash.is_zero ())

--- a/nano/secure/ledger_set_confirmed.hpp
+++ b/nano/secure/ledger_set_confirmed.hpp
@@ -34,6 +34,7 @@ public: // Operations on accounts
 public: // Operations on blocks
 	std::optional<nano::amount> block_balance (secure::transaction const & transaction, nano::block_hash const & hash) const;
 	bool block_exists (secure::transaction const & transaction, nano::block_hash const & hash) const;
+	bool block_exists (secure::transaction const & transaction, nano::block const & block) const;
 	bool block_exists_or_pruned (secure::transaction const & transaction, nano::block_hash const & hash) const;
 	std::shared_ptr<nano::block> block_get (secure::transaction const & transaction, nano::block_hash const & hash) const;
 


### PR DESCRIPTION
Previously, `ledger::confirm` performed redundant `block_get` calls — each block was fetched from the store twice (once to compute dependencies, once to confirm). Additionally, checking whether a dependency was already confirmed required 3 DB lookups (pruned check, block fetch, confirmation height check).

By changing the DFS to operate on block instances rather than hashes:
  - Blocks are fetched once when discovered as dependencies and reused when resolved — saves 2 `store.block.get()` calls per confirmed block
  - A new `confirmed.block_exists(block)` overload skips the store fetch and only checks confirmation height — saves 2 DB lookups per already-confirmed dependency

The `bounded_dfs` helper is extracted as a generic, tested algorithm that handles stack bounding, overflow detection, and partial progress for the caller's outer loop.