### PR TITLE
Clean up wallet_store initialization and error handling 

### DIFF
--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -271,7 +271,9 @@ TEST (wallet, rekey)
 	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::raw_key password;
 	wallet.password.value (password);
-	ASSERT_TRUE (password.is_zero ());
+	nano::raw_key default_password_key;
+	wallet.derive_key (default_password_key, transaction, nano::wallet_store::default_password);
+	ASSERT_EQ (default_password_key, password);
 	nano::keypair key1;
 	wallet.insert_adhoc (transaction, key1.prv);
 	nano::raw_key prv1;
@@ -349,16 +351,18 @@ TEST (wallet, reopen_default_password)
 		ASSERT_TRUE (wallet.valid_password (transaction));
 	}
 	{
+		// Rekey to a non-default password
 		nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-		wallet.rekey (transaction, "");
+		wallet.rekey (transaction, "secret");
 		ASSERT_TRUE (wallet.valid_password (transaction));
 	}
 	{
+		// Default password no longer works after rekey
 		nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 		ASSERT_FALSE (wallet.valid_password (transaction));
-		wallet.attempt_password (transaction, " ");
-		ASSERT_FALSE (wallet.valid_password (transaction));
 		wallet.attempt_password (transaction, "");
+		ASSERT_FALSE (wallet.valid_password (transaction));
+		wallet.attempt_password (transaction, "secret");
 		ASSERT_TRUE (wallet.valid_password (transaction));
 	}
 }
@@ -801,7 +805,6 @@ TEST (wallet, change_seed)
 {
 	nano::test::system system (1);
 	auto wallet (system.wallet (0));
-	wallet->enter_initial_password ();
 	nano::raw_key seed1;
 	seed1 = 1;
 	nano::public_key pub;
@@ -826,7 +829,6 @@ TEST (wallet, deterministic_restore)
 {
 	nano::test::system system (1);
 	auto wallet (system.wallet (0));
-	wallet->enter_initial_password ();
 	nano::raw_key seed1;
 	seed1 = 1;
 	nano::public_key pub;

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -393,7 +393,7 @@ TEST (wallet, serialize_json_empty)
 	nano::wallet_store wallet1 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	std::string serialized;
 	wallet1.serialize_json (transaction, serialized);
-	nano::wallet_store wallet2 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1", serialized);
+	nano::wallet_store wallet2 (kdf, transaction, env, 1, "1", serialized);
 	nano::raw_key password1;
 	nano::raw_key password2;
 	wallet1.wallet_key (password1, transaction);
@@ -416,7 +416,7 @@ TEST (wallet, serialize_json_one)
 	wallet1.insert_adhoc (transaction, key.prv);
 	std::string serialized;
 	wallet1.serialize_json (transaction, serialized);
-	nano::wallet_store wallet2 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1", serialized);
+	nano::wallet_store wallet2 (kdf, transaction, env, 1, "1", serialized);
 	nano::raw_key password1;
 	nano::raw_key password2;
 	wallet1.wallet_key (password1, transaction);
@@ -442,7 +442,7 @@ TEST (wallet, serialize_json_password)
 	wallet1.insert_adhoc (transaction, key.prv);
 	std::string serialized;
 	wallet1.serialize_json (transaction, serialized);
-	nano::wallet_store wallet2 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1", serialized);
+	nano::wallet_store wallet2 (kdf, transaction, env, 1, "1", serialized);
 	ASSERT_FALSE (wallet2.valid_password (transaction));
 	ASSERT_FALSE (wallet2.attempt_password (transaction, "password"));
 	ASSERT_TRUE (wallet2.valid_password (transaction));

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -17,12 +17,10 @@ unsigned constexpr nano::wallet_store::version_current;
 
 TEST (wallet, no_special_keys_accounts)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (init);
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::keypair key1;
 	ASSERT_FALSE (wallet.exists (transaction, key1.pub));
 	wallet.insert_adhoc (transaction, key1.prv);
@@ -37,12 +35,10 @@ TEST (wallet, no_special_keys_accounts)
 
 TEST (wallet, no_key)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (init);
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::keypair key1;
 	nano::raw_key prv1;
 	ASSERT_TRUE (wallet.fetch (transaction, key1.pub, prv1));
@@ -51,11 +47,10 @@ TEST (wallet, no_key)
 
 TEST (wallet, fetch_locked)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	ASSERT_TRUE (wallet.valid_password (transaction));
 	nano::keypair key1;
 	ASSERT_EQ (key1.pub, wallet.insert_adhoc (transaction, key1.prv));
@@ -72,12 +67,10 @@ TEST (wallet, fetch_locked)
 
 TEST (wallet, retrieval)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (init);
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::keypair key1;
 	ASSERT_TRUE (wallet.valid_password (transaction));
 	wallet.insert_adhoc (transaction, key1.prv);
@@ -93,12 +86,10 @@ TEST (wallet, retrieval)
 
 TEST (wallet, empty_iteration)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (init);
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	auto i (wallet.begin (transaction));
 	auto j (wallet.end (transaction));
 	ASSERT_EQ (i, j);
@@ -106,12 +97,10 @@ TEST (wallet, empty_iteration)
 
 TEST (wallet, one_item_iteration)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (init);
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::keypair key1;
 	wallet.insert_adhoc (transaction, key1.prv);
 	for (auto i (wallet.begin (transaction)), j (wallet.end (transaction)); i != j; ++i)
@@ -127,7 +116,6 @@ TEST (wallet, one_item_iteration)
 
 TEST (wallet, two_item_iteration)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	nano::keypair key1;
 	nano::keypair key2;
@@ -137,8 +125,7 @@ TEST (wallet, two_item_iteration)
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	{
 		auto transaction (env.tx_begin_write ());
-		nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-		ASSERT_FALSE (init);
+		nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 		wallet.insert_adhoc (transaction, key1.prv);
 		wallet.insert_adhoc (transaction, key2.prv);
 		for (auto i (wallet.begin (transaction)), j (wallet.end (transaction)); i != j; ++i)
@@ -252,24 +239,20 @@ TEST (wallet, spend_no_previous)
 
 TEST (wallet, find_none)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (init);
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::account account (1000);
 	ASSERT_EQ (wallet.end (transaction), wallet.find (transaction, account));
 }
 
 TEST (wallet, find_existing)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (init);
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::keypair key1;
 	ASSERT_FALSE (wallet.exists (transaction, key1.pub));
 	wallet.insert_adhoc (transaction, key1.prv);
@@ -282,16 +265,13 @@ TEST (wallet, find_existing)
 
 TEST (wallet, rekey)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (init);
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::raw_key password;
 	wallet.password.value (password);
 	ASSERT_TRUE (password.is_zero ());
-	ASSERT_FALSE (init);
 	nano::keypair key1;
 	wallet.insert_adhoc (transaction, key1.prv);
 	nano::raw_key prv1;
@@ -311,12 +291,10 @@ TEST (wallet, rekey)
 
 TEST (wallet, hash_password)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (init);
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::raw_key hash1;
 	wallet.derive_key (hash1, transaction, "");
 	nano::raw_key hash2;
@@ -359,31 +337,24 @@ TEST (fan, change)
 
 TEST (wallet, reopen_default_password)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	{
-		nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-		ASSERT_FALSE (init);
+		nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 		ASSERT_TRUE (wallet.valid_password (transaction));
 	}
 	{
-		bool init;
-		nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-		ASSERT_FALSE (init);
+		nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 		ASSERT_TRUE (wallet.valid_password (transaction));
 	}
 	{
-		nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-		ASSERT_FALSE (init);
+		nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 		wallet.rekey (transaction, "");
 		ASSERT_TRUE (wallet.valid_password (transaction));
 	}
 	{
-		bool init;
-		nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-		ASSERT_FALSE (init);
+		nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 		ASSERT_FALSE (wallet.valid_password (transaction));
 		wallet.attempt_password (transaction, " ");
 		ASSERT_FALSE (wallet.valid_password (transaction));
@@ -394,12 +365,10 @@ TEST (wallet, reopen_default_password)
 
 TEST (wallet, representative)
 {
-	auto error (false);
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (error, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (error);
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	ASSERT_FALSE (wallet.is_representative (transaction));
 	ASSERT_EQ (nano::dev::genesis_key.pub, wallet.representative (transaction));
 	ASSERT_FALSE (wallet.is_representative (transaction));
@@ -414,16 +383,13 @@ TEST (wallet, representative)
 
 TEST (wallet, serialize_json_empty)
 {
-	auto error (false);
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet1 (error, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (error);
+	nano::wallet_store wallet1 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	std::string serialized;
 	wallet1.serialize_json (transaction, serialized);
-	nano::wallet_store wallet2 (error, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1", serialized);
-	ASSERT_FALSE (error);
+	nano::wallet_store wallet2 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1", serialized);
 	nano::raw_key password1;
 	nano::raw_key password2;
 	wallet1.wallet_key (password1, transaction);
@@ -438,18 +404,15 @@ TEST (wallet, serialize_json_empty)
 
 TEST (wallet, serialize_json_one)
 {
-	auto error (false);
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet1 (error, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (error);
+	nano::wallet_store wallet1 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::keypair key;
 	wallet1.insert_adhoc (transaction, key.prv);
 	std::string serialized;
 	wallet1.serialize_json (transaction, serialized);
-	nano::wallet_store wallet2 (error, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1", serialized);
-	ASSERT_FALSE (error);
+	nano::wallet_store wallet2 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1", serialized);
 	nano::raw_key password1;
 	nano::raw_key password2;
 	wallet1.wallet_key (password1, transaction);
@@ -466,19 +429,16 @@ TEST (wallet, serialize_json_one)
 
 TEST (wallet, serialize_json_password)
 {
-	auto error (false);
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet1 (error, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (error);
+	nano::wallet_store wallet1 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::keypair key;
 	wallet1.rekey (transaction, "password");
 	wallet1.insert_adhoc (transaction, key.prv);
 	std::string serialized;
 	wallet1.serialize_json (transaction, serialized);
-	nano::wallet_store wallet2 (error, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1", serialized);
-	ASSERT_FALSE (error);
+	nano::wallet_store wallet2 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1", serialized);
 	ASSERT_FALSE (wallet2.valid_password (transaction));
 	ASSERT_FALSE (wallet2.attempt_password (transaction, "password"));
 	ASSERT_TRUE (wallet2.valid_password (transaction));
@@ -498,16 +458,13 @@ TEST (wallet, serialize_json_password)
 
 TEST (wallet_store, move)
 {
-	auto error (false);
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet1 (error, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
-	ASSERT_FALSE (error);
+	nano::wallet_store wallet1 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::keypair key1;
 	wallet1.insert_adhoc (transaction, key1.prv);
-	nano::wallet_store wallet2 (error, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1");
-	ASSERT_FALSE (error);
+	nano::wallet_store wallet2 (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "1");
 	nano::keypair key2;
 	wallet2.insert_adhoc (transaction, key2.prv);
 	ASSERT_FALSE (wallet1.exists (transaction, key2.pub));
@@ -642,11 +599,10 @@ TEST (wallet, insert_locked)
 
 TEST (wallet, deterministic_keys)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	auto key1 = wallet.deterministic_key (transaction, 0);
 	auto key2 = wallet.deterministic_key (transaction, 0);
 	ASSERT_EQ (key1, key2);
@@ -684,11 +640,10 @@ TEST (wallet, deterministic_keys)
 
 TEST (wallet, reseed)
 {
-	bool init;
 	nano::store::lmdb::env env (nano::unique_path () / "wallet.ldb");
 	auto transaction (env.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
-	nano::wallet_store wallet (init, kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
+	nano::wallet_store wallet (kdf, transaction, env, nano::dev::genesis_key.pub, 1, "0");
 	nano::raw_key seed1;
 	seed1 = 1;
 	nano::raw_key seed2;

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -60,59 +60,67 @@ nano::wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transact
 	env{ env_a }
 {
 	initialize (transaction_a, wallet_a);
-	MDB_val junk;
-	nano::store::lmdb::db_val version_key (version_special);
-	auto mdb_version_key = nano::store::lmdb::to_mdb_val (version_key);
-	debug_assert (mdb_get (env.tx (transaction_a), handle, &mdb_version_key, &junk) == MDB_NOTFOUND);
-	boost::property_tree::ptree wallet_l;
-	std::stringstream istream (json_a);
 	try
 	{
-		boost::property_tree::read_json (istream, wallet_l);
+		MDB_val junk;
+		nano::store::lmdb::db_val version_key (version_special);
+		auto mdb_version_key = nano::store::lmdb::to_mdb_val (version_key);
+		debug_assert (mdb_get (env.tx (transaction_a), handle, &mdb_version_key, &junk) == MDB_NOTFOUND);
+		boost::property_tree::ptree wallet_l;
+		std::stringstream istream (json_a);
+		try
+		{
+			boost::property_tree::read_json (istream, wallet_l);
+		}
+		catch (...)
+		{
+			throw std::runtime_error ("Failed to parse wallet JSON");
+		}
+		for (auto i (wallet_l.begin ()), n (wallet_l.end ()); i != n; ++i)
+		{
+			nano::account key;
+			if (key.decode_hex (i->first))
+			{
+				throw std::runtime_error ("Failed to decode wallet key hex");
+			}
+			nano::raw_key value;
+			if (value.decode_hex (wallet_l.get<std::string> (i->first)))
+			{
+				throw std::runtime_error ("Failed to decode wallet value hex");
+			}
+			entry_put_raw (transaction_a, key, nano::wallet_value (value, 0));
+		}
+		nano::store::lmdb::db_val wallet_key_key (wallet_key_special);
+		nano::store::lmdb::db_val salt_key (salt_special);
+		nano::store::lmdb::db_val check_key (check_special);
+		auto mdb_version_key2 = nano::store::lmdb::to_mdb_val (version_key);
+		auto mdb_wallet_key_key = nano::store::lmdb::to_mdb_val (wallet_key_key);
+		auto mdb_salt_key = nano::store::lmdb::to_mdb_val (salt_key);
+		auto mdb_check_key = nano::store::lmdb::to_mdb_val (check_key);
+		bool missing = false;
+		missing |= mdb_get (env.tx (transaction_a), handle, &mdb_version_key2, &junk) != 0;
+		missing |= mdb_get (env.tx (transaction_a), handle, &mdb_wallet_key_key, &junk) != 0;
+		missing |= mdb_get (env.tx (transaction_a), handle, &mdb_salt_key, &junk) != 0;
+		missing |= mdb_get (env.tx (transaction_a), handle, &mdb_check_key, &junk) != 0;
+		nano::store::lmdb::db_val rep_key (representative_special);
+		auto mdb_rep_key = nano::store::lmdb::to_mdb_val (rep_key);
+		missing |= mdb_get (env.tx (transaction_a), handle, &mdb_rep_key, &junk) != 0;
+		if (missing)
+		{
+			throw std::runtime_error ("Wallet is missing required entries");
+		}
+		nano::raw_key key;
+		key.clear ();
+		password.value_set (key);
+		key = entry_get_raw (transaction_a, nano::wallet_store::wallet_key_special).key;
+		wallet_key_mem.value_set (key);
+		attempt_password (transaction_a, default_password);
 	}
 	catch (...)
 	{
-		throw std::runtime_error ("Failed to parse wallet JSON");
+		destroy (transaction_a);
+		throw;
 	}
-	for (auto i (wallet_l.begin ()), n (wallet_l.end ()); i != n; ++i)
-	{
-		nano::account key;
-		if (key.decode_hex (i->first))
-		{
-			throw std::runtime_error ("Failed to decode wallet key hex");
-		}
-		nano::raw_key value;
-		if (value.decode_hex (wallet_l.get<std::string> (i->first)))
-		{
-			throw std::runtime_error ("Failed to decode wallet value hex");
-		}
-		entry_put_raw (transaction_a, key, nano::wallet_value (value, 0));
-	}
-	nano::store::lmdb::db_val wallet_key_key (wallet_key_special);
-	nano::store::lmdb::db_val salt_key (salt_special);
-	nano::store::lmdb::db_val check_key (check_special);
-	auto mdb_version_key2 = nano::store::lmdb::to_mdb_val (version_key);
-	auto mdb_wallet_key_key = nano::store::lmdb::to_mdb_val (wallet_key_key);
-	auto mdb_salt_key = nano::store::lmdb::to_mdb_val (salt_key);
-	auto mdb_check_key = nano::store::lmdb::to_mdb_val (check_key);
-	bool missing = false;
-	missing |= mdb_get (env.tx (transaction_a), handle, &mdb_version_key2, &junk) != 0;
-	missing |= mdb_get (env.tx (transaction_a), handle, &mdb_wallet_key_key, &junk) != 0;
-	missing |= mdb_get (env.tx (transaction_a), handle, &mdb_salt_key, &junk) != 0;
-	missing |= mdb_get (env.tx (transaction_a), handle, &mdb_check_key, &junk) != 0;
-	nano::store::lmdb::db_val rep_key (representative_special);
-	auto mdb_rep_key = nano::store::lmdb::to_mdb_val (rep_key);
-	missing |= mdb_get (env.tx (transaction_a), handle, &mdb_rep_key, &junk) != 0;
-	if (missing)
-	{
-		throw std::runtime_error ("Wallet is missing required entries");
-	}
-	nano::raw_key key;
-	key.clear ();
-	password.value_set (key);
-	key = entry_get_raw (transaction_a, nano::wallet_store::wallet_key_special).key;
-	wallet_key_mem.value_set (key);
-	attempt_password (transaction_a, default_password);
 }
 
 nano::wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transaction & transaction_a, store::lmdb::env & env_a, nano::account representative_a, unsigned fanout_a, std::string const & wallet_a) :
@@ -122,47 +130,55 @@ nano::wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transact
 	env{ env_a }
 {
 	initialize (transaction_a, wallet_a);
-	int version_status;
-	MDB_val version_value;
-	nano::store::lmdb::db_val version_lookup_key (version_special);
-	auto mdb_version_lookup_key = nano::store::lmdb::to_mdb_val (version_lookup_key);
-	version_status = mdb_get (env.tx (transaction_a), handle, &mdb_version_lookup_key, &version_value);
-	if (version_status == MDB_NOTFOUND)
+	try
 	{
-		version_put (transaction_a, version_current);
-		nano::raw_key salt_l;
-		random_pool::generate_block (salt_l.bytes.data (), salt_l.bytes.size ());
-		entry_put_raw (transaction_a, nano::wallet_store::salt_special, nano::wallet_value (salt_l, 0));
-		// Wallet key is a fixed random key that encrypts all entries
-		nano::raw_key wallet_key;
-		random_pool::generate_block (wallet_key.bytes.data (), sizeof (wallet_key.bytes));
-		nano::raw_key password_l;
-		derive_key (password_l, transaction_a, default_password);
-		password.value_set (password_l);
-		// Wallet key is encrypted by the user's password
-		nano::raw_key encrypted;
-		encrypted.encrypt (wallet_key, password_l, salt_l.owords[0]);
-		entry_put_raw (transaction_a, nano::wallet_store::wallet_key_special, nano::wallet_value (encrypted, 0));
-		nano::raw_key wallet_key_enc;
-		wallet_key_enc = encrypted;
-		wallet_key_mem.value_set (wallet_key_enc);
-		nano::raw_key zero;
-		zero.clear ();
-		nano::raw_key check;
-		check.encrypt (zero, wallet_key, salt_l.owords[check_iv_index]);
-		entry_put_raw (transaction_a, nano::wallet_store::check_special, nano::wallet_value (check, 0));
-		nano::raw_key rep;
-		rep.bytes = representative_a.bytes;
-		entry_put_raw (transaction_a, nano::wallet_store::representative_special, nano::wallet_value (rep, 0));
-		nano::raw_key seed;
-		random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
-		seed_set (transaction_a, seed);
-		entry_put_raw (transaction_a, nano::wallet_store::deterministic_index_special, nano::wallet_value (0, 0));
+		int version_status;
+		MDB_val version_value;
+		nano::store::lmdb::db_val version_lookup_key (version_special);
+		auto mdb_version_lookup_key = nano::store::lmdb::to_mdb_val (version_lookup_key);
+		version_status = mdb_get (env.tx (transaction_a), handle, &mdb_version_lookup_key, &version_value);
+		if (version_status == MDB_NOTFOUND)
+		{
+			version_put (transaction_a, version_current);
+			nano::raw_key salt_l;
+			random_pool::generate_block (salt_l.bytes.data (), salt_l.bytes.size ());
+			entry_put_raw (transaction_a, nano::wallet_store::salt_special, nano::wallet_value (salt_l, 0));
+			// Wallet key is a fixed random key that encrypts all entries
+			nano::raw_key wallet_key;
+			random_pool::generate_block (wallet_key.bytes.data (), sizeof (wallet_key.bytes));
+			nano::raw_key password_l;
+			derive_key (password_l, transaction_a, default_password);
+			password.value_set (password_l);
+			// Wallet key is encrypted by the user's password
+			nano::raw_key encrypted;
+			encrypted.encrypt (wallet_key, password_l, salt_l.owords[0]);
+			entry_put_raw (transaction_a, nano::wallet_store::wallet_key_special, nano::wallet_value (encrypted, 0));
+			nano::raw_key wallet_key_enc;
+			wallet_key_enc = encrypted;
+			wallet_key_mem.value_set (wallet_key_enc);
+			nano::raw_key zero;
+			zero.clear ();
+			nano::raw_key check;
+			check.encrypt (zero, wallet_key, salt_l.owords[check_iv_index]);
+			entry_put_raw (transaction_a, nano::wallet_store::check_special, nano::wallet_value (check, 0));
+			nano::raw_key rep;
+			rep.bytes = representative_a.bytes;
+			entry_put_raw (transaction_a, nano::wallet_store::representative_special, nano::wallet_value (rep, 0));
+			nano::raw_key seed;
+			random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
+			seed_set (transaction_a, seed);
+			entry_put_raw (transaction_a, nano::wallet_store::deterministic_index_special, nano::wallet_value (0, 0));
+		}
+		nano::raw_key key;
+		key = entry_get_raw (transaction_a, nano::wallet_store::wallet_key_special).key;
+		wallet_key_mem.value_set (key);
+		attempt_password (transaction_a, default_password);
 	}
-	nano::raw_key key;
-	key = entry_get_raw (transaction_a, nano::wallet_store::wallet_key_special).key;
-	wallet_key_mem.value_set (key);
-	attempt_password (transaction_a, default_password);
+	catch (...)
+	{
+		destroy (transaction_a);
+		throw;
+	}
 }
 
 std::vector<nano::account> nano::wallet_store::accounts (nano::store::transaction const & transaction_a) const
@@ -190,7 +206,7 @@ void nano::wallet_store::initialize (nano::store::write_transaction const & tran
 
 void nano::wallet_store::destroy (nano::store::write_transaction const & transaction_a)
 {
-	auto status (mdb_drop (env.tx (transaction_a), handle, 1));
+	auto status (mdb_drop (env.tx (transaction_a), handle, /* delete from database */ 1));
 	release_assert (nano::store::lmdb::success (status), nano::store::lmdb::error_string (status));
 	handle = 0;
 }

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -183,7 +183,7 @@ void nano::wallet_store::initialize (nano::store::write_transaction const & tran
 	auto error = mdb_dbi_open (env.tx (transaction_a), path_a.c_str (), MDB_CREATE, &handle_l);
 	if (error != 0)
 	{
-		throw std::runtime_error ("Failed to open wallet database");
+		throw std::runtime_error ("Failed to open wallet database '" + path_a + "': " + nano::store::lmdb::error_string (error));
 	}
 	handle = handle_l;
 }

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -49,6 +49,7 @@ nano::account const nano::wallet_store::seed_special (5);
 // Current key index for deterministic keys
 nano::account const nano::wallet_store::deterministic_index_special (6);
 int const nano::wallet_store::special_count (7);
+std::string const nano::wallet_store::default_password{ "" };
 std::size_t const nano::wallet_store::check_iv_index (0);
 std::size_t const nano::wallet_store::seed_iv_index (1);
 
@@ -111,6 +112,7 @@ nano::wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transact
 	password.value_set (key);
 	key = entry_get_raw (transaction_a, nano::wallet_store::wallet_key_special).key;
 	wallet_key_mem.value_set (key);
+	attempt_password (transaction_a, default_password);
 }
 
 nano::wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transaction & transaction_a, store::lmdb::env & env_a, nano::account representative_a, unsigned fanout_a, std::string const & wallet_a) :
@@ -135,17 +137,17 @@ nano::wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transact
 		nano::raw_key wallet_key;
 		random_pool::generate_block (wallet_key.bytes.data (), sizeof (wallet_key.bytes));
 		nano::raw_key password_l;
-		password_l.clear ();
+		derive_key (password_l, transaction_a, default_password);
 		password.value_set (password_l);
-		nano::raw_key zero;
-		zero.clear ();
 		// Wallet key is encrypted by the user's password
 		nano::raw_key encrypted;
-		encrypted.encrypt (wallet_key, zero, salt_l.owords[0]);
+		encrypted.encrypt (wallet_key, password_l, salt_l.owords[0]);
 		entry_put_raw (transaction_a, nano::wallet_store::wallet_key_special, nano::wallet_value (encrypted, 0));
 		nano::raw_key wallet_key_enc;
 		wallet_key_enc = encrypted;
 		wallet_key_mem.value_set (wallet_key_enc);
+		nano::raw_key zero;
+		zero.clear ();
 		nano::raw_key check;
 		check.encrypt (zero, wallet_key, salt_l.owords[check_iv_index]);
 		entry_put_raw (transaction_a, nano::wallet_store::check_special, nano::wallet_value (check, 0));
@@ -160,6 +162,7 @@ nano::wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transact
 	nano::raw_key key;
 	key = entry_get_raw (transaction_a, nano::wallet_store::wallet_key_special).key;
 	wallet_key_mem.value_set (key);
+	attempt_password (transaction_a, default_password);
 }
 
 std::vector<nano::account> nano::wallet_store::accounts (nano::store::transaction const & transaction_a) const
@@ -718,16 +721,8 @@ void nano::wallet::enter_initial_password ()
 	}
 	if (password_l.is_zero ())
 	{
-		auto transaction (wallets.tx_begin_write ());
-		if (store.valid_password (transaction))
-		{
-			// Newly created wallets have a zero key
-			store.rekey (transaction, "");
-		}
-		else
-		{
-			enter_password_impl (transaction, "");
-		}
+		auto transaction (wallets.tx_begin_read ());
+		enter_password_impl (transaction, wallet_store::default_password);
 	}
 }
 
@@ -1727,8 +1722,8 @@ std::shared_ptr<nano::wallet> nano::wallets::create (nano::wallet_id const & id_
 		try
 		{
 			auto result = std::make_shared<nano::wallet> (transaction, *this, id_a.to_string ());
+			debug_assert (result->store.valid_password (transaction));
 			items[id_a] = result;
-			result->enter_initial_password ();
 			return result;
 		}
 		catch (std::exception const & ex)

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -53,7 +53,7 @@ std::string const nano::wallet_store::default_password{ "" };
 std::size_t const nano::wallet_store::check_iv_index (0);
 std::size_t const nano::wallet_store::seed_iv_index (1);
 
-nano::wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transaction & transaction_a, store::lmdb::env & env_a, nano::account representative_a, unsigned fanout_a, std::string const & wallet_a, std::string const & json_a) :
+nano::wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transaction & transaction_a, store::lmdb::env & env_a, unsigned fanout_a, std::string const & wallet_a, std::string const & json_a) :
 	password (0, fanout_a),
 	wallet_key_mem (0, fanout_a),
 	kdf (kdf_a),
@@ -706,7 +706,7 @@ nano::wallet::wallet (nano::store::write_transaction & transaction_a, nano::wall
 
 nano::wallet::wallet (nano::store::write_transaction & transaction_a, nano::wallets & wallets_a, std::string const & wallet_a, std::string const & json) :
 	lock_observer ([] (bool, bool) {}),
-	store (wallets_a.kdf, transaction_a, wallets_a.env, wallets_a.config.random_representative (), wallets_a.config.password_fanout, wallet_a, json),
+	store (wallets_a.kdf, transaction_a, wallets_a.env, wallets_a.config.password_fanout, wallet_a, json),
 	wallets (wallets_a),
 	logger (wallets_a.logger)
 {
@@ -855,7 +855,7 @@ bool nano::wallet::import (std::string const & json_a, std::string const & passw
 	random_pool::generate_block (id.bytes.data (), id.bytes.size ());
 	try
 	{
-		auto temp = std::make_unique<nano::wallet_store> (wallets.kdf, transaction, wallets.env, 0, 1, id.to_string (), json_a);
+		auto temp = std::make_unique<nano::wallet_store> (wallets.kdf, transaction, wallets.env, 1, id.to_string (), json_a);
 		if (!temp->attempt_password (transaction, password_a))
 		{
 			error = store.import (transaction, *temp);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -29,228 +29,6 @@
 
 template class nano::store::typed_iterator<nano::account, nano::wallet_value>;
 
-nano::uint256_union nano::wallet_store::check (nano::store::transaction const & transaction_a) const
-{
-	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::check_special));
-	return value.key;
-}
-
-nano::uint256_union nano::wallet_store::salt (nano::store::transaction const & transaction_a) const
-{
-	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::salt_special));
-	return value.key;
-}
-
-void nano::wallet_store::wallet_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a) const
-{
-	nano::lock_guard<std::recursive_mutex> lock{ mutex };
-	nano::raw_key wallet_l;
-	wallet_key_mem.value (wallet_l);
-	nano::raw_key password_l;
-	password.value (password_l);
-	prv_a.decrypt (wallet_l, password_l, salt (transaction_a).owords[0]);
-}
-
-void nano::wallet_store::seed (nano::raw_key & prv_a, nano::store::transaction const & transaction_a) const
-{
-	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::seed_special));
-	nano::raw_key password_l;
-	wallet_key (password_l, transaction_a);
-	prv_a.decrypt (value.key, password_l, salt (transaction_a).owords[seed_iv_index]);
-}
-
-void nano::wallet_store::seed_set (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv_a)
-{
-	nano::raw_key password_l;
-	wallet_key (password_l, transaction_a);
-	nano::raw_key ciphertext;
-	ciphertext.encrypt (prv_a, password_l, salt (transaction_a).owords[seed_iv_index]);
-	entry_put_raw (transaction_a, nano::wallet_store::seed_special, nano::wallet_value (ciphertext, 0));
-	deterministic_clear (transaction_a);
-}
-
-nano::public_key nano::wallet_store::deterministic_insert (nano::store::write_transaction const & transaction_a)
-{
-	auto index (deterministic_index_get (transaction_a));
-	auto prv = deterministic_key (transaction_a, index);
-	nano::public_key result (nano::pub_key (prv));
-	while (exists (transaction_a, result))
-	{
-		++index;
-		prv = deterministic_key (transaction_a, index);
-		result = nano::pub_key (prv);
-	}
-	uint64_t marker (1);
-	marker <<= 32;
-	marker |= index;
-	entry_put_raw (transaction_a, result, nano::wallet_value (marker, 0));
-	++index;
-	deterministic_index_set (transaction_a, index);
-	return result;
-}
-
-nano::public_key nano::wallet_store::deterministic_insert (nano::store::write_transaction const & transaction_a, uint32_t const index)
-{
-	auto prv = deterministic_key (transaction_a, index);
-	nano::public_key result (nano::pub_key (prv));
-	uint64_t marker (1);
-	marker <<= 32;
-	marker |= index;
-	entry_put_raw (transaction_a, result, nano::wallet_value (marker, 0));
-	return result;
-}
-
-nano::raw_key nano::wallet_store::deterministic_key (nano::store::transaction const & transaction_a, uint32_t index_a) const
-{
-	debug_assert (valid_password (transaction_a));
-	nano::raw_key seed_l;
-	seed (seed_l, transaction_a);
-	return nano::deterministic_key (seed_l, index_a);
-}
-
-uint32_t nano::wallet_store::deterministic_index_get (nano::store::transaction const & transaction_a) const
-{
-	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::deterministic_index_special));
-	return static_cast<uint32_t> (value.key.number () & static_cast<uint32_t> (-1));
-}
-
-void nano::wallet_store::deterministic_index_set (nano::store::write_transaction const & transaction_a, uint32_t index_a)
-{
-	nano::raw_key index_l (index_a);
-	nano::wallet_value value (index_l, 0);
-	entry_put_raw (transaction_a, nano::wallet_store::deterministic_index_special, value);
-}
-
-void nano::wallet_store::deterministic_clear (nano::store::write_transaction const & transaction_a)
-{
-	nano::uint256_union key (0);
-	for (auto i (begin (transaction_a)), n (end (transaction_a)); i != n;)
-	{
-		switch (key_type (nano::wallet_value (i->second)))
-		{
-			case nano::key_type::deterministic:
-			{
-				auto const & key (i->first);
-				erase (transaction_a, key);
-				i = begin (transaction_a, key);
-				break;
-			}
-			default:
-			{
-				++i;
-				break;
-			}
-		}
-	}
-	deterministic_index_set (transaction_a, 0);
-}
-
-bool nano::wallet_store::valid_password (nano::store::transaction const & transaction_a) const
-{
-	nano::raw_key zero;
-	zero.clear ();
-	nano::raw_key wallet_key_l;
-	wallet_key (wallet_key_l, transaction_a);
-	nano::uint256_union check_l;
-	check_l.encrypt (zero, wallet_key_l, salt (transaction_a).owords[check_iv_index]);
-	bool ok = check (transaction_a) == check_l;
-	return ok;
-}
-
-bool nano::wallet_store::attempt_password (nano::store::transaction const & transaction_a, std::string const & password_a)
-{
-	bool result = false;
-	{
-		nano::lock_guard<std::recursive_mutex> lock{ mutex };
-		nano::raw_key password_l;
-		derive_key (password_l, transaction_a, password_a);
-		password.value_set (password_l);
-		result = !valid_password (transaction_a);
-	}
-	if (!result)
-	{
-		switch (version (transaction_a))
-		{
-			case version_4:
-				break;
-			default:
-				debug_assert (false);
-		}
-	}
-	return result;
-}
-
-bool nano::wallet_store::rekey (nano::store::write_transaction const & transaction_a, std::string const & password_a)
-{
-	nano::lock_guard<std::recursive_mutex> lock{ mutex };
-	bool result (false);
-	if (valid_password (transaction_a))
-	{
-		nano::raw_key password_new;
-		derive_key (password_new, transaction_a, password_a);
-		nano::raw_key wallet_key_l;
-		wallet_key (wallet_key_l, transaction_a);
-		nano::raw_key password_l;
-		password.value (password_l);
-		password.value_set (password_new);
-		nano::raw_key encrypted;
-		encrypted.encrypt (wallet_key_l, password_new, salt (transaction_a).owords[0]);
-		nano::raw_key wallet_enc;
-		wallet_enc = encrypted;
-		wallet_key_mem.value_set (wallet_enc);
-		entry_put_raw (transaction_a, nano::wallet_store::wallet_key_special, nano::wallet_value (encrypted, 0));
-	}
-	else
-	{
-		result = true;
-	}
-	return result;
-}
-
-void nano::wallet_store::derive_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a, std::string const & password_a) const
-{
-	auto salt_l (salt (transaction_a));
-	kdf.phs (prv_a, password_a, salt_l);
-}
-
-nano::fan::fan (nano::raw_key const & key, std::size_t count_a)
-{
-	auto first (std::make_unique<nano::raw_key> (key));
-	for (auto i (1); i < count_a; ++i)
-	{
-		auto entry (std::make_unique<nano::raw_key> ());
-		nano::random_pool::generate_block (entry->bytes.data (), entry->bytes.size ());
-		*first ^= *entry;
-		values.push_back (std::move (entry));
-	}
-	values.push_back (std::move (first));
-}
-
-void nano::fan::value (nano::raw_key & prv_a) const
-{
-	nano::lock_guard<nano::mutex> lock{ mutex };
-	value_get (prv_a);
-}
-
-void nano::fan::value_get (nano::raw_key & prv_a) const
-{
-	debug_assert (!mutex.try_lock ());
-	prv_a.clear ();
-	for (auto & i : values)
-	{
-		prv_a ^= *i;
-	}
-}
-
-void nano::fan::value_set (nano::raw_key const & value_a)
-{
-	nano::lock_guard<nano::mutex> lock{ mutex };
-	nano::raw_key value_l;
-	value_get (value_l);
-	*(values[0]) ^= value_l;
-	*(values[0]) ^= value_a;
-}
-
 /*
  * wallet_store
  */
@@ -413,6 +191,13 @@ void nano::wallet_store::initialize (nano::store::write_transaction const & tran
 	error |= mdb_dbi_open (env.tx (transaction_a), path_a.c_str (), MDB_CREATE, &handle_l);
 	handle = handle_l;
 	init_a = error != 0;
+}
+
+void nano::wallet_store::destroy (nano::store::write_transaction const & transaction_a)
+{
+	auto status (mdb_drop (env.tx (transaction_a), handle, 1));
+	release_assert (nano::store::lmdb::success (status), nano::store::lmdb::error_string (status));
+	handle = 0;
 }
 
 bool nano::wallet_store::is_representative (nano::store::transaction const & transaction_a) const
@@ -691,12 +476,225 @@ void nano::wallet_store::version_put (nano::store::write_transaction const & tra
 	entry_put_raw (transaction_a, nano::wallet_store::version_special, nano::wallet_value (entry, 0));
 }
 
-void nano::kdf::phs (nano::raw_key & result_a, std::string const & password_a, nano::uint256_union const & salt_a)
+nano::uint256_union nano::wallet_store::check (nano::store::transaction const & transaction_a) const
 {
-	nano::lock_guard<nano::mutex> lock{ mutex };
-	auto success (argon2_hash (1, kdf_work, 1, password_a.data (), password_a.size (), salt_a.bytes.data (), salt_a.bytes.size (), result_a.bytes.data (), result_a.bytes.size (), NULL, 0, Argon2_d, 0x10));
-	release_assert (success == 0);
-	(void)success;
+	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::check_special));
+	return value.key;
+}
+
+nano::uint256_union nano::wallet_store::salt (nano::store::transaction const & transaction_a) const
+{
+	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::salt_special));
+	return value.key;
+}
+
+void nano::wallet_store::wallet_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a) const
+{
+	nano::lock_guard<std::recursive_mutex> lock{ mutex };
+	nano::raw_key wallet_l;
+	wallet_key_mem.value (wallet_l);
+	nano::raw_key password_l;
+	password.value (password_l);
+	prv_a.decrypt (wallet_l, password_l, salt (transaction_a).owords[0]);
+}
+
+void nano::wallet_store::seed (nano::raw_key & prv_a, nano::store::transaction const & transaction_a) const
+{
+	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::seed_special));
+	nano::raw_key password_l;
+	wallet_key (password_l, transaction_a);
+	prv_a.decrypt (value.key, password_l, salt (transaction_a).owords[seed_iv_index]);
+}
+
+void nano::wallet_store::seed_set (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv_a)
+{
+	nano::raw_key password_l;
+	wallet_key (password_l, transaction_a);
+	nano::raw_key ciphertext;
+	ciphertext.encrypt (prv_a, password_l, salt (transaction_a).owords[seed_iv_index]);
+	entry_put_raw (transaction_a, nano::wallet_store::seed_special, nano::wallet_value (ciphertext, 0));
+	deterministic_clear (transaction_a);
+}
+
+nano::public_key nano::wallet_store::deterministic_insert (nano::store::write_transaction const & transaction_a)
+{
+	auto index (deterministic_index_get (transaction_a));
+	auto prv = deterministic_key (transaction_a, index);
+	nano::public_key result (nano::pub_key (prv));
+	while (exists (transaction_a, result))
+	{
+		++index;
+		prv = deterministic_key (transaction_a, index);
+		result = nano::pub_key (prv);
+	}
+	uint64_t marker (1);
+	marker <<= 32;
+	marker |= index;
+	entry_put_raw (transaction_a, result, nano::wallet_value (marker, 0));
+	++index;
+	deterministic_index_set (transaction_a, index);
+	return result;
+}
+
+nano::public_key nano::wallet_store::deterministic_insert (nano::store::write_transaction const & transaction_a, uint32_t const index)
+{
+	auto prv = deterministic_key (transaction_a, index);
+	nano::public_key result (nano::pub_key (prv));
+	uint64_t marker (1);
+	marker <<= 32;
+	marker |= index;
+	entry_put_raw (transaction_a, result, nano::wallet_value (marker, 0));
+	return result;
+}
+
+nano::raw_key nano::wallet_store::deterministic_key (nano::store::transaction const & transaction_a, uint32_t index_a) const
+{
+	debug_assert (valid_password (transaction_a));
+	nano::raw_key seed_l;
+	seed (seed_l, transaction_a);
+	return nano::deterministic_key (seed_l, index_a);
+}
+
+uint32_t nano::wallet_store::deterministic_index_get (nano::store::transaction const & transaction_a) const
+{
+	nano::wallet_value value (entry_get_raw (transaction_a, nano::wallet_store::deterministic_index_special));
+	return static_cast<uint32_t> (value.key.number () & static_cast<uint32_t> (-1));
+}
+
+void nano::wallet_store::deterministic_index_set (nano::store::write_transaction const & transaction_a, uint32_t index_a)
+{
+	nano::raw_key index_l (index_a);
+	nano::wallet_value value (index_l, 0);
+	entry_put_raw (transaction_a, nano::wallet_store::deterministic_index_special, value);
+}
+
+void nano::wallet_store::deterministic_clear (nano::store::write_transaction const & transaction_a)
+{
+	nano::uint256_union key (0);
+	for (auto i (begin (transaction_a)), n (end (transaction_a)); i != n;)
+	{
+		switch (key_type (nano::wallet_value (i->second)))
+		{
+			case nano::key_type::deterministic:
+			{
+				auto const & key (i->first);
+				erase (transaction_a, key);
+				i = begin (transaction_a, key);
+				break;
+			}
+			default:
+			{
+				++i;
+				break;
+			}
+		}
+	}
+	deterministic_index_set (transaction_a, 0);
+}
+
+bool nano::wallet_store::valid_password (nano::store::transaction const & transaction_a) const
+{
+	nano::raw_key zero;
+	zero.clear ();
+	nano::raw_key wallet_key_l;
+	wallet_key (wallet_key_l, transaction_a);
+	nano::uint256_union check_l;
+	check_l.encrypt (zero, wallet_key_l, salt (transaction_a).owords[check_iv_index]);
+	bool ok = check (transaction_a) == check_l;
+	return ok;
+}
+
+bool nano::wallet_store::attempt_password (nano::store::transaction const & transaction_a, std::string const & password_a)
+{
+	bool result = false;
+	{
+		nano::lock_guard<std::recursive_mutex> lock{ mutex };
+		nano::raw_key password_l;
+		derive_key (password_l, transaction_a, password_a);
+		password.value_set (password_l);
+		result = !valid_password (transaction_a);
+	}
+	if (!result)
+	{
+		switch (version (transaction_a))
+		{
+			case version_4:
+				break;
+			default:
+				debug_assert (false);
+		}
+	}
+	return result;
+}
+
+bool nano::wallet_store::rekey (nano::store::write_transaction const & transaction_a, std::string const & password_a)
+{
+	nano::lock_guard<std::recursive_mutex> lock{ mutex };
+	bool result (false);
+	if (valid_password (transaction_a))
+	{
+		nano::raw_key password_new;
+		derive_key (password_new, transaction_a, password_a);
+		nano::raw_key wallet_key_l;
+		wallet_key (wallet_key_l, transaction_a);
+		nano::raw_key password_l;
+		password.value (password_l);
+		password.value_set (password_new);
+		nano::raw_key encrypted;
+		encrypted.encrypt (wallet_key_l, password_new, salt (transaction_a).owords[0]);
+		nano::raw_key wallet_enc;
+		wallet_enc = encrypted;
+		wallet_key_mem.value_set (wallet_enc);
+		entry_put_raw (transaction_a, nano::wallet_store::wallet_key_special, nano::wallet_value (encrypted, 0));
+	}
+	else
+	{
+		result = true;
+	}
+	return result;
+}
+
+void nano::wallet_store::derive_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a, std::string const & password_a) const
+{
+	auto salt_l (salt (transaction_a));
+	kdf.phs (prv_a, password_a, salt_l);
+}
+
+auto nano::wallet_store::begin (nano::store::transaction const & txn) const -> iterator
+{
+	nano::account account{ special_count };
+	return iterator{ nano::store::iterator{ txn, nano::store::lmdb::iterator::lower_bound (env.tx (txn), handle, nano::store::lmdb::to_mdb_val (account)) } };
+}
+
+auto nano::wallet_store::begin (nano::store::transaction const & txn, nano::account const & key) const -> iterator
+{
+	nano::account account (key);
+	return iterator{ nano::store::iterator{ txn, nano::store::lmdb::iterator::lower_bound (env.tx (txn), handle, nano::store::lmdb::to_mdb_val (account)) } };
+}
+
+auto nano::wallet_store::end (nano::store::transaction const & txn) const -> iterator
+{
+	return iterator{ nano::store::iterator{ txn, nano::store::lmdb::iterator::end (env.tx (txn), handle) } };
+}
+
+auto nano::wallet_store::find (nano::store::transaction const & txn, nano::account const & key) const -> iterator
+{
+	auto it = begin (txn, key);
+	auto end_it = end (txn);
+	if (it == end_it)
+	{
+		return end_it;
+	}
+	if (it->first == key)
+	{
+		return it;
+	}
+	return end_it;
+}
+
+nano::mdb_wallets_store::mdb_wallets_store (std::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a) :
+	environment (path_a, nano::store::lmdb::env::options::make ().set_config (lmdb_config_a).override_config_sync (nano::lmdb_config::sync_strategy::always).override_config_map_size (1ULL * 1024 * 1024 * 1024))
+{
 }
 
 /*
@@ -896,13 +894,6 @@ void nano::wallet::write_backup (std::filesystem::path const & path_a)
 {
 	auto transaction (wallets.tx_begin_read ());
 	store.write_backup (transaction, path_a);
-}
-
-void nano::wallet_store::destroy (nano::store::write_transaction const & transaction_a)
-{
-	auto status (mdb_drop (env.tx (transaction_a), handle, 1));
-	release_assert (nano::store::lmdb::success (status), nano::store::lmdb::error_string (status));
-	handle = 0;
 }
 
 std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash const & send_hash_a, nano::account const & representative_a, nano::uint128_union const & amount_a, nano::account const & account_a, uint64_t work_a, bool generate_work_a)
@@ -1574,6 +1565,9 @@ void nano::wallet::work_cache_blocking (nano::account const & account_a, nano::r
  * wallets
  */
 
+nano::uint128_t const nano::wallets::generate_priority = std::numeric_limits<nano::uint128_t>::max ();
+nano::uint128_t const nano::wallets::high_priority = std::numeric_limits<nano::uint128_t>::max () - 1;
+
 nano::wallets::wallets (
 nano::node & node_a,
 nano::wallets_store & wallets_store_a,
@@ -2127,50 +2121,6 @@ void nano::wallets::do_wallet_actions ()
 	}
 }
 
-/*
- *
- */
-
-nano::uint128_t const nano::wallets::generate_priority = std::numeric_limits<nano::uint128_t>::max ();
-nano::uint128_t const nano::wallets::high_priority = std::numeric_limits<nano::uint128_t>::max () - 1;
-
-auto nano::wallet_store::begin (nano::store::transaction const & txn) const -> iterator
-{
-	nano::account account{ special_count };
-	return iterator{ nano::store::iterator{ txn, nano::store::lmdb::iterator::lower_bound (env.tx (txn), handle, nano::store::lmdb::to_mdb_val (account)) } };
-}
-
-auto nano::wallet_store::begin (nano::store::transaction const & txn, nano::account const & key) const -> iterator
-{
-	nano::account account (key);
-	return iterator{ nano::store::iterator{ txn, nano::store::lmdb::iterator::lower_bound (env.tx (txn), handle, nano::store::lmdb::to_mdb_val (account)) } };
-}
-
-auto nano::wallet_store::end (nano::store::transaction const & txn) const -> iterator
-{
-	return iterator{ nano::store::iterator{ txn, nano::store::lmdb::iterator::end (env.tx (txn), handle) } };
-}
-
-auto nano::wallet_store::find (nano::store::transaction const & txn, nano::account const & key) const -> iterator
-{
-	auto it = begin (txn, key);
-	auto end_it = end (txn);
-	if (it == end_it)
-	{
-		return end_it;
-	}
-	if (it->first == key)
-	{
-		return it;
-	}
-	return end_it;
-}
-
-nano::mdb_wallets_store::mdb_wallets_store (std::filesystem::path const & path_a, nano::lmdb_config const & lmdb_config_a) :
-	environment (path_a, nano::store::lmdb::env::options::make ().set_config (lmdb_config_a).override_config_sync (nano::lmdb_config::sync_strategy::always).override_config_map_size (1ULL * 1024 * 1024 * 1024))
-{
-}
-
 nano::container_info nano::wallets::container_info () const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
@@ -2179,4 +2129,58 @@ nano::container_info nano::wallets::container_info () const
 	info.put ("items", items.size ());
 	info.put ("actions", actions.size ());
 	return info;
+}
+
+/*
+ * fan
+ */
+
+nano::fan::fan (nano::raw_key const & key, std::size_t count_a)
+{
+	auto first (std::make_unique<nano::raw_key> (key));
+	for (auto i (1); i < count_a; ++i)
+	{
+		auto entry (std::make_unique<nano::raw_key> ());
+		nano::random_pool::generate_block (entry->bytes.data (), entry->bytes.size ());
+		*first ^= *entry;
+		values.push_back (std::move (entry));
+	}
+	values.push_back (std::move (first));
+}
+
+void nano::fan::value (nano::raw_key & prv_a) const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	value_get (prv_a);
+}
+
+void nano::fan::value_get (nano::raw_key & prv_a) const
+{
+	debug_assert (!mutex.try_lock ());
+	prv_a.clear ();
+	for (auto & i : values)
+	{
+		prv_a ^= *i;
+	}
+}
+
+void nano::fan::value_set (nano::raw_key const & value_a)
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	nano::raw_key value_l;
+	value_get (value_l);
+	*(values[0]) ^= value_l;
+	*(values[0]) ^= value_a;
+}
+
+/*
+ * kdf
+ */
+
+void nano::kdf::phs (nano::raw_key & result_a, std::string const & password_a, nano::uint256_union const & salt_a)
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	auto success (argon2_hash (1, kdf_work, 1, password_a.data (), password_a.size (), salt_a.bytes.data (), salt_a.bytes.size (), result_a.bytes.data (), result_a.bytes.size (), NULL, 0, Argon2_d, 0x10));
+	release_assert (success == 0);
+	(void)success;
 }

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -24,6 +24,7 @@
 #include <boost/property_tree/json_parser.hpp>
 
 #include <future>
+#include <stdexcept>
 
 #include <argon2.h>
 
@@ -51,121 +52,110 @@ int const nano::wallet_store::special_count (7);
 std::size_t const nano::wallet_store::check_iv_index (0);
 std::size_t const nano::wallet_store::seed_iv_index (1);
 
-nano::wallet_store::wallet_store (bool & init_a, nano::kdf & kdf_a, nano::store::write_transaction & transaction_a, store::lmdb::env & env_a, nano::account representative_a, unsigned fanout_a, std::string const & wallet_a, std::string const & json_a) :
+nano::wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transaction & transaction_a, store::lmdb::env & env_a, nano::account representative_a, unsigned fanout_a, std::string const & wallet_a, std::string const & json_a) :
 	password (0, fanout_a),
 	wallet_key_mem (0, fanout_a),
 	kdf (kdf_a),
 	env{ env_a }
 {
-	init_a = false;
-	initialize (transaction_a, init_a, wallet_a);
-	if (!init_a)
+	initialize (transaction_a, wallet_a);
+	MDB_val junk;
+	nano::store::lmdb::db_val version_key (version_special);
+	auto mdb_version_key = nano::store::lmdb::to_mdb_val (version_key);
+	debug_assert (mdb_get (env.tx (transaction_a), handle, &mdb_version_key, &junk) == MDB_NOTFOUND);
+	boost::property_tree::ptree wallet_l;
+	std::stringstream istream (json_a);
+	try
 	{
-		MDB_val junk;
-		nano::store::lmdb::db_val version_key (version_special);
-		auto mdb_version_key = nano::store::lmdb::to_mdb_val (version_key);
-		debug_assert (mdb_get (env.tx (transaction_a), handle, &mdb_version_key, &junk) == MDB_NOTFOUND);
-		boost::property_tree::ptree wallet_l;
-		std::stringstream istream (json_a);
-		try
-		{
-			boost::property_tree::read_json (istream, wallet_l);
-		}
-		catch (...)
-		{
-			init_a = true;
-		}
-		for (auto i (wallet_l.begin ()), n (wallet_l.end ()); i != n; ++i)
-		{
-			nano::account key;
-			init_a = key.decode_hex (i->first);
-			if (!init_a)
-			{
-				nano::raw_key value;
-				init_a = value.decode_hex (wallet_l.get<std::string> (i->first));
-				if (!init_a)
-				{
-					entry_put_raw (transaction_a, key, nano::wallet_value (value, 0));
-				}
-				else
-				{
-					init_a = true;
-				}
-			}
-			else
-			{
-				init_a = true;
-			}
-		}
-		nano::store::lmdb::db_val wallet_key_key (wallet_key_special);
-		nano::store::lmdb::db_val salt_key (salt_special);
-		nano::store::lmdb::db_val check_key (check_special);
-		auto mdb_version_key2 = nano::store::lmdb::to_mdb_val (version_key);
-		auto mdb_wallet_key_key = nano::store::lmdb::to_mdb_val (wallet_key_key);
-		auto mdb_salt_key = nano::store::lmdb::to_mdb_val (salt_key);
-		auto mdb_check_key = nano::store::lmdb::to_mdb_val (check_key);
-		init_a |= mdb_get (env.tx (transaction_a), handle, &mdb_version_key2, &junk) != 0;
-		init_a |= mdb_get (env.tx (transaction_a), handle, &mdb_wallet_key_key, &junk) != 0;
-		init_a |= mdb_get (env.tx (transaction_a), handle, &mdb_salt_key, &junk) != 0;
-		init_a |= mdb_get (env.tx (transaction_a), handle, &mdb_check_key, &junk) != 0;
-		nano::store::lmdb::db_val rep_key (representative_special);
-		auto mdb_rep_key = nano::store::lmdb::to_mdb_val (rep_key);
-		init_a |= mdb_get (env.tx (transaction_a), handle, &mdb_rep_key, &junk) != 0;
-		nano::raw_key key;
-		key.clear ();
-		password.value_set (key);
-		key = entry_get_raw (transaction_a, nano::wallet_store::wallet_key_special).key;
-		wallet_key_mem.value_set (key);
+		boost::property_tree::read_json (istream, wallet_l);
 	}
+	catch (...)
+	{
+		throw std::runtime_error ("Failed to parse wallet JSON");
+	}
+	for (auto i (wallet_l.begin ()), n (wallet_l.end ()); i != n; ++i)
+	{
+		nano::account key;
+		if (key.decode_hex (i->first))
+		{
+			throw std::runtime_error ("Failed to decode wallet key hex");
+		}
+		nano::raw_key value;
+		if (value.decode_hex (wallet_l.get<std::string> (i->first)))
+		{
+			throw std::runtime_error ("Failed to decode wallet value hex");
+		}
+		entry_put_raw (transaction_a, key, nano::wallet_value (value, 0));
+	}
+	nano::store::lmdb::db_val wallet_key_key (wallet_key_special);
+	nano::store::lmdb::db_val salt_key (salt_special);
+	nano::store::lmdb::db_val check_key (check_special);
+	auto mdb_version_key2 = nano::store::lmdb::to_mdb_val (version_key);
+	auto mdb_wallet_key_key = nano::store::lmdb::to_mdb_val (wallet_key_key);
+	auto mdb_salt_key = nano::store::lmdb::to_mdb_val (salt_key);
+	auto mdb_check_key = nano::store::lmdb::to_mdb_val (check_key);
+	bool missing = false;
+	missing |= mdb_get (env.tx (transaction_a), handle, &mdb_version_key2, &junk) != 0;
+	missing |= mdb_get (env.tx (transaction_a), handle, &mdb_wallet_key_key, &junk) != 0;
+	missing |= mdb_get (env.tx (transaction_a), handle, &mdb_salt_key, &junk) != 0;
+	missing |= mdb_get (env.tx (transaction_a), handle, &mdb_check_key, &junk) != 0;
+	nano::store::lmdb::db_val rep_key (representative_special);
+	auto mdb_rep_key = nano::store::lmdb::to_mdb_val (rep_key);
+	missing |= mdb_get (env.tx (transaction_a), handle, &mdb_rep_key, &junk) != 0;
+	if (missing)
+	{
+		throw std::runtime_error ("Wallet is missing required entries");
+	}
+	nano::raw_key key;
+	key.clear ();
+	password.value_set (key);
+	key = entry_get_raw (transaction_a, nano::wallet_store::wallet_key_special).key;
+	wallet_key_mem.value_set (key);
 }
 
-nano::wallet_store::wallet_store (bool & init_a, nano::kdf & kdf_a, nano::store::write_transaction & transaction_a, store::lmdb::env & env_a, nano::account representative_a, unsigned fanout_a, std::string const & wallet_a) :
+nano::wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transaction & transaction_a, store::lmdb::env & env_a, nano::account representative_a, unsigned fanout_a, std::string const & wallet_a) :
 	password (0, fanout_a),
 	wallet_key_mem (0, fanout_a),
 	kdf (kdf_a),
 	env{ env_a }
 {
-	init_a = false;
-	initialize (transaction_a, init_a, wallet_a);
-	if (!init_a)
+	initialize (transaction_a, wallet_a);
+	int version_status;
+	MDB_val version_value;
+	nano::store::lmdb::db_val version_lookup_key (version_special);
+	auto mdb_version_lookup_key = nano::store::lmdb::to_mdb_val (version_lookup_key);
+	version_status = mdb_get (env.tx (transaction_a), handle, &mdb_version_lookup_key, &version_value);
+	if (version_status == MDB_NOTFOUND)
 	{
-		int version_status;
-		MDB_val version_value;
-		nano::store::lmdb::db_val version_lookup_key (version_special);
-		auto mdb_version_lookup_key = nano::store::lmdb::to_mdb_val (version_lookup_key);
-		version_status = mdb_get (env.tx (transaction_a), handle, &mdb_version_lookup_key, &version_value);
-		if (version_status == MDB_NOTFOUND)
-		{
-			version_put (transaction_a, version_current);
-			nano::raw_key salt_l;
-			random_pool::generate_block (salt_l.bytes.data (), salt_l.bytes.size ());
-			entry_put_raw (transaction_a, nano::wallet_store::salt_special, nano::wallet_value (salt_l, 0));
-			// Wallet key is a fixed random key that encrypts all entries
-			nano::raw_key wallet_key;
-			random_pool::generate_block (wallet_key.bytes.data (), sizeof (wallet_key.bytes));
-			nano::raw_key password_l;
-			password_l.clear ();
-			password.value_set (password_l);
-			nano::raw_key zero;
-			zero.clear ();
-			// Wallet key is encrypted by the user's password
-			nano::raw_key encrypted;
-			encrypted.encrypt (wallet_key, zero, salt_l.owords[0]);
-			entry_put_raw (transaction_a, nano::wallet_store::wallet_key_special, nano::wallet_value (encrypted, 0));
-			nano::raw_key wallet_key_enc;
-			wallet_key_enc = encrypted;
-			wallet_key_mem.value_set (wallet_key_enc);
-			nano::raw_key check;
-			check.encrypt (zero, wallet_key, salt_l.owords[check_iv_index]);
-			entry_put_raw (transaction_a, nano::wallet_store::check_special, nano::wallet_value (check, 0));
-			nano::raw_key rep;
-			rep.bytes = representative_a.bytes;
-			entry_put_raw (transaction_a, nano::wallet_store::representative_special, nano::wallet_value (rep, 0));
-			nano::raw_key seed;
-			random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
-			seed_set (transaction_a, seed);
-			entry_put_raw (transaction_a, nano::wallet_store::deterministic_index_special, nano::wallet_value (0, 0));
-		}
+		version_put (transaction_a, version_current);
+		nano::raw_key salt_l;
+		random_pool::generate_block (salt_l.bytes.data (), salt_l.bytes.size ());
+		entry_put_raw (transaction_a, nano::wallet_store::salt_special, nano::wallet_value (salt_l, 0));
+		// Wallet key is a fixed random key that encrypts all entries
+		nano::raw_key wallet_key;
+		random_pool::generate_block (wallet_key.bytes.data (), sizeof (wallet_key.bytes));
+		nano::raw_key password_l;
+		password_l.clear ();
+		password.value_set (password_l);
+		nano::raw_key zero;
+		zero.clear ();
+		// Wallet key is encrypted by the user's password
+		nano::raw_key encrypted;
+		encrypted.encrypt (wallet_key, zero, salt_l.owords[0]);
+		entry_put_raw (transaction_a, nano::wallet_store::wallet_key_special, nano::wallet_value (encrypted, 0));
+		nano::raw_key wallet_key_enc;
+		wallet_key_enc = encrypted;
+		wallet_key_mem.value_set (wallet_key_enc);
+		nano::raw_key check;
+		check.encrypt (zero, wallet_key, salt_l.owords[check_iv_index]);
+		entry_put_raw (transaction_a, nano::wallet_store::check_special, nano::wallet_value (check, 0));
+		nano::raw_key rep;
+		rep.bytes = representative_a.bytes;
+		entry_put_raw (transaction_a, nano::wallet_store::representative_special, nano::wallet_value (rep, 0));
+		nano::raw_key seed;
+		random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
+		seed_set (transaction_a, seed);
+		entry_put_raw (transaction_a, nano::wallet_store::deterministic_index_special, nano::wallet_value (0, 0));
 	}
 	nano::raw_key key;
 	key = entry_get_raw (transaction_a, nano::wallet_store::wallet_key_special).key;
@@ -183,14 +173,16 @@ std::vector<nano::account> nano::wallet_store::accounts (nano::store::transactio
 	return result;
 }
 
-void nano::wallet_store::initialize (nano::store::write_transaction const & transaction_a, bool & init_a, std::string const & path_a)
+void nano::wallet_store::initialize (nano::store::write_transaction const & transaction_a, std::string const & path_a)
 {
 	debug_assert (strlen (path_a.c_str ()) == path_a.size ());
-	auto error (0);
 	MDB_dbi handle_l;
-	error |= mdb_dbi_open (env.tx (transaction_a), path_a.c_str (), MDB_CREATE, &handle_l);
+	auto error = mdb_dbi_open (env.tx (transaction_a), path_a.c_str (), MDB_CREATE, &handle_l);
+	if (error != 0)
+	{
+		throw std::runtime_error ("Failed to open wallet database");
+	}
 	handle = handle_l;
-	init_a = error != 0;
 }
 
 void nano::wallet_store::destroy (nano::store::write_transaction const & transaction_a)
@@ -418,7 +410,7 @@ bool nano::wallet_store::import (nano::store::write_transaction const & transact
 	debug_assert (valid_password (transaction_a));
 	debug_assert (other_a.valid_password (transaction_a));
 	auto result (false);
-	for (auto i (other_a.begin (transaction_a)), n (end (transaction_a)); i != n; ++i)
+	for (auto i (other_a.begin (transaction_a)), n (other_a.end (transaction_a)); i != n; ++i)
 	{
 		nano::raw_key prv;
 		auto error (other_a.fetch (transaction_a, i->first, prv));
@@ -701,17 +693,17 @@ nano::mdb_wallets_store::mdb_wallets_store (std::filesystem::path const & path_a
  * wallet
  */
 
-nano::wallet::wallet (bool & init_a, nano::store::write_transaction & transaction_a, nano::wallets & wallets_a, std::string const & wallet_a) :
+nano::wallet::wallet (nano::store::write_transaction & transaction_a, nano::wallets & wallets_a, std::string const & wallet_a) :
 	lock_observer ([] (bool, bool) {}),
-	store (init_a, wallets_a.kdf, transaction_a, wallets_a.env, wallets_a.config.random_representative (), wallets_a.config.password_fanout, wallet_a),
+	store (wallets_a.kdf, transaction_a, wallets_a.env, wallets_a.config.random_representative (), wallets_a.config.password_fanout, wallet_a),
 	wallets (wallets_a),
 	logger (wallets_a.logger)
 {
 }
 
-nano::wallet::wallet (bool & init_a, nano::store::write_transaction & transaction_a, nano::wallets & wallets_a, std::string const & wallet_a, std::string const & json) :
+nano::wallet::wallet (nano::store::write_transaction & transaction_a, nano::wallets & wallets_a, std::string const & wallet_a, std::string const & json) :
 	lock_observer ([] (bool, bool) {}),
-	store (init_a, wallets_a.kdf, transaction_a, wallets_a.env, wallets_a.config.random_representative (), wallets_a.config.password_fanout, wallet_a, json),
+	store (wallets_a.kdf, transaction_a, wallets_a.env, wallets_a.config.random_representative (), wallets_a.config.password_fanout, wallet_a, json),
 	wallets (wallets_a),
 	logger (wallets_a.logger)
 {
@@ -862,25 +854,23 @@ bool nano::wallet::exists (nano::public_key const & account_a)
 
 bool nano::wallet::import (std::string const & json_a, std::string const & password_a)
 {
-	auto error (false);
-	std::unique_ptr<nano::wallet_store> temp;
-	{
-		auto transaction (wallets.tx_begin_write ());
-		nano::uint256_union id;
-		random_pool::generate_block (id.bytes.data (), id.bytes.size ());
-		temp = std::make_unique<nano::wallet_store> (error, wallets.kdf, transaction, wallets.env, 0, 1, id.to_string (), json_a);
-	}
-	if (!error)
-	{
-		auto transaction (wallets.tx_begin_write ());
-		error = temp->attempt_password (transaction, password_a);
-	}
+	bool error (true);
 	auto transaction (wallets.tx_begin_write ());
-	if (!error)
+	nano::uint256_union id;
+	random_pool::generate_block (id.bytes.data (), id.bytes.size ());
+	try
 	{
-		error = store.import (transaction, *temp);
+		auto temp = std::make_unique<nano::wallet_store> (wallets.kdf, transaction, wallets.env, 0, 1, id.to_string (), json_a);
+		if (!temp->attempt_password (transaction, password_a))
+		{
+			error = store.import (transaction, *temp);
+		}
+		temp->destroy (transaction);
 	}
-	temp->destroy (transaction);
+	catch (std::exception const & ex)
+	{
+		logger.error (nano::log::type::wallet, "Failed to import wallet: {}", ex.what ());
+	}
 	return error;
 }
 
@@ -1615,14 +1605,14 @@ nano::logger & logger_a) :
 			auto error (id.decode_hex (text));
 			release_assert (!error, "failed to decode wallet id from text: {}", text);
 			release_assert (items.find (id) == items.end ());
-			auto wallet (std::make_shared<nano::wallet> (error, transaction, *this, text));
-			if (!error)
+			try
 			{
+				auto wallet = std::make_shared<nano::wallet> (transaction, *this, text);
 				items[id] = wallet;
 			}
-			else
+			catch (std::exception const & ex)
 			{
-				// Couldn't open wallet
+				logger.error (nano::log::type::wallet, "Failed to open wallet {}: {}", text, ex.what ());
 			}
 		}
 	}
@@ -1732,39 +1722,41 @@ std::shared_ptr<nano::wallet> nano::wallets::create (nano::wallet_id const & id_
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	debug_assert (items.find (id_a) == items.end ());
-	std::shared_ptr<nano::wallet> result;
-	bool error;
 	{
 		auto transaction (tx_begin_write ());
-		result = std::make_shared<nano::wallet> (error, transaction, *this, id_a.to_string ());
+		try
+		{
+			auto result = std::make_shared<nano::wallet> (transaction, *this, id_a.to_string ());
+			items[id_a] = result;
+			result->enter_initial_password ();
+			return result;
+		}
+		catch (std::exception const & ex)
+		{
+			logger.error (nano::log::type::wallet, "Failed to create wallet {}: {}", id_a.to_string (), ex.what ());
+		}
 	}
-	if (!error)
-	{
-		items[id_a] = result;
-		result->enter_initial_password ();
-	}
-	return result;
+	return nullptr;
 }
 
 std::shared_ptr<nano::wallet> nano::wallets::create_from_json (nano::wallet_id const & id_a, std::string const & json_a)
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	debug_assert (items.find (id_a) == items.end ());
-	std::shared_ptr<nano::wallet> result;
-	bool error;
 	{
 		auto transaction (tx_begin_write ());
-		result = std::make_shared<nano::wallet> (error, transaction, *this, id_a.to_string (), json_a);
+		try
+		{
+			auto result = std::make_shared<nano::wallet> (transaction, *this, id_a.to_string (), json_a);
+			items[id_a] = result;
+			return result;
+		}
+		catch (std::exception const & ex)
+		{
+			logger.error (nano::log::type::wallet, "Failed to create wallet {} from JSON: {}", id_a.to_string (), ex.what ());
+		}
 	}
-	if (!error)
-	{
-		items[id_a] = result;
-	}
-	else
-	{
-		result = nullptr;
-	}
-	return result;
+	return nullptr;
 }
 
 bool nano::wallets::search_receivable (nano::wallet_id const & wallet_a)
@@ -1821,10 +1813,14 @@ void nano::wallets::reload ()
 		// New wallet
 		if (items.find (id) == items.end ())
 		{
-			auto wallet (std::make_shared<nano::wallet> (error, transaction, *this, text));
-			if (!error)
+			try
 			{
+				auto wallet = std::make_shared<nano::wallet> (transaction, *this, text);
 				items[id] = wallet;
+			}
+			catch (std::exception const & ex)
+			{
+				logger.error (nano::log::type::wallet, "Failed to open wallet {}: {}", text, ex.what ());
 			}
 		}
 		// List of wallets on disk

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -67,9 +67,10 @@ public:
 	using iterator = store::typed_iterator<nano::account, nano::wallet_value>;
 
 public:
-	wallet_store (bool & error, nano::kdf &, nano::store::write_transaction &, store::lmdb::env &, nano::account representative, unsigned fanout, std::string const & wallet_path);
-	wallet_store (bool & error, nano::kdf &, nano::store::write_transaction &, store::lmdb::env &, nano::account representative, unsigned fanout, std::string const & wallet_path, std::string const & json);
-	void initialize (nano::store::write_transaction const &, bool & error, std::string const & path);
+	wallet_store (nano::kdf &, nano::store::write_transaction &, store::lmdb::env &, nano::account representative, unsigned fanout, std::string const & wallet_path);
+	wallet_store (nano::kdf &, nano::store::write_transaction &, store::lmdb::env &, nano::account representative, unsigned fanout, std::string const & wallet_path, std::string const & json);
+
+	void initialize (nano::store::write_transaction const &, std::string const & path);
 	std::vector<nano::account> accounts (nano::store::transaction const &) const;
 	nano::uint256_union check (nano::store::transaction const &) const;
 	bool rekey (nano::store::write_transaction const &, std::string const & password);
@@ -146,8 +147,8 @@ public:
 class wallet final : public std::enable_shared_from_this<nano::wallet>
 {
 public:
-	wallet (bool & error, nano::store::write_transaction &, nano::wallets &, std::string const & wallet_path);
-	wallet (bool & error, nano::store::write_transaction &, nano::wallets &, std::string const & wallet_path, std::string const & json);
+	wallet (nano::store::write_transaction &, nano::wallets &, std::string const & wallet_path);
+	wallet (nano::store::write_transaction &, nano::wallets &, std::string const & wallet_path, std::string const & json);
 
 	// Password and lock management
 	void enter_initial_password ();

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -139,6 +139,7 @@ public:
 	static std::size_t const check_iv_index;
 	static std::size_t const seed_iv_index;
 	static int const special_count;
+	static std::string const default_password;
 };
 
 /**

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <nano/lib/id_dispenser.hpp>
 #include <nano/lib/lmdbconfig.hpp>
 #include <nano/lib/locks.hpp>
 #include <nano/lib/numbers.hpp>
@@ -21,11 +20,11 @@
 
 namespace nano
 {
-class node;
-class node_config;
 class wallets;
 
-// The fan spreads a key out over the heap to decrease the likelihood of it being recovered by memory inspection
+/*
+ * The fan spreads a key out over the heap to decrease the likelihood of it being recovered by memory inspection
+ */
 class fan final
 {
 public:
@@ -39,6 +38,9 @@ private:
 	void value_get (nano::raw_key & result) const;
 };
 
+/*
+ * Key derivation function using password hashing scheme (PHS) to derive encryption keys from passwords
+ */
 class kdf final
 {
 public:
@@ -138,7 +140,9 @@ public:
 	static int const special_count;
 };
 
-// A wallet is a set of account keys encrypted by a common encryption key
+/**
+ * A wallet is a set of account keys encrypted by a common encryption key
+ */
 class wallet final : public std::enable_shared_from_this<nano::wallet>
 {
 public:

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -68,7 +68,7 @@ public:
 
 public:
 	wallet_store (nano::kdf &, nano::store::write_transaction &, store::lmdb::env &, nano::account representative, unsigned fanout, std::string const & wallet_path);
-	wallet_store (nano::kdf &, nano::store::write_transaction &, store::lmdb::env &, nano::account representative, unsigned fanout, std::string const & wallet_path, std::string const & json);
+	wallet_store (nano::kdf &, nano::store::write_transaction &, store::lmdb::env &, unsigned fanout, std::string const & wallet_path, std::string const & json);
 
 	void initialize (nano::store::write_transaction const &, std::string const & path);
 	std::vector<nano::account> accounts (nano::store::transaction const &) const;


### PR DESCRIPTION
Replace wallet_store initialization error output parameters with exceptions for cleaner error propagation. Initialize new wallets directly with a KDF-derived default password (empty string) instead of bootstrapping with a raw zero key and immediately rekeying in a separate transaction.