### PR TITLE
Standardizing terminology to distinguish between confirmed vs cemented

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -34,7 +34,7 @@ add_executable(
   fork_cache.cpp
   ipc.cpp
   ledger.cpp
-  ledger_confirm.cpp
+  ledger_cement.cpp
   ledger_priority.cpp
   ledger_upgrades.cpp
   locks.cpp

--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -354,7 +354,7 @@ TEST (active_elections, cached_vote_basic)
 	node.vote_processor.vote (vote, std::make_shared<nano::transport::inproc::channel> (node, node));
 	ASSERT_TIMELY_EQ (5s, node.vote_cache.size (), 1);
 	node.process_active (send);
-	ASSERT_TIMELY (5s, node.ledger.confirmed.block_exists_or_pruned (node.ledger.tx_begin_read (), send->hash ()));
+	ASSERT_TIMELY (5s, node.ledger.cemented.block_exists_or_pruned (node.ledger.tx_begin_read (), send->hash ()));
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::election_vote, nano::stat::detail::cache));
 }
 
@@ -1829,7 +1829,7 @@ TEST (active_elections, cancel_cemented_races)
 	{
 		for (auto & block : blocks)
 		{
-			ASSERT_TRUE (node.ledger.confirmed.block_exists (transaction, block->hash ()));
+			ASSERT_TRUE (node.ledger.cemented.block_exists (transaction, block->hash ()));
 		}
 	}
 
@@ -1862,7 +1862,7 @@ TEST (active_elections, cancel_already_cemented)
 	}
 
 	// Verify the block is actually cemented
-	ASSERT_TRUE (node.ledger.confirmed.block_exists (node.ledger.tx_begin_read (), last_block->hash ()));
+	ASSERT_TRUE (node.ledger.cemented.block_exists (node.ledger.tx_begin_read (), last_block->hash ()));
 
 	// Now start an election for the already cemented block
 	auto election = node.active.insert (last_block, nano::election_behavior::priority);

--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -13,7 +13,7 @@
 #include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -1858,7 +1858,7 @@ TEST (active_elections, cancel_already_cemented)
 	// First, cement the block through direct ledger confirmation process, skips callbacks
 	{
 		auto transaction = node.ledger.tx_begin_write ();
-		node.ledger.confirm (transaction, last_block->hash ());
+		node.ledger.cement (transaction, last_block->hash ());
 	}
 
 	// Verify the block is actually cemented

--- a/nano/core_test/cementing_set.cpp
+++ b/nano/core_test/cementing_set.cpp
@@ -8,7 +8,7 @@
 #include <nano/node/make_store.hpp>
 #include <nano/node/unchecked_map.hpp>
 #include <nano/secure/ledger.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/test_common/ledger_context.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/cementing_set.cpp
+++ b/nano/core_test/cementing_set.cpp
@@ -70,7 +70,7 @@ TEST (cementing_set, process_one)
 	nano::test::start_stop_guard guard{ cementing_set };
 	std::unique_lock lock{ mutex };
 	ASSERT_TRUE (condition.wait_for (lock, 5s, [&] () { return count == 1; }));
-	ASSERT_EQ (1, ctx.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
+	ASSERT_EQ (1, ctx.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (2, ctx.ledger.cemented_count ());
 }
 
@@ -89,7 +89,7 @@ TEST (cementing_set, process_multiple)
 	nano::test::start_stop_guard guard{ cementing_set };
 	std::unique_lock lock{ mutex };
 	ASSERT_TRUE (condition.wait_for (lock, 5s, [&] () { return count == 2; }));
-	ASSERT_EQ (2, ctx.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
+	ASSERT_EQ (2, ctx.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (3, ctx.ledger.cemented_count ());
 }
 
@@ -134,7 +134,7 @@ TEST (confirmation_callback, observer_callbacks)
 	// Callback is performed for all blocks that are confirmed
 	ASSERT_TIMELY_EQ (5s, 2, node->ledger.stats.count (nano::stat::type::confirmation_observer, nano::stat::dir::out));
 
-	ASSERT_EQ (2, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
+	ASSERT_EQ (2, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (3, node->ledger.cemented_count ());
 }
 
@@ -206,7 +206,7 @@ TEST (confirmation_callback, confirmed_history)
 	// Confirm the callback is not called under this circumstance
 	ASSERT_TIMELY_EQ (5s, 1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out));
 	ASSERT_TIMELY_EQ (5s, 1, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::inactive_conf_height, nano::stat::dir::out));
-	ASSERT_TIMELY_EQ (5s, 2, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
+	ASSERT_TIMELY_EQ (5s, 2, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (3, node->ledger.cemented_count ());
 }
 
@@ -261,7 +261,7 @@ TEST (confirmation_callback, dependent_election)
 	election->force_confirm ();
 
 	// Wait for blocks to be confirmed in ledger, callbacks will happen after
-	ASSERT_TIMELY_EQ (5s, 3, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
+	ASSERT_TIMELY_EQ (5s, 3, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	// Once the item added to the confirming set no longer exists, callbacks have completed
 	ASSERT_TIMELY (5s, !node->cementing_set.contains (send2->hash ()));
 

--- a/nano/core_test/cementing_set.cpp
+++ b/nano/core_test/cementing_set.cpp
@@ -184,7 +184,7 @@ TEST (confirmation_callback, confirmed_history)
 		ASSERT_TRUE (node->active.empty ());
 
 		auto transaction = node->ledger.tx_begin_read ();
-		ASSERT_FALSE (node->ledger.confirmed.block_exists (transaction, send->hash ()));
+		ASSERT_FALSE (node->ledger.cemented.block_exists (transaction, send->hash ()));
 
 		ASSERT_TIMELY (10s, node->store.write_queue.contains (nano::store::writer::confirmation_height));
 
@@ -194,7 +194,7 @@ TEST (confirmation_callback, confirmed_history)
 
 	ASSERT_TIMELY (10s, !node->store.write_queue.contains (nano::store::writer::confirmation_height));
 
-	ASSERT_TIMELY (5s, node->ledger.confirmed.block_exists (node->ledger.tx_begin_read (), send->hash ()));
+	ASSERT_TIMELY (5s, node->ledger.cemented.block_exists (node->ledger.tx_begin_read (), send->hash ()));
 
 	ASSERT_TIMELY_EQ (10s, node->active.size (), 0);
 	ASSERT_TIMELY_EQ (10s, node->stats.count (nano::stat::type::confirmation_observer, nano::stat::detail::active_quorum, nano::stat::dir::out), 1);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5057,7 +5057,7 @@ TEST (ledger, dependencies_confirmed)
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive1));
 	ASSERT_FALSE (ledger.dependencies_confirmed (transaction, *receive1));
-	ledger.confirm (transaction, send1->hash ());
+	ledger.cement (transaction, send1->hash ());
 	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *receive1));
 	auto receive2 = builder.state ()
 					.account (key1.pub)
@@ -5070,9 +5070,9 @@ TEST (ledger, dependencies_confirmed)
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive2));
 	ASSERT_FALSE (ledger.dependencies_confirmed (transaction, *receive2));
-	ledger.confirm (transaction, receive1->hash ());
+	ledger.cement (transaction, receive1->hash ());
 	ASSERT_FALSE (ledger.dependencies_confirmed (transaction, *receive2));
-	ledger.confirm (transaction, send2->hash ());
+	ledger.cement (transaction, send2->hash ());
 	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *receive2));
 }
 
@@ -5107,7 +5107,7 @@ TEST (ledger, dependencies_confirmed_pruning)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
-	ledger.confirm (transaction, send2->hash ());
+	ledger.cement (transaction, send2->hash ());
 	ASSERT_TRUE (ledger.confirmed.block_exists_or_pruned (transaction, send1->hash ()));
 	ASSERT_EQ (2, ledger.pruning_action (transaction, send2->hash (), 1));
 	auto receive1 = builder.state ()
@@ -5146,7 +5146,7 @@ TEST (ledger, block_confirmed)
 	ASSERT_FALSE (ledger.confirmed.block_exists_or_pruned (transaction, send1->hash ()));
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send1));
 	ASSERT_FALSE (ledger.confirmed.block_exists_or_pruned (transaction, send1->hash ()));
-	ledger.confirm (transaction, send1->hash ());
+	ledger.cement (transaction, send1->hash ());
 	ASSERT_TRUE (ledger.confirmed.block_exists_or_pruned (transaction, send1->hash ()));
 }
 
@@ -5224,7 +5224,7 @@ TEST (ledger, cache)
 
 		{
 			auto transaction = ledger.tx_begin_write ();
-			ledger.confirm (transaction, send->hash ());
+			ledger.cement (transaction, send->hash ());
 			ASSERT_TRUE (ledger.confirmed.block_exists_or_pruned (transaction, send->hash ()));
 		}
 
@@ -5234,7 +5234,7 @@ TEST (ledger, cache)
 
 		{
 			auto transaction = ledger.tx_begin_write ();
-			ledger.confirm (transaction, open->hash ());
+			ledger.cement (transaction, open->hash ());
 			ASSERT_TRUE (ledger.confirmed.block_exists_or_pruned (transaction, open->hash ()));
 		}
 
@@ -5291,7 +5291,7 @@ TEST (ledger, pruning_action)
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
 	ASSERT_TRUE (ledger.any.block_exists (transaction, send2->hash ()));
 	// Pruning action
-	ledger.confirm (transaction, send1->hash ());
+	ledger.cement (transaction, send1->hash ());
 	ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 1));
 	ASSERT_EQ (0, ledger.pruning_action (transaction, nano::dev::genesis->hash (), 1));
 	ASSERT_TRUE (ledger.any.pending_get (transaction, nano::pending_key{ nano::dev::genesis_key.pub, send1->hash () }));
@@ -5327,7 +5327,7 @@ TEST (ledger, pruning_action)
 	ASSERT_FALSE (receive1_stored->sideband ().details.is_epoch);
 	// Middle block pruning
 	ASSERT_TRUE (ledger.any.block_exists (transaction, send2->hash ()));
-	ledger.confirm (transaction, send2->hash ());
+	ledger.cement (transaction, send2->hash ());
 	ASSERT_EQ (1, ledger.pruning_action (transaction, send2->hash (), 1));
 	ASSERT_TRUE (store->pruned.exists (transaction, send2->hash ()));
 	ASSERT_FALSE (ledger.any.block_exists (transaction, send2->hash ()));
@@ -5378,7 +5378,7 @@ TEST (ledger, pruning_large_chain)
 	}
 	ASSERT_EQ (0, store->pruned.count (transaction));
 	ASSERT_EQ (send_receive_pairs * 2 + 1, store->block.count (transaction));
-	ledger.confirm (transaction, last_hash);
+	ledger.cement (transaction, last_hash);
 	// Pruning action
 	ASSERT_EQ (send_receive_pairs * 2, ledger.pruning_action (transaction, last_hash, 5));
 	ASSERT_TRUE (store->pruned.exists (transaction, last_hash));
@@ -5435,7 +5435,7 @@ TEST (ledger, pruning_source_rollback)
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
 	ASSERT_TRUE (ledger.any.block_exists (transaction, send2->hash ()));
-	ledger.confirm (transaction, send1->hash ());
+	ledger.cement (transaction, send1->hash ());
 	// Pruning action
 	ASSERT_EQ (2, ledger.pruning_action (transaction, send1->hash (), 1));
 	ASSERT_FALSE (ledger.any.block_exists (transaction, send1->hash ()));
@@ -5520,7 +5520,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send3));
 	ASSERT_TRUE (ledger.any.block_exists (transaction, send3->hash ()));
 	ASSERT_TRUE (ledger.any.pending_get (transaction, nano::pending_key{ nano::dev::genesis_key.pub, send3->hash () }));
-	ledger.confirm (transaction, send2->hash ());
+	ledger.cement (transaction, send2->hash ());
 	// Pruning action
 	ASSERT_EQ (2, ledger.pruning_action (transaction, send2->hash (), 1));
 	ASSERT_FALSE (ledger.any.block_exists (transaction, send2->hash ()));
@@ -5653,7 +5653,7 @@ TEST (ledger, pruning_legacy_blocks)
 				 .work (*pool.generate (open1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send3));
-	ledger.confirm (transaction, open1->hash ());
+	ledger.cement (transaction, open1->hash ());
 	// Pruning action
 	ASSERT_EQ (3, ledger.pruning_action (transaction, change1->hash (), 2));
 	ASSERT_EQ (1, ledger.pruning_action (transaction, open1->hash (), 1));
@@ -5708,7 +5708,7 @@ TEST (ledger, pruning_safe_functions)
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
 	ASSERT_TRUE (ledger.any.block_exists (transaction, send2->hash ()));
-	ledger.confirm (transaction, send1->hash ());
+	ledger.cement (transaction, send1->hash ());
 	// Pruning action
 	ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 1));
 	ASSERT_FALSE (ledger.any.block_exists (transaction, send1->hash ()));
@@ -5758,7 +5758,7 @@ TEST (ledger, random_blocks)
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
 	ASSERT_TRUE (ledger.any.block_exists (transaction, send2->hash ()));
-	ledger.confirm (transaction, send1->hash ());
+	ledger.cement (transaction, send1->hash ());
 	// Pruning action
 	ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 1));
 	ASSERT_FALSE (ledger.any.block_exists (transaction, send1->hash ()));
@@ -5939,7 +5939,7 @@ TEST (ledger, cement_unbounded)
 	std::deque<std::shared_ptr<nano::block>> confirmed;
 	{
 		auto tx = ledger.tx_begin_write ();
-		confirmed = ledger.confirm (tx, bottom->hash ());
+		confirmed = ledger.cement (tx, bottom->hash ());
 	}
 	ASSERT_TRUE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	// Check that all blocks got confirmed in a single call
@@ -5963,7 +5963,7 @@ TEST (ledger, cement_bounded)
 	{
 		// This should only cement some of the dependencies
 		auto tx = ledger.tx_begin_write ();
-		confirmed1 = ledger.confirm (tx, bottom->hash (), /* max cementing batch size */ 3);
+		confirmed1 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 3);
 	}
 	ASSERT_FALSE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_EQ (confirmed1.size (), 3);
@@ -5975,7 +5975,7 @@ TEST (ledger, cement_bounded)
 	{
 		// This should cement a few more dependencies
 		auto tx = ledger.tx_begin_write ();
-		confirmed2 = ledger.confirm (tx, bottom->hash (), /* max cementing batch size */ 16);
+		confirmed2 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 16);
 	}
 	ASSERT_FALSE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_EQ (confirmed2.size (), 16);
@@ -5987,7 +5987,7 @@ TEST (ledger, cement_bounded)
 	{
 		// This should cement the remaining dependencies
 		auto tx = ledger.tx_begin_write ();
-		confirmed3 = ledger.confirm (tx, bottom->hash (), /* max cementing batch size */ 64);
+		confirmed3 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 64);
 	}
 	ASSERT_TRUE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_LE (confirmed3.size (), 64);
@@ -6009,7 +6009,7 @@ TEST (ledger, cement_bounded_diamond)
 	{
 		// This should only cement some of the dependencies
 		auto tx = ledger.tx_begin_write ();
-		confirmed1 = ledger.confirm (tx, bottom->hash (), /* max cementing batch size */ 3);
+		confirmed1 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 3);
 	}
 	ASSERT_FALSE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_EQ (confirmed1.size (), 3);
@@ -6021,7 +6021,7 @@ TEST (ledger, cement_bounded_diamond)
 	{
 		// This should cement a few more dependencies
 		auto tx = ledger.tx_begin_write ();
-		confirmed2 = ledger.confirm (tx, bottom->hash (), /* max cementing batch size */ 16);
+		confirmed2 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 16);
 	}
 	ASSERT_FALSE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_EQ (confirmed2.size (), 16);
@@ -6033,7 +6033,7 @@ TEST (ledger, cement_bounded_diamond)
 	{
 		// A few more bounded calls should confirm the whole tree
 		auto tx = ledger.tx_begin_write ();
-		confirmed3 = ledger.confirm (tx, bottom->hash (), /* max cementing batch size */ 64);
+		confirmed3 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 64);
 	}
 	ASSERT_FALSE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_EQ (confirmed3.size (), 64);
@@ -6044,7 +6044,7 @@ TEST (ledger, cement_bounded_diamond)
 
 	{
 		auto tx = ledger.tx_begin_write ();
-		confirmed4 = ledger.confirm (tx, bottom->hash (), /* max cementing batch size */ 64);
+		confirmed4 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 64);
 	}
 	ASSERT_TRUE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_LT (confirmed4.size (), 64);

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -12,7 +12,7 @@
 #include <nano/node/transport/inproc.hpp>
 #include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/block.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5014,14 +5014,14 @@ TEST (ledger, block_dependencies)
 	}
 }
 
-TEST (ledger, dependencies_confirmed)
+TEST (ledger, dependencies_cemented)
 {
 	auto ctx = nano::test::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto transaction = ledger.tx_begin_write ();
 	nano::block_builder builder;
-	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *nano::dev::genesis));
+	ASSERT_TRUE (ledger.dependencies_cemented (transaction, *nano::dev::genesis));
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	auto send1 = builder.state ()
@@ -5034,7 +5034,7 @@ TEST (ledger, dependencies_confirmed)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send1));
-	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *send1));
+	ASSERT_TRUE (ledger.dependencies_cemented (transaction, *send1));
 	auto send2 = builder.state ()
 				 .account (nano::dev::genesis_key.pub)
 				 .previous (send1->hash ())
@@ -5045,7 +5045,7 @@ TEST (ledger, dependencies_confirmed)
 				 .work (*pool.generate (send1->hash ()))
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
-	ASSERT_FALSE (ledger.dependencies_confirmed (transaction, *send2));
+	ASSERT_FALSE (ledger.dependencies_cemented (transaction, *send2));
 	auto receive1 = builder.state ()
 					.account (key1.pub)
 					.previous (0)
@@ -5056,9 +5056,9 @@ TEST (ledger, dependencies_confirmed)
 					.work (*pool.generate (key1.pub))
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive1));
-	ASSERT_FALSE (ledger.dependencies_confirmed (transaction, *receive1));
+	ASSERT_FALSE (ledger.dependencies_cemented (transaction, *receive1));
 	ledger.cement (transaction, send1->hash ());
-	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *receive1));
+	ASSERT_TRUE (ledger.dependencies_cemented (transaction, *receive1));
 	auto receive2 = builder.state ()
 					.account (key1.pub)
 					.previous (receive1->hash ())
@@ -5069,14 +5069,14 @@ TEST (ledger, dependencies_confirmed)
 					.work (*pool.generate (receive1->hash ()))
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive2));
-	ASSERT_FALSE (ledger.dependencies_confirmed (transaction, *receive2));
+	ASSERT_FALSE (ledger.dependencies_cemented (transaction, *receive2));
 	ledger.cement (transaction, receive1->hash ());
-	ASSERT_FALSE (ledger.dependencies_confirmed (transaction, *receive2));
+	ASSERT_FALSE (ledger.dependencies_cemented (transaction, *receive2));
 	ledger.cement (transaction, send2->hash ());
-	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *receive2));
+	ASSERT_TRUE (ledger.dependencies_cemented (transaction, *receive2));
 }
 
-TEST (ledger, dependencies_confirmed_pruning)
+TEST (ledger, dependencies_cemented_pruning)
 {
 	nano::logger logger;
 	nano::stats stats{ logger };
@@ -5120,7 +5120,7 @@ TEST (ledger, dependencies_confirmed_pruning)
 					.work (*pool.generate (key1.pub))
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive1));
-	ASSERT_TRUE (ledger.dependencies_confirmed (transaction, *receive1));
+	ASSERT_TRUE (ledger.dependencies_cemented (transaction, *receive1));
 }
 
 TEST (ledger, block_confirmed)
@@ -5969,7 +5969,7 @@ TEST (ledger, cement_bounded)
 	ASSERT_EQ (confirmed1.size (), 3);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed1.begin (), confirmed1.end (), [&] (auto const & block) {
-		return ledger.dependencies_confirmed (ledger.tx_begin_read (), *block);
+		return ledger.dependencies_cemented (ledger.tx_begin_read (), *block);
 	}));
 
 	{
@@ -5981,7 +5981,7 @@ TEST (ledger, cement_bounded)
 	ASSERT_EQ (confirmed2.size (), 16);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed2.begin (), confirmed2.end (), [&] (auto const & block) {
-		return ledger.dependencies_confirmed (ledger.tx_begin_read (), *block);
+		return ledger.dependencies_cemented (ledger.tx_begin_read (), *block);
 	}));
 
 	{
@@ -6015,7 +6015,7 @@ TEST (ledger, cement_bounded_diamond)
 	ASSERT_EQ (confirmed1.size (), 3);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed1.begin (), confirmed1.end (), [&] (auto const & block) {
-		return ledger.dependencies_confirmed (ledger.tx_begin_read (), *block);
+		return ledger.dependencies_cemented (ledger.tx_begin_read (), *block);
 	}));
 
 	{
@@ -6027,7 +6027,7 @@ TEST (ledger, cement_bounded_diamond)
 	ASSERT_EQ (confirmed2.size (), 16);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed2.begin (), confirmed2.end (), [&] (auto const & block) {
-		return ledger.dependencies_confirmed (ledger.tx_begin_read (), *block);
+		return ledger.dependencies_cemented (ledger.tx_begin_read (), *block);
 	}));
 
 	{
@@ -6039,7 +6039,7 @@ TEST (ledger, cement_bounded_diamond)
 	ASSERT_EQ (confirmed3.size (), 64);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed2.begin (), confirmed2.end (), [&] (auto const & block) {
-		return ledger.dependencies_confirmed (ledger.tx_begin_read (), *block);
+		return ledger.dependencies_cemented (ledger.tx_begin_read (), *block);
 	}));
 
 	{

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -61,7 +61,7 @@ TEST (ledger, confirmed_unconfirmed_view)
 	auto ctx = nano::test::ledger_empty ();
 	auto & ledger = ctx.ledger ();
 	auto & unconfirmed = ledger;
-	auto & confirmed = ledger.confirmed;
+	auto & cemented = ledger.cemented;
 }
 
 // Genesis account should have the max balance on empty initialization
@@ -5108,7 +5108,7 @@ TEST (ledger, dependencies_confirmed_pruning)
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
 	ledger.cement (transaction, send2->hash ());
-	ASSERT_TRUE (ledger.confirmed.block_exists_or_pruned (transaction, send1->hash ()));
+	ASSERT_TRUE (ledger.cemented.block_exists_or_pruned (transaction, send1->hash ()));
 	ASSERT_EQ (2, ledger.pruning_action (transaction, send2->hash (), 1));
 	auto receive1 = builder.state ()
 					.account (key1.pub)
@@ -5130,7 +5130,7 @@ TEST (ledger, block_confirmed)
 	auto & store = ctx.store ();
 	auto transaction = ledger.tx_begin_write ();
 	nano::block_builder builder;
-	ASSERT_TRUE (ledger.confirmed.block_exists_or_pruned (transaction, nano::dev::genesis->hash ()));
+	ASSERT_TRUE (ledger.cemented.block_exists_or_pruned (transaction, nano::dev::genesis->hash ()));
 	auto & pool = ctx.pool ();
 	nano::keypair key1;
 	auto send1 = builder.state ()
@@ -5143,11 +5143,11 @@ TEST (ledger, block_confirmed)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
 	// Must be safe against non-existing blocks
-	ASSERT_FALSE (ledger.confirmed.block_exists_or_pruned (transaction, send1->hash ()));
+	ASSERT_FALSE (ledger.cemented.block_exists_or_pruned (transaction, send1->hash ()));
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send1));
-	ASSERT_FALSE (ledger.confirmed.block_exists_or_pruned (transaction, send1->hash ()));
+	ASSERT_FALSE (ledger.cemented.block_exists_or_pruned (transaction, send1->hash ()));
 	ledger.cement (transaction, send1->hash ());
-	ASSERT_TRUE (ledger.confirmed.block_exists_or_pruned (transaction, send1->hash ()));
+	ASSERT_TRUE (ledger.cemented.block_exists_or_pruned (transaction, send1->hash ()));
 }
 
 TEST (ledger, cache)
@@ -5225,7 +5225,7 @@ TEST (ledger, cache)
 		{
 			auto transaction = ledger.tx_begin_write ();
 			ledger.cement (transaction, send->hash ());
-			ASSERT_TRUE (ledger.confirmed.block_exists_or_pruned (transaction, send->hash ()));
+			ASSERT_TRUE (ledger.cemented.block_exists_or_pruned (transaction, send->hash ()));
 		}
 
 		++cemented_count;
@@ -5235,7 +5235,7 @@ TEST (ledger, cache)
 		{
 			auto transaction = ledger.tx_begin_write ();
 			ledger.cement (transaction, open->hash ());
-			ASSERT_TRUE (ledger.confirmed.block_exists_or_pruned (transaction, open->hash ()));
+			ASSERT_TRUE (ledger.cemented.block_exists_or_pruned (transaction, open->hash ()));
 		}
 
 		++cemented_count;
@@ -5941,7 +5941,7 @@ TEST (ledger, cement_unbounded)
 		auto tx = ledger.tx_begin_write ();
 		confirmed = ledger.cement (tx, bottom->hash ());
 	}
-	ASSERT_TRUE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
+	ASSERT_TRUE (ledger.cemented.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	// Check that all blocks got confirmed in a single call
 	ASSERT_TRUE (std::all_of (ctx.blocks ().begin (), ctx.blocks ().end (), [&] (auto const & block) {
 		return std::find_if (confirmed.begin (), confirmed.end (), [&] (auto const & block2) {
@@ -5965,7 +5965,7 @@ TEST (ledger, cement_bounded)
 		auto tx = ledger.tx_begin_write ();
 		confirmed1 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 3);
 	}
-	ASSERT_FALSE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
+	ASSERT_FALSE (ledger.cemented.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_EQ (confirmed1.size (), 3);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed1.begin (), confirmed1.end (), [&] (auto const & block) {
@@ -5977,7 +5977,7 @@ TEST (ledger, cement_bounded)
 		auto tx = ledger.tx_begin_write ();
 		confirmed2 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 16);
 	}
-	ASSERT_FALSE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
+	ASSERT_FALSE (ledger.cemented.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_EQ (confirmed2.size (), 16);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed2.begin (), confirmed2.end (), [&] (auto const & block) {
@@ -5989,11 +5989,11 @@ TEST (ledger, cement_bounded)
 		auto tx = ledger.tx_begin_write ();
 		confirmed3 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 64);
 	}
-	ASSERT_TRUE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
+	ASSERT_TRUE (ledger.cemented.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_LE (confirmed3.size (), 64);
 	// Every block in the ledger should be cemented
 	ASSERT_TRUE (std::all_of (ctx.blocks ().begin (), ctx.blocks ().end (), [&] (auto const & block) {
-		return ledger.confirmed.block_exists (ledger.tx_begin_read (), block->hash ());
+		return ledger.cemented.block_exists (ledger.tx_begin_read (), block->hash ());
 	}));
 }
 
@@ -6011,7 +6011,7 @@ TEST (ledger, cement_bounded_diamond)
 		auto tx = ledger.tx_begin_write ();
 		confirmed1 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 3);
 	}
-	ASSERT_FALSE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
+	ASSERT_FALSE (ledger.cemented.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_EQ (confirmed1.size (), 3);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed1.begin (), confirmed1.end (), [&] (auto const & block) {
@@ -6023,7 +6023,7 @@ TEST (ledger, cement_bounded_diamond)
 		auto tx = ledger.tx_begin_write ();
 		confirmed2 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 16);
 	}
-	ASSERT_FALSE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
+	ASSERT_FALSE (ledger.cemented.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_EQ (confirmed2.size (), 16);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed2.begin (), confirmed2.end (), [&] (auto const & block) {
@@ -6035,7 +6035,7 @@ TEST (ledger, cement_bounded_diamond)
 		auto tx = ledger.tx_begin_write ();
 		confirmed3 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 64);
 	}
-	ASSERT_FALSE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
+	ASSERT_FALSE (ledger.cemented.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_EQ (confirmed3.size (), 64);
 	// Only topmost dependencies should get cemented during this call
 	ASSERT_TRUE (std::all_of (confirmed2.begin (), confirmed2.end (), [&] (auto const & block) {
@@ -6046,11 +6046,11 @@ TEST (ledger, cement_bounded_diamond)
 		auto tx = ledger.tx_begin_write ();
 		confirmed4 = ledger.cement (tx, bottom->hash (), /* max cementing batch size */ 64);
 	}
-	ASSERT_TRUE (ledger.confirmed.block_exists (ledger.tx_begin_read (), bottom->hash ()));
+	ASSERT_TRUE (ledger.cemented.block_exists (ledger.tx_begin_read (), bottom->hash ()));
 	ASSERT_LT (confirmed4.size (), 64);
 	// Every block in the ledger should be cemented
 	ASSERT_TRUE (std::all_of (ctx.blocks ().begin (), ctx.blocks ().end (), [&] (auto const & block) {
-		return ledger.confirmed.block_exists (ledger.tx_begin_read (), block->hash ());
+		return ledger.cemented.block_exists (ledger.tx_begin_read (), block->hash ());
 	}));
 }
 

--- a/nano/core_test/ledger_cement.cpp
+++ b/nano/core_test/ledger_cement.cpp
@@ -6,7 +6,7 @@
 #include <nano/node/online_reps.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/ledger_cement.cpp
+++ b/nano/core_test/ledger_cement.cpp
@@ -42,11 +42,11 @@ TEST (ledger_cement, single)
 	ASSERT_EQ (nano::dev::genesis->hash (), node->store.confirmation_height.get (transaction, nano::dev::genesis_key.pub).value ().frontier);
 
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send1));
-	ASSERT_FALSE (node->ledger.confirmed.block_exists (transaction, send1->hash ()));
+	ASSERT_FALSE (node->ledger.cemented.block_exists (transaction, send1->hash ()));
 	node->ledger.cement (transaction, send1->hash ());
-	ASSERT_TRUE (node->ledger.confirmed.block_exists (transaction, send1->hash ()));
-	ASSERT_EQ (2, node->ledger.confirmed.account_height (transaction, nano::dev::genesis_key.pub));
-	ASSERT_EQ (send1->hash (), node->ledger.confirmed.account_head (transaction, nano::dev::genesis_key.pub));
+	ASSERT_TRUE (node->ledger.cemented.block_exists (transaction, send1->hash ()));
+	ASSERT_EQ (2, node->ledger.cemented.account_height (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (send1->hash (), node->ledger.cemented.account_head (transaction, nano::dev::genesis_key.pub));
 
 	// Rollbacks should fail as these blocks have been cemented
 	ASSERT_TRUE (node->ledger.rollback (transaction, latest1));
@@ -199,19 +199,19 @@ TEST (ledger_cement, multiple_accounts)
 	ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (11, node->ledger.cemented_count ());
 
-	ASSERT_TRUE (node->ledger.confirmed.block_exists (transaction, receive3->hash ()));
+	ASSERT_TRUE (node->ledger.cemented.block_exists (transaction, receive3->hash ()));
 	ASSERT_EQ (4, node->ledger.any.account_get (transaction, nano::dev::genesis_key.pub).value ().block_count);
-	ASSERT_EQ (4, node->ledger.confirmed.account_height (transaction, nano::dev::genesis_key.pub));
-	ASSERT_EQ (send3->hash (), node->ledger.confirmed.account_head (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (4, node->ledger.cemented.account_height (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (send3->hash (), node->ledger.cemented.account_head (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (3, node->ledger.any.account_get (transaction, key1.pub).value ().block_count);
-	ASSERT_EQ (2, node->ledger.confirmed.account_height (transaction, key1.pub));
-	ASSERT_EQ (send4->hash (), node->ledger.confirmed.account_head (transaction, key1.pub));
+	ASSERT_EQ (2, node->ledger.cemented.account_height (transaction, key1.pub));
+	ASSERT_EQ (send4->hash (), node->ledger.cemented.account_head (transaction, key1.pub));
 	ASSERT_EQ (4, node->ledger.any.account_get (transaction, key2.pub).value ().block_count);
-	ASSERT_EQ (3, node->ledger.confirmed.account_height (transaction, key2.pub));
-	ASSERT_EQ (send6->hash (), node->ledger.confirmed.account_head (transaction, key2.pub));
+	ASSERT_EQ (3, node->ledger.cemented.account_height (transaction, key2.pub));
+	ASSERT_EQ (send6->hash (), node->ledger.cemented.account_head (transaction, key2.pub));
 	ASSERT_EQ (2, node->ledger.any.account_get (transaction, key3.pub).value ().block_count);
-	ASSERT_EQ (2, node->ledger.confirmed.account_height (transaction, key3.pub));
-	ASSERT_EQ (receive3->hash (), node->ledger.confirmed.account_head (transaction, key3.pub));
+	ASSERT_EQ (2, node->ledger.cemented.account_height (transaction, key3.pub));
+	ASSERT_EQ (receive3->hash (), node->ledger.cemented.account_head (transaction, key3.pub));
 
 	// The accounts for key1 and key2 have 1 more block in the chain than is confirmed.
 	// So this can be rolled back, but the one before that cannot. Check that this is the case
@@ -349,13 +349,13 @@ TEST (ledger_cement, send_receive_between_2_accounts)
 	ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (11, node->ledger.cemented_count ());
 
-	ASSERT_TRUE (node->ledger.confirmed.block_exists (transaction, receive4->hash ()));
+	ASSERT_TRUE (node->ledger.cemented.block_exists (transaction, receive4->hash ()));
 	ASSERT_EQ (7, node->ledger.any.account_get (transaction, nano::dev::genesis_key.pub).value ().block_count);
-	ASSERT_EQ (6, node->ledger.confirmed.account_height (transaction, nano::dev::genesis_key.pub));
-	ASSERT_EQ (send5->hash (), node->ledger.confirmed.account_head (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (6, node->ledger.cemented.account_height (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (send5->hash (), node->ledger.cemented.account_head (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (5, node->ledger.any.account_get (transaction, key1.pub).value ().block_count);
-	ASSERT_EQ (5, node->ledger.confirmed.account_height (transaction, key1.pub));
-	ASSERT_EQ (receive4->hash (), node->ledger.confirmed.account_head (transaction, key1.pub));
+	ASSERT_EQ (5, node->ledger.cemented.account_height (transaction, key1.pub));
+	ASSERT_EQ (receive4->hash (), node->ledger.cemented.account_head (transaction, key1.pub));
 }
 
 TEST (ledger_cement, send_receive_self)
@@ -439,10 +439,10 @@ TEST (ledger_cement, send_receive_self)
 	ASSERT_EQ (6, confirmed.size ());
 	ASSERT_EQ (6, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 
-	ASSERT_TRUE (node->ledger.confirmed.block_exists (transaction, receive3->hash ()));
+	ASSERT_TRUE (node->ledger.cemented.block_exists (transaction, receive3->hash ()));
 	ASSERT_EQ (8, node->ledger.any.account_get (transaction, nano::dev::genesis_key.pub).value ().block_count);
-	ASSERT_EQ (7, node->ledger.confirmed.account_height (transaction, nano::dev::genesis_key.pub));
-	ASSERT_EQ (receive3->hash (), node->ledger.confirmed.account_head (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (7, node->ledger.cemented.account_height (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (receive3->hash (), node->ledger.cemented.account_head (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (7, node->ledger.cemented_count ());
 }
 
@@ -665,18 +665,18 @@ TEST (ledger_cement, all_block_types)
 	ASSERT_EQ (15, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (16, node->ledger.cemented_count ());
 
-	ASSERT_TRUE (node->ledger.confirmed.block_exists (transaction, state_send2->hash ()));
+	ASSERT_TRUE (node->ledger.cemented.block_exists (transaction, state_send2->hash ()));
 	nano::confirmation_height_info confirmation_height_info;
 	ASSERT_LE (4, node->ledger.any.account_get (transaction, nano::dev::genesis_key.pub).value ().block_count);
-	ASSERT_EQ (3, node->ledger.confirmed.account_height (transaction, nano::dev::genesis_key.pub));
-	ASSERT_EQ (send1->hash (), node->ledger.confirmed.account_head (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (3, node->ledger.cemented.account_height (transaction, nano::dev::genesis_key.pub));
+	ASSERT_EQ (send1->hash (), node->ledger.cemented.account_head (transaction, nano::dev::genesis_key.pub));
 
 	ASSERT_LE (7, node->ledger.any.account_get (transaction, key1.pub).value ().block_count);
-	ASSERT_EQ (6, node->ledger.confirmed.account_height (transaction, key1.pub));
-	ASSERT_EQ (state_send1->hash (), node->ledger.confirmed.account_head (transaction, key1.pub));
+	ASSERT_EQ (6, node->ledger.cemented.account_height (transaction, key1.pub));
+	ASSERT_EQ (state_send1->hash (), node->ledger.cemented.account_head (transaction, key1.pub));
 	ASSERT_EQ (8, node->ledger.any.account_get (transaction, key2.pub).value ().block_count);
-	ASSERT_EQ (7, node->ledger.confirmed.account_height (transaction, key2.pub));
-	ASSERT_EQ (state_send2->hash (), node->ledger.confirmed.account_head (transaction, key2.pub));
+	ASSERT_EQ (7, node->ledger.cemented.account_height (transaction, key2.pub));
+	ASSERT_EQ (state_send2->hash (), node->ledger.cemented.account_head (transaction, key2.pub));
 }
 
 // This test ensures a block that's cemented cannot be rolled back by the node
@@ -749,7 +749,7 @@ TEST (ledger_cement, observers)
 	auto transaction = node1->ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node1->ledger.process (transaction, send1));
 	node1->ledger.cement (transaction, send1->hash ());
-	ASSERT_TRUE (node1->ledger.confirmed.block_exists (transaction, send1->hash ()));
+	ASSERT_TRUE (node1->ledger.cemented.block_exists (transaction, send1->hash ()));
 	ASSERT_EQ (1, node1->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (2, node1->ledger.cemented_count ());
 }
@@ -826,9 +826,9 @@ TEST (ledger_cement, pruned_source)
 	ledger.cement (transaction, send2->hash ());
 	ASSERT_EQ (2, ledger.pruning_action (transaction, send2->hash (), 2));
 	ASSERT_FALSE (ledger.any.block_exists (transaction, send2->hash ()));
-	ASSERT_FALSE (ledger.confirmed.block_exists (transaction, open2->hash ()));
+	ASSERT_FALSE (ledger.cemented.block_exists (transaction, open2->hash ()));
 	auto confirmed = ledger.cement (transaction, open2->hash ());
-	ASSERT_TRUE (ledger.confirmed.block_exists (transaction, open2->hash ()));
+	ASSERT_TRUE (ledger.cemented.block_exists (transaction, open2->hash ()));
 }
 
 // TODO: It doesn't look like this test is actually testing anything related to rollbacks anymore

--- a/nano/core_test/ledger_cement.cpp
+++ b/nano/core_test/ledger_cement.cpp
@@ -15,7 +15,7 @@
 
 using namespace std::chrono_literals;
 
-TEST (ledger_confirm, single)
+TEST (ledger_cement, single)
 {
 	auto amount (std::numeric_limits<nano::uint128_t>::max ());
 	nano::test::system system;
@@ -43,7 +43,7 @@ TEST (ledger_confirm, single)
 
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send1));
 	ASSERT_FALSE (node->ledger.confirmed.block_exists (transaction, send1->hash ()));
-	node->ledger.confirm (transaction, send1->hash ());
+	node->ledger.cement (transaction, send1->hash ());
 	ASSERT_TRUE (node->ledger.confirmed.block_exists (transaction, send1->hash ()));
 	ASSERT_EQ (2, node->ledger.confirmed.account_height (transaction, nano::dev::genesis_key.pub));
 	ASSERT_EQ (send1->hash (), node->ledger.confirmed.account_head (transaction, nano::dev::genesis_key.pub));
@@ -51,11 +51,11 @@ TEST (ledger_confirm, single)
 	// Rollbacks should fail as these blocks have been cemented
 	ASSERT_TRUE (node->ledger.rollback (transaction, latest1));
 	ASSERT_TRUE (node->ledger.rollback (transaction, send1->hash ()));
-	ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
+	ASSERT_EQ (1, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (2, node->ledger.cemented_count ());
 }
 
-TEST (ledger_confirm, multiple_accounts)
+TEST (ledger_cement, multiple_accounts)
 {
 	nano::test::system system;
 	nano::node_flags node_flags;
@@ -194,9 +194,9 @@ TEST (ledger_confirm, multiple_accounts)
 					.work (*system.work.generate (open3->hash ()))
 					.build ();
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, receive3));
-	auto confirmed = node->ledger.confirm (transaction, receive3->hash ());
+	auto confirmed = node->ledger.cement (transaction, receive3->hash ());
 	ASSERT_EQ (10, confirmed.size ());
-	ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
+	ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (11, node->ledger.cemented_count ());
 
 	ASSERT_TRUE (node->ledger.confirmed.block_exists (transaction, receive3->hash ()));
@@ -229,7 +229,7 @@ TEST (ledger_confirm, multiple_accounts)
 	ASSERT_TRUE (node->ledger.rollback (transaction, send2->hash ()));
 }
 
-TEST (ledger_confirm, send_receive_between_2_accounts)
+TEST (ledger_cement, send_receive_between_2_accounts)
 {
 	nano::test::system system;
 	nano::node_flags node_flags;
@@ -344,9 +344,9 @@ TEST (ledger_confirm, send_receive_between_2_accounts)
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send6));
 
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, receive4));
-	auto confirmed = node->ledger.confirm (transaction, receive4->hash ());
+	auto confirmed = node->ledger.cement (transaction, receive4->hash ());
 	ASSERT_EQ (10, confirmed.size ());
-	ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
+	ASSERT_EQ (10, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (11, node->ledger.cemented_count ());
 
 	ASSERT_TRUE (node->ledger.confirmed.block_exists (transaction, receive4->hash ()));
@@ -358,7 +358,7 @@ TEST (ledger_confirm, send_receive_between_2_accounts)
 	ASSERT_EQ (receive4->hash (), node->ledger.confirmed.account_head (transaction, key1.pub));
 }
 
-TEST (ledger_confirm, send_receive_self)
+TEST (ledger_cement, send_receive_self)
 {
 	nano::test::system system;
 	nano::node_flags node_flags;
@@ -435,9 +435,9 @@ TEST (ledger_confirm, send_receive_self)
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, receive3));
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, send4));
 
-	auto confirmed = node->ledger.confirm (transaction, receive3->hash ());
+	auto confirmed = node->ledger.cement (transaction, receive3->hash ());
 	ASSERT_EQ (6, confirmed.size ());
-	ASSERT_EQ (6, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
+	ASSERT_EQ (6, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 
 	ASSERT_TRUE (node->ledger.confirmed.block_exists (transaction, receive3->hash ()));
 	ASSERT_EQ (8, node->ledger.any.account_get (transaction, nano::dev::genesis_key.pub).value ().block_count);
@@ -446,7 +446,7 @@ TEST (ledger_confirm, send_receive_self)
 	ASSERT_EQ (7, node->ledger.cemented_count ());
 }
 
-TEST (ledger_confirm, all_block_types)
+TEST (ledger_cement, all_block_types)
 {
 	nano::test::system system;
 	nano::node_flags node_flags;
@@ -660,9 +660,9 @@ TEST (ledger_confirm, all_block_types)
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, state_send4));
 	ASSERT_EQ (nano::block_status::progress, node->ledger.process (transaction, state_receive3));
 
-	auto confirmed = node->ledger.confirm (transaction, state_send2->hash ());
+	auto confirmed = node->ledger.cement (transaction, state_send2->hash ());
 	ASSERT_EQ (15, confirmed.size ());
-	ASSERT_EQ (15, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
+	ASSERT_EQ (15, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (16, node->ledger.cemented_count ());
 
 	ASSERT_TRUE (node->ledger.confirmed.block_exists (transaction, state_send2->hash ()));
@@ -681,7 +681,7 @@ TEST (ledger_confirm, all_block_types)
 
 // This test ensures a block that's cemented cannot be rolled back by the node
 // A block is inserted and confirmed then later a different block is force inserted with a rollback attempt
-TEST (ledger_confirm, conflict_rollback_cemented)
+TEST (ledger_cement, conflict_rollback_cemented)
 {
 	nano::state_block_builder builder;
 	auto const genesis_hash = nano::dev::genesis->hash ();
@@ -704,7 +704,7 @@ TEST (ledger_confirm, conflict_rollback_cemented)
 	{
 		auto transaction = node1->ledger.tx_begin_write ();
 		ASSERT_EQ (nano::block_status::progress, node1->ledger.process (transaction, fork1a));
-		node1->ledger.confirm (transaction, fork1a->hash ());
+		node1->ledger.cement (transaction, fork1a->hash ());
 	}
 	ASSERT_TRUE (nano::test::confirmed (*node1, { fork1a }));
 
@@ -728,7 +728,7 @@ TEST (ledger_confirm, conflict_rollback_cemented)
 	ASSERT_TRUE (nano::test::confirmed (*node1, { fork1a->hash () })); // fork1a should still remain after the rollback failed event
 }
 
-TEST (ledger_confirm, observers)
+TEST (ledger_cement, observers)
 {
 	auto amount (std::numeric_limits<nano::uint128_t>::max ());
 	nano::test::system system;
@@ -748,13 +748,13 @@ TEST (ledger_confirm, observers)
 
 	auto transaction = node1->ledger.tx_begin_write ();
 	ASSERT_EQ (nano::block_status::progress, node1->ledger.process (transaction, send1));
-	node1->ledger.confirm (transaction, send1->hash ());
+	node1->ledger.cement (transaction, send1->hash ());
 	ASSERT_TRUE (node1->ledger.confirmed.block_exists (transaction, send1->hash ()));
-	ASSERT_EQ (1, node1->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in));
+	ASSERT_EQ (1, node1->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in));
 	ASSERT_EQ (2, node1->ledger.cemented_count ());
 }
 
-TEST (ledger_confirm, pruned_source)
+TEST (ledger_cement, pruned_source)
 {
 	nano::test::system system;
 
@@ -823,17 +823,17 @@ TEST (ledger_confirm, pruned_source)
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send2));
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send3));
 	ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open2));
-	ledger.confirm (transaction, send2->hash ());
+	ledger.cement (transaction, send2->hash ());
 	ASSERT_EQ (2, ledger.pruning_action (transaction, send2->hash (), 2));
 	ASSERT_FALSE (ledger.any.block_exists (transaction, send2->hash ()));
 	ASSERT_FALSE (ledger.confirmed.block_exists (transaction, open2->hash ()));
-	auto confirmed = ledger.confirm (transaction, open2->hash ());
+	auto confirmed = ledger.cement (transaction, open2->hash ());
 	ASSERT_TRUE (ledger.confirmed.block_exists (transaction, open2->hash ()));
 }
 
 // TODO: It doesn't look like this test is actually testing anything related to rollbacks anymore
 // Test that if a block is marked to be confirmed that doesn't exist in the ledger the program aborts
-TEST (ledger_confirmDeathTest, rollback_added_block)
+TEST (ledger_cementDeathTest, rollback_cemented_block)
 {
 	// For ASSERT_DEATH_IF_SUPPORTED
 	testing::FLAGS_gtest_death_test_style = "threadsafe";
@@ -860,6 +860,6 @@ TEST (ledger_confirmDeathTest, rollback_added_block)
 					.work (*pool.generate (nano::dev::genesis->hash ()))
 					.build ();
 		auto transaction = ledger.tx_begin_write ();
-		ASSERT_DEATH_IF_SUPPORTED (ledger.confirm (transaction, send->hash ()), "");
+		ASSERT_DEATH_IF_SUPPORTED (ledger.cement (transaction, send->hash ()), "");
 	}
 }

--- a/nano/core_test/ledger_priority.cpp
+++ b/nano/core_test/ledger_priority.cpp
@@ -2,7 +2,7 @@
 #include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/test_common/ledger_context.hpp>
 #include <nano/test_common/make_store.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/logging.cpp
+++ b/nano/core_test/logging.cpp
@@ -81,7 +81,7 @@ TEST (log_parse, parse_type)
 TEST (log_parse, parse_detail)
 {
 	ASSERT_EQ (nano::log::parse_detail ("all"), nano::log::detail::all);
-	ASSERT_EQ (nano::log::parse_detail ("process_confirmed"), nano::log::detail::process_confirmed);
+	ASSERT_EQ (nano::log::parse_detail ("test"), nano::log::detail::test);
 	ASSERT_THROW (nano::log::parse_detail ("enumnotpresent"), std::invalid_argument);
 	ASSERT_THROW (nano::log::parse_detail (""), std::invalid_argument);
 	ASSERT_THROW (nano::log::parse_detail ("_last"), std::invalid_argument);
@@ -92,7 +92,7 @@ TEST (log_parse, parse_logger_id)
 {
 	ASSERT_EQ (nano::log::parse_logger_id ("node"), std::make_pair (nano::log::type::node, nano::log::detail::all));
 	ASSERT_EQ (nano::log::parse_logger_id ("node::all"), std::make_pair (nano::log::type::node, nano::log::detail::all));
-	ASSERT_EQ (nano::log::parse_logger_id ("node::process_confirmed"), std::make_pair (nano::log::type::node, nano::log::detail::process_confirmed));
+	ASSERT_EQ (nano::log::parse_logger_id ("node::test"), std::make_pair (nano::log::type::node, nano::log::detail::test));
 	ASSERT_THROW (nano::log::parse_logger_id ("_last"), std::invalid_argument);
 	ASSERT_THROW (nano::log::parse_logger_id ("node::enumnotpresent"), std::invalid_argument);
 	ASSERT_THROW (nano::log::parse_logger_id ("node::"), std::invalid_argument);

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3452,7 +3452,7 @@ TEST (node, deferred_dependent_elections)
 	ASSERT_FALSE (node.active.active (receive->qualified_root ()));
 	election_open->force_confirm ();
 	ASSERT_TIMELY (5s, node.block_confirmed (open->hash ()));
-	ASSERT_FALSE (node.ledger.dependencies_confirmed (node.ledger.tx_begin_read (), *receive));
+	ASSERT_FALSE (node.ledger.dependencies_cemented (node.ledger.tx_begin_read (), *receive));
 	ASSERT_NEVER (0.5s, node.active.active (receive->qualified_root ()));
 	ASSERT_FALSE (node.ledger.rollback (node.ledger.tx_begin_write (), receive->hash ()));
 	ASSERT_FALSE (node.block (receive->hash ()));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -22,7 +22,7 @@
 #include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/peer.hpp>
 #include <nano/store/ledger/pruned.hpp>

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -403,7 +403,7 @@ TEST (node, search_receivable_pruned)
 
 	// Confirmation
 	ASSERT_TIMELY (10s, node1->active.empty () && node2->active.empty ());
-	ASSERT_TIMELY (5s, node1->ledger.confirmed.block_exists_or_pruned (node1->ledger.tx_begin_read (), send2->hash ()));
+	ASSERT_TIMELY (5s, node1->ledger.cemented.block_exists_or_pruned (node1->ledger.tx_begin_read (), send2->hash ()));
 	ASSERT_TIMELY_EQ (5s, node2->ledger.cemented_count (), 3);
 	system.wallet (0)->remove_account (nano::dev::genesis_key.pub);
 
@@ -1602,7 +1602,7 @@ TEST (node, unconfirmed_send)
 	ASSERT_TIMELY (5s, node2.block_confirmed (send1->hash ()));
 
 	// wait until receive1 (auto-receive created by wallet) is cemented
-	ASSERT_TIMELY_EQ (5s, node2.ledger.confirmed.account_height (node2.ledger.tx_begin_read (), key2.pub), 1);
+	ASSERT_TIMELY_EQ (5s, node2.ledger.cemented.account_height (node2.ledger.tx_begin_read (), key2.pub), 1);
 	ASSERT_EQ (node2.balance (key2.pub), 2 * nano::nano_ratio);
 	auto recv1 = node2.ledger.find_receive_block_by_send_hash (node2.ledger.tx_begin_read (), key2.pub, send1->hash ());
 
@@ -1861,7 +1861,7 @@ TEST (node, DISABLED_local_votes_cache_batch)
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, node.ledger.process (node.ledger.tx_begin_write (), send1));
 	node.cementing_set.add (send1->hash ());
-	ASSERT_TIMELY (5s, node.ledger.confirmed.block_exists_or_pruned (node.ledger.tx_begin_read (), send1->hash ()));
+	ASSERT_TIMELY (5s, node.ledger.cemented.block_exists_or_pruned (node.ledger.tx_begin_read (), send1->hash ()));
 	auto send2 = nano::state_block_builder ()
 				 .account (nano::dev::genesis_key.pub)
 				 .previous (send1->hash ())
@@ -2775,7 +2775,7 @@ TEST (node, bidirectional_tcp)
 	while (!confirmed)
 	{
 		auto transaction2 = node2->ledger.tx_begin_read ();
-		confirmed = node2->ledger.confirmed.block_exists_or_pruned (transaction2, send1->hash ());
+		confirmed = node2->ledger.cemented.block_exists_or_pruned (transaction2, send1->hash ());
 		ASSERT_NO_ERROR (system.poll ());
 	}
 	// Test block propagation & confirmation from node 2 (remove representative from node 1)
@@ -2805,7 +2805,7 @@ TEST (node, bidirectional_tcp)
 	while (!confirmed)
 	{
 		auto transaction1 = node1->ledger.tx_begin_read ();
-		confirmed = node1->ledger.confirmed.block_exists_or_pruned (transaction1, send2->hash ());
+		confirmed = node1->ledger.cemented.block_exists_or_pruned (transaction1, send2->hash ());
 		ASSERT_NO_ERROR (system.poll ());
 	}
 }

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -308,7 +308,7 @@ TEST (request_aggregator, split)
 	{
 		// Confirm all blocks
 		auto tx = node.ledger.tx_begin_write ();
-		node.ledger.confirm (tx, blocks.back ()->hash ());
+		node.ledger.cement (tx, blocks.back ()->hash ());
 	}
 	ASSERT_TIMELY_EQ (5s, max_vbh + 2, node.ledger.cemented_count ());
 	ASSERT_EQ (max_vbh + 1, request.size ());

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -10,7 +10,7 @@
 #include <nano/node/transport/fake.hpp>
 #include <nano/node/transport/inproc.hpp>
 #include <nano/secure/ledger.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>

--- a/nano/core_test/request_aggregator.cpp
+++ b/nano/core_test/request_aggregator.cpp
@@ -422,7 +422,7 @@ TEST (request_aggregator, cannot_vote)
 	ASSERT_EQ (nano::block_status::progress, node.process (send1));
 	ASSERT_EQ (nano::block_status::progress, node.process (send2));
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	ASSERT_FALSE (node.ledger.dependencies_confirmed (node.ledger.tx_begin_read (), *send2));
+	ASSERT_FALSE (node.ledger.dependencies_cemented (node.ledger.tx_begin_read (), *send2));
 
 	std::vector<std::pair<nano::block_hash, nano::root>> request;
 	// Correct hash, correct root

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -119,9 +119,6 @@ enum class detail
 
 	test,
 
-	// node
-	process_confirmed,
-
 	// active_elections
 	active_started,
 	active_stopped,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -447,9 +447,9 @@ enum class detail
 	invocations,
 
 	// confirmation height
-	blocks_confirmed,
-	blocks_confirmed_unbounded,
-	blocks_confirmed_bounded,
+	blocks_cemented,
+	blocks_cemented_unbounded,
+	blocks_cemented_bounded,
 
 	// request aggregator
 	aggregator_accepted,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -132,7 +132,6 @@ enum class type
 	message_processor,
 	message_processor_overfill,
 	message_processor_type,
-	process_confirmed,
 	online_reps,
 	pruning,
 	fork_cache,

--- a/nano/nano_node/benchmarks/benchmark_elections.cpp
+++ b/nano/nano_node/benchmarks/benchmark_elections.cpp
@@ -231,7 +231,7 @@ void elections_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 			release_assert (result == nano::block_status::progress, to_string (result));
 
 			// Add to cementing set for direct cementing
-			auto cemented = node->ledger.confirm (transaction, send->hash ());
+			auto cemented = node->ledger.cement (transaction, send->hash ());
 			release_assert (!cemented.empty () && cemented.back ()->hash () == send->hash ());
 		}
 	}

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -572,7 +572,7 @@ void nano::active_elections::checkup_elections (nano::unique_lock<nano::mutex> &
 		if (target)
 		{
 			// Cancel if the election's block is already cemented
-			return node.ledger.confirmed.block_exists (transaction, *target);
+			return node.ledger.cemented.block_exists (transaction, *target);
 		}
 		else
 		{

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -16,7 +16,7 @@
 #include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 
 #include <ranges>
 

--- a/nano/node/bounded_backlog.cpp
+++ b/nano/node/bounded_backlog.cpp
@@ -11,7 +11,7 @@
 #include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/secure/transaction.hpp>
 
 nano::bounded_backlog::bounded_backlog (nano::node_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::ledger_notifications & ledger_notifications_a, nano::bucketing & bucketing_a, nano::backlog_scan & backlog_scan_a, nano::block_processor & block_processor_a, nano::cementing_set & cementing_set_a, nano::stats & stats_a, nano::logger & logger_a) :

--- a/nano/node/bounded_backlog.cpp
+++ b/nano/node/bounded_backlog.cpp
@@ -173,7 +173,7 @@ void nano::bounded_backlog::activate (nano::secure::transaction & transaction, n
 void nano::bounded_backlog::update (nano::secure::transaction const & transaction, nano::block_hash const & hash)
 {
 	// Erase if the block is either confirmed or missing
-	if (!ledger.unconfirmed_exists (transaction, hash))
+	if (!ledger.block_uncemented (transaction, hash))
 	{
 		nano::lock_guard<nano::mutex> guard{ mutex };
 		index.erase (hash);
@@ -303,7 +303,7 @@ std::deque<nano::block_hash> nano::bounded_backlog::perform_rollbacks (std::dequ
 	for (auto const & hash : targets)
 	{
 		// Skip the rollback if the block is being used by the node, this should be race free as it's checked while holding the ledger write lock
-		if (!should_rollback (hash) || !ledger.unconfirmed_exists (transaction, hash))
+		if (!should_rollback (hash) || !ledger.block_uncemented (transaction, hash))
 		{
 			stats.inc (nano::stat::type::bounded_backlog, nano::stat::detail::rollback_skipped);
 			continue;

--- a/nano/node/cementing_set.cpp
+++ b/nano/node/cementing_set.cpp
@@ -7,7 +7,7 @@
 #include <nano/node/ledger_notifications.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/write_queue.hpp>
 
 nano::cementing_set::cementing_set (cementing_set_config const & config_a, nano::ledger & ledger_a, nano::ledger_notifications & ledger_notifications_a, nano::stats & stats_a, nano::logger & logger_a) :

--- a/nano/node/cementing_set.cpp
+++ b/nano/node/cementing_set.cpp
@@ -253,7 +253,7 @@ void nano::cementing_set::run_batch (std::unique_lock<std::mutex> & lock)
 					break;
 				}
 
-				auto added = ledger.confirm (transaction, hash, config.max_blocks);
+				auto added = ledger.cement (transaction, hash, config.max_blocks);
 				if (!added.empty ())
 				{
 					// Confirming this block may implicitly confirm more

--- a/nano/node/cementing_set.cpp
+++ b/nano/node/cementing_set.cpp
@@ -264,13 +264,13 @@ void nano::cementing_set::run_batch (std::unique_lock<std::mutex> & lock)
 					}
 					cemented_count += added.size ();
 				}
-				else if (ledger.confirmed.block_exists (transaction, hash))
+				else if (ledger.cemented.block_exists (transaction, hash))
 				{
 					stats.inc (nano::stat::type::cementing_set, nano::stat::detail::already_cemented);
 					already.push_back (hash);
 				}
 
-				success = ledger.confirmed.block_exists (transaction, hash);
+				success = ledger.cemented.block_exists (transaction, hash);
 			} while (!success);
 
 			if (success)

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -10,7 +10,7 @@
 #include <nano/node/node.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>
 #include <nano/store/ledger/final_vote.hpp>
 #include <nano/store/ledger/online_weight.hpp>

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -523,7 +523,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 					auto block = node.node->ledger.any.block_get (transaction, block_hash);
 					if (block != nullptr)
 					{
-						if (!node.node->ledger.confirmed.block_exists (transaction, block_hash))
+						if (!node.node->ledger.cemented.block_exists (transaction, block_hash))
 						{
 							std::cout << "Rolling back " << block_hash.to_string () << " ..." << std::endl;
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1160,7 +1160,7 @@ void nano::json_handler::block_info ()
 			response_l.put ("height", std::to_string (block->sideband ().height));
 			response_l.put ("local_timestamp", std::to_string (block->sideband ().timestamp));
 			response_l.put ("successor", block->sideband ().successor.to_string ());
-			auto confirmed (node.ledger.confirmed.block_exists_or_pruned (transaction, hash));
+			auto confirmed (node.ledger.cemented.block_exists_or_pruned (transaction, hash));
 			response_l.put ("confirmed", confirmed);
 
 			bool json_block_l = request.get<bool> ("json_block", false);
@@ -1199,7 +1199,7 @@ void nano::json_handler::block_confirm ()
 		auto block_l = node.ledger.any.block_get (transaction, hash);
 		if (block_l != nullptr)
 		{
-			if (!node.ledger.confirmed.block_exists_or_pruned (transaction, hash))
+			if (!node.ledger.cemented.block_exists_or_pruned (transaction, hash))
 			{
 				// Start new confirmation for unconfirmed (or not being confirmed) block
 				if (!node.cementing_set.contains (hash))
@@ -1330,7 +1330,7 @@ void nano::json_handler::blocks_info ()
 					entry.put ("height", std::to_string (block->sideband ().height));
 					entry.put ("local_timestamp", std::to_string (block->sideband ().timestamp));
 					entry.put ("successor", block->sideband ().successor.to_string ());
-					auto confirmed (node.ledger.confirmed.block_exists_or_pruned (transaction, hash));
+					auto confirmed (node.ledger.cemented.block_exists_or_pruned (transaction, hash));
 					entry.put ("confirmed", confirmed);
 
 					if (json_block_l)
@@ -2719,7 +2719,7 @@ void nano::json_handler::account_history ()
 					entry.put ("local_timestamp", std::to_string (block->sideband ().timestamp));
 					entry.put ("height", std::to_string (block->sideband ().height));
 					entry.put ("hash", hash.to_string ());
-					entry.put ("confirmed", node.ledger.confirmed.block_exists_or_pruned (transaction, hash));
+					entry.put ("confirmed", node.ledger.cemented.block_exists_or_pruned (transaction, hash));
 					if (output_raw)
 					{
 						entry.put ("work", nano::to_string_hex (block->block_work ()));
@@ -5413,7 +5413,7 @@ bool block_confirmed (nano::node & node, nano::secure::transaction & transaction
 		is_confirmed = true;
 	}
 	// Check whether the confirmation height is set
-	else if (node.ledger.confirmed.block_exists_or_pruned (transaction, hash))
+	else if (node.ledger.cemented.block_exists_or_pruned (transaction, hash))
 	{
 		is_confirmed = true;
 	}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -20,7 +20,7 @@
 #include <nano/node/wallet.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/secure/transaction.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -689,7 +689,7 @@ std::pair<nano::uint128_t, nano::uint128_t> nano::node::balance_pending (nano::a
 {
 	std::pair<nano::uint128_t, nano::uint128_t> result;
 	auto const transaction = ledger.tx_begin_read ();
-	result.first = only_confirmed_a ? ledger.confirmed.account_balance (transaction, account_a).value_or (0).number () : ledger.any.account_balance (transaction, account_a).value_or (0).number ();
+	result.first = only_confirmed_a ? ledger.cemented.account_balance (transaction, account_a).value_or (0).number () : ledger.any.account_balance (transaction, account_a).value_or (0).number ();
 	result.second = ledger.account_receivable (transaction, account_a, only_confirmed_a);
 	return result;
 }
@@ -844,12 +844,12 @@ void nano::node::start_election (std::shared_ptr<nano::block> const & block)
 
 bool nano::node::block_confirmed (nano::block_hash const & hash)
 {
-	return ledger.confirmed.block_exists_or_pruned (ledger.tx_begin_read (), hash);
+	return ledger.cemented.block_exists_or_pruned (ledger.tx_begin_read (), hash);
 }
 
 bool nano::node::block_confirmed_or_being_confirmed (nano::secure::transaction const & transaction, nano::block_hash const & hash)
 {
-	return cementing_set.contains (hash) || ledger.confirmed.block_exists_or_pruned (transaction, hash);
+	return cementing_set.contains (hash) || ledger.cemented.block_exists_or_pruned (transaction, hash);
 }
 
 bool nano::node::block_confirmed_or_being_confirmed (nano::block_hash const & hash_a)

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -52,7 +52,7 @@
 #include <nano/node/websocket.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/block.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -702,10 +702,6 @@ nano::error nano::node_config::deserialize_toml (nano::tomlconfig & toml)
 		{
 			toml.get_error ().set ("max_work_generate_multiplier must be greater than or equal to 1");
 		}
-		if (block_processor_batch_max_time < network_params.node.process_confirmed_interval)
-		{
-			toml.get_error ().set ((boost::format ("block_processor_batch_max_time value must be equal or larger than %1%ms") % network_params.node.process_confirmed_interval.count ()).str ());
-		}
 		if (max_pruning_age < std::chrono::seconds (5 * 60) && !network_params.network.is_dev_network ())
 		{
 			toml.get_error ().set ("max_pruning_age must be greater than or equal to 5 minutes");

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -4,7 +4,7 @@
 #include <nano/node/online_reps.hpp>
 #include <nano/node/repcrawler.hpp>
 #include <nano/secure/ledger.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 
 #include <ranges>
 

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -307,7 +307,7 @@ auto nano::rep_crawler::prepare_query_target () const -> hash_root_t
 		}
 
 		// Nodes will not respond to queries for blocks that are not confirmed
-		if (!node.ledger.confirmed.block_exists (transaction, block->hash ()))
+		if (!node.ledger.cemented.block_exists (transaction, block->hash ()))
 		{
 			continue;
 		}

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -265,7 +265,7 @@ auto nano::request_aggregator::aggregate (nano::secure::transaction const & tran
 			// If the final vote is not set, generate vote if the block is confirmed
 			else
 			{
-				return ledger.confirmed.block_exists (transaction, block->hash ());
+				return ledger.cemented.block_exists (transaction, block->hash ());
 			}
 		};
 

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -12,7 +12,7 @@
 #include <nano/node/wallet.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/final_vote.hpp>
 
 nano::request_aggregator::request_aggregator (request_aggregator_config const & config_a, nano::node & node_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_router & vote_router_a) :

--- a/nano/node/scheduler/hinted.cpp
+++ b/nano/node/scheduler/hinted.cpp
@@ -97,7 +97,7 @@ void nano::scheduler::hinted::activate (secure::read_transaction & transaction, 
 			if (check_dependencies)
 			{
 				// Perform a depth-first search of the dependency graph
-				if (!node.ledger.dependencies_confirmed (transaction, *block))
+				if (!node.ledger.dependencies_cemented (transaction, *block))
 				{
 					stats.inc (nano::stat::type::hinting, nano::stat::detail::dependency_unconfirmed);
 					auto dependencies = block->dependencies ();

--- a/nano/node/scheduler/optimistic.cpp
+++ b/nano/node/scheduler/optimistic.cpp
@@ -7,7 +7,7 @@
 #include <nano/node/scheduler/optimistic.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 
 nano::scheduler::optimistic::optimistic (optimistic_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::active_elections & active_a, nano::network_constants const & network_constants_a, nano::stats & stats_a) :
 	config{ config_a },

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -7,7 +7,7 @@
 #include <nano/node/scheduler/priority.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>
 
 nano::scheduler::priority::priority (nano::node_config & node_config, nano::node & node_a, nano::ledger & ledger_a, nano::ledger_notifications & ledger_notifications_a, nano::bucketing & bucketing_a, nano::active_elections & active_a, nano::cementing_set & cementing_set_a, nano::stats & stats_a, nano::logger & logger_a) :

--- a/nano/node/scheduler/priority.cpp
+++ b/nano/node/scheduler/priority.cpp
@@ -132,7 +132,7 @@ bool nano::scheduler::priority::activate (secure::transaction const & transactio
 		return false; // Not activated
 	}
 
-	if (ledger.dependencies_confirmed (transaction, *block))
+	if (ledger.dependencies_cemented (transaction, *block))
 	{
 		auto const [priority_balance, priority_timestamp] = ledger.block_priority (transaction, *block);
 		auto const bucket_index = bucketing.bucket_index (priority_balance);

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -54,7 +54,7 @@ bool nano::vote_generator::should_vote (transaction_variant_t const & transactio
 		auto const & transaction = std::get<nano::secure::write_transaction> (transaction_variant);
 
 		block = ledger.any.block_get (transaction, hash_a);
-		should_vote = block != nullptr && ledger.dependencies_confirmed (transaction, *block) && ledger.store.final_vote.put (transaction, block->qualified_root (), hash_a);
+		should_vote = block != nullptr && ledger.dependencies_cemented (transaction, *block) && ledger.store.final_vote.put (transaction, block->qualified_root (), hash_a);
 		debug_assert (block == nullptr || root_a == block->root ());
 	}
 	else
@@ -63,7 +63,7 @@ bool nano::vote_generator::should_vote (transaction_variant_t const & transactio
 		auto const & transaction = std::get<nano::secure::read_transaction> (transaction_variant);
 
 		block = ledger.any.block_get (transaction, hash_a);
-		should_vote = block != nullptr && ledger.dependencies_confirmed (transaction, *block);
+		should_vote = block != nullptr && ledger.dependencies_cemented (transaction, *block);
 	}
 
 	logger.trace (log_type (), nano::log::detail::should_vote,
@@ -154,13 +154,13 @@ std::size_t nano::vote_generator::generate (std::vector<std::shared_ptr<nano::bl
 	request_t::first_type req_candidates;
 	{
 		auto transaction = ledger.tx_begin_read ();
-		auto dependencies_confirmed = [&transaction, this] (auto const & block_a) {
-			return this->ledger.dependencies_confirmed (transaction, *block_a);
+		auto dependencies_cemented = [&transaction, this] (auto const & block_a) {
+			return this->ledger.dependencies_cemented (transaction, *block_a);
 		};
 		auto as_candidate = [] (auto const & block_a) {
 			return candidate_t{ block_a->root (), block_a->hash () };
 		};
-		nano::transform_if (blocks_a.begin (), blocks_a.end (), std::back_inserter (req_candidates), dependencies_confirmed, as_candidate);
+		nano::transform_if (blocks_a.begin (), blocks_a.end (), std::back_inserter (req_candidates), dependencies_cemented, as_candidate);
 	}
 	auto const result = req_candidates.size ();
 	nano::lock_guard<nano::mutex> guard{ mutex };

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1321,7 +1321,7 @@ bool nano::wallet::search_receivable_impl (nano::store::transaction const & wall
 					auto amount (pending.amount.number ());
 					if (wallets.config.receive_minimum.number () <= amount)
 					{
-						bool const confirmed = wallets.ledger.confirmed.block_exists_or_pruned (ledger_txn, hash);
+						bool const confirmed = wallets.ledger.cemented.block_exists_or_pruned (ledger_txn, hash);
 
 						logger.info (nano::log::type::wallet, "Found a receivable block: {} ({}) for account: {} from: {}",
 						hash.to_string (),
@@ -2080,7 +2080,7 @@ void nano::wallets::receive_confirmed (nano::block_hash const & hash_a, nano::ac
 			}
 			else
 			{
-				if (!ledger.confirmed.block_exists_or_pruned (ledger.tx_begin_read (), hash_a))
+				if (!ledger.cemented.block_exists_or_pruned (ledger.tx_begin_read (), hash_a))
 				{
 					logger.warn (nano::log::type::wallet, "Confirmed block is missing: {}", hash_a.to_string ());
 					debug_assert (false, "confirmed block is missing");

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -11,7 +11,7 @@
 #include <nano/node/wallet.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/pending.hpp>
 #include <nano/store/lmdb/common.hpp>
 #include <nano/store/lmdb/db_val.hpp>

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -513,7 +513,7 @@ TEST (history, pruned_source)
 		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive1));
 		auto open = std::make_shared<nano::open_block> (send2->hash (), key.pub, key.pub, key.prv, key.pub, *system.work.generate (key.pub));
 		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open));
-		ledger.confirm (transaction, send1->hash ());
+		ledger.cement (transaction, send1->hash ());
 		ASSERT_EQ (1, ledger.pruning_action (transaction, send1->hash (), 2));
 		next_pruning = send2->hash ();
 	}
@@ -555,7 +555,7 @@ TEST (history, pruned_source)
 	// Additional legacy test
 	{
 		auto transaction = ledger.tx_begin_write ();
-		ledger.confirm (transaction, next_pruning);
+		ledger.cement (transaction, next_pruning);
 		ASSERT_EQ (1, ledger.pruning_action (transaction, next_pruning, 2));
 	}
 	// Genesis account pruned values
@@ -587,9 +587,9 @@ TEST (history, pruned_source)
 		auto latest_key (ledger.any.account_head (transaction, key.pub));
 		auto receive2 = std::make_shared<nano::state_block> (key.pub, latest_key, key.pub, 200, send3->hash (), key.prv, key.pub, *system.work.generate (latest_key));
 		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, receive2));
-		ledger.confirm (transaction, latest);
+		ledger.cement (transaction, latest);
 		ASSERT_EQ (1, ledger.pruning_action (transaction, latest, 2));
-		ledger.confirm (transaction, latest_key);
+		ledger.cement (transaction, latest_key);
 		ASSERT_EQ (1, ledger.pruning_action (transaction, latest_key, 2));
 	}
 	// Genesis account pruned values
@@ -619,7 +619,7 @@ TEST (history, pruned_source)
 		auto latest (ledger.any.account_head (transaction, nano::dev::genesis_key.pub));
 		auto change = std::make_shared<nano::state_block> (nano::dev::genesis_key.pub, latest, key.pub, nano::dev::constants.genesis_amount - 200, 0, nano::dev::genesis_key.prv, nano::dev::genesis_key.pub, *system.work.generate (latest));
 		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, change));
-		ledger.confirm (transaction, latest);
+		ledger.cement (transaction, latest);
 		ASSERT_EQ (1, ledger.pruning_action (transaction, latest, 2));
 	}
 	// Genesis account pruned values
@@ -653,7 +653,7 @@ TEST (history, pruned_source)
 		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send4));
 		auto open2 = std::make_shared<nano::state_block> (key2.pub, 0, key2.pub, 100, send4->hash (), key2.prv, key2.pub, *system.work.generate (key2.pub));
 		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, open2));
-		ledger.confirm (transaction, latest_key);
+		ledger.cement (transaction, latest_key);
 		ASSERT_EQ (1, ledger.pruning_action (transaction, latest_key, 2));
 	}
 	// New account (key) pruned values

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2411,7 +2411,7 @@ TEST (rpc, account_representative_set)
 	nano::keypair key2;
 	wallet.insert_adhoc (key2.prv);
 	auto key2_open_block_hash = wallet.send_sync (nano::dev::genesis_key.pub, key2.pub, node->config.receive_minimum.number ());
-	ASSERT_TIMELY (5s, node->ledger.confirmed.block_exists_or_pruned (node->ledger.tx_begin_read (), key2_open_block_hash));
+	ASSERT_TIMELY (5s, node->ledger.cemented.block_exists_or_pruned (node->ledger.tx_begin_read (), key2_open_block_hash));
 	auto key2_open_block = node->ledger.any.block_get (node->ledger.tx_begin_read (), key2_open_block_hash);
 	ASSERT_EQ (nano::dev::genesis_key.pub, key2_open_block->representative_field ().value ());
 
@@ -2431,7 +2431,7 @@ TEST (rpc, account_representative_set)
 	ASSERT_FALSE (hash.is_zero ());
 	auto block = node->ledger.any.block_get (node->ledger.tx_begin_read (), hash);
 	ASSERT_NE (block, nullptr);
-	ASSERT_TIMELY (5s, node->ledger.confirmed.block_exists_or_pruned (node->ledger.tx_begin_read (), hash));
+	ASSERT_TIMELY (5s, node->ledger.cemented.block_exists_or_pruned (node->ledger.tx_begin_read (), hash));
 	ASSERT_EQ (key2.pub, block->representative_field ().value ());
 }
 
@@ -3288,7 +3288,7 @@ TEST (rpc, wallet_pending)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	system.wallet (0)->insert_adhoc (key1.prv);
 	auto block1 = system.wallet (0)->send_action (nano::dev::genesis_key.pub, key1.pub, 100);
-	ASSERT_TIMELY_EQ (5s, node->ledger.confirmed.account_height (node->ledger.tx_begin_read (), nano::dev::genesis_key.pub), 2);
+	ASSERT_TIMELY_EQ (5s, node->ledger.cemented.account_height (node->ledger.tx_begin_read (), nano::dev::genesis_key.pub), 2);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_pending");
@@ -4098,7 +4098,7 @@ TEST (rpc, blocks_info_receive_hash)
 	};
 
 	ASSERT_TIMELY (5s, all_blocks_cemented ());
-	ASSERT_EQ (node->ledger.confirmed.account_balance (node->ledger.tx_begin_read (), key1.pub), 10);
+	ASSERT_EQ (node->ledger.cemented.account_balance (node->ledger.tx_begin_read (), key1.pub), 10);
 
 	// create the RPC request
 	boost::property_tree::ptree request;
@@ -5301,7 +5301,7 @@ TEST (rpc, block_confirm_confirmed)
 	auto node = add_ipc_enabled_node (system, config);
 	{
 		auto transaction = node->ledger.tx_begin_read ();
-		ASSERT_TRUE (node->ledger.confirmed.block_exists_or_pruned (transaction, nano::dev::genesis->hash ()));
+		ASSERT_TRUE (node->ledger.cemented.block_exists_or_pruned (transaction, nano::dev::genesis->hash ()));
 	}
 	ASSERT_EQ (0, node->stats.count (nano::stat::type::http_callbacks_ec));
 	auto const rpc_ctx = add_rpc (system, node);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -28,7 +28,7 @@
 #include <nano/rpc_test/test_response.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>
 #include <nano/store/ledger/peer.hpp>

--- a/nano/secure/CMakeLists.txt
+++ b/nano/secure/CMakeLists.txt
@@ -17,8 +17,8 @@ add_library(
   ledger_rollback.cpp
   ledger_set_any.hpp
   ledger_set_any.cpp
-  ledger_set_confirmed.hpp
-  ledger_set_confirmed.cpp
+  ledger_set_cemented.hpp
+  ledger_set_cemented.cpp
   pending_info.hpp
   pending_info.cpp
   receivable_iterator.cpp

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -250,7 +250,6 @@ nano::node_constants::node_constants (nano::network_constants const & network_co
 	backup_interval = std::chrono::minutes (5);
 	search_pending_interval = network_constants.is_dev_network () ? std::chrono::seconds (1) : std::chrono::seconds (5 * 60);
 	unchecked_cleaning_interval = std::chrono::minutes (30);
-	process_confirmed_interval = network_constants.is_dev_network () ? std::chrono::milliseconds (50) : std::chrono::milliseconds (500);
 	weight_interval = network_constants.is_dev_network () ? std::chrono::seconds (1) : std::chrono::minutes (5);
 	weight_cutoff = (network_constants.is_live_network () || network_constants.is_test_network ()) ? std::chrono::weeks (2) : std::chrono::days (1);
 }

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -201,7 +201,6 @@ public:
 	std::chrono::minutes backup_interval;
 	std::chrono::seconds search_pending_interval;
 	std::chrono::minutes unchecked_cleaning_interval;
-	std::chrono::milliseconds process_confirmed_interval;
 
 	/** Time between collecting online representative samples */
 	std::chrono::seconds weight_interval;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -285,8 +285,8 @@ nano::uint128_t nano::ledger::account_receivable (secure::transaction const & tr
 }
 
 // Both stack and result set are bounded to limit maximum memory usage
-// Callers must ensure that the target block was confirmed, and if not, call this function multiple times
-std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_transaction & transaction, nano::block_hash const & target_hash, size_t max_blocks)
+// Due to the max_blocks limit, the target block may not be cemented in a single call. Callers should call this function multiple times until the target is cemented.
+std::deque<std::shared_ptr<nano::block>> nano::ledger::cement (secure::write_transaction & transaction, nano::block_hash const & target_hash, size_t max_blocks)
 {
 	std::deque<std::shared_ptr<nano::block>> result;
 
@@ -326,9 +326,9 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_tr
 	};
 
 	auto resolve = [&] (std::shared_ptr<nano::block> const & block) -> bool {
-		// We must only confirm blocks that have their dependencies confirmed
+		// We must only cement blocks that have their dependencies cemented
 		debug_assert (dependencies_confirmed (transaction, *block));
-		confirm_one (transaction, *block);
+		cement_one (transaction, *block);
 
 		result.push_back (block);
 
@@ -343,7 +343,7 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_tr
 			}
 		}
 
-		// Early return might leave parts of the dependency tree unconfirmed
+		// Early return might leave parts of the dependency tree uncemented
 		return result.size () < max_blocks;
 	};
 
@@ -357,14 +357,14 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::confirm (secure::write_tr
 	return result;
 }
 
-void nano::ledger::confirm_one (secure::write_transaction & transaction, nano::block const & block)
+void nano::ledger::cement_one (secure::write_transaction & transaction, nano::block const & block)
 {
 	debug_assert ((!store.confirmation_height.get (transaction, block.account ()) && block.sideband ().height == 1) || store.confirmation_height.get (transaction, block.account ()).value ().height + 1 == block.sideband ().height);
 	confirmation_height_info info{ block.sideband ().height, block.hash () };
 	store.confirmation_height.put (transaction, block.account (), info);
 	++cache.cemented_count;
 
-	stats.inc (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed);
+	stats.inc (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented);
 }
 
 nano::block_status nano::ledger::process (secure::write_transaction const & transaction, std::shared_ptr<nano::block> block)

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -257,9 +257,14 @@ void nano::ledger::verify_consistency (secure::transaction const & transaction) 
 	rep_weights.verify_consistency (0); // It's impractical to recompute burned weight, so we skip it here
 }
 
-bool nano::ledger::unconfirmed_exists (secure::transaction const & transaction, nano::block_hash const & hash) const
+bool nano::ledger::block_uncemented (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
-	return any.block_exists (transaction, hash) && !confirmed.block_exists (transaction, hash);
+	auto block = any.block_get (transaction, hash);
+	if (block)
+	{
+		return !confirmed.block_exists (transaction, *block);
+	}
+	return false; // Block doesn't exist
 }
 
 nano::uint128_t nano::ledger::account_receivable (secure::transaction const & transaction_a, nano::account const & account_a, bool only_confirmed_a) const

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -41,9 +41,9 @@ nano::ledger::ledger (nano::store::ledger_store & store_a, nano::network_params 
 	rep_weights{ store_a.rep_weight, min_rep_weight_a },
 	max_backlog_size{ max_backlog_a },
 	any_impl{ std::make_unique<ledger_set_any> (*this) },
-	confirmed_impl{ std::make_unique<ledger_set_cemented> (*this) },
+	cemented_impl{ std::make_unique<ledger_set_cemented> (*this) },
 	any{ *any_impl },
-	confirmed{ *confirmed_impl }
+	cemented{ *cemented_impl }
 {
 	initialize (generate_cache_flags_a);
 }
@@ -262,7 +262,7 @@ bool nano::ledger::block_uncemented (secure::transaction const & transaction, na
 	auto block = any.block_get (transaction, hash);
 	if (block)
 	{
-		return !confirmed.block_exists (transaction, *block);
+		return !cemented.block_exists (transaction, *block);
 	}
 	return false; // Block doesn't exist
 }
@@ -276,7 +276,7 @@ nano::uint128_t nano::ledger::account_receivable (secure::transaction const & tr
 		nano::pending_info const & info (i->second);
 		if (only_confirmed_a)
 		{
-			if (confirmed.block_exists_or_pruned (transaction_a, i->first.hash))
+			if (cemented.block_exists_or_pruned (transaction_a, i->first.hash))
 			{
 				result += info.amount.number ();
 			}
@@ -301,7 +301,7 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::cement (secure::write_tra
 	auto is_resolved = [&] (std::shared_ptr<nano::block> const & block) {
 		if (block)
 		{
-			return confirmed.block_exists (transaction, *block);
+			return cemented.block_exists (transaction, *block);
 		}
 		return true; // Pruned, must have been cemented
 	};
@@ -588,7 +588,7 @@ bool nano::ledger::dependencies_confirmed (secure::transaction const & transacti
 	release_assert (block.has_sideband ());
 	auto dependencies = block.dependencies ();
 	return std::all_of (dependencies.begin (), dependencies.end (), [this, &transaction] (nano::block_hash const & hash) {
-		return hash.is_zero () || confirmed.block_exists_or_pruned (transaction, hash);
+		return hash.is_zero () || cemented.block_exists_or_pruned (transaction, hash);
 	});
 }
 
@@ -707,7 +707,7 @@ uint64_t nano::ledger::pruning_action (secure::write_transaction & transaction_a
 		auto block_l = any.block_get (transaction_a, hash);
 		if (block_l != nullptr)
 		{
-			release_assert (confirmed.block_exists (transaction_a, hash));
+			release_assert (cemented.block_exists (transaction_a, hash));
 			store.block.del (transaction_a, hash);
 			store.pruned.put (transaction_a, hash);
 			hash = block_l->previous ();

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -332,7 +332,7 @@ std::deque<std::shared_ptr<nano::block>> nano::ledger::cement (secure::write_tra
 
 	auto resolve = [&] (std::shared_ptr<nano::block> const & block) -> bool {
 		// We must only cement blocks that have their dependencies cemented
-		debug_assert (dependencies_confirmed (transaction, *block));
+		debug_assert (dependencies_cemented (transaction, *block));
 		cement_one (transaction, *block);
 
 		result.push_back (block);
@@ -583,7 +583,7 @@ nano::root nano::ledger::latest_root (secure::transaction const & transaction_a,
 	}
 }
 
-bool nano::ledger::dependencies_confirmed (secure::transaction const & transaction, nano::block const & block) const
+bool nano::ledger::dependencies_cemented (secure::transaction const & transaction, nano::block const & block) const
 {
 	release_assert (block.has_sideband ());
 	auto dependencies = block.dependencies ();

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -14,7 +14,7 @@
 #include <nano/secure/ledger_processor.hpp>
 #include <nano/secure/ledger_rollback.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/secure/rep_weights.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/block.hpp>
@@ -41,7 +41,7 @@ nano::ledger::ledger (nano::store::ledger_store & store_a, nano::network_params 
 	rep_weights{ store_a.rep_weight, min_rep_weight_a },
 	max_backlog_size{ max_backlog_a },
 	any_impl{ std::make_unique<ledger_set_any> (*this) },
-	confirmed_impl{ std::make_unique<ledger_set_confirmed> (*this) },
+	confirmed_impl{ std::make_unique<ledger_set_cemented> (*this) },
 	any{ *any_impl },
 	confirmed{ *confirmed_impl }
 {

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -48,7 +48,6 @@ public:
 	/** Start read-only transaction */
 	secure::read_transaction tx_begin_read () const;
 
-	bool unconfirmed_exists (secure::transaction const &, nano::block_hash const &) const;
 	nano::uint128_t account_receivable (secure::transaction const &, nano::account const &, bool = false) const;
 	/**
 	 * Returns the cached vote weight for the given representative.
@@ -81,6 +80,11 @@ public:
 
 	static nano::epoch version (nano::block const & block);
 	nano::epoch version (secure::transaction const &, nano::block_hash const & hash) const;
+
+	/**
+	 * Checks if a block exists in the ledger but has not yet been cemented
+	 */
+	bool block_uncemented (secure::transaction const &, nano::block_hash const &) const;
 
 	/**
 	 * Checks if all blocks that this block depends on are confirmed (or pruned)

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -87,9 +87,9 @@ public:
 	bool block_uncemented (secure::transaction const &, nano::block_hash const &) const;
 
 	/**
-	 * Checks if all blocks that this block depends on are confirmed (or pruned)
+	 * Checks if all blocks that this block depends on are cemented (or pruned)
 	 */
-	bool dependencies_confirmed (secure::transaction const &, nano::block const &) const;
+	bool dependencies_cemented (secure::transaction const &, nano::block const &) const;
 
 	/**
 	 * Computes the priority balance and timestamp for bucket-based prioritization

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -65,7 +65,7 @@ public:
 	std::string block_text (nano::block_hash const &);
 	std::deque<std::shared_ptr<nano::block>> random_blocks (secure::transaction const &, size_t count) const;
 	std::optional<nano::pending_info> pending_info (secure::transaction const &, nano::pending_key const & key) const;
-	std::deque<std::shared_ptr<nano::block>> confirm (secure::write_transaction &, nano::block_hash const & hash, size_t max_blocks = 1024 * 128);
+	std::deque<std::shared_ptr<nano::block>> cement (secure::write_transaction &, nano::block_hash const & hash, size_t max_blocks = 1024 * 128);
 	nano::block_status process (secure::write_transaction const &, std::shared_ptr<nano::block> block);
 	bool rollback (secure::write_transaction const &, nano::block_hash const &, std::deque<std::shared_ptr<nano::block>> & rollback_list, size_t depth = 0, size_t max_depth = nano::ledger_max_rollback_depth ());
 	bool rollback (secure::write_transaction const &, nano::block_hash const &);
@@ -124,7 +124,7 @@ public:
 
 private:
 	void initialize (nano::generate_cache_flags const &);
-	void confirm_one (secure::write_transaction &, nano::block const & block);
+	void cement_one (secure::write_transaction &, nano::block const & block);
 
 	std::unique_ptr<ledger_set_any> any_impl;
 	std::unique_ptr<ledger_set_confirmed> confirmed_impl;

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -21,7 +21,7 @@ namespace nano
 {
 class ledger;
 class ledger_set_any;
-class ledger_set_confirmed;
+class ledger_set_cemented;
 
 class ledger_cache
 {
@@ -127,10 +127,10 @@ private:
 	void cement_one (secure::write_transaction &, nano::block const & block);
 
 	std::unique_ptr<ledger_set_any> any_impl;
-	std::unique_ptr<ledger_set_confirmed> confirmed_impl;
+	std::unique_ptr<ledger_set_cemented> confirmed_impl;
 
 public:
 	ledger_set_any & any;
-	ledger_set_confirmed & confirmed;
+	ledger_set_cemented & confirmed;
 };
 }

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -131,10 +131,10 @@ private:
 	void cement_one (secure::write_transaction &, nano::block const & block);
 
 	std::unique_ptr<ledger_set_any> any_impl;
-	std::unique_ptr<ledger_set_cemented> confirmed_impl;
+	std::unique_ptr<ledger_set_cemented> cemented_impl;
 
 public:
 	ledger_set_any & any;
-	ledger_set_cemented & confirmed;
+	ledger_set_cemented & cemented;
 };
 }

--- a/nano/secure/ledger_set_any.hpp
+++ b/nano/secure/ledger_set_any.hpp
@@ -17,49 +17,49 @@ public:
 	explicit ledger_set_any (nano::ledger const &);
 
 public: // Operations on accounts
-	std::optional<nano::amount> account_balance (secure::transaction const & transaction, nano::account const & account) const;
-	account_iterator account_begin (secure::transaction const & transaction) const;
+	std::optional<nano::amount> account_balance (nano::secure::transaction const &, nano::account const &) const;
+	account_iterator account_begin (nano::secure::transaction const &) const;
 	account_iterator account_end () const;
-	std::optional<nano::account_info> account_get (secure::transaction const & transaction, nano::account const & account) const;
-	bool account_exists (secure::transaction const & transaction, nano::account const & account) const;
-	nano::block_hash account_head (secure::transaction const & transaction, nano::account const & account) const;
-	uint64_t account_height (secure::transaction const & transaction, nano::account const & account) const;
+	std::optional<nano::account_info> account_get (nano::secure::transaction const &, nano::account const &) const;
+	bool account_exists (nano::secure::transaction const &, nano::account const &) const;
+	nano::block_hash account_head (nano::secure::transaction const &, nano::account const &) const;
+	uint64_t account_height (nano::secure::transaction const &, nano::account const &) const;
 	// Returns the next account entry equal or greater than 'account'
 	// Mirrors std::map::lower_bound
-	account_iterator account_lower_bound (secure::transaction const & transaction, nano::account const & account) const;
+	account_iterator account_lower_bound (nano::secure::transaction const &, nano::account const &) const;
 	// Returns the next account entry greater than 'account'
 	// Returns account_lower_bound (transaction, account + 1)
 	// Mirrors std::map::upper_bound
-	account_iterator account_upper_bound (secure::transaction const & transaction, nano::account const & account) const;
+	account_iterator account_upper_bound (nano::secure::transaction const &, nano::account const &) const;
 
 public: // Operations on blocks
-	std::optional<nano::account> block_account (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	std::optional<nano::amount> block_amount (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	std::optional<nano::amount> block_amount (secure::transaction const & transaction, std::shared_ptr<nano::block> const & block) const;
-	std::optional<nano::amount> block_balance (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	bool block_exists (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	bool block_exists_or_pruned (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	std::shared_ptr<nano::block> block_get (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	bool block_pruned (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	uint64_t block_height (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	std::optional<nano::block_hash> block_successor (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	std::optional<nano::block_hash> block_successor (secure::transaction const & transaction, nano::qualified_root const & root) const;
+	std::optional<nano::account> block_account (nano::secure::transaction const &, nano::block_hash const &) const;
+	std::optional<nano::amount> block_amount (nano::secure::transaction const &, nano::block_hash const &) const;
+	std::optional<nano::amount> block_amount (nano::secure::transaction const &, std::shared_ptr<nano::block> const &) const;
+	std::optional<nano::amount> block_balance (nano::secure::transaction const &, nano::block_hash const &) const;
+	bool block_exists (nano::secure::transaction const &, nano::block_hash const &) const;
+	bool block_exists_or_pruned (nano::secure::transaction const &, nano::block_hash const &) const;
+	std::shared_ptr<nano::block> block_get (nano::secure::transaction const &, nano::block_hash const &) const;
+	bool block_pruned (nano::secure::transaction const &, nano::block_hash const &) const;
+	uint64_t block_height (nano::secure::transaction const &, nano::block_hash const &) const;
+	std::optional<nano::block_hash> block_successor (nano::secure::transaction const &, nano::block_hash const &) const;
+	std::optional<nano::block_hash> block_successor (nano::secure::transaction const &, nano::qualified_root const &) const;
 
 public: // Operations on pending entries
-	std::optional<nano::pending_info> pending_get (secure::transaction const & transaction, nano::pending_key const & key) const;
+	std::optional<nano::pending_info> pending_get (nano::secure::transaction const &, nano::pending_key const &) const;
 	receivable_iterator receivable_end () const;
-	bool receivable_exists (secure::transaction const & transaction, nano::account const & account) const;
+	bool receivable_exists (nano::secure::transaction const &, nano::account const &) const;
 	// Returns the next receivable entry equal or greater than 'key'
 	// Mirrors std::map::lower_bound
-	std::optional<std::pair<nano::pending_key, nano::pending_info>> receivable_lower_bound (secure::transaction const & transaction, nano::account const & account, nano::block_hash const & hash) const;
+	std::optional<std::pair<nano::pending_key, nano::pending_info>> receivable_lower_bound (nano::secure::transaction const &, nano::account const &, nano::block_hash const &) const;
 	// Returns the next receivable entry for an account greater than 'account'
 	// Returns receivable_lower_bound (transaction, account + 1, 0)
 	// Mirrors std::map::upper_bound
-	receivable_iterator receivable_upper_bound (secure::transaction const & transaction, nano::account const & account) const;
+	receivable_iterator receivable_upper_bound (nano::secure::transaction const &, nano::account const &) const;
 	// Returns the next receivable entry for the account 'account' with hash greater than 'hash'
 	// Returns receivable_lower_bound (transaction, account + 1, hash)
 	// Mirrors std::map::upper_bound
-	receivable_iterator receivable_upper_bound (secure::transaction const & transaction, nano::account const & account, nano::block_hash const & hash) const;
+	receivable_iterator receivable_upper_bound (nano::secure::transaction const &, nano::account const &, nano::block_hash const &) const;
 
 private:
 	nano::ledger const & ledger;

--- a/nano/secure/ledger_set_any.hpp
+++ b/nano/secure/ledger_set_any.hpp
@@ -1,24 +1,10 @@
 #pragma once
 
 #include <nano/secure/account_iterator.hpp>
+#include <nano/secure/fwd.hpp>
 #include <nano/secure/receivable_iterator.hpp>
 
 #include <optional>
-
-namespace nano
-{
-class account_info;
-class block;
-class block_hash;
-class ledger;
-class pending_info;
-class pending_key;
-class qualified_root;
-}
-namespace nano::store
-{
-class transaction;
-}
 
 namespace nano
 {
@@ -28,7 +14,7 @@ public:
 	using account_iterator = nano::account_iterator<ledger_set_any>;
 	using receivable_iterator = nano::receivable_iterator<ledger_set_any>;
 
-	ledger_set_any (nano::ledger const & ledger);
+	explicit ledger_set_any (nano::ledger const &);
 
 public: // Operations on accounts
 	std::optional<nano::amount> account_balance (secure::transaction const & transaction, nano::account const & account) const;
@@ -77,5 +63,5 @@ public: // Operations on pending entries
 
 private:
 	nano::ledger const & ledger;
-}; // class ledger_set_any
-} // namespace nano
+};
+}

--- a/nano/secure/ledger_set_cemented.cpp
+++ b/nano/secure/ledger_set_cemented.cpp
@@ -1,6 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/secure/ledger.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/block.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>
@@ -8,12 +8,12 @@
 #include <nano/store/ledger/pruned.hpp>
 #include <nano/store/ledger_store.hpp>
 
-nano::ledger_set_confirmed::ledger_set_confirmed (nano::ledger const & ledger) :
+nano::ledger_set_cemented::ledger_set_cemented (nano::ledger const & ledger) :
 	ledger{ ledger }
 {
 }
 
-std::optional<nano::amount> nano::ledger_set_confirmed::account_balance (secure::transaction const & transaction, nano::account const & account_a) const
+std::optional<nano::amount> nano::ledger_set_cemented::account_balance (secure::transaction const & transaction, nano::account const & account_a) const
 {
 	auto block = block_get (transaction, account_head (transaction, account_a));
 	if (!block)
@@ -23,7 +23,7 @@ std::optional<nano::amount> nano::ledger_set_confirmed::account_balance (secure:
 	return block->balance ();
 }
 
-nano::block_hash nano::ledger_set_confirmed::account_head (secure::transaction const & transaction, nano::account const & account) const
+nano::block_hash nano::ledger_set_cemented::account_head (secure::transaction const & transaction, nano::account const & account) const
 {
 	auto info = ledger.store.confirmation_height.get (transaction, account);
 	if (!info)
@@ -33,7 +33,7 @@ nano::block_hash nano::ledger_set_confirmed::account_head (secure::transaction c
 	return info.value ().frontier;
 }
 
-uint64_t nano::ledger_set_confirmed::account_height (secure::transaction const & transaction, nano::account const & account) const
+uint64_t nano::ledger_set_cemented::account_height (secure::transaction const & transaction, nano::account const & account) const
 {
 	auto head_l = account_head (transaction, account);
 	if (head_l.is_zero ())
@@ -45,7 +45,7 @@ uint64_t nano::ledger_set_confirmed::account_height (secure::transaction const &
 	return block->sideband ().height;
 }
 
-std::optional<nano::amount> nano::ledger_set_confirmed::block_balance (secure::transaction const & transaction, nano::block_hash const & hash) const
+std::optional<nano::amount> nano::ledger_set_cemented::block_balance (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	auto block = block_get (transaction, hash);
 	if (!block)
@@ -55,12 +55,12 @@ std::optional<nano::amount> nano::ledger_set_confirmed::block_balance (secure::t
 	return block->balance ();
 }
 
-bool nano::ledger_set_confirmed::block_exists (secure::transaction const & transaction, nano::block_hash const & hash) const
+bool nano::ledger_set_cemented::block_exists (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	return block_get (transaction, hash) != nullptr;
 }
 
-bool nano::ledger_set_confirmed::block_exists (secure::transaction const & transaction, nano::block const & block) const
+bool nano::ledger_set_cemented::block_exists (secure::transaction const & transaction, nano::block const & block) const
 {
 	auto info = ledger.store.confirmation_height.get (transaction, block.account ());
 	if (!info)
@@ -70,7 +70,7 @@ bool nano::ledger_set_confirmed::block_exists (secure::transaction const & trans
 	return block.sideband ().height <= info.value ().height;
 }
 
-bool nano::ledger_set_confirmed::block_exists_or_pruned (secure::transaction const & transaction, nano::block_hash const & hash) const
+bool nano::ledger_set_cemented::block_exists_or_pruned (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	if (hash.is_zero ())
 	{
@@ -83,7 +83,7 @@ bool nano::ledger_set_confirmed::block_exists_or_pruned (secure::transaction con
 	return block_exists (transaction, hash);
 }
 
-std::shared_ptr<nano::block> nano::ledger_set_confirmed::block_get (secure::transaction const & transaction, nano::block_hash const & hash) const
+std::shared_ptr<nano::block> nano::ledger_set_cemented::block_get (secure::transaction const & transaction, nano::block_hash const & hash) const
 {
 	if (hash.is_zero ())
 	{
@@ -101,17 +101,17 @@ std::shared_ptr<nano::block> nano::ledger_set_confirmed::block_get (secure::tran
 	}
 	return block->sideband ().height <= info.value ().height ? block : nullptr;
 }
-auto nano::ledger_set_confirmed::receivable_end () const -> receivable_iterator
+auto nano::ledger_set_cemented::receivable_end () const -> receivable_iterator
 {
 	return receivable_iterator{};
 }
 
-auto nano::ledger_set_confirmed::receivable_upper_bound (secure::transaction const & transaction, nano::account const & account) const -> receivable_iterator
+auto nano::ledger_set_cemented::receivable_upper_bound (secure::transaction const & transaction, nano::account const & account) const -> receivable_iterator
 {
 	return receivable_iterator{ transaction, *this, receivable_lower_bound (transaction, account.number () + 1, 0) };
 }
 
-auto nano::ledger_set_confirmed::receivable_upper_bound (secure::transaction const & transaction, nano::account const & account, nano::block_hash const & hash) const -> receivable_iterator
+auto nano::ledger_set_cemented::receivable_upper_bound (secure::transaction const & transaction, nano::account const & account, nano::block_hash const & hash) const -> receivable_iterator
 {
 	auto result = receivable_lower_bound (transaction, account, hash.number () + 1);
 	if (!result || result.value ().first.account != account)
@@ -121,7 +121,7 @@ auto nano::ledger_set_confirmed::receivable_upper_bound (secure::transaction con
 	return receivable_iterator{ transaction, *this, result };
 }
 
-std::optional<std::pair<nano::pending_key, nano::pending_info>> nano::ledger_set_confirmed::receivable_lower_bound (secure::transaction const & transaction, nano::account const & account, nano::block_hash const & hash) const
+std::optional<std::pair<nano::pending_key, nano::pending_info>> nano::ledger_set_cemented::receivable_lower_bound (secure::transaction const & transaction, nano::account const & account, nano::block_hash const & hash) const
 {
 	auto result = ledger.store.pending.begin (transaction, { account, hash });
 	while (result != ledger.store.pending.end (transaction) && !block_exists (transaction, result->first.hash))

--- a/nano/secure/ledger_set_cemented.hpp
+++ b/nano/secure/ledger_set_cemented.hpp
@@ -1,30 +1,18 @@
 #pragma once
 
+#include <nano/secure/fwd.hpp>
 #include <nano/secure/receivable_iterator.hpp>
 
 #include <optional>
 
 namespace nano
 {
-class account_info;
-class block;
-class block_hash;
-class ledger;
-class qualified_root;
-}
-namespace nano::store
-{
-class transaction;
-}
-
-namespace nano
-{
-class ledger_set_confirmed
+class ledger_set_cemented
 {
 public:
-	using receivable_iterator = nano::receivable_iterator<ledger_set_confirmed>;
+	using receivable_iterator = nano::receivable_iterator<ledger_set_cemented>;
 
-	ledger_set_confirmed (nano::ledger const & ledger);
+	explicit ledger_set_cemented (nano::ledger const &);
 
 public: // Operations on accounts
 	std::optional<nano::amount> account_balance (secure::transaction const & transaction, nano::account const & account) const;
@@ -54,5 +42,5 @@ public: // Operations on pending entries
 
 private:
 	nano::ledger const & ledger;
-}; // class ledger_set_confirmed
-} // namespace nano
+};
+}

--- a/nano/secure/ledger_set_cemented.hpp
+++ b/nano/secure/ledger_set_cemented.hpp
@@ -15,30 +15,30 @@ public:
 	explicit ledger_set_cemented (nano::ledger const &);
 
 public: // Operations on accounts
-	std::optional<nano::amount> account_balance (secure::transaction const & transaction, nano::account const & account) const;
-	nano::block_hash account_head (secure::transaction const & transaction, nano::account const & account) const;
-	uint64_t account_height (secure::transaction const & transaction, nano::account const & account) const;
+	std::optional<nano::amount> account_balance (nano::secure::transaction const &, nano::account const &) const;
+	nano::block_hash account_head (nano::secure::transaction const &, nano::account const &) const;
+	uint64_t account_height (nano::secure::transaction const &, nano::account const &) const;
 
 public: // Operations on blocks
-	std::optional<nano::amount> block_balance (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	bool block_exists (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	bool block_exists (secure::transaction const & transaction, nano::block const & block) const;
-	bool block_exists_or_pruned (secure::transaction const & transaction, nano::block_hash const & hash) const;
-	std::shared_ptr<nano::block> block_get (secure::transaction const & transaction, nano::block_hash const & hash) const;
+	std::optional<nano::amount> block_balance (nano::secure::transaction const &, nano::block_hash const &) const;
+	bool block_exists (nano::secure::transaction const &, nano::block_hash const &) const;
+	bool block_exists (nano::secure::transaction const &, nano::block const &) const;
+	bool block_exists_or_pruned (nano::secure::transaction const &, nano::block_hash const &) const;
+	std::shared_ptr<nano::block> block_get (nano::secure::transaction const &, nano::block_hash const &) const;
 
 public: // Operations on pending entries
 	receivable_iterator receivable_end () const;
 	// Returns the next receivable entry equal or greater than 'key'
 	// Mirrors std::map::lower_bound
-	std::optional<std::pair<nano::pending_key, nano::pending_info>> receivable_lower_bound (secure::transaction const & transaction, nano::account const & account, nano::block_hash const & hash) const;
+	std::optional<std::pair<nano::pending_key, nano::pending_info>> receivable_lower_bound (nano::secure::transaction const &, nano::account const &, nano::block_hash const &) const;
 	// Returns the next receivable entry for an account greater than 'account'
 	// Returns receivable_lower_bound (transaction, account + 1, 0)
 	// Mirrors std::map::upper_bound
-	receivable_iterator receivable_upper_bound (secure::transaction const & transaction, nano::account const & account) const;
+	receivable_iterator receivable_upper_bound (nano::secure::transaction const &, nano::account const &) const;
 	// Returns the next receivable entry for the account 'account' with hash greater than 'hash'
 	// Returns receivable_lower_bound (transaction, account + 1, hash)
 	// Mirrors std::map::upper_bound
-	receivable_iterator receivable_upper_bound (secure::transaction const & transaction, nano::account const & account, nano::block_hash const & hash) const;
+	receivable_iterator receivable_upper_bound (nano::secure::transaction const &, nano::account const &, nano::block_hash const &) const;
 
 private:
 	nano::ledger const & ledger;

--- a/nano/secure/receivable_iterator.cpp
+++ b/nano/secure/receivable_iterator.cpp
@@ -1,6 +1,6 @@
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/secure/receivable_iterator_impl.hpp>
 
 template class nano::receivable_iterator<nano::ledger_set_any>;
-template class nano::receivable_iterator<nano::ledger_set_confirmed>;
+template class nano::receivable_iterator<nano::ledger_set_cemented>;

--- a/nano/slow_test/ledger.cpp
+++ b/nano/slow_test/ledger.cpp
@@ -1,7 +1,7 @@
 #include <nano/lib/config.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/test_common/ledger_context.hpp>
 #include <nano/test_common/make_store.hpp>
 #include <nano/test_common/network.hpp>

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -717,9 +717,9 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 	}
 
 	ASSERT_EQ (cemented_count, node->ledger.cemented_count ());
-	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_accounts * 2 - 2);
-	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in), num_accounts * 2 - 2);
-	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), 0);
+	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in), num_accounts * 2 - 2);
+	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented_bounded, nano::stat::dir::in), num_accounts * 2 - 2);
+	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented_unbounded, nano::stat::dir::in), 0);
 
 	ASSERT_TIMELY_EQ (40s, (node->ledger.cemented_count () - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::dir::out));
 }
@@ -777,11 +777,11 @@ TEST (confirmation_height, many_accounts_many_confirmations)
 	}
 
 	auto const num_blocks_to_confirm = (num_accounts - 1) * 2;
-	ASSERT_TIMELY_EQ (1500s, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_blocks_to_confirm);
+	ASSERT_TIMELY_EQ (1500s, node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in), num_blocks_to_confirm);
 
-	auto num_confirmed_bounded = node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in);
+	auto num_confirmed_bounded = node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented_bounded, nano::stat::dir::in);
 	ASSERT_GE (num_confirmed_bounded, nano::confirmation_height::unbounded_cutoff);
-	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), num_blocks_to_confirm - num_confirmed_bounded);
+	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented_unbounded, nano::stat::dir::in), num_blocks_to_confirm - num_confirmed_bounded);
 
 	ASSERT_TIMELY_EQ (60s, (node->ledger.cemented_count () - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::dir::out));
 
@@ -936,9 +936,9 @@ TEST (confirmation_height, long_chains)
 	}
 
 	ASSERT_EQ (cemented_count, node->ledger.cemented_count ());
-	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_blocks * 2 + 2);
-	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in), num_blocks * 2 + 2);
-	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), 0);
+	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in), num_blocks * 2 + 2);
+	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented_bounded, nano::stat::dir::in), num_blocks * 2 + 2);
+	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented_unbounded, nano::stat::dir::in), 0);
 
 	ASSERT_TIMELY_EQ (40s, (node->ledger.cemented_count () - 1), node->stats.count (nano::stat::type::confirmation_observer, nano::stat::dir::out));
 }
@@ -985,9 +985,9 @@ TEST (confirmation_height, dynamic_algorithm)
 
 	ASSERT_TIMELY_EQ (20s, node->ledger.cemented_count (), num_blocks + 1);
 
-	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in), num_blocks);
-	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_bounded, nano::stat::dir::in), 1);
-	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed_unbounded, nano::stat::dir::in), num_blocks - 1);
+	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in), num_blocks);
+	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented_bounded, nano::stat::dir::in), 1);
+	ASSERT_EQ (node->ledger.stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented_unbounded, nano::stat::dir::in), num_blocks - 1);
 }
 
 TEST (confirmation_height, many_accounts_send_receive_self)
@@ -1052,7 +1052,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 
 	system.deadline_set (100s);
 	auto num_blocks_to_confirm = num_accounts * 2;
-	while (node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in) != num_blocks_to_confirm)
+	while (node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in) != num_blocks_to_confirm)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -1090,7 +1090,7 @@ TEST (confirmation_height, many_accounts_send_receive_self)
 
 	system.deadline_set (300s);
 	num_blocks_to_confirm = num_accounts * 4;
-	while (node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in) != num_blocks_to_confirm)
+	while (node->stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in) != num_blocks_to_confirm)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -1191,7 +1191,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 
 	system.deadline_set (1000s);
 	auto num_blocks_to_confirm = num_accounts * 2;
-	while (stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in) != num_blocks_to_confirm)
+	while (stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in) != num_blocks_to_confirm)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}
@@ -1243,7 +1243,7 @@ TEST (confirmation_height, many_accounts_send_receive_self_no_elections)
 
 	system.deadline_set (1000s);
 	num_blocks_to_confirm = num_accounts * 4;
-	while (stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_confirmed, nano::stat::dir::in) != num_blocks_to_confirm)
+	while (stats.count (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented, nano::stat::dir::in) != num_blocks_to_confirm)
 	{
 		ASSERT_NO_ERROR (system.poll ());
 	}

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -695,7 +695,7 @@ TEST (confirmation_height, many_accounts_single_confirmation)
 		election->force_confirm ();
 	}
 
-	ASSERT_TIMELY (120s, node->ledger.confirmed.block_exists_or_pruned (node->ledger.tx_begin_read (), last_open_hash));
+	ASSERT_TIMELY (120s, node->ledger.cemented.block_exists_or_pruned (node->ledger.tx_begin_read (), last_open_hash));
 
 	// All frontiers (except last) should have 2 blocks and both should be confirmed
 	auto transaction = node->store.tx_begin_read ();
@@ -913,7 +913,7 @@ TEST (confirmation_height, long_chains)
 		election->force_confirm ();
 	}
 
-	ASSERT_TIMELY (30s, node->ledger.confirmed.block_exists_or_pruned (node->ledger.tx_begin_read (), receive1->hash ()));
+	ASSERT_TIMELY (30s, node->ledger.cemented.block_exists_or_pruned (node->ledger.tx_begin_read (), receive1->hash ()));
 
 	auto transaction = node->ledger.tx_begin_read ();
 	auto info = node->ledger.any.account_get (transaction, nano::dev::genesis_key.pub);
@@ -2065,7 +2065,7 @@ TEST (node, wallet_create_block_confirm_conflicts)
 			election->force_confirm ();
 		}
 
-		ASSERT_TIMELY (120s, node->ledger.confirmed.block_exists_or_pruned (node->ledger.tx_begin_read (), latest) && node->cementing_set.size () == 0);
+		ASSERT_TIMELY (120s, node->ledger.cemented.block_exists_or_pruned (node->ledger.tx_begin_read (), latest) && node->cementing_set.size () == 0);
 		done = true;
 		t.join ();
 	}

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -19,7 +19,7 @@
 #include <nano/node/unchecked_map.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>
 #include <nano/store/ledger/peer.hpp>

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -191,7 +191,7 @@ void nano::test::system::setup_node (nano::node & node)
 		auto result = node.ledger.process (transaction, block);
 		debug_assert (result == nano::block_status::progress);
 
-		auto cemented = node.ledger.confirm (transaction, block->hash ());
+		auto cemented = node.ledger.cement (transaction, block->hash ());
 		debug_assert (std::find_if (cemented.begin (), cemented.end (), [&block] (auto const & cemented_block) {
 			return cemented_block->hash () == block->hash ();
 		})

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -328,7 +328,7 @@ void nano::test::print_all_account_info (const nano::ledger & ledger)
 		nano::confirmation_height_info height_info;
 		std::cout << "Account: " << acc.to_account () << std::endl;
 		std::cout << "  Unconfirmed Balance: " << acc_info.balance.to_string_dec () << std::endl;
-		std::cout << "  Confirmed Balance:   " << ledger.confirmed.account_balance (tx, acc).value_or (0) << std::endl;
+		std::cout << "  Confirmed Balance:   " << ledger.cemented.account_balance (tx, acc).value_or (0) << std::endl;
 		std::cout << "  Block Count:         " << acc_info.block_count << std::endl;
 		if (!ledger.store.confirmation_height.get (tx, acc, height_info))
 		{

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -129,7 +129,7 @@ void nano::test::confirm (nano::ledger & ledger, std::shared_ptr<nano::block> co
 void nano::test::confirm (nano::ledger & ledger, nano::block_hash const & hash)
 {
 	auto transaction = ledger.tx_begin_write ();
-	ledger.confirm (transaction, hash);
+	ledger.cement (transaction, hash);
 }
 
 bool nano::test::block_or_pruned_all_exists (nano::node & node, std::vector<nano::block_hash> hashes)

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -10,7 +10,7 @@
 #include <nano/node/vote_router.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_confirmed.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/block.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>


### PR DESCRIPTION
Terminology standardization to distinguish between:
     
 - Election confirmation: consensus achieved through voting
 - Ledger cementing: blocks permanently written to disk

Changes:
- Rename ledger members: confirmed_impl/confirmed → cemented_impl/cemented
- Rename method: dependencies_confirmed() → dependencies_cemented()
- Rename scheduler tag: tag_unconfirmed_height → tag_uncemented_height
- Update all usage sites: ledger.confirmed.* → ledger.cemented.*
- Remove unused: process_cemented_interval, process_cemented stat type