### PR TITLE
Extend telemetry data

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -1094,8 +1094,6 @@ TEST (active_elections, fork_replacement_tally)
 	ASSERT_TRUE (votes2.find (nano::dev::genesis_key.pub) != votes2.end ());
 }
 
-namespace nano
-{
 // Blocks that won an election must always be seen as confirming or cemented
 TEST (active_elections, confirmation_consistency)
 {
@@ -1111,11 +1109,10 @@ TEST (active_elections, confirmation_consistency)
 		ASSERT_TIMELY (5s, node.block_confirmed (block->hash ()));
 		ASSERT_NO_ERROR (system.poll_until_true (1s, [&node, &block, i] {
 			EXPECT_EQ (i + 1, node.active.recently_confirmed.size ());
-			EXPECT_EQ (block->qualified_root (), node.active.recently_confirmed.back ().first);
+			EXPECT_TRUE (node.active.recently_confirmed.contains (block->qualified_root ()));
 			return i + 1 == node.active.recently_cemented.size (); // done after a callback
 		}));
 	}
-}
 }
 
 TEST (active_elections, confirm_new)

--- a/nano/core_test/recently_cache.cpp
+++ b/nano/core_test/recently_cache.cpp
@@ -24,14 +24,14 @@ std::shared_ptr<nano::block> make_test_block ()
 	.build ();
 }
 
-nano::election_status make_test_election_status ()
+nano::election_status make_test_election_status (std::chrono::milliseconds duration = std::chrono::milliseconds (100))
 {
 	auto block = make_test_block ();
 	nano::election_status status;
 	status.winner = block;
 	status.type = nano::election_status_type::active_confirmed_quorum;
 	status.election_end = std::chrono::system_clock::now ();
-	status.election_duration = std::chrono::milliseconds (100);
+	status.election_duration = duration;
 	return status;
 }
 }
@@ -59,13 +59,13 @@ TEST (recently_confirmed_cache, put)
 		auto hash = nano::test::random_hash ();
 		roots.push_back (root);
 		hashes.push_back (hash);
-		cache.put (root, hash);
+		cache.put (root, hash, {});
 	}
 
 	ASSERT_EQ (3, cache.size ());
 
 	// Test duplicate filtering
-	cache.put (roots[4], hashes[4]);
+	cache.put (roots[4], hashes[4], {});
 	ASSERT_EQ (3, cache.size ());
 
 	// First entries should have been evicted (LRU)
@@ -84,7 +84,7 @@ TEST (recently_confirmed_cache, erase)
 	auto root = nano::test::random_qualified_root ();
 	auto hash = nano::test::random_hash ();
 
-	cache.put (root, hash);
+	cache.put (root, hash, {});
 	ASSERT_TRUE (cache.contains (hash));
 	ASSERT_EQ (1, cache.size ());
 
@@ -101,12 +101,69 @@ TEST (recently_confirmed_cache, clear)
 	{
 		auto root = nano::test::random_qualified_root ();
 		auto hash = nano::test::random_hash ();
-		cache.put (root, hash);
+		cache.put (root, hash, {});
 	}
 
 	ASSERT_EQ (5, cache.size ());
 	cache.clear ();
 	ASSERT_EQ (0, cache.size ());
+}
+
+TEST (recently_confirmed_cache, latency_percentiles_empty)
+{
+	nano::recently_confirmed_cache cache (10);
+	auto stats = cache.latency_percentiles ();
+	ASSERT_EQ (0, stats.p50);
+	ASSERT_EQ (0, stats.p90);
+	ASSERT_EQ (0, stats.p99);
+}
+
+TEST (recently_confirmed_cache, latency_percentiles_single)
+{
+	nano::recently_confirmed_cache cache (10);
+	auto status = make_test_election_status (std::chrono::milliseconds (500));
+	cache.put (status.winner->qualified_root (), status.winner->hash (), status);
+
+	auto stats = cache.latency_percentiles ();
+	ASSERT_EQ (500, stats.p50);
+	ASSERT_EQ (500, stats.p90);
+	ASSERT_EQ (500, stats.p99);
+}
+
+TEST (recently_confirmed_cache, latency_percentiles_distribution)
+{
+	nano::recently_confirmed_cache cache (1000);
+	for (int i = 1; i <= 100; ++i)
+	{
+		auto status = make_test_election_status (std::chrono::milliseconds (i));
+		cache.put (status.winner->qualified_root (), status.winner->hash (), status);
+	}
+
+	auto stats = cache.latency_percentiles ();
+	ASSERT_EQ (50, stats.p50);
+	ASSERT_EQ (90, stats.p90);
+	ASSERT_EQ (99, stats.p99);
+}
+
+TEST (recently_confirmed_cache, latency_percentiles_outliers)
+{
+	nano::recently_confirmed_cache cache (1000);
+
+	// 9 fast confirmations + 1 slow outlier (10 total)
+	for (int i = 0; i < 9; ++i)
+	{
+		auto status = make_test_election_status (std::chrono::milliseconds (10));
+		cache.put (status.winner->qualified_root (), status.winner->hash (), status);
+	}
+	auto status = make_test_election_status (std::chrono::milliseconds (10000));
+	cache.put (status.winner->qualified_root (), status.winner->hash (), status);
+
+	auto stats = cache.latency_percentiles ();
+	// p50 and p90 should reflect the fast majority
+	ASSERT_EQ (10, stats.p50);
+	ASSERT_EQ (10, stats.p90);
+	// p99 with 10 entries: ceil(0.99*10)-1 = 9, captures the outlier
+	ASSERT_EQ (10000, stats.p99);
 }
 
 /*

--- a/nano/core_test/rep_crawler.cpp
+++ b/nano/core_test/rep_crawler.cpp
@@ -273,7 +273,9 @@ TEST (rep_crawler, DISABLED_recently_confirmed)
 	auto & node1 (*system.nodes[0]);
 	ASSERT_EQ (1, node1.ledger.block_count ());
 	auto const block = nano::dev::genesis;
-	node1.active.recently_confirmed.put (block->qualified_root (), block->hash ());
+	nano::election_status status;
+	status.winner = block;
+	node1.active.recently_confirmed.put (block->qualified_root (), block->hash (), status);
 	auto & node2 (*system.add_node ());
 	system.wallet (1)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto channel = node1.network.find_node_id (node2.get_node_id ());

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -23,18 +23,18 @@ TEST (telemetry, signatures)
 	data.minor_version = 1;
 	data.patch_version = 5;
 	data.pre_release_version = 2;
-	data.maker = 1;
-	data.database_backend = static_cast<uint8_t> (nano::messages::telemetry_database_backend::lmdb);
+	data.maker = nano::messages::telemetry_maker::nf_pruned_node;
+	data.database_backend = nano::messages::telemetry_database_backend::lmdb;
 	data.confirmation_latency_ms_p50 = 250;
 	data.confirmation_latency_ms_p90 = 500;
 	data.confirmation_latency_ms_p99 = 750;
-	data.bootstrap_status = static_cast<uint8_t> (nano::messages::telemetry_bootstrap_status::synced);
+	data.bootstrap_status = nano::messages::telemetry_bootstrap_status::synced;
 	data.timestamp = std::chrono::system_clock::time_point (100ms);
 	data.sign (node_id);
 	ASSERT_FALSE (data.validate_signature ());
 	auto signature = data.signature;
 	// Check that the signature is different if changing a piece of data
-	data.maker = 2;
+	data.maker = nano::messages::telemetry_maker::nf_node;
 	data.sign (node_id);
 	ASSERT_NE (data.signature, signature);
 }
@@ -48,7 +48,7 @@ TEST (telemetry, unknown_data)
 	data.minor_version = 1;
 	data.patch_version = 5;
 	data.pre_release_version = 2;
-	data.maker = 1;
+	data.maker = nano::messages::telemetry_maker::nf_pruned_node;
 	data.timestamp = std::chrono::system_clock::time_point (100ms);
 	data.unknown_data.push_back (1);
 	data.sign (node_id);
@@ -65,7 +65,7 @@ TEST (telemetry, backward_compat_v1_to_new)
 	data.minor_version = 1;
 	data.patch_version = 5;
 	data.pre_release_version = 2;
-	data.maker = 1;
+	data.maker = nano::messages::telemetry_maker::nf_pruned_node;
 	data.timestamp = std::chrono::system_clock::time_point (100ms);
 	data.active_difficulty = 0xffffffc000000000;
 
@@ -88,7 +88,7 @@ TEST (telemetry, backward_compat_v1_to_new)
 		nano::write (stream, data.minor_version);
 		nano::write (stream, data.patch_version);
 		nano::write (stream, data.pre_release_version);
-		nano::write (stream, data.maker);
+		nano::write (stream, static_cast<uint8_t> (data.maker));
 		nano::write (stream, boost::endian::native_to_big (std::chrono::duration_cast<std::chrono::milliseconds> (data.timestamp.time_since_epoch ()).count ()));
 		nano::write (stream, boost::endian::native_to_big (data.active_difficulty));
 	}
@@ -102,12 +102,12 @@ TEST (telemetry, backward_compat_v1_to_new)
 	nano::bufferstream stream (old_payload.data (), old_payload.size ());
 	received.deserialize (stream, nano::messages::telemetry_data::size_v1);
 
-	ASSERT_EQ (received.version, nano::messages::telemetry_version::v1);
-	ASSERT_EQ (received.database_backend, 0);
+	ASSERT_EQ (received.version, nano::messages::telemetry_data_version::v1);
+	ASSERT_EQ (received.database_backend, nano::messages::telemetry_database_backend::unknown);
 	ASSERT_EQ (received.confirmation_latency_ms_p50, 0);
 	ASSERT_EQ (received.confirmation_latency_ms_p90, 0);
 	ASSERT_EQ (received.confirmation_latency_ms_p99, 0);
-	ASSERT_EQ (received.bootstrap_status, 0);
+	ASSERT_EQ (received.bootstrap_status, nano::messages::telemetry_bootstrap_status::unknown);
 	ASSERT_FALSE (received.validate_signature ());
 	ASSERT_EQ (received.node_id, node_id.pub);
 }
@@ -122,12 +122,12 @@ TEST (telemetry, forward_compat_new_to_old)
 	data.minor_version = 1;
 	data.patch_version = 5;
 	data.pre_release_version = 2;
-	data.maker = 1;
-	data.database_backend = static_cast<uint8_t> (nano::messages::telemetry_database_backend::lmdb);
+	data.maker = nano::messages::telemetry_maker::nf_pruned_node;
+	data.database_backend = nano::messages::telemetry_database_backend::lmdb;
 	data.confirmation_latency_ms_p50 = 100;
 	data.confirmation_latency_ms_p90 = 250;
 	data.confirmation_latency_ms_p99 = 500;
-	data.bootstrap_status = static_cast<uint8_t> (nano::messages::telemetry_bootstrap_status::synced);
+	data.bootstrap_status = nano::messages::telemetry_bootstrap_status::synced;
 	data.timestamp = std::chrono::system_clock::time_point (100ms);
 	data.active_difficulty = 0xffffffc000000000;
 	data.sign (node_id);
@@ -168,7 +168,9 @@ TEST (telemetry, forward_compat_new_to_old)
 		nano::read (stream, old_received.minor_version);
 		nano::read (stream, old_received.patch_version);
 		nano::read (stream, old_received.pre_release_version);
-		nano::read (stream, old_received.maker);
+		uint8_t maker_l;
+		nano::read (stream, maker_l);
+		old_received.maker = static_cast<nano::messages::telemetry_maker> (maker_l);
 		uint64_t timestamp_l;
 		nano::read (stream, timestamp_l);
 		boost::endian::big_to_native_inplace (timestamp_l);
@@ -181,7 +183,7 @@ TEST (telemetry, forward_compat_new_to_old)
 		nano::read (stream, old_received.unknown_data, remaining);
 	}
 
-	ASSERT_EQ (old_received.database_backend, 0);
+	ASSERT_EQ (old_received.database_backend, nano::messages::telemetry_database_backend::unknown);
 	ASSERT_EQ (old_received.unknown_data.size (), 14);
 
 	// Old node's validate_signature: serialize known fields + unknown_data
@@ -202,7 +204,7 @@ TEST (telemetry, forward_compat_new_to_old)
 		nano::write (stream, old_received.minor_version);
 		nano::write (stream, old_received.patch_version);
 		nano::write (stream, old_received.pre_release_version);
-		nano::write (stream, old_received.maker);
+		nano::write (stream, static_cast<uint8_t> (old_received.maker));
 		nano::write (stream, boost::endian::native_to_big (std::chrono::duration_cast<std::chrono::milliseconds> (old_received.timestamp.time_since_epoch ()).count ()));
 		nano::write (stream, boost::endian::native_to_big (old_received.active_difficulty));
 		nano::write (stream, old_received.unknown_data);
@@ -384,7 +386,7 @@ TEST (telemetry, maker_pruning)
 	ASSERT_EQ (node_server->get_node_id (), telemetry_data->node_id);
 
 	// Ensure telemetry response indicates pruned node
-	ASSERT_EQ (nano::messages::telemetry_maker::nf_pruned_node, static_cast<nano::messages::telemetry_maker> (telemetry_data->maker));
+	ASSERT_EQ (nano::messages::telemetry_maker::nf_pruned_node, telemetry_data->maker);
 }
 
 TEST (telemetry, invalid_signature)

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -100,6 +100,7 @@ TEST (telemetry, backward_compat_v1_to_new)
 	nano::bufferstream stream (old_payload.data (), old_payload.size ());
 	received.deserialize (stream, nano::messages::telemetry_data::size_v1);
 
+	ASSERT_EQ (received.version, nano::messages::telemetry_version::v1);
 	ASSERT_EQ (received.database_backend, 0);
 	ASSERT_EQ (received.confirmation_latency_ms, 0);
 	ASSERT_EQ (received.bootstrap_status, 0);

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/stream.hpp>
 #include <nano/node/telemetry.hpp>
 #include <nano/node/transport/fake.hpp>
 #include <nano/test_common/network.hpp>
@@ -6,6 +7,8 @@
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
+
+#include <boost/endian/conversion.hpp>
 
 #include <numeric>
 
@@ -21,6 +24,7 @@ TEST (telemetry, signatures)
 	data.patch_version = 5;
 	data.pre_release_version = 2;
 	data.maker = 1;
+	data.database_backend = static_cast<uint8_t> (nano::messages::telemetry_database_backend::lmdb);
 	data.timestamp = std::chrono::system_clock::time_point (100ms);
 	data.sign (node_id);
 	ASSERT_FALSE (data.validate_signature ());
@@ -45,6 +49,168 @@ TEST (telemetry, unknown_data)
 	data.unknown_data.push_back (1);
 	data.sign (node_id);
 	ASSERT_FALSE (data.validate_signature ());
+}
+
+// Old node (150-byte payload) -> New node: signature must validate, database_backend defaults to 0
+TEST (telemetry, backward_compat_old_to_new)
+{
+	nano::keypair node_id;
+	nano::messages::telemetry_data data;
+	data.node_id = node_id.pub;
+	data.major_version = 20;
+	data.minor_version = 1;
+	data.patch_version = 5;
+	data.pre_release_version = 2;
+	data.maker = 1;
+	data.timestamp = std::chrono::system_clock::time_point (100ms);
+	data.active_difficulty = 0xffffffc000000000;
+
+	// Simulate old node: serialize with size_v1 (150 bytes, no database_backend)
+	// Old node signs data without database_backend field
+	std::vector<uint8_t> old_payload;
+	{
+		nano::vectorstream stream (old_payload);
+		// Manually serialize old-format payload (size_v1 = 150 bytes, no database_backend)
+		nano::write (stream, data.signature);
+		nano::write (stream, data.node_id);
+		nano::write (stream, boost::endian::native_to_big (data.block_count));
+		nano::write (stream, boost::endian::native_to_big (data.cemented_count));
+		nano::write (stream, boost::endian::native_to_big (data.unchecked_count));
+		nano::write (stream, boost::endian::native_to_big (data.account_count));
+		nano::write (stream, boost::endian::native_to_big (data.bandwidth_cap));
+		nano::write (stream, boost::endian::native_to_big (data.peer_count));
+		nano::write (stream, data.protocol_version);
+		nano::write (stream, boost::endian::native_to_big (data.uptime));
+		nano::write (stream, data.genesis_block.bytes);
+		nano::write (stream, data.major_version);
+		nano::write (stream, data.minor_version);
+		nano::write (stream, data.patch_version);
+		nano::write (stream, data.pre_release_version);
+		nano::write (stream, data.maker);
+		nano::write (stream, boost::endian::native_to_big (std::chrono::duration_cast<std::chrono::milliseconds> (data.timestamp.time_since_epoch ()).count ()));
+		nano::write (stream, boost::endian::native_to_big (data.active_difficulty));
+	}
+
+	// Sign using only old-format fields (without signature prefix)
+	std::vector<uint8_t> sign_bytes (old_payload.begin () + sizeof (nano::signature), old_payload.end ());
+	auto sig = nano::sign_message (node_id.prv, node_id.pub, sign_bytes.data (), sign_bytes.size ());
+
+	// Write signature into the payload
+	std::copy (sig.bytes.begin (), sig.bytes.end (), old_payload.begin ());
+
+	// Now deserialize with new code using size_v1 payload length
+	nano::messages::telemetry_data received;
+	nano::bufferstream stream (old_payload.data (), old_payload.size ());
+	received.deserialize (stream, nano::messages::telemetry_data::size_v1);
+
+	ASSERT_EQ (received.database_backend, 0); // defaults to unknown
+	ASSERT_FALSE (received.validate_signature ()); // signature must validate
+	ASSERT_EQ (received.node_id, node_id.pub);
+}
+
+// New node (151-byte payload) -> Old node: extra byte goes to unknown_data, signature validates
+TEST (telemetry, forward_compat_new_to_old)
+{
+	nano::keypair node_id;
+	nano::messages::telemetry_data data;
+	data.node_id = node_id.pub;
+	data.major_version = 20;
+	data.minor_version = 1;
+	data.patch_version = 5;
+	data.pre_release_version = 2;
+	data.maker = 1;
+	data.database_backend = static_cast<uint8_t> (nano::messages::telemetry_database_backend::lmdb);
+	data.timestamp = std::chrono::system_clock::time_point (100ms);
+	data.active_difficulty = 0xffffffc000000000;
+	data.sign (node_id);
+	ASSERT_FALSE (data.validate_signature ());
+
+	// Serialize the new-format data (151 bytes)
+	std::vector<uint8_t> payload;
+	{
+		nano::vectorstream stream (payload);
+		data.serialize (stream);
+	}
+	ASSERT_EQ (payload.size (), nano::messages::telemetry_data::size);
+
+	// Simulate old node deserializing: it only knows size_v1 as its latest_size,
+	// so it reads only the first size_v1 known fields and puts the remaining
+	// byte(s) into unknown_data. We manually replicate old-node deserialization
+	// since the current code's latest_size has already been updated.
+	nano::messages::telemetry_data old_received;
+	uint16_t const old_latest_size = nano::messages::telemetry_data::size_v1;
+	{
+		nano::bufferstream stream (payload.data (), payload.size ());
+		// Read all fields that the old node knows about (up to size_v1)
+		nano::read (stream, old_received.signature);
+		nano::read (stream, old_received.node_id);
+		nano::read (stream, old_received.block_count);
+		boost::endian::big_to_native_inplace (old_received.block_count);
+		nano::read (stream, old_received.cemented_count);
+		boost::endian::big_to_native_inplace (old_received.cemented_count);
+		nano::read (stream, old_received.unchecked_count);
+		boost::endian::big_to_native_inplace (old_received.unchecked_count);
+		nano::read (stream, old_received.account_count);
+		boost::endian::big_to_native_inplace (old_received.account_count);
+		nano::read (stream, old_received.bandwidth_cap);
+		boost::endian::big_to_native_inplace (old_received.bandwidth_cap);
+		nano::read (stream, old_received.peer_count);
+		boost::endian::big_to_native_inplace (old_received.peer_count);
+		nano::read (stream, old_received.protocol_version);
+		nano::read (stream, old_received.uptime);
+		boost::endian::big_to_native_inplace (old_received.uptime);
+		nano::read (stream, old_received.genesis_block.bytes);
+		nano::read (stream, old_received.major_version);
+		nano::read (stream, old_received.minor_version);
+		nano::read (stream, old_received.patch_version);
+		nano::read (stream, old_received.pre_release_version);
+		nano::read (stream, old_received.maker);
+		uint64_t timestamp_l;
+		nano::read (stream, timestamp_l);
+		boost::endian::big_to_native_inplace (timestamp_l);
+		old_received.timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (timestamp_l));
+		nano::read (stream, old_received.active_difficulty);
+		boost::endian::big_to_native_inplace (old_received.active_difficulty);
+		// Old node doesn't know about database_backend, so remaining bytes
+		// (payload.size() - size_v1 = 1 byte) go into unknown_data
+		auto remaining = static_cast<uint16_t> (payload.size ()) - old_latest_size;
+		ASSERT_EQ (remaining, 1); // the database_backend byte
+		nano::read (stream, old_received.unknown_data, remaining);
+	}
+
+	// Old node does not interpret database_backend — it stays at default 0
+	ASSERT_EQ (old_received.database_backend, 0);
+	// The extra byte is in unknown_data instead
+	ASSERT_EQ (old_received.unknown_data.size (), 1);
+	ASSERT_EQ (old_received.unknown_data[0], static_cast<uint8_t> (nano::messages::telemetry_database_backend::lmdb));
+
+	// Old node's validate_signature serializes known fields + unknown_data,
+	// which reconstructs the original signed payload — signature must validate
+	// We replicate old-node validation: serialize without signature, then verify
+	std::vector<uint8_t> verify_bytes;
+	{
+		nano::vectorstream stream (verify_bytes);
+		nano::write (stream, old_received.node_id);
+		nano::write (stream, boost::endian::native_to_big (old_received.block_count));
+		nano::write (stream, boost::endian::native_to_big (old_received.cemented_count));
+		nano::write (stream, boost::endian::native_to_big (old_received.unchecked_count));
+		nano::write (stream, boost::endian::native_to_big (old_received.account_count));
+		nano::write (stream, boost::endian::native_to_big (old_received.bandwidth_cap));
+		nano::write (stream, boost::endian::native_to_big (old_received.peer_count));
+		nano::write (stream, old_received.protocol_version);
+		nano::write (stream, boost::endian::native_to_big (old_received.uptime));
+		nano::write (stream, old_received.genesis_block.bytes);
+		nano::write (stream, old_received.major_version);
+		nano::write (stream, old_received.minor_version);
+		nano::write (stream, old_received.patch_version);
+		nano::write (stream, old_received.pre_release_version);
+		nano::write (stream, old_received.maker);
+		nano::write (stream, boost::endian::native_to_big (std::chrono::duration_cast<std::chrono::milliseconds> (old_received.timestamp.time_since_epoch ()).count ()));
+		nano::write (stream, boost::endian::native_to_big (old_received.active_difficulty));
+		// Old node appends unknown_data verbatim
+		nano::write (stream, old_received.unknown_data);
+	}
+	ASSERT_FALSE (nano::validate_message (old_received.node_id, verify_bytes.data (), verify_bytes.size (), old_received.signature));
 }
 
 TEST (telemetry, no_peers)

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -25,6 +25,8 @@ TEST (telemetry, signatures)
 	data.pre_release_version = 2;
 	data.maker = 1;
 	data.database_backend = static_cast<uint8_t> (nano::messages::telemetry_database_backend::lmdb);
+	data.confirmation_latency_ms = 500;
+	data.bootstrap_status = static_cast<uint8_t> (nano::messages::telemetry_bootstrap_status::synced);
 	data.timestamp = std::chrono::system_clock::time_point (100ms);
 	data.sign (node_id);
 	ASSERT_FALSE (data.validate_signature ());
@@ -51,8 +53,8 @@ TEST (telemetry, unknown_data)
 	ASSERT_FALSE (data.validate_signature ());
 }
 
-// Old node (150-byte payload) -> New node: signature must validate, database_backend defaults to 0
-TEST (telemetry, backward_compat_old_to_new)
+// Old node (150-byte payload, size_v1) -> New node: signature must validate, new fields default to 0
+TEST (telemetry, backward_compat_v1_to_new)
 {
 	nano::keypair node_id;
 	nano::messages::telemetry_data data;
@@ -66,11 +68,9 @@ TEST (telemetry, backward_compat_old_to_new)
 	data.active_difficulty = 0xffffffc000000000;
 
 	// Simulate old node: serialize with size_v1 (150 bytes, no database_backend)
-	// Old node signs data without database_backend field
 	std::vector<uint8_t> old_payload;
 	{
 		nano::vectorstream stream (old_payload);
-		// Manually serialize old-format payload (size_v1 = 150 bytes, no database_backend)
 		nano::write (stream, data.signature);
 		nano::write (stream, data.node_id);
 		nano::write (stream, boost::endian::native_to_big (data.block_count));
@@ -94,21 +94,20 @@ TEST (telemetry, backward_compat_old_to_new)
 	// Sign using only old-format fields (without signature prefix)
 	std::vector<uint8_t> sign_bytes (old_payload.begin () + sizeof (nano::signature), old_payload.end ());
 	auto sig = nano::sign_message (node_id.prv, node_id.pub, sign_bytes.data (), sign_bytes.size ());
-
-	// Write signature into the payload
 	std::copy (sig.bytes.begin (), sig.bytes.end (), old_payload.begin ());
 
-	// Now deserialize with new code using size_v1 payload length
 	nano::messages::telemetry_data received;
 	nano::bufferstream stream (old_payload.data (), old_payload.size ());
 	received.deserialize (stream, nano::messages::telemetry_data::size_v1);
 
-	ASSERT_EQ (received.database_backend, 0); // defaults to unknown
-	ASSERT_FALSE (received.validate_signature ()); // signature must validate
+	ASSERT_EQ (received.database_backend, 0);
+	ASSERT_EQ (received.confirmation_latency_ms, 0);
+	ASSERT_EQ (received.bootstrap_status, 0);
+	ASSERT_FALSE (received.validate_signature ());
 	ASSERT_EQ (received.node_id, node_id.pub);
 }
 
-// New node (151-byte payload) -> Old node: extra byte goes to unknown_data, signature validates
+// New node (156-byte payload) -> Old v1 node: extra 6 bytes go to unknown_data, signature validates
 TEST (telemetry, forward_compat_new_to_old)
 {
 	nano::keypair node_id;
@@ -120,12 +119,14 @@ TEST (telemetry, forward_compat_new_to_old)
 	data.pre_release_version = 2;
 	data.maker = 1;
 	data.database_backend = static_cast<uint8_t> (nano::messages::telemetry_database_backend::lmdb);
+	data.confirmation_latency_ms = 250;
+	data.bootstrap_status = static_cast<uint8_t> (nano::messages::telemetry_bootstrap_status::synced);
 	data.timestamp = std::chrono::system_clock::time_point (100ms);
 	data.active_difficulty = 0xffffffc000000000;
 	data.sign (node_id);
 	ASSERT_FALSE (data.validate_signature ());
 
-	// Serialize the new-format data (151 bytes)
+	// Serialize the new-format data (156 bytes)
 	std::vector<uint8_t> payload;
 	{
 		nano::vectorstream stream (payload);
@@ -133,15 +134,11 @@ TEST (telemetry, forward_compat_new_to_old)
 	}
 	ASSERT_EQ (payload.size (), nano::messages::telemetry_data::size);
 
-	// Simulate old node deserializing: it only knows size_v1 as its latest_size,
-	// so it reads only the first size_v1 known fields and puts the remaining
-	// byte(s) into unknown_data. We manually replicate old-node deserialization
-	// since the current code's latest_size has already been updated.
+	// Simulate old v1 node deserializing: it only knows size_v1 as its latest_size
 	nano::messages::telemetry_data old_received;
 	uint16_t const old_latest_size = nano::messages::telemetry_data::size_v1;
 	{
 		nano::bufferstream stream (payload.data (), payload.size ());
-		// Read all fields that the old node knows about (up to size_v1)
 		nano::read (stream, old_received.signature);
 		nano::read (stream, old_received.node_id);
 		nano::read (stream, old_received.block_count);
@@ -171,22 +168,16 @@ TEST (telemetry, forward_compat_new_to_old)
 		old_received.timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (timestamp_l));
 		nano::read (stream, old_received.active_difficulty);
 		boost::endian::big_to_native_inplace (old_received.active_difficulty);
-		// Old node doesn't know about database_backend, so remaining bytes
-		// (payload.size() - size_v1 = 1 byte) go into unknown_data
+		// Old node doesn't know about database_backend or new fields
 		auto remaining = static_cast<uint16_t> (payload.size ()) - old_latest_size;
-		ASSERT_EQ (remaining, 1); // the database_backend byte
+		ASSERT_EQ (remaining, 6); // database_backend(1) + confirmation_latency_ms(4) + bootstrap_status(1)
 		nano::read (stream, old_received.unknown_data, remaining);
 	}
 
-	// Old node does not interpret database_backend — it stays at default 0
 	ASSERT_EQ (old_received.database_backend, 0);
-	// The extra byte is in unknown_data instead
-	ASSERT_EQ (old_received.unknown_data.size (), 1);
-	ASSERT_EQ (old_received.unknown_data[0], static_cast<uint8_t> (nano::messages::telemetry_database_backend::lmdb));
+	ASSERT_EQ (old_received.unknown_data.size (), 6);
 
-	// Old node's validate_signature serializes known fields + unknown_data,
-	// which reconstructs the original signed payload — signature must validate
-	// We replicate old-node validation: serialize without signature, then verify
+	// Old node's validate_signature: serialize known fields + unknown_data
 	std::vector<uint8_t> verify_bytes;
 	{
 		nano::vectorstream stream (verify_bytes);
@@ -207,7 +198,6 @@ TEST (telemetry, forward_compat_new_to_old)
 		nano::write (stream, old_received.maker);
 		nano::write (stream, boost::endian::native_to_big (std::chrono::duration_cast<std::chrono::milliseconds> (old_received.timestamp.time_since_epoch ()).count ()));
 		nano::write (stream, boost::endian::native_to_big (old_received.active_difficulty));
-		// Old node appends unknown_data verbatim
 		nano::write (stream, old_received.unknown_data);
 	}
 	ASSERT_FALSE (nano::validate_message (old_received.node_id, verify_bytes.data (), verify_bytes.size (), old_received.signature));

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -55,7 +55,7 @@ TEST (telemetry, unknown_data)
 	ASSERT_FALSE (data.validate_signature ());
 }
 
-// Old node (150-byte payload, size_v1) -> New node: signature must validate, new fields default to 0
+// Old node (size_v1 payload) -> New node: signature must validate, new fields default to 0
 TEST (telemetry, backward_compat_v1_to_new)
 {
 	nano::keypair node_id;
@@ -69,7 +69,7 @@ TEST (telemetry, backward_compat_v1_to_new)
 	data.timestamp = std::chrono::system_clock::time_point (100ms);
 	data.active_difficulty = 0xffffffc000000000;
 
-	// Simulate old node: serialize with size_v1 (150 bytes, no database_backend)
+	// Simulate old node: serialize with size_v1 (no v2 fields)
 	std::vector<uint8_t> old_payload;
 	{
 		nano::vectorstream stream (old_payload);
@@ -112,7 +112,7 @@ TEST (telemetry, backward_compat_v1_to_new)
 	ASSERT_EQ (received.node_id, node_id.pub);
 }
 
-// New node (v2 payload) -> Old v1 node: extra 14 bytes go to unknown_data, signature validates
+// New node (v2 payload) -> Old v1 node: extra v2 bytes go to unknown_data, signature validates
 TEST (telemetry, forward_compat_new_to_old)
 {
 	nano::keypair node_id;
@@ -133,7 +133,7 @@ TEST (telemetry, forward_compat_new_to_old)
 	data.sign (node_id);
 	ASSERT_FALSE (data.validate_signature ());
 
-	// Serialize the new-format data (156 bytes)
+	// Serialize the new-format data (size_v2)
 	std::vector<uint8_t> payload;
 	{
 		nano::vectorstream stream (payload);
@@ -179,12 +179,12 @@ TEST (telemetry, forward_compat_new_to_old)
 		boost::endian::big_to_native_inplace (old_received.active_difficulty);
 		// Old node doesn't know about database_backend or new fields
 		auto remaining = static_cast<uint16_t> (payload.size ()) - old_latest_size;
-		ASSERT_EQ (remaining, 14); // database_backend(1) + confirmation_latency_ms_p50(4) + p90(4) + p99(4) + bootstrap_status(1)
+		ASSERT_EQ (remaining, nano::messages::telemetry_data::size_v2 - nano::messages::telemetry_data::size_v1);
 		nano::read (stream, old_received.unknown_data, remaining);
 	}
 
 	ASSERT_EQ (old_received.database_backend, nano::messages::telemetry_database_backend::unknown);
-	ASSERT_EQ (old_received.unknown_data.size (), 14);
+	ASSERT_EQ (old_received.unknown_data.size (), nano::messages::telemetry_data::size_v2 - nano::messages::telemetry_data::size_v1);
 
 	// Old node's validate_signature: serialize known fields + unknown_data
 	std::vector<uint8_t> verify_bytes;

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -25,7 +25,9 @@ TEST (telemetry, signatures)
 	data.pre_release_version = 2;
 	data.maker = 1;
 	data.database_backend = static_cast<uint8_t> (nano::messages::telemetry_database_backend::lmdb);
-	data.confirmation_latency_ms = 500;
+	data.confirmation_latency_ms_p50 = 250;
+	data.confirmation_latency_ms_p90 = 500;
+	data.confirmation_latency_ms_p99 = 750;
 	data.bootstrap_status = static_cast<uint8_t> (nano::messages::telemetry_bootstrap_status::synced);
 	data.timestamp = std::chrono::system_clock::time_point (100ms);
 	data.sign (node_id);
@@ -102,13 +104,15 @@ TEST (telemetry, backward_compat_v1_to_new)
 
 	ASSERT_EQ (received.version, nano::messages::telemetry_version::v1);
 	ASSERT_EQ (received.database_backend, 0);
-	ASSERT_EQ (received.confirmation_latency_ms, 0);
+	ASSERT_EQ (received.confirmation_latency_ms_p50, 0);
+	ASSERT_EQ (received.confirmation_latency_ms_p90, 0);
+	ASSERT_EQ (received.confirmation_latency_ms_p99, 0);
 	ASSERT_EQ (received.bootstrap_status, 0);
 	ASSERT_FALSE (received.validate_signature ());
 	ASSERT_EQ (received.node_id, node_id.pub);
 }
 
-// New node (156-byte payload) -> Old v1 node: extra 6 bytes go to unknown_data, signature validates
+// New node (v2 payload) -> Old v1 node: extra 14 bytes go to unknown_data, signature validates
 TEST (telemetry, forward_compat_new_to_old)
 {
 	nano::keypair node_id;
@@ -120,7 +124,9 @@ TEST (telemetry, forward_compat_new_to_old)
 	data.pre_release_version = 2;
 	data.maker = 1;
 	data.database_backend = static_cast<uint8_t> (nano::messages::telemetry_database_backend::lmdb);
-	data.confirmation_latency_ms = 250;
+	data.confirmation_latency_ms_p50 = 100;
+	data.confirmation_latency_ms_p90 = 250;
+	data.confirmation_latency_ms_p99 = 500;
 	data.bootstrap_status = static_cast<uint8_t> (nano::messages::telemetry_bootstrap_status::synced);
 	data.timestamp = std::chrono::system_clock::time_point (100ms);
 	data.active_difficulty = 0xffffffc000000000;
@@ -171,12 +177,12 @@ TEST (telemetry, forward_compat_new_to_old)
 		boost::endian::big_to_native_inplace (old_received.active_difficulty);
 		// Old node doesn't know about database_backend or new fields
 		auto remaining = static_cast<uint16_t> (payload.size ()) - old_latest_size;
-		ASSERT_EQ (remaining, 6); // database_backend(1) + confirmation_latency_ms(4) + bootstrap_status(1)
+		ASSERT_EQ (remaining, 14); // database_backend(1) + confirmation_latency_ms_p50(4) + p90(4) + p99(4) + bootstrap_status(1)
 		nano::read (stream, old_received.unknown_data, remaining);
 	}
 
 	ASSERT_EQ (old_received.database_backend, 0);
-	ASSERT_EQ (old_received.unknown_data.size (), 6);
+	ASSERT_EQ (old_received.unknown_data.size (), 14);
 
 	// Old node's validate_signature: serialize known fields + unknown_data
 	std::vector<uint8_t> verify_bytes;

--- a/nano/messages/telemetry.cpp
+++ b/nano/messages/telemetry.cpp
@@ -67,9 +67,9 @@ telemetry_ack::telemetry_ack (nano::network_constants const & constants, telemet
 	message (constants, message_type::telemetry_ack),
 	data (telemetry_data_a)
 {
-	debug_assert (telemetry_data::size + telemetry_data_a.unknown_data.size () <= message_header::telemetry_size_mask.to_ulong ()); // Maximum size the mask allows
+	debug_assert (telemetry_data_a.serialized_size () <= message_header::telemetry_size_mask.to_ulong ()); // Maximum size the mask allows
 	header.extensions &= ~message_header::telemetry_size_mask;
-	header.extensions |= std::bitset<16> (static_cast<unsigned long long> (telemetry_data::size) + telemetry_data_a.unknown_data.size ());
+	header.extensions |= std::bitset<16> (static_cast<unsigned long long> (telemetry_data_a.serialized_size ()));
 }
 
 void telemetry_ack::serialize (nano::stream & stream_a) const
@@ -166,6 +166,11 @@ void telemetry_data::deserialize (nano::stream & stream_a, uint16_t payload_leng
 	timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (timestamp_l));
 	read (stream_a, active_difficulty);
 	boost::endian::big_to_native_inplace (active_difficulty);
+	if (payload_length_a >= size)
+	{
+		read (stream_a, database_backend);
+	}
+	data_size_ = std::min (payload_length_a, static_cast<uint16_t> (latest_size));
 	if (payload_length_a > latest_size)
 	{
 		read (stream_a, unknown_data, payload_length_a - latest_size);
@@ -192,6 +197,10 @@ void telemetry_data::serialize_without_signature (nano::stream & stream_a) const
 	write (stream_a, maker);
 	write (stream_a, boost::endian::native_to_big (std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ()));
 	write (stream_a, boost::endian::native_to_big (active_difficulty));
+	if (data_size_ > size_v1)
+	{
+		write (stream_a, database_backend);
+	}
 	write (stream_a, unknown_data);
 }
 
@@ -219,6 +228,7 @@ nano::error telemetry_data::serialize_json (nano::jsonconfig & json, bool ignore
 	json.put ("maker", maker);
 	json.put ("timestamp", std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ());
 	json.put ("active_difficulty", nano::to_string_hex (active_difficulty));
+	json.put ("database_backend", database_backend);
 	// Keep these last for UI purposes
 	if (!ignore_identification_metrics_a)
 	{
@@ -280,12 +290,13 @@ nano::error telemetry_data::deserialize_json (nano::jsonconfig & json, bool igno
 	auto current_active_difficulty_text = json.get<std::string> ("active_difficulty");
 	auto ec = nano::from_string_hex (current_active_difficulty_text, active_difficulty);
 	debug_assert (!ec);
+	json.get ("database_backend", database_backend);
 	return json.get_error ();
 }
 
 bool telemetry_data::operator== (telemetry_data const & data_a) const
 {
-	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp && active_difficulty == data_a.active_difficulty && unknown_data == data_a.unknown_data);
+	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp && active_difficulty == data_a.active_difficulty && database_backend == data_a.database_backend && unknown_data == data_a.unknown_data);
 }
 
 bool telemetry_data::operator!= (telemetry_data const & data_a) const
@@ -296,6 +307,8 @@ bool telemetry_data::operator!= (telemetry_data const & data_a) const
 void telemetry_data::sign (nano::keypair const & node_id_a)
 {
 	debug_assert (node_id == node_id_a.pub);
+	// Always sign with latest format so all current fields are included
+	data_size_ = latest_size;
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -316,8 +329,26 @@ bool telemetry_data::validate_signature () const
 	return nano::validate_message (node_id, bytes.data (), bytes.size (), signature);
 }
 
+uint16_t telemetry_data::serialized_size () const
+{
+	return data_size_ + static_cast<uint16_t> (unknown_data.size ());
+}
+
 void telemetry_data::operator() (nano::object_stream & obs) const
 {
 	// TODO: Telemetry data
+}
+
+telemetry_database_backend to_telemetry_database_backend (nano::database_backend backend)
+{
+	switch (backend)
+	{
+		case nano::database_backend::lmdb:
+			return telemetry_database_backend::lmdb;
+		case nano::database_backend::rocksdb:
+			return telemetry_database_backend::rocksdb;
+		default:
+			return telemetry_database_backend::unknown;
+	}
 }
 }

--- a/nano/messages/telemetry.cpp
+++ b/nano/messages/telemetry.cpp
@@ -178,9 +178,10 @@ void telemetry_data::deserialize (nano::stream & stream_a, uint16_t payload_leng
 	{
 		version = telemetry_version::v1;
 	}
-	if (payload_length_a > latest_size)
+	auto known_size = size_for_version (version);
+	if (payload_length_a > known_size)
 	{
-		read (stream_a, unknown_data, payload_length_a - latest_size);
+		read (stream_a, unknown_data, payload_length_a - known_size);
 	}
 }
 

--- a/nano/messages/telemetry.cpp
+++ b/nano/messages/telemetry.cpp
@@ -169,6 +169,9 @@ void telemetry_data::deserialize (nano::stream & stream_a, uint16_t payload_leng
 	if (payload_length_a >= size)
 	{
 		read (stream_a, database_backend);
+		read (stream_a, confirmation_latency_ms);
+		boost::endian::big_to_native_inplace (confirmation_latency_ms);
+		read (stream_a, bootstrap_status);
 	}
 	data_size_ = std::min (payload_length_a, static_cast<uint16_t> (latest_size));
 	if (payload_length_a > latest_size)
@@ -200,6 +203,8 @@ void telemetry_data::serialize_without_signature (nano::stream & stream_a) const
 	if (data_size_ > size_v1)
 	{
 		write (stream_a, database_backend);
+		write (stream_a, boost::endian::native_to_big (confirmation_latency_ms));
+		write (stream_a, bootstrap_status);
 	}
 	write (stream_a, unknown_data);
 }
@@ -229,6 +234,8 @@ nano::error telemetry_data::serialize_json (nano::jsonconfig & json, bool ignore
 	json.put ("timestamp", std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ());
 	json.put ("active_difficulty", nano::to_string_hex (active_difficulty));
 	json.put ("database_backend", database_backend);
+	json.put ("confirmation_latency_ms", confirmation_latency_ms);
+	json.put ("bootstrap_status", bootstrap_status);
 	// Keep these last for UI purposes
 	if (!ignore_identification_metrics_a)
 	{
@@ -291,12 +298,14 @@ nano::error telemetry_data::deserialize_json (nano::jsonconfig & json, bool igno
 	auto ec = nano::from_string_hex (current_active_difficulty_text, active_difficulty);
 	debug_assert (!ec);
 	json.get ("database_backend", database_backend);
+	json.get ("confirmation_latency_ms", confirmation_latency_ms);
+	json.get ("bootstrap_status", bootstrap_status);
 	return json.get_error ();
 }
 
 bool telemetry_data::operator== (telemetry_data const & data_a) const
 {
-	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp && active_difficulty == data_a.active_difficulty && database_backend == data_a.database_backend && unknown_data == data_a.unknown_data);
+	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp && active_difficulty == data_a.active_difficulty && database_backend == data_a.database_backend && confirmation_latency_ms == data_a.confirmation_latency_ms && bootstrap_status == data_a.bootstrap_status && unknown_data == data_a.unknown_data);
 }
 
 bool telemetry_data::operator!= (telemetry_data const & data_a) const

--- a/nano/messages/telemetry.cpp
+++ b/nano/messages/telemetry.cpp
@@ -158,7 +158,9 @@ void telemetry_data::deserialize (nano::stream & stream_a, uint16_t payload_leng
 	read (stream_a, minor_version);
 	read (stream_a, patch_version);
 	read (stream_a, pre_release_version);
-	read (stream_a, maker);
+	uint8_t maker_l;
+	read (stream_a, maker_l);
+	maker = static_cast<telemetry_maker> (maker_l);
 
 	uint64_t timestamp_l;
 	read (stream_a, timestamp_l);
@@ -168,19 +170,23 @@ void telemetry_data::deserialize (nano::stream & stream_a, uint16_t payload_leng
 	boost::endian::big_to_native_inplace (active_difficulty);
 	if (payload_length_a >= size_v2)
 	{
-		read (stream_a, database_backend);
+		uint8_t database_backend_l;
+		read (stream_a, database_backend_l);
+		database_backend = static_cast<telemetry_database_backend> (database_backend_l);
 		read (stream_a, confirmation_latency_ms_p50);
 		boost::endian::big_to_native_inplace (confirmation_latency_ms_p50);
 		read (stream_a, confirmation_latency_ms_p90);
 		boost::endian::big_to_native_inplace (confirmation_latency_ms_p90);
 		read (stream_a, confirmation_latency_ms_p99);
 		boost::endian::big_to_native_inplace (confirmation_latency_ms_p99);
-		read (stream_a, bootstrap_status);
-		version = telemetry_version::v2;
+		uint8_t bootstrap_status_l;
+		read (stream_a, bootstrap_status_l);
+		bootstrap_status = static_cast<telemetry_bootstrap_status> (bootstrap_status_l);
+		version = telemetry_data_version::v2;
 	}
 	else
 	{
-		version = telemetry_version::v1;
+		version = telemetry_data_version::v1;
 	}
 	auto known_size = size_for_version (version);
 	if (payload_length_a > known_size)
@@ -206,16 +212,16 @@ void telemetry_data::serialize_without_signature (nano::stream & stream_a) const
 	write (stream_a, minor_version);
 	write (stream_a, patch_version);
 	write (stream_a, pre_release_version);
-	write (stream_a, maker);
+	write (stream_a, static_cast<uint8_t> (maker));
 	write (stream_a, boost::endian::native_to_big (std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ()));
 	write (stream_a, boost::endian::native_to_big (active_difficulty));
-	if (version >= telemetry_version::v2)
+	if (version >= telemetry_data_version::v2)
 	{
-		write (stream_a, database_backend);
+		write (stream_a, static_cast<uint8_t> (database_backend));
 		write (stream_a, boost::endian::native_to_big (confirmation_latency_ms_p50));
 		write (stream_a, boost::endian::native_to_big (confirmation_latency_ms_p90));
 		write (stream_a, boost::endian::native_to_big (confirmation_latency_ms_p99));
-		write (stream_a, bootstrap_status);
+		write (stream_a, static_cast<uint8_t> (bootstrap_status));
 	}
 	write (stream_a, unknown_data);
 }
@@ -241,16 +247,16 @@ nano::error telemetry_data::serialize_json (nano::jsonconfig & json, bool ignore
 	json.put ("minor_version", minor_version);
 	json.put ("patch_version", patch_version);
 	json.put ("pre_release_version", pre_release_version);
-	json.put ("maker", maker);
+	json.put ("maker", to_string (maker));
 	json.put ("timestamp", std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ());
 	json.put ("active_difficulty", nano::to_string_hex (active_difficulty));
-	if (version >= telemetry_version::v2)
+	if (version >= telemetry_data_version::v2)
 	{
-		json.put ("database_backend", database_backend);
+		json.put ("database_backend", to_string (database_backend));
 		json.put ("confirmation_latency_ms_p50", confirmation_latency_ms_p50);
 		json.put ("confirmation_latency_ms_p90", confirmation_latency_ms_p90);
 		json.put ("confirmation_latency_ms_p99", confirmation_latency_ms_p99);
-		json.put ("bootstrap_status", bootstrap_status);
+		json.put ("bootstrap_status", to_string (bootstrap_status));
 	}
 	// Keep these last for UI purposes
 	if (!ignore_identification_metrics_a)
@@ -307,7 +313,8 @@ nano::error telemetry_data::deserialize_json (nano::jsonconfig & json, bool igno
 	json.get ("minor_version", minor_version);
 	json.get ("patch_version", patch_version);
 	json.get ("pre_release_version", pre_release_version);
-	json.get ("maker", maker);
+	auto maker_l = json.get<std::string> ("maker");
+	maker = telemetry_maker_from_string (maker_l);
 	auto timestamp_l = json.get<uint64_t> ("timestamp");
 	timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (timestamp_l));
 	auto current_active_difficulty_text = json.get<std::string> ("active_difficulty");
@@ -315,16 +322,18 @@ nano::error telemetry_data::deserialize_json (nano::jsonconfig & json, bool igno
 	debug_assert (!ec);
 	if (json.has_key ("database_backend"))
 	{
-		json.get ("database_backend", database_backend);
+		auto database_backend_l = json.get<std::string> ("database_backend");
+		database_backend = telemetry_database_backend_from_string (database_backend_l);
 		json.get ("confirmation_latency_ms_p50", confirmation_latency_ms_p50);
 		json.get ("confirmation_latency_ms_p90", confirmation_latency_ms_p90);
 		json.get ("confirmation_latency_ms_p99", confirmation_latency_ms_p99);
-		json.get ("bootstrap_status", bootstrap_status);
-		version = telemetry_version::v2;
+		auto bootstrap_status_l = json.get<std::string> ("bootstrap_status");
+		bootstrap_status = telemetry_bootstrap_status_from_string (bootstrap_status_l);
+		version = telemetry_data_version::v2;
 	}
 	else
 	{
-		version = telemetry_version::v1;
+		version = telemetry_data_version::v1;
 	}
 	return json.get_error ();
 }
@@ -367,13 +376,13 @@ uint16_t telemetry_data::serialized_size () const
 	return size_for_version (version) + static_cast<uint16_t> (unknown_data.size ());
 }
 
-uint16_t telemetry_data::size_for_version (telemetry_version ver)
+uint16_t telemetry_data::size_for_version (telemetry_data_version ver)
 {
 	switch (ver)
 	{
-		case telemetry_version::v1:
+		case telemetry_data_version::v1:
 			return size_v1;
-		case telemetry_version::v2:
+		case telemetry_data_version::v2:
 			return size_v2;
 		default:
 			debug_assert (false, "unknown telemetry version");
@@ -385,7 +394,14 @@ void telemetry_data::operator() (nano::object_stream & obs) const
 {
 	// TODO: Telemetry data
 }
+}
 
+/*
+ *
+ */
+
+namespace nano::messages
+{
 telemetry_database_backend to_telemetry_database_backend (nano::database_backend backend)
 {
 	switch (backend)
@@ -397,5 +413,72 @@ telemetry_database_backend to_telemetry_database_backend (nano::database_backend
 		default:
 			return telemetry_database_backend::unknown;
 	}
+}
+
+std::string to_string (telemetry_maker maker)
+{
+	switch (maker)
+	{
+		case telemetry_maker::nf_node:
+			return "nf_node";
+		case telemetry_maker::nf_pruned_node:
+			return "nf_pruned_node";
+	}
+	return "invalid";
+}
+
+std::string to_string (telemetry_database_backend backend)
+{
+	switch (backend)
+	{
+		case telemetry_database_backend::unknown:
+			return "unknown";
+		case telemetry_database_backend::lmdb:
+			return "lmdb";
+		case telemetry_database_backend::rocksdb:
+			return "rocksdb";
+	}
+	return "invalid";
+}
+
+std::string to_string (telemetry_bootstrap_status status)
+{
+	switch (status)
+	{
+		case telemetry_bootstrap_status::unknown:
+			return "unknown";
+		case telemetry_bootstrap_status::syncing:
+			return "syncing";
+		case telemetry_bootstrap_status::synced:
+			return "synced";
+	}
+	return "invalid";
+}
+
+telemetry_maker telemetry_maker_from_string (std::string const & str)
+{
+	if (str == "nf_node")
+		return telemetry_maker::nf_node;
+	if (str == "nf_pruned_node")
+		return telemetry_maker::nf_pruned_node;
+	return telemetry_maker::nf_node;
+}
+
+telemetry_database_backend telemetry_database_backend_from_string (std::string const & str)
+{
+	if (str == "lmdb")
+		return telemetry_database_backend::lmdb;
+	if (str == "rocksdb")
+		return telemetry_database_backend::rocksdb;
+	return telemetry_database_backend::unknown;
+}
+
+telemetry_bootstrap_status telemetry_bootstrap_status_from_string (std::string const & str)
+{
+	if (str == "syncing")
+		return telemetry_bootstrap_status::syncing;
+	if (str == "synced")
+		return telemetry_bootstrap_status::synced;
+	return telemetry_bootstrap_status::unknown;
 }
 }

--- a/nano/messages/telemetry.cpp
+++ b/nano/messages/telemetry.cpp
@@ -169,8 +169,12 @@ void telemetry_data::deserialize (nano::stream & stream_a, uint16_t payload_leng
 	if (payload_length_a >= size_v2)
 	{
 		read (stream_a, database_backend);
-		read (stream_a, confirmation_latency_ms);
-		boost::endian::big_to_native_inplace (confirmation_latency_ms);
+		read (stream_a, confirmation_latency_ms_p50);
+		boost::endian::big_to_native_inplace (confirmation_latency_ms_p50);
+		read (stream_a, confirmation_latency_ms_p90);
+		boost::endian::big_to_native_inplace (confirmation_latency_ms_p90);
+		read (stream_a, confirmation_latency_ms_p99);
+		boost::endian::big_to_native_inplace (confirmation_latency_ms_p99);
 		read (stream_a, bootstrap_status);
 		version = telemetry_version::v2;
 	}
@@ -208,7 +212,9 @@ void telemetry_data::serialize_without_signature (nano::stream & stream_a) const
 	if (version >= telemetry_version::v2)
 	{
 		write (stream_a, database_backend);
-		write (stream_a, boost::endian::native_to_big (confirmation_latency_ms));
+		write (stream_a, boost::endian::native_to_big (confirmation_latency_ms_p50));
+		write (stream_a, boost::endian::native_to_big (confirmation_latency_ms_p90));
+		write (stream_a, boost::endian::native_to_big (confirmation_latency_ms_p99));
 		write (stream_a, bootstrap_status);
 	}
 	write (stream_a, unknown_data);
@@ -241,7 +247,9 @@ nano::error telemetry_data::serialize_json (nano::jsonconfig & json, bool ignore
 	if (version >= telemetry_version::v2)
 	{
 		json.put ("database_backend", database_backend);
-		json.put ("confirmation_latency_ms", confirmation_latency_ms);
+		json.put ("confirmation_latency_ms_p50", confirmation_latency_ms_p50);
+		json.put ("confirmation_latency_ms_p90", confirmation_latency_ms_p90);
+		json.put ("confirmation_latency_ms_p99", confirmation_latency_ms_p99);
 		json.put ("bootstrap_status", bootstrap_status);
 	}
 	// Keep these last for UI purposes
@@ -308,7 +316,9 @@ nano::error telemetry_data::deserialize_json (nano::jsonconfig & json, bool igno
 	if (json.has_key ("database_backend"))
 	{
 		json.get ("database_backend", database_backend);
-		json.get ("confirmation_latency_ms", confirmation_latency_ms);
+		json.get ("confirmation_latency_ms_p50", confirmation_latency_ms_p50);
+		json.get ("confirmation_latency_ms_p90", confirmation_latency_ms_p90);
+		json.get ("confirmation_latency_ms_p99", confirmation_latency_ms_p99);
 		json.get ("bootstrap_status", bootstrap_status);
 		version = telemetry_version::v2;
 	}
@@ -321,7 +331,7 @@ nano::error telemetry_data::deserialize_json (nano::jsonconfig & json, bool igno
 
 bool telemetry_data::operator== (telemetry_data const & data_a) const
 {
-	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp && active_difficulty == data_a.active_difficulty && version == data_a.version && database_backend == data_a.database_backend && confirmation_latency_ms == data_a.confirmation_latency_ms && bootstrap_status == data_a.bootstrap_status && unknown_data == data_a.unknown_data);
+	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp && active_difficulty == data_a.active_difficulty && version == data_a.version && database_backend == data_a.database_backend && confirmation_latency_ms_p50 == data_a.confirmation_latency_ms_p50 && confirmation_latency_ms_p90 == data_a.confirmation_latency_ms_p90 && confirmation_latency_ms_p99 == data_a.confirmation_latency_ms_p99 && bootstrap_status == data_a.bootstrap_status && unknown_data == data_a.unknown_data);
 }
 
 bool telemetry_data::operator!= (telemetry_data const & data_a) const

--- a/nano/messages/telemetry.cpp
+++ b/nano/messages/telemetry.cpp
@@ -166,14 +166,18 @@ void telemetry_data::deserialize (nano::stream & stream_a, uint16_t payload_leng
 	timestamp = std::chrono::system_clock::time_point (std::chrono::milliseconds (timestamp_l));
 	read (stream_a, active_difficulty);
 	boost::endian::big_to_native_inplace (active_difficulty);
-	if (payload_length_a >= size)
+	if (payload_length_a >= size_v2)
 	{
 		read (stream_a, database_backend);
 		read (stream_a, confirmation_latency_ms);
 		boost::endian::big_to_native_inplace (confirmation_latency_ms);
 		read (stream_a, bootstrap_status);
+		version = telemetry_version::v2;
 	}
-	data_size_ = std::min (payload_length_a, static_cast<uint16_t> (latest_size));
+	else
+	{
+		version = telemetry_version::v1;
+	}
 	if (payload_length_a > latest_size)
 	{
 		read (stream_a, unknown_data, payload_length_a - latest_size);
@@ -200,7 +204,7 @@ void telemetry_data::serialize_without_signature (nano::stream & stream_a) const
 	write (stream_a, maker);
 	write (stream_a, boost::endian::native_to_big (std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ()));
 	write (stream_a, boost::endian::native_to_big (active_difficulty));
-	if (data_size_ > size_v1)
+	if (version >= telemetry_version::v2)
 	{
 		write (stream_a, database_backend);
 		write (stream_a, boost::endian::native_to_big (confirmation_latency_ms));
@@ -233,9 +237,12 @@ nano::error telemetry_data::serialize_json (nano::jsonconfig & json, bool ignore
 	json.put ("maker", maker);
 	json.put ("timestamp", std::chrono::duration_cast<std::chrono::milliseconds> (timestamp.time_since_epoch ()).count ());
 	json.put ("active_difficulty", nano::to_string_hex (active_difficulty));
-	json.put ("database_backend", database_backend);
-	json.put ("confirmation_latency_ms", confirmation_latency_ms);
-	json.put ("bootstrap_status", bootstrap_status);
+	if (version >= telemetry_version::v2)
+	{
+		json.put ("database_backend", database_backend);
+		json.put ("confirmation_latency_ms", confirmation_latency_ms);
+		json.put ("bootstrap_status", bootstrap_status);
+	}
 	// Keep these last for UI purposes
 	if (!ignore_identification_metrics_a)
 	{
@@ -297,15 +304,23 @@ nano::error telemetry_data::deserialize_json (nano::jsonconfig & json, bool igno
 	auto current_active_difficulty_text = json.get<std::string> ("active_difficulty");
 	auto ec = nano::from_string_hex (current_active_difficulty_text, active_difficulty);
 	debug_assert (!ec);
-	json.get ("database_backend", database_backend);
-	json.get ("confirmation_latency_ms", confirmation_latency_ms);
-	json.get ("bootstrap_status", bootstrap_status);
+	if (json.has_key ("database_backend"))
+	{
+		json.get ("database_backend", database_backend);
+		json.get ("confirmation_latency_ms", confirmation_latency_ms);
+		json.get ("bootstrap_status", bootstrap_status);
+		version = telemetry_version::v2;
+	}
+	else
+	{
+		version = telemetry_version::v1;
+	}
 	return json.get_error ();
 }
 
 bool telemetry_data::operator== (telemetry_data const & data_a) const
 {
-	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp && active_difficulty == data_a.active_difficulty && database_backend == data_a.database_backend && confirmation_latency_ms == data_a.confirmation_latency_ms && bootstrap_status == data_a.bootstrap_status && unknown_data == data_a.unknown_data);
+	return (signature == data_a.signature && node_id == data_a.node_id && block_count == data_a.block_count && cemented_count == data_a.cemented_count && unchecked_count == data_a.unchecked_count && account_count == data_a.account_count && bandwidth_cap == data_a.bandwidth_cap && uptime == data_a.uptime && peer_count == data_a.peer_count && protocol_version == data_a.protocol_version && genesis_block == data_a.genesis_block && major_version == data_a.major_version && minor_version == data_a.minor_version && patch_version == data_a.patch_version && pre_release_version == data_a.pre_release_version && maker == data_a.maker && timestamp == data_a.timestamp && active_difficulty == data_a.active_difficulty && version == data_a.version && database_backend == data_a.database_backend && confirmation_latency_ms == data_a.confirmation_latency_ms && bootstrap_status == data_a.bootstrap_status && unknown_data == data_a.unknown_data);
 }
 
 bool telemetry_data::operator!= (telemetry_data const & data_a) const
@@ -316,8 +331,6 @@ bool telemetry_data::operator!= (telemetry_data const & data_a) const
 void telemetry_data::sign (nano::keypair const & node_id_a)
 {
 	debug_assert (node_id == node_id_a.pub);
-	// Always sign with latest format so all current fields are included
-	data_size_ = latest_size;
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream (bytes);
@@ -340,7 +353,21 @@ bool telemetry_data::validate_signature () const
 
 uint16_t telemetry_data::serialized_size () const
 {
-	return data_size_ + static_cast<uint16_t> (unknown_data.size ());
+	return size_for_version (version) + static_cast<uint16_t> (unknown_data.size ());
+}
+
+uint16_t telemetry_data::size_for_version (telemetry_version ver)
+{
+	switch (ver)
+	{
+		case telemetry_version::v1:
+			return size_v1;
+		case telemetry_version::v2:
+			return size_v2;
+		default:
+			debug_assert (false, "unknown telemetry version");
+			return size_v2;
+	}
 }
 
 void telemetry_data::operator() (nano::object_stream & obs) const

--- a/nano/messages/telemetry.hpp
+++ b/nano/messages/telemetry.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/common.hpp>
 #include <nano/lib/errors.hpp>
 #include <nano/lib/fwd.hpp>
 #include <nano/lib/keypair.hpp>
@@ -17,6 +18,15 @@ enum class telemetry_maker : uint8_t
 	nf_node = 0,
 	nf_pruned_node = 1
 };
+
+enum class telemetry_database_backend : uint8_t
+{
+	unknown = 0,
+	lmdb = 1,
+	rocksdb = 2
+};
+
+telemetry_database_backend to_telemetry_database_backend (nano::database_backend);
 
 class telemetry_data
 {
@@ -39,6 +49,7 @@ public:
 	uint8_t maker{ static_cast<std::underlying_type_t<telemetry_maker>> (telemetry_maker::nf_node) }; // Where this telemetry information originated
 	std::chrono::system_clock::time_point timestamp;
 	uint64_t active_difficulty{ 0 };
+	uint8_t database_backend{ 0 };
 	std::vector<uint8_t> unknown_data;
 
 	void serialize (nano::stream &) const;
@@ -51,10 +62,14 @@ public:
 	bool operator!= (telemetry_data const &) const;
 
 	// Size does not include unknown_data
-	static auto constexpr size = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty);
+	static auto constexpr size_v1 = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty);
+	static auto constexpr size = size_v1 + sizeof (database_backend);
 	static auto constexpr latest_size = size; // This needs to be updated for each new telemetry version
 
+	uint16_t serialized_size () const;
+
 private:
+	uint16_t data_size_{ latest_size };
 	void serialize_without_signature (nano::stream &) const;
 
 public: // Logging

--- a/nano/messages/telemetry.hpp
+++ b/nano/messages/telemetry.hpp
@@ -26,6 +26,13 @@ enum class telemetry_database_backend : uint8_t
 	rocksdb = 2
 };
 
+enum class telemetry_bootstrap_status : uint8_t
+{
+	unknown = 0,
+	syncing = 1,
+	synced = 2
+};
+
 telemetry_database_backend to_telemetry_database_backend (nano::database_backend);
 
 class telemetry_data
@@ -50,6 +57,8 @@ public:
 	std::chrono::system_clock::time_point timestamp;
 	uint64_t active_difficulty{ 0 };
 	uint8_t database_backend{ 0 };
+	uint32_t confirmation_latency_ms{ 0 };
+	uint8_t bootstrap_status{ 0 };
 	std::vector<uint8_t> unknown_data;
 
 	void serialize (nano::stream &) const;
@@ -63,7 +72,7 @@ public:
 
 	// Size does not include unknown_data
 	static auto constexpr size_v1 = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty);
-	static auto constexpr size = size_v1 + sizeof (database_backend);
+	static auto constexpr size = size_v1 + sizeof (database_backend) + sizeof (confirmation_latency_ms) + sizeof (bootstrap_status);
 	static auto constexpr latest_size = size; // This needs to be updated for each new telemetry version
 
 	uint16_t serialized_size () const;

--- a/nano/messages/telemetry.hpp
+++ b/nano/messages/telemetry.hpp
@@ -64,7 +64,9 @@ public:
 	std::chrono::system_clock::time_point timestamp;
 	uint64_t active_difficulty{ 0 };
 	uint8_t database_backend{ 0 };
-	uint32_t confirmation_latency_ms{ 0 };
+	uint32_t confirmation_latency_ms_p50{ 0 };
+	uint32_t confirmation_latency_ms_p90{ 0 };
+	uint32_t confirmation_latency_ms_p99{ 0 };
 	uint8_t bootstrap_status{ 0 };
 	std::vector<uint8_t> unknown_data;
 	telemetry_version version{ telemetry_version::v2 };
@@ -80,7 +82,7 @@ public:
 
 	// Size does not include unknown_data
 	static auto constexpr size_v1 = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty);
-	static auto constexpr size_v2 = size_v1 + sizeof (database_backend) + sizeof (confirmation_latency_ms) + sizeof (bootstrap_status);
+	static auto constexpr size_v2 = size_v1 + sizeof (database_backend) + sizeof (confirmation_latency_ms_p50) + sizeof (confirmation_latency_ms_p90) + sizeof (confirmation_latency_ms_p99) + sizeof (bootstrap_status);
 	static auto constexpr size = size_v2; // Current version size
 	static auto constexpr latest_size = size; // This needs to be updated for each new telemetry version
 

--- a/nano/messages/telemetry.hpp
+++ b/nano/messages/telemetry.hpp
@@ -9,6 +9,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace nano::messages
@@ -33,18 +34,26 @@ enum class telemetry_bootstrap_status : uint8_t
 	synced = 2
 };
 
-// Tracks which set of fields are present in a telemetry payload.
-enum class telemetry_version : uint8_t
+// Tracks which set of fields are present in a telemetry payload
+enum class telemetry_data_version : uint8_t
 {
 	v1 = 1,
 	v2 = 2,
 };
 
+std::string to_string (telemetry_maker);
+std::string to_string (telemetry_database_backend);
+std::string to_string (telemetry_bootstrap_status);
+
+telemetry_maker telemetry_maker_from_string (std::string const &);
+telemetry_database_backend telemetry_database_backend_from_string (std::string const &);
+telemetry_bootstrap_status telemetry_bootstrap_status_from_string (std::string const &);
+
 telemetry_database_backend to_telemetry_database_backend (nano::database_backend);
 
 class telemetry_data
 {
-public:
+public: // Payload
 	nano::signature signature{ 0 };
 	nano::account node_id{};
 	uint64_t block_count{ 0 };
@@ -60,17 +69,20 @@ public:
 	uint8_t minor_version{ 0 };
 	uint8_t patch_version{ 0 };
 	uint8_t pre_release_version{ 0 };
-	uint8_t maker{ static_cast<std::underlying_type_t<telemetry_maker>> (telemetry_maker::nf_node) }; // Where this telemetry information originated
+	telemetry_maker maker{ telemetry_maker::nf_node };
 	std::chrono::system_clock::time_point timestamp;
 	uint64_t active_difficulty{ 0 };
-	uint8_t database_backend{ 0 };
+	telemetry_database_backend database_backend{ telemetry_database_backend::unknown };
 	uint32_t confirmation_latency_ms_p50{ 0 };
 	uint32_t confirmation_latency_ms_p90{ 0 };
 	uint32_t confirmation_latency_ms_p99{ 0 };
-	uint8_t bootstrap_status{ 0 };
+	telemetry_bootstrap_status bootstrap_status{ telemetry_bootstrap_status::unknown };
 	std::vector<uint8_t> unknown_data;
-	telemetry_version version{ telemetry_version::v2 };
 
+public:
+	telemetry_data_version version{ telemetry_data_version::v2 };
+
+public:
 	void serialize (nano::stream &) const;
 	void deserialize (nano::stream &, uint16_t);
 	nano::error serialize_json (nano::jsonconfig &, bool) const;
@@ -79,17 +91,17 @@ public:
 	bool validate_signature () const;
 	bool operator== (telemetry_data const &) const;
 	bool operator!= (telemetry_data const &) const;
+	uint16_t serialized_size () const;
 
+public:
 	// Size does not include unknown_data
 	static auto constexpr size_v1 = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty);
 	static auto constexpr size_v2 = size_v1 + sizeof (database_backend) + sizeof (confirmation_latency_ms_p50) + sizeof (confirmation_latency_ms_p90) + sizeof (confirmation_latency_ms_p99) + sizeof (bootstrap_status);
 	static auto constexpr size = size_v2; // Current version size
 	static auto constexpr latest_size = size; // This needs to be updated for each new telemetry version
 
-	uint16_t serialized_size () const;
-
 private:
-	static uint16_t size_for_version (telemetry_version ver);
+	static uint16_t size_for_version (telemetry_data_version);
 	void serialize_without_signature (nano::stream &) const;
 
 public: // Logging

--- a/nano/messages/telemetry.hpp
+++ b/nano/messages/telemetry.hpp
@@ -33,6 +33,13 @@ enum class telemetry_bootstrap_status : uint8_t
 	synced = 2
 };
 
+// Tracks which set of fields are present in a telemetry payload.
+enum class telemetry_version : uint8_t
+{
+	v1 = 1,
+	v2 = 2,
+};
+
 telemetry_database_backend to_telemetry_database_backend (nano::database_backend);
 
 class telemetry_data
@@ -60,6 +67,7 @@ public:
 	uint32_t confirmation_latency_ms{ 0 };
 	uint8_t bootstrap_status{ 0 };
 	std::vector<uint8_t> unknown_data;
+	telemetry_version version{ telemetry_version::v2 };
 
 	void serialize (nano::stream &) const;
 	void deserialize (nano::stream &, uint16_t);
@@ -72,13 +80,14 @@ public:
 
 	// Size does not include unknown_data
 	static auto constexpr size_v1 = sizeof (signature) + sizeof (node_id) + sizeof (block_count) + sizeof (cemented_count) + sizeof (unchecked_count) + sizeof (account_count) + sizeof (bandwidth_cap) + sizeof (peer_count) + sizeof (protocol_version) + sizeof (uptime) + sizeof (genesis_block) + sizeof (major_version) + sizeof (minor_version) + sizeof (patch_version) + sizeof (pre_release_version) + sizeof (maker) + sizeof (uint64_t) + sizeof (active_difficulty);
-	static auto constexpr size = size_v1 + sizeof (database_backend) + sizeof (confirmation_latency_ms) + sizeof (bootstrap_status);
+	static auto constexpr size_v2 = size_v1 + sizeof (database_backend) + sizeof (confirmation_latency_ms) + sizeof (bootstrap_status);
+	static auto constexpr size = size_v2; // Current version size
 	static auto constexpr latest_size = size; // This needs to be updated for each new telemetry version
 
 	uint16_t serialized_size () const;
 
 private:
-	uint16_t data_size_{ latest_size };
+	static uint16_t size_for_version (telemetry_version ver);
 	void serialize_without_signature (nano::stream &) const;
 
 public: // Logging

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -57,7 +57,7 @@ void nano::election::confirm_once (nano::unique_lock<nano::mutex> & lock)
 		status.voter_count = nano::narrow_cast<decltype (status.voter_count)> (last_votes.size ());
 		auto const status_l = status;
 
-		node.active.recently_confirmed.put (qualified_root, status_l.winner->hash ());
+		node.active.recently_confirmed.put (qualified_root, status_l.winner->hash (), status_l);
 
 		auto const extended_status = current_status_locked ();
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -929,16 +929,10 @@ nano::messages::telemetry_data nano::node::local_telemetry () const
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
 	telemetry_data.active_difficulty = default_difficulty (nano::work_version::work_1);
 	telemetry_data.database_backend = static_cast<uint8_t> (nano::messages::to_telemetry_database_backend (config.database_backend));
-	auto cemented = active.recently_cemented.list ();
-	if (!cemented.empty ())
-	{
-		uint64_t total = 0;
-		for (auto const & status : cemented)
-		{
-			total += status.election_duration.count ();
-		}
-		telemetry_data.confirmation_latency_ms = static_cast<uint32_t> (total / cemented.size ());
-	}
+	auto conf_latency = active.recently_confirmed.latency_percentiles ();
+	telemetry_data.confirmation_latency_ms_p50 = conf_latency.p50;
+	telemetry_data.confirmation_latency_ms_p90 = conf_latency.p90;
+	telemetry_data.confirmation_latency_ms_p99 = conf_latency.p99;
 	auto bs = bootstrap.status ();
 	telemetry_data.bootstrap_status = static_cast<uint8_t> (
 	bs.priorities == 0

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -925,19 +925,18 @@ nano::messages::telemetry_data nano::node::local_telemetry () const
 	telemetry_data.minor_version = nano::get_minor_node_version ();
 	telemetry_data.patch_version = nano::get_patch_node_version ();
 	telemetry_data.pre_release_version = nano::get_pre_release_node_version ();
-	telemetry_data.maker = static_cast<std::underlying_type_t<nano::messages::telemetry_maker>> (ledger.pruning ? nano::messages::telemetry_maker::nf_pruned_node : nano::messages::telemetry_maker::nf_node);
+	telemetry_data.maker = ledger.pruning ? nano::messages::telemetry_maker::nf_pruned_node : nano::messages::telemetry_maker::nf_node;
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
 	telemetry_data.active_difficulty = default_difficulty (nano::work_version::work_1);
-	telemetry_data.database_backend = static_cast<uint8_t> (nano::messages::to_telemetry_database_backend (config.database_backend));
+	telemetry_data.database_backend = nano::messages::to_telemetry_database_backend (config.database_backend);
 	auto conf_latency = active.recently_confirmed.latency_percentiles ();
 	telemetry_data.confirmation_latency_ms_p50 = conf_latency.p50;
 	telemetry_data.confirmation_latency_ms_p90 = conf_latency.p90;
 	telemetry_data.confirmation_latency_ms_p99 = conf_latency.p99;
 	auto bs = bootstrap.status ();
-	telemetry_data.bootstrap_status = static_cast<uint8_t> (
-	bs.priorities == 0
+	telemetry_data.bootstrap_status = bs.priorities == 0
 	? nano::messages::telemetry_bootstrap_status::synced
-	: nano::messages::telemetry_bootstrap_status::syncing);
+	: nano::messages::telemetry_bootstrap_status::syncing;
 	// Make sure this is the final operation!
 	telemetry_data.sign (node_id);
 	return telemetry_data;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -941,9 +941,9 @@ nano::messages::telemetry_data nano::node::local_telemetry () const
 	}
 	auto bs = bootstrap.status ();
 	telemetry_data.bootstrap_status = static_cast<uint8_t> (
-		bs.priorities == 0
-			? nano::messages::telemetry_bootstrap_status::synced
-			: nano::messages::telemetry_bootstrap_status::syncing);
+	bs.priorities == 0
+	? nano::messages::telemetry_bootstrap_status::synced
+	: nano::messages::telemetry_bootstrap_status::syncing);
 	// Make sure this is the final operation!
 	telemetry_data.sign (node_id);
 	return telemetry_data;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -928,6 +928,7 @@ nano::messages::telemetry_data nano::node::local_telemetry () const
 	telemetry_data.maker = static_cast<std::underlying_type_t<nano::messages::telemetry_maker>> (ledger.pruning ? nano::messages::telemetry_maker::nf_pruned_node : nano::messages::telemetry_maker::nf_node);
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
 	telemetry_data.active_difficulty = default_difficulty (nano::work_version::work_1);
+	telemetry_data.database_backend = static_cast<uint8_t> (nano::messages::to_telemetry_database_backend (config.database_backend));
 	// Make sure this is the final operation!
 	telemetry_data.sign (node_id);
 	return telemetry_data;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -929,6 +929,21 @@ nano::messages::telemetry_data nano::node::local_telemetry () const
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
 	telemetry_data.active_difficulty = default_difficulty (nano::work_version::work_1);
 	telemetry_data.database_backend = static_cast<uint8_t> (nano::messages::to_telemetry_database_backend (config.database_backend));
+	auto cemented = active.recently_cemented.list ();
+	if (!cemented.empty ())
+	{
+		uint64_t total = 0;
+		for (auto const & status : cemented)
+		{
+			total += status.election_duration.count ();
+		}
+		telemetry_data.confirmation_latency_ms = static_cast<uint32_t> (total / cemented.size ());
+	}
+	auto bs = bootstrap.status ();
+	telemetry_data.bootstrap_status = static_cast<uint8_t> (
+		bs.priorities == 0
+			? nano::messages::telemetry_bootstrap_status::synced
+			: nano::messages::telemetry_bootstrap_status::syncing);
 	// Make sure this is the final operation!
 	telemetry_data.sign (node_id);
 	return telemetry_data;

--- a/nano/node/recently_confirmed_cache.cpp
+++ b/nano/node/recently_confirmed_cache.cpp
@@ -1,15 +1,19 @@
 #include <nano/lib/utility.hpp>
 #include <nano/node/recently_confirmed_cache.hpp>
 
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
 nano::recently_confirmed_cache::recently_confirmed_cache (std::size_t max_size_a) :
 	max_size{ max_size_a }
 {
 }
 
-void nano::recently_confirmed_cache::put (const nano::qualified_root & root, const nano::block_hash & hash)
+void nano::recently_confirmed_cache::put (const nano::qualified_root & root, const nano::block_hash & hash, nano::election_status const & status)
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	entries.emplace_back (root, hash);
+	entries.push_back (entry{ root, hash, status });
 	if (entries.size () > max_size)
 	{
 		entries.pop_front ();
@@ -46,10 +50,38 @@ std::size_t nano::recently_confirmed_cache::size () const
 	return entries.size ();
 }
 
-nano::recently_confirmed_cache::entry_t nano::recently_confirmed_cache::back () const
+auto nano::recently_confirmed_cache::latency_percentiles () const -> latency_stats
 {
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	return entries.back ();
+	nano::unique_lock<nano::mutex> lock{ mutex };
+
+	if (entries.empty ())
+	{
+		return {};
+	}
+
+	std::vector<uint64_t> durations;
+	durations.reserve (entries.size ());
+	for (auto const & entry : entries)
+	{
+		durations.push_back (entry.status.election_duration.count ());
+	}
+
+	lock.unlock ();
+
+	std::sort (durations.begin (), durations.end ());
+
+	auto percentile = [&durations] (double p) -> uint32_t {
+		auto n = durations.size ();
+		auto index = static_cast<size_t> (std::ceil (p / 100.0 * n)) - 1;
+		release_assert (index < durations.size ());
+		return static_cast<uint32_t> (durations[index]);
+	};
+
+	return {
+		.p50 = percentile (50),
+		.p90 = percentile (90),
+		.p99 = percentile (99)
+	};
 }
 
 nano::container_info nano::recently_confirmed_cache::container_info () const

--- a/nano/node/recently_confirmed_cache.hpp
+++ b/nano/node/recently_confirmed_cache.hpp
@@ -3,6 +3,7 @@
 #include <nano/lib/locks.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/numbers_templ.hpp>
+#include <nano/node/election_status.hpp>
 #include <nano/secure/common.hpp>
 
 #include <boost/multi_index/hashed_index.hpp>
@@ -18,11 +19,9 @@ namespace nano
 class recently_confirmed_cache final
 {
 public:
-	using entry_t = std::pair<nano::qualified_root, nano::block_hash>;
-
 	explicit recently_confirmed_cache (std::size_t max_size);
 
-	void put (nano::qualified_root const &, nano::block_hash const &);
+	void put (nano::qualified_root const &, nano::block_hash const &, nano::election_status const &);
 	void erase (nano::block_hash const &);
 	void clear ();
 	std::size_t size () const;
@@ -30,24 +29,37 @@ public:
 	bool contains (nano::qualified_root const &) const;
 	bool contains (nano::block_hash const &) const;
 
+	struct latency_stats
+	{
+		uint32_t p50{ 0 };
+		uint32_t p90{ 0 };
+		uint32_t p99{ 0 };
+	};
+
+	latency_stats latency_percentiles () const;
+
 	nano::container_info container_info () const;
 
-public: // Tests
-	entry_t back () const;
-
 private:
+	struct entry
+	{
+		nano::qualified_root root;
+		nano::block_hash hash;
+		nano::election_status status;
+	};
+
 	// clang-format off
 	class tag_hash {};
 	class tag_root {};
 	class tag_sequenced {};
 
-	using ordered_entries = boost::multi_index_container<entry_t,
+	using ordered_entries = boost::multi_index_container<entry,
 	mi::indexed_by<
 		mi::sequenced<mi::tag<tag_sequenced>>,
 		mi::hashed_unique<mi::tag<tag_root>,
-			mi::member<entry_t, nano::qualified_root, &entry_t::first>>,
+			mi::member<entry, nano::qualified_root, &entry::root>>,
 		mi::hashed_unique<mi::tag<tag_hash>,
-			mi::member<entry_t, nano::block_hash, &entry_t::second>>>>;
+			mi::member<entry, nano::block_hash, &entry::hash>>>>;
 	// clang-format on
 	ordered_entries entries;
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6804,6 +6804,34 @@ TEST (rpc, telemetry_self)
 	}
 }
 
+// Verify that telemetry JSON response contains string representations of enum fields
+TEST (rpc, telemetry_json_serialization)
+{
+	nano::test::system system{ 1 };
+	auto node1 = add_ipc_enabled_node (system);
+	auto const rpc_ctx = add_rpc (system, node1);
+
+	auto outer_node = system.nodes[0];
+	nano::test::establish_tcp (system, *node1, outer_node->network.endpoint ());
+
+	boost::property_tree::ptree request;
+	request.put ("action", "telemetry");
+	request.put ("address", "::1");
+	request.put ("port", node1->network.endpoint ().port ());
+
+	auto response (wait_response (system, rpc_ctx, request, 10s));
+
+	// Verify enum fields are serialized as human-readable strings, not raw integers
+	auto maker_str = response.get<std::string> ("maker");
+	ASSERT_TRUE (maker_str == "nf_node");
+
+	auto database_backend_str = response.get<std::string> ("database_backend");
+	ASSERT_TRUE (database_backend_str == "lmdb" || database_backend_str == "rocksdb");
+
+	auto bootstrap_status_str = response.get<std::string> ("bootstrap_status");
+	ASSERT_TRUE (bootstrap_status_str == "syncing" || bootstrap_status_str == "synced");
+}
+
 TEST (rpc, confirmation_active)
 {
 	nano::test::system system;

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -1620,7 +1620,7 @@ TEST (telemetry, many_nodes)
 		ASSERT_EQ (data.minor_version, nano::get_minor_node_version ());
 		ASSERT_EQ (data.patch_version, nano::get_patch_node_version ());
 		ASSERT_EQ (data.pre_release_version, nano::get_pre_release_node_version ());
-		ASSERT_EQ (data.maker, 0);
+		ASSERT_EQ (data.maker, nano::messages::telemetry_maker::nf_node);
 		ASSERT_LT (data.uptime, 100);
 		ASSERT_EQ (data.genesis_block, nano::dev::genesis->hash ());
 		ASSERT_LE (data.timestamp, std::chrono::system_clock::now ());

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -26,6 +26,7 @@ void compare_telemetry_data_impl (const nano::messages::telemetry_data & data_a,
 	ASSERT_EQ (data_a.maker, static_cast<std::underlying_type_t<nano::messages::telemetry_maker>> (nano::messages::telemetry_maker::nf_node));
 	ASSERT_GT (data_a.timestamp, std::chrono::system_clock::now () - std::chrono::seconds (100));
 	ASSERT_EQ (data_a.active_difficulty, data_b.active_difficulty);
+	ASSERT_EQ (data_a.database_backend, data_b.database_backend);
 	ASSERT_EQ (data_a.unknown_data, std::vector<uint8_t>{});
 	result = true;
 }

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -27,6 +27,8 @@ void compare_telemetry_data_impl (const nano::messages::telemetry_data & data_a,
 	ASSERT_GT (data_a.timestamp, std::chrono::system_clock::now () - std::chrono::seconds (100));
 	ASSERT_EQ (data_a.active_difficulty, data_b.active_difficulty);
 	ASSERT_EQ (data_a.database_backend, data_b.database_backend);
+	ASSERT_EQ (data_a.confirmation_latency_ms, data_b.confirmation_latency_ms);
+	// bootstrap_status is not compared because it can change between telemetry snapshots
 	ASSERT_EQ (data_a.unknown_data, std::vector<uint8_t>{});
 	result = true;
 }

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -27,7 +27,9 @@ void compare_telemetry_data_impl (const nano::messages::telemetry_data & data_a,
 	ASSERT_GT (data_a.timestamp, std::chrono::system_clock::now () - std::chrono::seconds (100));
 	ASSERT_EQ (data_a.active_difficulty, data_b.active_difficulty);
 	ASSERT_EQ (data_a.database_backend, data_b.database_backend);
-	ASSERT_EQ (data_a.confirmation_latency_ms, data_b.confirmation_latency_ms);
+	ASSERT_EQ (data_a.confirmation_latency_ms_p50, data_b.confirmation_latency_ms_p50);
+	ASSERT_EQ (data_a.confirmation_latency_ms_p90, data_b.confirmation_latency_ms_p90);
+	ASSERT_EQ (data_a.confirmation_latency_ms_p99, data_b.confirmation_latency_ms_p99);
 	// bootstrap_status is not compared because it can change between telemetry snapshots
 	ASSERT_EQ (data_a.unknown_data, std::vector<uint8_t>{});
 	result = true;

--- a/nano/test_common/telemetry.cpp
+++ b/nano/test_common/telemetry.cpp
@@ -23,7 +23,7 @@ void compare_telemetry_data_impl (const nano::messages::telemetry_data & data_a,
 	ASSERT_EQ (data_a.minor_version, nano::get_minor_node_version ());
 	ASSERT_EQ (data_a.patch_version, nano::get_patch_node_version ());
 	ASSERT_EQ (data_a.pre_release_version, nano::get_pre_release_node_version ());
-	ASSERT_EQ (data_a.maker, static_cast<std::underlying_type_t<nano::messages::telemetry_maker>> (nano::messages::telemetry_maker::nf_node));
+	ASSERT_EQ (data_a.maker, nano::messages::telemetry_maker::nf_node);
 	ASSERT_GT (data_a.timestamp, std::chrono::system_clock::now () - std::chrono::seconds (100));
 	ASSERT_EQ (data_a.active_difficulty, data_b.active_difficulty);
 	ASSERT_EQ (data_a.database_backend, data_b.database_backend);


### PR DESCRIPTION
Extends the telemetry message with three new fields: database_backend (uint8), confirmation_latency_ms (uint32), and bootstrap_status (uint8), adding 6 bytes to the payload (150 → 156 bytes)
Introduces versioned size constants (size_v1 = 150, size = 156)

**Forward compatibility**: An old node receives a 156-byte payload but only knows about 150 bytes of structured fields. The extra 6 bytes are read into unknown_data. Signature validation succeeds because serialize_without_signature appends unknown_data to the verification bytes, matching what the new node signed. No code changes are needed on old nodes

**Backward compatibility**: A new node receives a 150-byte payload. The deserialize check payload_length_a >= size (156) is false, so the three new fields remain at their zero-initialized defaults. data_size_ is set to 150 (the payload length), so serialize_without_signature skips the new fields, producing the same bytes the old node signed. Signature validation succeeds.

**Partial payload protection**: If a payload length falls between 151–155 bytes (more than v1 but less than the full v2 size), the new fields are not read