### PR TITLE
Remove succssor field from block sideband

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -96,7 +96,6 @@ TEST (block_store, sideband_serialization)
 	sideband1.account = 1;
 	sideband1.balance = 2;
 	sideband1.height = 3;
-	sideband1.successor = 4;
 	sideband1.timestamp = 5;
 	std::vector<uint8_t> vector;
 	{
@@ -109,8 +108,6 @@ TEST (block_store, sideband_serialization)
 	ASSERT_EQ (sideband1.account, sideband2.account);
 	ASSERT_EQ (sideband1.balance, sideband2.balance);
 	ASSERT_EQ (sideband1.height, sideband2.height);
-	// Successor is no longer serialized in sideband (stored in separate table since v25)
-	ASSERT_EQ (sideband2.successor, nano::block_hash{ 0 });
 	ASSERT_EQ (sideband1.timestamp, sideband2.timestamp);
 }
 

--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -109,7 +109,8 @@ TEST (block_store, sideband_serialization)
 	ASSERT_EQ (sideband1.account, sideband2.account);
 	ASSERT_EQ (sideband1.balance, sideband2.balance);
 	ASSERT_EQ (sideband1.height, sideband2.height);
-	ASSERT_EQ (sideband1.successor, sideband2.successor);
+	// Successor is no longer serialized in sideband (stored in separate table since v25)
+	ASSERT_EQ (sideband2.successor, nano::block_hash{ 0 });
 	ASSERT_EQ (sideband1.timestamp, sideband2.timestamp);
 }
 

--- a/nano/core_test/ledger_upgrades.cpp
+++ b/nano/core_test/ledger_upgrades.cpp
@@ -742,7 +742,7 @@ public:
 	}
 
 	// Write a block with v25 sideband format (successor is part of sideband)
-	void add_block (nano::block & block, nano::block_hash const & successor_hash)
+	void add_block_legacy (nano::block & block, nano::block_hash const & successor_hash)
 	{
 		auto tx = backend->tx_begin_write ();
 
@@ -767,6 +767,29 @@ public:
 		backend->release_assert_success (status);
 
 		// Also populate successor table (as v25 migration would have done)
+		if (!successor_hash.is_zero ())
+		{
+			status = backend->put (tx, nano::store::table::successor, block.hash (), successor_hash);
+			backend->release_assert_success (status);
+		}
+	}
+
+	// Write a block with v26 sideband format (no successor in sideband)
+	void add_block (nano::block & block, nano::block_hash const & successor_hash)
+	{
+		auto tx = backend->tx_begin_write ();
+
+		std::vector<uint8_t> data;
+		{
+			nano::vectorstream stream{ data };
+			nano::serialize_block (stream, block);
+			block.sideband ().serialize (stream, block.type ());
+		}
+
+		nano::store::db_val value{ data.size (), data.data () };
+		auto status = backend->put (tx, nano::store::table::blocks, block.hash (), value);
+		backend->release_assert_success (status);
+
 		if (!successor_hash.is_zero ())
 		{
 			status = backend->put (tx, nano::store::table::successor, block.hash (), successor_hash);
@@ -840,10 +863,10 @@ TEST (ledger_upgrades, upgrade_v25_to_v26)
 		legacy_database_v25 legacy_db{ path };
 
 		// block1 has block2 as successor
-		legacy_db.add_block (*block1, block2->hash ());
+		legacy_db.add_block_legacy (*block1, block2->hash ());
 
 		// block2 has no successor (zero hash)
-		legacy_db.add_block (*block2, nano::block_hash{ 0 });
+		legacy_db.add_block_legacy (*block2, nano::block_hash{ 0 });
 
 		// Verify blocks are stored with v25 format size
 		auto tx = legacy_db.backend->tx_begin_read ();
@@ -887,6 +910,92 @@ TEST (ledger_upgrades, upgrade_v25_to_v26)
 	// Verify successor is no longer in sideband (always zero from disk)
 	ASSERT_EQ (stored_block1->sideband ().successor, nano::block_hash{ 0 });
 	ASSERT_EQ (stored_block2->sideband ().successor, nano::block_hash{ 0 });
+}
+
+/*
+ * Test v25 to v26 upgrade resilience: handles interrupted upgrade where some blocks
+ * are already in v26 format and some are still in v25 format
+ */
+TEST (ledger_upgrades, upgrade_v25_to_v26_interrupted)
+{
+	nano::keypair key1;
+	nano::keypair key2;
+
+	nano::block_builder builder;
+
+	auto block1 = builder
+				  .open ()
+				  .source (nano::block_hash{ key1.pub.number () })
+				  .representative (key1.pub)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (0)
+				  .build ();
+	block1->sideband_set (nano::block_sideband{
+	key1.pub,
+	nano::block_hash{ 0 },
+	nano::amount{ 1000 },
+	1, 0, nano::epoch::epoch_0,
+	false, false, false, nano::epoch::epoch_0 });
+
+	auto block2 = builder
+				  .state ()
+				  .account (key1.pub)
+				  .previous (block1->hash ())
+				  .representative (key1.pub)
+				  .balance (500)
+				  .link (key2.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (0)
+				  .build ();
+	block2->sideband_set (nano::block_sideband{
+	key1.pub,
+	nano::block_hash{ 0 },
+	nano::amount{ 500 },
+	2, 0, nano::epoch::epoch_0,
+	true, false, false, nano::epoch::epoch_0 });
+
+	auto const path = nano::unique_path ();
+	{
+		// Simulate an interrupted v25->v26 upgrade:
+		// block1 is already in v26 format (no successor in sideband)
+		// block2 is still in v25 format (successor in sideband)
+		legacy_database_v25 legacy_db{ path };
+
+		// block1 already converted to v26 format
+		legacy_db.add_block (*block1, block2->hash ());
+
+		// block2 still in v25 format (not yet converted)
+		legacy_db.add_block_legacy (*block2, nano::block_hash{ 0 });
+	}
+
+	// Open through ledger_store which should trigger v25->v26 upgrade
+	// Must handle the mixed v25/v26 format blocks
+	nano::store::ledger_store store (
+	nano::test::make_backend (path),
+	nano::store::open_mode::read_write,
+	nano::test::default_stats (),
+	nano::test::default_logger ());
+
+	auto tx = store.tx_begin_read ();
+
+	ASSERT_EQ (store.version.get (tx), 26);
+
+	// Both blocks should be readable
+	auto stored_block1 = store.block.get (tx, block1->hash ());
+	ASSERT_NE (nullptr, stored_block1);
+	ASSERT_EQ (stored_block1->sideband ().height, 1);
+	ASSERT_EQ (stored_block1->sideband ().balance, nano::amount{ 1000 });
+
+	auto stored_block2 = store.block.get (tx, block2->hash ());
+	ASSERT_NE (nullptr, stored_block2);
+	ASSERT_EQ (stored_block2->sideband ().height, 2);
+	ASSERT_TRUE (stored_block2->sideband ().details.is_send);
+
+	// Successor table should still work
+	auto successor_result = store.successor.get (tx, block1->hash ());
+	ASSERT_TRUE (successor_result.has_value ());
+	ASSERT_EQ (*successor_result, block2->hash ());
 }
 
 /*

--- a/nano/core_test/ledger_upgrades.cpp
+++ b/nano/core_test/ledger_upgrades.cpp
@@ -666,7 +666,6 @@ TEST (ledger_upgrades, upgrade_v24_to_v25)
 				  .build ();
 	block1->sideband_set (nano::block_sideband{
 	key1.pub,
-	nano::block_hash{ 0 },
 	nano::amount{ 1000 },
 	1, 0, nano::epoch::epoch_0,
 	false, false, false, nano::epoch::epoch_0 });
@@ -684,7 +683,6 @@ TEST (ledger_upgrades, upgrade_v24_to_v25)
 				  .build ();
 	block2->sideband_set (nano::block_sideband{
 	key1.pub,
-	nano::block_hash{ 0 },
 	nano::amount{ 500 },
 	2, 0, nano::epoch::epoch_0,
 	true, false, false, nano::epoch::epoch_0 });
@@ -724,8 +722,6 @@ TEST (ledger_upgrades, upgrade_v24_to_v25)
 	auto stored_block2 = store.block.get (tx, block2->hash ());
 	ASSERT_NE (nullptr, stored_block2);
 	ASSERT_EQ (stored_block2->sideband ().height, 2);
-	// After v26 migration, successor is no longer stored in sideband (always zero on disk)
-	ASSERT_EQ (stored_block2->sideband ().successor, nano::block_hash{ 0 });
 }
 
 namespace
@@ -823,7 +819,6 @@ TEST (ledger_upgrades, upgrade_v25_to_v26)
 				  .build ();
 	block1->sideband_set (nano::block_sideband{
 	key1.pub,
-	nano::block_hash{ 0 },
 	nano::amount{ 1000 },
 	1, 0, nano::epoch::epoch_0,
 	false, false, false, nano::epoch::epoch_0 });
@@ -841,7 +836,6 @@ TEST (ledger_upgrades, upgrade_v25_to_v26)
 				  .build ();
 	block2->sideband_set (nano::block_sideband{
 	key1.pub,
-	nano::block_hash{ 0 },
 	nano::amount{ 500 },
 	2, 0, nano::epoch::epoch_0,
 	true, false, false, nano::epoch::epoch_0 });
@@ -906,10 +900,6 @@ TEST (ledger_upgrades, upgrade_v25_to_v26)
 
 	auto no_successor = store.successor.get (tx, block2->hash ());
 	ASSERT_FALSE (no_successor.has_value ());
-
-	// Verify successor is no longer in sideband (always zero from disk)
-	ASSERT_EQ (stored_block1->sideband ().successor, nano::block_hash{ 0 });
-	ASSERT_EQ (stored_block2->sideband ().successor, nano::block_hash{ 0 });
 }
 
 /*
@@ -933,7 +923,6 @@ TEST (ledger_upgrades, upgrade_v25_to_v26_interrupted)
 				  .build ();
 	block1->sideband_set (nano::block_sideband{
 	key1.pub,
-	nano::block_hash{ 0 },
 	nano::amount{ 1000 },
 	1, 0, nano::epoch::epoch_0,
 	false, false, false, nano::epoch::epoch_0 });
@@ -950,7 +939,6 @@ TEST (ledger_upgrades, upgrade_v25_to_v26_interrupted)
 				  .build ();
 	block2->sideband_set (nano::block_sideband{
 	key1.pub,
-	nano::block_hash{ 0 },
 	nano::amount{ 500 },
 	2, 0, nano::epoch::epoch_0,
 	true, false, false, nano::epoch::epoch_0 });

--- a/nano/core_test/ledger_upgrades.cpp
+++ b/nano/core_test/ledger_upgrades.cpp
@@ -619,16 +619,20 @@ public:
 	{
 		auto tx = backend->tx_begin_write ();
 
-		// Set successor in sideband before serializing
-		auto sideband = block.sideband ();
-		sideband.successor = successor_hash;
-		block.sideband_set (sideband);
+		nano::block_sideband_v25 sideband_v25;
+		sideband_v25.successor = successor_hash;
+		sideband_v25.account = block.sideband ().account;
+		sideband_v25.balance = block.sideband ().balance;
+		sideband_v25.height = block.sideband ().height;
+		sideband_v25.timestamp = block.sideband ().timestamp;
+		sideband_v25.details = block.sideband ().details;
+		sideband_v25.source_epoch = block.sideband ().source_epoch;
 
 		std::vector<uint8_t> data;
 		{
 			nano::vectorstream stream{ data };
 			nano::serialize_block (stream, block);
-			block.sideband ().serialize_v25 (stream, block.type ());
+			sideband_v25.serialize (stream, block.type ());
 		}
 
 		nano::store::db_val value{ data.size (), data.data () };
@@ -742,16 +746,20 @@ public:
 	{
 		auto tx = backend->tx_begin_write ();
 
-		// Set successor in sideband before serializing
-		auto sideband = block.sideband ();
-		sideband.successor = successor_hash;
-		block.sideband_set (sideband);
+		nano::block_sideband_v25 sideband_v25;
+		sideband_v25.successor = successor_hash;
+		sideband_v25.account = block.sideband ().account;
+		sideband_v25.balance = block.sideband ().balance;
+		sideband_v25.height = block.sideband ().height;
+		sideband_v25.timestamp = block.sideband ().timestamp;
+		sideband_v25.details = block.sideband ().details;
+		sideband_v25.source_epoch = block.sideband ().source_epoch;
 
 		std::vector<uint8_t> data;
 		{
 			nano::vectorstream stream{ data };
 			nano::serialize_block (stream, block);
-			block.sideband ().serialize_v25 (stream, block.type ());
+			sideband_v25.serialize (stream, block.type ());
 		}
 
 		nano::store::db_val value{ data.size (), data.data () };
@@ -772,7 +780,7 @@ public:
 }
 
 /*
- * Test v25 to v26 upgrade: removes successor from block sideband and compacts
+ * Test v25 to v26 upgrade: removes successor from block sideband
  */
 TEST (ledger_upgrades, upgrade_v25_to_v26)
 {
@@ -816,8 +824,8 @@ TEST (ledger_upgrades, upgrade_v25_to_v26)
 	true, false, false, nano::epoch::epoch_0 });
 
 	// Record old sideband sizes (v25 format, includes successor)
-	auto const old_size_open = nano::block_sideband::size_v25 (nano::block_type::open);
-	auto const old_size_state = nano::block_sideband::size_v25 (nano::block_type::state);
+	auto const old_size_open = nano::block_sideband_v25::size (nano::block_type::open);
+	auto const old_size_state = nano::block_sideband_v25::size (nano::block_type::state);
 
 	// Record new sideband sizes (v26 format, no successor)
 	auto const new_size_open = nano::block_sideband::size (nano::block_type::open);

--- a/nano/core_test/ledger_upgrades.cpp
+++ b/nano/core_test/ledger_upgrades.cpp
@@ -86,6 +86,7 @@ nano::store::column_schema const schema_v24{
 	{ nano::store::table::final_votes, "final_votes" },
 	{ nano::store::table::meta, "meta" }
 };
+
 }
 
 /*
@@ -627,7 +628,7 @@ public:
 		{
 			nano::vectorstream stream{ data };
 			nano::serialize_block (stream, block);
-			block.sideband ().serialize (stream, block.type ());
+			block.sideband ().serialize_v25 (stream, block.type ());
 		}
 
 		nano::store::db_val value{ data.size (), data.data () };
@@ -719,6 +720,164 @@ TEST (ledger_upgrades, upgrade_v24_to_v25)
 	auto stored_block2 = store.block.get (tx, block2->hash ());
 	ASSERT_NE (nullptr, stored_block2);
 	ASSERT_EQ (stored_block2->sideband ().height, 2);
+	// After v26 migration, successor is no longer stored in sideband (always zero on disk)
+	ASSERT_EQ (stored_block2->sideband ().successor, nano::block_hash{ 0 });
+}
+
+namespace
+{
+class legacy_database_v25
+{
+public:
+	legacy_database_v25 (std::filesystem::path const & path_a) :
+		path{ path_a },
+		backend{ nano::test::make_backend (path_a) }
+	{
+		backend->create (nano::store::ledger_store::schema_v25, 25);
+		backend->open (nano::store::ledger_store::schema_v25, nano::store::open_mode::read_write);
+	}
+
+	// Write a block with v25 sideband format (successor is part of sideband)
+	void add_block (nano::block & block, nano::block_hash const & successor_hash)
+	{
+		auto tx = backend->tx_begin_write ();
+
+		// Set successor in sideband before serializing
+		auto sideband = block.sideband ();
+		sideband.successor = successor_hash;
+		block.sideband_set (sideband);
+
+		std::vector<uint8_t> data;
+		{
+			nano::vectorstream stream{ data };
+			nano::serialize_block (stream, block);
+			block.sideband ().serialize_v25 (stream, block.type ());
+		}
+
+		nano::store::db_val value{ data.size (), data.data () };
+		auto status = backend->put (tx, nano::store::table::blocks, block.hash (), value);
+		backend->release_assert_success (status);
+
+		// Also populate successor table (as v25 migration would have done)
+		if (!successor_hash.is_zero ())
+		{
+			status = backend->put (tx, nano::store::table::successor, block.hash (), successor_hash);
+			backend->release_assert_success (status);
+		}
+	}
+
+	std::filesystem::path path;
+	std::unique_ptr<nano::store::backend> backend;
+};
+}
+
+/*
+ * Test v25 to v26 upgrade: removes successor from block sideband and compacts
+ */
+TEST (ledger_upgrades, upgrade_v25_to_v26)
+{
+	nano::keypair key1;
+	nano::keypair key2;
+
+	nano::block_builder builder;
+
+	// Create an open block (genesis-like, no predecessor)
+	auto block1 = builder
+				  .open ()
+				  .source (nano::block_hash{ key1.pub.number () })
+				  .representative (key1.pub)
+				  .account (key1.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (0)
+				  .build ();
+	block1->sideband_set (nano::block_sideband{
+	key1.pub,
+	nano::block_hash{ 0 },
+	nano::amount{ 1000 },
+	1, 0, nano::epoch::epoch_0,
+	false, false, false, nano::epoch::epoch_0 });
+
+	// Create a state block with a previous (block1)
+	auto block2 = builder
+				  .state ()
+				  .account (key1.pub)
+				  .previous (block1->hash ())
+				  .representative (key1.pub)
+				  .balance (500)
+				  .link (key2.pub)
+				  .sign (key1.prv, key1.pub)
+				  .work (0)
+				  .build ();
+	block2->sideband_set (nano::block_sideband{
+	key1.pub,
+	nano::block_hash{ 0 },
+	nano::amount{ 500 },
+	2, 0, nano::epoch::epoch_0,
+	true, false, false, nano::epoch::epoch_0 });
+
+	// Record old sideband sizes (v25 format, includes successor)
+	auto const old_size_open = nano::block_sideband::size_v25 (nano::block_type::open);
+	auto const old_size_state = nano::block_sideband::size_v25 (nano::block_type::state);
+
+	// Record new sideband sizes (v26 format, no successor)
+	auto const new_size_open = nano::block_sideband::size (nano::block_type::open);
+	auto const new_size_state = nano::block_sideband::size (nano::block_type::state);
+
+	// Verify the new format is 32 bytes smaller (sizeof block_hash)
+	ASSERT_EQ (old_size_open - new_size_open, 32);
+	ASSERT_EQ (old_size_state - new_size_state, 32);
+
+	auto const path = nano::unique_path ();
+	{
+		legacy_database_v25 legacy_db{ path };
+
+		// block1 has block2 as successor
+		legacy_db.add_block (*block1, block2->hash ());
+
+		// block2 has no successor (zero hash)
+		legacy_db.add_block (*block2, nano::block_hash{ 0 });
+
+		// Verify blocks are stored with v25 format size
+		auto tx = legacy_db.backend->tx_begin_read ();
+		nano::store::db_val value;
+		auto status = legacy_db.backend->get (tx, nano::store::table::blocks, block1->hash (), value);
+		ASSERT_TRUE (legacy_db.backend->success (status));
+	}
+
+	// Open through ledger_store which should trigger upgrade
+	nano::store::ledger_store store (
+	nano::test::make_backend (path),
+	nano::store::open_mode::read_write,
+	nano::test::default_stats (),
+	nano::test::default_logger ());
+
+	auto tx = store.tx_begin_read ();
+
+	// Verify version is now 26
+	ASSERT_EQ (store.version.get (tx), nano::store::ledger_store::version_current);
+	ASSERT_EQ (store.version.get (tx), 26);
+
+	// Verify blocks are readable with new format
+	auto stored_block1 = store.block.get (tx, block1->hash ());
+	ASSERT_NE (nullptr, stored_block1);
+	ASSERT_EQ (stored_block1->sideband ().height, 1);
+	ASSERT_EQ (stored_block1->sideband ().balance, nano::amount{ 1000 });
+
+	auto stored_block2 = store.block.get (tx, block2->hash ());
+	ASSERT_NE (nullptr, stored_block2);
+	ASSERT_EQ (stored_block2->sideband ().height, 2);
+	ASSERT_TRUE (stored_block2->sideband ().details.is_send);
+
+	// Verify successor table still works
+	auto successor_result = store.successor.get (tx, block1->hash ());
+	ASSERT_TRUE (successor_result.has_value ());
+	ASSERT_EQ (*successor_result, block2->hash ());
+
+	auto no_successor = store.successor.get (tx, block2->hash ());
+	ASSERT_FALSE (no_successor.has_value ());
+
+	// Verify successor is no longer in sideband (always zero from disk)
+	ASSERT_EQ (stored_block1->sideband ().successor, nano::block_hash{ 0 });
 	ASSERT_EQ (stored_block2->sideband ().successor, nano::block_hash{ 0 });
 }
 

--- a/nano/core_test/migrations.cpp
+++ b/nano/core_test/migrations.cpp
@@ -134,7 +134,7 @@ migration_test_data populate_ledger_for_migration (nano::store::ledger_store & s
 		for (size_t i = 0; i < data.blocks.size (); ++i)
 		{
 			data.blocks[i]->sideband_set (nano::block_sideband{
-			nano::dev::genesis_key.pub, 0,
+			nano::dev::genesis_key.pub,
 			nano::dev::constants.genesis_amount - (i + 1) * 1000,
 			i + 2, nano::seconds_since_epoch (), nano::epoch::epoch_0,
 			false, false, false, nano::epoch::epoch_0 });

--- a/nano/lib/block_sideband.cpp
+++ b/nano/lib/block_sideband.cpp
@@ -93,8 +93,7 @@ std::string nano::state_subtype (nano::block_details const details_a)
  * block_sideband
  */
 
-nano::block_sideband::block_sideband (nano::account const & account_a, nano::block_hash const & successor_a, nano::amount const & balance_a, uint64_t const height_a, nano::seconds_t const timestamp_a, nano::block_details const & details_a, nano::epoch const source_epoch_a) :
-	successor (successor_a),
+nano::block_sideband::block_sideband (nano::account const & account_a, nano::amount const & balance_a, uint64_t const height_a, nano::seconds_t const timestamp_a, nano::block_details const & details_a, nano::epoch const source_epoch_a) :
 	account (account_a),
 	balance (balance_a),
 	height (height_a),
@@ -104,8 +103,7 @@ nano::block_sideband::block_sideband (nano::account const & account_a, nano::blo
 {
 }
 
-nano::block_sideband::block_sideband (nano::account const & account_a, nano::block_hash const & successor_a, nano::amount const & balance_a, uint64_t const height_a, nano::seconds_t const timestamp_a, nano::epoch const epoch_a, bool const is_send, bool const is_receive, bool const is_epoch, nano::epoch const source_epoch_a) :
-	successor (successor_a),
+nano::block_sideband::block_sideband (nano::account const & account_a, nano::amount const & balance_a, uint64_t const height_a, nano::seconds_t const timestamp_a, nano::epoch const epoch_a, bool const is_send, bool const is_receive, bool const is_epoch, nano::epoch const source_epoch_a) :
 	account (account_a),
 	balance (balance_a),
 	height (height_a),
@@ -186,7 +184,6 @@ bool nano::block_sideband::deserialize (nano::stream & stream_a, nano::block_typ
 	bool result (false);
 	try
 	{
-		successor.clear ();
 		if (includes_account (type))
 		{
 			nano::read (stream_a, account.bytes);
@@ -237,7 +234,6 @@ bool nano::block_sideband::deserialize (nano::stream & stream_a, nano::block_typ
 
 void nano::block_sideband::operator() (nano::object_stream & obs) const
 {
-	obs.write ("successor", successor);
 	obs.write ("account", account);
 	obs.write ("balance", balance);
 	obs.write ("height", height);

--- a/nano/lib/block_sideband.cpp
+++ b/nano/lib/block_sideband.cpp
@@ -159,36 +159,8 @@ size_t nano::block_sideband::size (nano::block_type type)
 	return result;
 }
 
-size_t nano::block_sideband::size_v25 (nano::block_type type)
-{
-	return size (type) + sizeof (successor);
-}
-
 void nano::block_sideband::serialize (nano::stream & stream_a, nano::block_type type) const
 {
-	if (includes_account (type))
-	{
-		nano::write (stream_a, account.bytes);
-	}
-	if (includes_height (type))
-	{
-		nano::write (stream_a, boost::endian::native_to_big (height));
-	}
-	if (includes_balance (type))
-	{
-		nano::write (stream_a, balance.bytes);
-	}
-	nano::write (stream_a, boost::endian::native_to_big (timestamp));
-	if (includes_details (type))
-	{
-		details.serialize (stream_a);
-		nano::write (stream_a, static_cast<uint8_t> (source_epoch));
-	}
-}
-
-void nano::block_sideband::serialize_v25 (nano::stream & stream_a, nano::block_type type) const
-{
-	nano::write (stream_a, successor.bytes);
 	if (includes_account (type))
 	{
 		nano::write (stream_a, account.bytes);
@@ -263,13 +235,56 @@ bool nano::block_sideband::deserialize (nano::stream & stream_a, nano::block_typ
 	return result;
 }
 
-bool nano::block_sideband::deserialize_v25 (nano::stream & stream_a, nano::block_type type)
+void nano::block_sideband::operator() (nano::object_stream & obs) const
+{
+	obs.write ("successor", successor);
+	obs.write ("account", account);
+	obs.write ("balance", balance);
+	obs.write ("height", height);
+	obs.write ("timestamp", timestamp);
+	obs.write ("source_epoch", source_epoch);
+	obs.write ("details", details);
+}
+
+/*
+ * block_sideband_v25
+ */
+
+size_t nano::block_sideband_v25::size (nano::block_type type)
+{
+	return nano::block_sideband::size (type) + sizeof (nano::block_hash);
+}
+
+void nano::block_sideband_v25::serialize (nano::stream & stream_a, nano::block_type type) const
+{
+	nano::write (stream_a, successor.bytes);
+	if (nano::block_sideband::includes_account (type))
+	{
+		nano::write (stream_a, account.bytes);
+	}
+	if (nano::block_sideband::includes_height (type))
+	{
+		nano::write (stream_a, boost::endian::native_to_big (height));
+	}
+	if (nano::block_sideband::includes_balance (type))
+	{
+		nano::write (stream_a, balance.bytes);
+	}
+	nano::write (stream_a, boost::endian::native_to_big (timestamp));
+	if (nano::block_sideband::includes_details (type))
+	{
+		details.serialize (stream_a);
+		nano::write (stream_a, static_cast<uint8_t> (source_epoch));
+	}
+}
+
+bool nano::block_sideband_v25::deserialize (nano::stream & stream_a, nano::block_type type)
 {
 	bool result (false);
 	try
 	{
 		nano::read (stream_a, successor.bytes);
-		if (includes_account (type))
+		if (nano::block_sideband::includes_account (type))
 		{
 			nano::read (stream_a, account.bytes);
 		}
@@ -277,7 +292,7 @@ bool nano::block_sideband::deserialize_v25 (nano::stream & stream_a, nano::block
 		{
 			account.clear ();
 		}
-		if (includes_height (type))
+		if (nano::block_sideband::includes_height (type))
 		{
 			nano::read (stream_a, height);
 			boost::endian::big_to_native_inplace (height);
@@ -286,7 +301,7 @@ bool nano::block_sideband::deserialize_v25 (nano::stream & stream_a, nano::block
 		{
 			height = 1;
 		}
-		if (includes_balance (type))
+		if (nano::block_sideband::includes_balance (type))
 		{
 			nano::read (stream_a, balance.bytes);
 		}
@@ -296,7 +311,7 @@ bool nano::block_sideband::deserialize_v25 (nano::stream & stream_a, nano::block
 		}
 		nano::read (stream_a, timestamp);
 		boost::endian::big_to_native_inplace (timestamp);
-		if (includes_details (type))
+		if (nano::block_sideband::includes_details (type))
 		{
 			result = details.deserialize (stream_a);
 			uint8_t source_epoch_uint8_t{ 0 };
@@ -315,15 +330,4 @@ bool nano::block_sideband::deserialize_v25 (nano::stream & stream_a, nano::block
 	}
 
 	return result;
-}
-
-void nano::block_sideband::operator() (nano::object_stream & obs) const
-{
-	obs.write ("successor", successor);
-	obs.write ("account", account);
-	obs.write ("balance", balance);
-	obs.write ("height", height);
-	obs.write ("timestamp", timestamp);
-	obs.write ("source_epoch", source_epoch);
-	obs.write ("details", details);
 }

--- a/nano/lib/block_sideband.cpp
+++ b/nano/lib/block_sideband.cpp
@@ -138,7 +138,6 @@ bool nano::block_sideband::includes_details (nano::block_type const type)
 size_t nano::block_sideband::size (nano::block_type type)
 {
 	size_t result (0);
-	result += sizeof (successor);
 	if (includes_account (type))
 	{
 		result += sizeof (account);
@@ -160,7 +159,34 @@ size_t nano::block_sideband::size (nano::block_type type)
 	return result;
 }
 
+size_t nano::block_sideband::size_v25 (nano::block_type type)
+{
+	return size (type) + sizeof (successor);
+}
+
 void nano::block_sideband::serialize (nano::stream & stream_a, nano::block_type type) const
+{
+	if (includes_account (type))
+	{
+		nano::write (stream_a, account.bytes);
+	}
+	if (includes_height (type))
+	{
+		nano::write (stream_a, boost::endian::native_to_big (height));
+	}
+	if (includes_balance (type))
+	{
+		nano::write (stream_a, balance.bytes);
+	}
+	nano::write (stream_a, boost::endian::native_to_big (timestamp));
+	if (includes_details (type))
+	{
+		details.serialize (stream_a);
+		nano::write (stream_a, static_cast<uint8_t> (source_epoch));
+	}
+}
+
+void nano::block_sideband::serialize_v25 (nano::stream & stream_a, nano::block_type type) const
 {
 	nano::write (stream_a, successor.bytes);
 	if (includes_account (type))
@@ -184,6 +210,60 @@ void nano::block_sideband::serialize (nano::stream & stream_a, nano::block_type 
 }
 
 bool nano::block_sideband::deserialize (nano::stream & stream_a, nano::block_type type)
+{
+	bool result (false);
+	try
+	{
+		successor.clear ();
+		if (includes_account (type))
+		{
+			nano::read (stream_a, account.bytes);
+		}
+		else
+		{
+			account.clear ();
+		}
+		if (includes_height (type))
+		{
+			nano::read (stream_a, height);
+			boost::endian::big_to_native_inplace (height);
+		}
+		else
+		{
+			height = 1;
+		}
+		if (includes_balance (type))
+		{
+			nano::read (stream_a, balance.bytes);
+		}
+		else
+		{
+			balance.clear ();
+		}
+		nano::read (stream_a, timestamp);
+		boost::endian::big_to_native_inplace (timestamp);
+		if (includes_details (type))
+		{
+			result = details.deserialize (stream_a);
+			uint8_t source_epoch_uint8_t{ 0 };
+			nano::read (stream_a, source_epoch_uint8_t);
+			source_epoch = static_cast<nano::epoch> (source_epoch_uint8_t);
+		}
+		else
+		{
+			details = {};
+			source_epoch = nano::epoch::epoch_0;
+		}
+	}
+	catch (std::runtime_error &)
+	{
+		result = true;
+	}
+
+	return result;
+}
+
+bool nano::block_sideband::deserialize_v25 (nano::stream & stream_a, nano::block_type type)
 {
 	bool result (false);
 	try

--- a/nano/lib/block_sideband.hpp
+++ b/nano/lib/block_sideband.hpp
@@ -55,12 +55,7 @@ public:
 	void serialize (nano::stream &, nano::block_type) const;
 	bool deserialize (nano::stream &, nano::block_type);
 
-	// Legacy v25 format (includes successor field in sideband)
-	void serialize_v25 (nano::stream &, nano::block_type) const;
-	bool deserialize_v25 (nano::stream &, nano::block_type);
-
 	static size_t size (nano::block_type);
-	static size_t size_v25 (nano::block_type);
 
 	static bool includes_account (nano::block_type);
 	static bool includes_height (nano::block_type);
@@ -78,5 +73,28 @@ public:
 
 public: // Logging
 	void operator() (nano::object_stream &) const;
+};
+
+/**
+ * Snapshot of the block sideband format at v25 (includes successor field).
+ * Used during v24->v25 and v25->v26 database migrations.
+ */
+class block_sideband_v25 final
+{
+public:
+	block_sideband_v25 () = default;
+
+	void serialize (nano::stream &, nano::block_type) const;
+	bool deserialize (nano::stream &, nano::block_type);
+	static size_t size (nano::block_type);
+
+public:
+	nano::block_hash successor{ 0 };
+	nano::account account{};
+	nano::amount balance{ 0 };
+	uint64_t height{ 0 };
+	uint64_t timestamp{ 0 };
+	nano::block_details details;
+	nano::epoch source_epoch{ nano::epoch::epoch_0 };
 };
 }

--- a/nano/lib/block_sideband.hpp
+++ b/nano/lib/block_sideband.hpp
@@ -49,8 +49,8 @@ class block_sideband final
 {
 public:
 	block_sideband () = default;
-	block_sideband (nano::account const & account, nano::block_hash const & successor, nano::amount const & balance, uint64_t height, nano::seconds_t timestamp, nano::block_details const & details, nano::epoch source_epoch);
-	block_sideband (nano::account const & account, nano::block_hash const & successor, nano::amount const & balance, uint64_t height, nano::seconds_t timestamp, nano::epoch epoch, bool is_send, bool is_receive, bool is_epoch, nano::epoch source_epoch);
+	block_sideband (nano::account const & account, nano::amount const & balance, uint64_t height, nano::seconds_t timestamp, nano::block_details const & details, nano::epoch source_epoch);
+	block_sideband (nano::account const & account, nano::amount const & balance, uint64_t height, nano::seconds_t timestamp, nano::epoch epoch, bool is_send, bool is_receive, bool is_epoch, nano::epoch source_epoch);
 
 	void serialize (nano::stream &, nano::block_type) const;
 	bool deserialize (nano::stream &, nano::block_type);
@@ -63,7 +63,6 @@ public:
 	static bool includes_details (nano::block_type);
 
 public:
-	nano::block_hash successor{ 0 };
 	nano::account account{}; // Not serialized for state/open blocks
 	nano::amount balance{ 0 }; // Serialized only for receive/change/open blocks
 	uint64_t height{ 0 }; // Not serialized for open blocks (deserialized as 1)

--- a/nano/lib/block_sideband.hpp
+++ b/nano/lib/block_sideband.hpp
@@ -55,7 +55,12 @@ public:
 	void serialize (nano::stream &, nano::block_type) const;
 	bool deserialize (nano::stream &, nano::block_type);
 
+	// Legacy v25 format (includes successor field in sideband)
+	void serialize_v25 (nano::stream &, nano::block_type) const;
+	bool deserialize_v25 (nano::stream &, nano::block_type);
+
 	static size_t size (nano::block_type);
+	static size_t size_v25 (nano::block_type);
 
 	static bool includes_account (nano::block_type);
 	static bool includes_height (nano::block_type);

--- a/nano/secure/account_info.hpp
+++ b/nano/secure/account_info.hpp
@@ -48,4 +48,4 @@ public:
 	uint64_t block_count{ 0 };
 	nano::epoch epoch_m{ nano::epoch::epoch_0 };
 };
-} // namespace nano
+}

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -136,7 +136,6 @@ nano::ledger_constants::ledger_constants (nano::network_type network_type) :
 {
 	nano_beta_genesis->sideband_set (nano::block_sideband{
 	/* account */ nano_beta_genesis->account_field ().value (),
-	/* successor (block_hash) */ nano::block_hash{ 0 },
 	/* balance (amount) */ nano::amount{ std::numeric_limits<nano::uint128_t>::max () },
 	/* height */ uint64_t{ 1 },
 	/* local_timestamp */ 0,
@@ -148,7 +147,6 @@ nano::ledger_constants::ledger_constants (nano::network_type network_type) :
 
 	nano_dev_genesis->sideband_set (nano::block_sideband{
 	/* account */ nano_dev_genesis->account_field ().value (),
-	/* successor (block_hash) */ nano::block_hash{ 0 },
 	/* balance (amount) */ nano::amount{ std::numeric_limits<nano::uint128_t>::max () },
 	/* height */ uint64_t{ 1 },
 	/* local_timestamp */ 0,
@@ -160,7 +158,6 @@ nano::ledger_constants::ledger_constants (nano::network_type network_type) :
 
 	nano_live_genesis->sideband_set (nano::block_sideband{
 	/* account */ nano_live_genesis->account_field ().value (),
-	/* successor (block_hash) */ nano::block_hash{ 0 },
 	/* balance (amount) */ nano::amount{ std::numeric_limits<nano::uint128_t>::max () },
 	/* height */ uint64_t{ 1 },
 	/* local_timestamp */ 0,
@@ -172,7 +169,6 @@ nano::ledger_constants::ledger_constants (nano::network_type network_type) :
 
 	nano_test_genesis->sideband_set (nano::block_sideband{
 	/* account */ nano_test_genesis->account_field ().value (),
-	/* successor (block_hash) */ nano::block_hash{ 0 },
 	/* balance (amount) */ nano::amount{ std::numeric_limits<nano::uint128_t>::max () },
 	/* height */ uint64_t{ 1 },
 	/* local_timestamp */ 0,

--- a/nano/secure/ledger_processor.cpp
+++ b/nano/secure/ledger_processor.cpp
@@ -54,7 +54,13 @@ void nano::ledger_processor::send_block (nano::send_block & block_a)
 							{
 								auto amount (info->balance.number () - block_a.hashables.balance.number ());
 								ledger.rep_weights.sub (transaction, info->representative, amount);
-								block_a.sideband_set (nano::block_sideband (account, 0, block_a.hashables.balance /* unused */, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+								block_a.sideband_set (nano::block_sideband{
+								/* account */ account,
+								/* balance */ block_a.hashables.balance,
+								/* height */ info->block_count + 1,
+								/* timestamp */ nano::seconds_since_epoch (),
+								/* details */ block_details,
+								/* source_epoch */ nano::epoch::epoch_0 });
 								ledger.store.block.put (transaction, hash, block_a);
 								nano::account_info new_info (hash, info->representative, info->open_block, block_a.hashables.balance, nano::seconds_since_epoch (), info->block_count + 1, nano::epoch::epoch_0);
 								ledger.update_account (transaction, account, *info, new_info);
@@ -113,7 +119,13 @@ void nano::ledger_processor::receive_block (nano::receive_block & block_a)
 										{
 											auto new_balance (info->balance.number () + pending.value ().amount.number ());
 											ledger.store.pending.del (transaction, key);
-											block_a.sideband_set (nano::block_sideband (account, 0, new_balance, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+											block_a.sideband_set (nano::block_sideband{
+											/* account */ account,
+											/* balance */ new_balance,
+											/* height */ info->block_count + 1,
+											/* timestamp */ nano::seconds_since_epoch (),
+											/* details */ block_details,
+											/* source_epoch */ nano::epoch::epoch_0 });
 											ledger.store.block.put (transaction, hash, block_a);
 											nano::account_info new_info (hash, info->representative, info->open_block, new_balance, nano::seconds_since_epoch (), info->block_count + 1, nano::epoch::epoch_0);
 											ledger.update_account (transaction, account, *info, new_info);
@@ -165,7 +177,13 @@ void nano::ledger_processor::open_block (nano::open_block & block_a)
 								if (result == nano::block_status::progress)
 								{
 									ledger.store.pending.del (transaction, key);
-									block_a.sideband_set (nano::block_sideband (block_a.hashables.account, 0, pending.value ().amount, 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+									block_a.sideband_set (nano::block_sideband{
+									/* account */ block_a.hashables.account,
+									/* balance */ pending.value ().amount,
+									/* height */ uint64_t{ 1 },
+									/* timestamp */ nano::seconds_since_epoch (),
+									/* details */ block_details,
+									/* source_epoch */ nano::epoch::epoch_0 });
 									ledger.store.block.put (transaction, hash, block_a);
 									nano::account_info new_info (hash, block_a.representative_field ().value (), hash, pending.value ().amount.number (), nano::seconds_since_epoch (), 1, nano::epoch::epoch_0);
 									ledger.update_account (transaction, block_a.hashables.account, info, new_info);
@@ -210,7 +228,13 @@ void nano::ledger_processor::change_block (nano::change_block & block_a)
 						if (result == nano::block_status::progress)
 						{
 							debug_assert (!validate_message (account, hash, block_a.signature));
-							block_a.sideband_set (nano::block_sideband (account, 0, info->balance, info->block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+							block_a.sideband_set (nano::block_sideband{
+							/* account */ account,
+							/* balance */ info->balance,
+							/* height */ info->block_count + 1,
+							/* timestamp */ nano::seconds_since_epoch (),
+							/* details */ block_details,
+							/* source_epoch */ nano::epoch::epoch_0 });
 							ledger.store.block.put (transaction, hash, block_a);
 							auto balance = previous->balance ();
 							ledger.rep_weights.move (transaction, info->representative, block_a.hashables.representative, balance);
@@ -330,7 +354,13 @@ void nano::ledger_processor::state_block_impl (nano::state_block & block_a)
 					if (result == nano::block_status::progress)
 					{
 						ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::state_block);
-						block_a.sideband_set (nano::block_sideband (block_a.hashables.account /* unused */, 0, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), block_details, source_epoch));
+						block_a.sideband_set (nano::block_sideband{
+						/* account */ block_a.hashables.account,
+						/* balance */ block_a.hashables.balance,
+						/* height */ info.block_count + 1,
+						/* timestamp */ nano::seconds_since_epoch (),
+						/* details */ block_details,
+						/* source_epoch */ source_epoch });
 						ledger.store.block.put (transaction, hash, block_a);
 
 						if (!info.head.is_zero ())
@@ -420,7 +450,13 @@ void nano::ledger_processor::epoch_block_impl (nano::state_block & block_a)
 							if (result == nano::block_status::progress)
 							{
 								ledger.stats.inc (nano::stat::type::ledger, nano::stat::detail::epoch_block);
-								block_a.sideband_set (nano::block_sideband (block_a.hashables.account /* unused */, 0, 0 /* unused */, info.block_count + 1, nano::seconds_since_epoch (), block_details, nano::epoch::epoch_0 /* unused */));
+								block_a.sideband_set (nano::block_sideband{
+								/* account */ block_a.hashables.account,
+								/* balance */ block_a.hashables.balance,
+								/* height */ info.block_count + 1,
+								/* timestamp */ nano::seconds_since_epoch (),
+								/* details */ block_details,
+								/* source_epoch */ nano::epoch::epoch_0 });
 								ledger.store.block.put (transaction, hash, block_a);
 								nano::account_info new_info (hash, block_a.hashables.representative, info.open_block.is_zero () ? hash : info.open_block, info.balance, nano::seconds_since_epoch (), info.block_count + 1, epoch);
 								ledger.update_account (transaction, block_a.hashables.account, info, new_info);

--- a/nano/store/block_w_sideband.hpp
+++ b/nano/store/block_w_sideband.hpp
@@ -4,10 +4,6 @@
 
 #include <memory>
 
-namespace nano
-{
-class block;
-}
 namespace nano::store
 {
 class block_w_sideband
@@ -17,11 +13,11 @@ public:
 	nano::block_sideband sideband;
 };
 
-// Legacy sideband format: includes successor field (used during migrations)
-class block_w_sideband_legacy
+// Snapshot of block + sideband at v25 format which needs to be read for the v25 to v26 upgrade
+class block_w_sideband_v25
 {
 public:
 	std::shared_ptr<nano::block> block;
-	nano::block_sideband sideband;
+	nano::block_sideband_v25 sideband;
 };
 }

--- a/nano/store/block_w_sideband.hpp
+++ b/nano/store/block_w_sideband.hpp
@@ -16,4 +16,12 @@ public:
 	std::shared_ptr<nano::block> block;
 	nano::block_sideband sideband;
 };
+
+// Legacy sideband format: includes successor field (used during migrations)
+class block_w_sideband_legacy
+{
+public:
+	std::shared_ptr<nano::block> block;
+	nano::block_sideband sideband;
+};
 }

--- a/nano/store/crawler.hpp
+++ b/nano/store/crawler.hpp
@@ -74,7 +74,7 @@ public:
 	/**
 	 * Construct a crawler starting at the given seek key.
 	 */
-	crawler (View const & view, Transaction & transaction, seek_key_type const & start) :
+	crawler (View const & view, Transaction & transaction, seek_key_type start = {}) :
 		view_{ view },
 		transaction_{ transaction },
 		it_{ view_.end (transaction_) },

--- a/nano/store/db_val.hpp
+++ b/nano/store/db_val.hpp
@@ -77,6 +77,7 @@ public:
 	explicit operator nano::account () const;
 	explicit operator std::array<char, 64> () const;
 	explicit operator block_w_sideband () const;
+	explicit operator block_w_sideband_legacy () const;
 	explicit operator std::shared_ptr<nano::vote> () const;
 	explicit operator std::nullptr_t () const;
 	explicit operator nano::no_value () const;

--- a/nano/store/db_val.hpp
+++ b/nano/store/db_val.hpp
@@ -77,7 +77,7 @@ public:
 	explicit operator nano::account () const;
 	explicit operator std::array<char, 64> () const;
 	explicit operator block_w_sideband () const;
-	explicit operator block_w_sideband_legacy () const;
+	explicit operator block_w_sideband_v25 () const;
 	explicit operator std::shared_ptr<nano::vote> () const;
 	explicit operator std::nullptr_t () const;
 	explicit operator nano::no_value () const;

--- a/nano/store/db_val_templ.hpp
+++ b/nano/store/db_val_templ.hpp
@@ -244,28 +244,13 @@ inline db_val::operator nano::store::block_w_sideband () const
 	return block_w_sideband;
 }
 
-inline db_val::operator nano::store::block_w_sideband_legacy () const
+inline db_val::operator nano::store::block_w_sideband_v25 () const
 {
 	nano::bufferstream stream{ span_view.data (), span_view.size () };
-	nano::store::block_w_sideband_legacy block_w_sideband;
+	nano::store::block_w_sideband_v25 block_w_sideband;
 	block_w_sideband.block = (nano::deserialize_block (stream));
-	auto remaining = stream.in_avail ();
-	auto block_type = block_w_sideband.block->type ();
-	bool error;
-	if (remaining == nano::block_sideband::size_v25 (block_type))
-	{
-		error = block_w_sideband.sideband.deserialize_v25 (stream, block_type);
-	}
-	else if (remaining == nano::block_sideband::size (block_type))
-	{
-		error = block_w_sideband.sideband.deserialize (stream, block_type);
-	}
-	else
-	{
-		release_assert (false, "unexpected sideband size", std::to_string (remaining));
-	}
+	auto error = block_w_sideband.sideband.deserialize (stream, block_w_sideband.block->type ());
 	release_assert (!error);
-	block_w_sideband.block->sideband_set (block_w_sideband.sideband);
 	return block_w_sideband;
 }
 

--- a/nano/store/db_val_templ.hpp
+++ b/nano/store/db_val_templ.hpp
@@ -244,6 +244,31 @@ inline db_val::operator nano::store::block_w_sideband () const
 	return block_w_sideband;
 }
 
+inline db_val::operator nano::store::block_w_sideband_legacy () const
+{
+	nano::bufferstream stream{ span_view.data (), span_view.size () };
+	nano::store::block_w_sideband_legacy block_w_sideband;
+	block_w_sideband.block = (nano::deserialize_block (stream));
+	auto remaining = stream.in_avail ();
+	auto block_type = block_w_sideband.block->type ();
+	bool error;
+	if (remaining == nano::block_sideband::size_v25 (block_type))
+	{
+		error = block_w_sideband.sideband.deserialize_v25 (stream, block_type);
+	}
+	else if (remaining == nano::block_sideband::size (block_type))
+	{
+		error = block_w_sideband.sideband.deserialize (stream, block_type);
+	}
+	else
+	{
+		release_assert (false, "unexpected sideband size", std::to_string (remaining));
+	}
+	release_assert (!error);
+	block_w_sideband.block->sideband_set (block_w_sideband.sideband);
+	return block_w_sideband;
+}
+
 inline db_val::operator std::shared_ptr<nano::vote> () const
 {
 	nano::bufferstream stream{ span_view.data (), span_view.size () };

--- a/nano/store/ledger_store.cpp
+++ b/nano/store/ledger_store.cpp
@@ -469,52 +469,87 @@ void ledger_store::upgrade_v25_to_v26 ()
 		// Smaller batch size for dev runs to potentially trigger edge cases
 		const size_t batch_size = nano::is_dev_run () ? 2 : 250000;
 		size_t processed = 0;
+		size_t skipped = 0;
 		auto const total_blocks = backend.count (backend.tx_begin_read (), nano::store::table::blocks);
 
 		// Use cursor-based iteration with short-lived read transactions
 		// This allows LMDB to reuse old pages between batches, preventing database bloat during migration
+		// Raw iterators are used instead of typed_iterator to avoid eager deserialization at the cursor position,
+		// since blocks at the cursor have already been rewritten in v26 format
 		nano::block_hash cursor{ 0 };
 		while (true)
 		{
 			auto read_txn = backend.tx_begin_read ();
 			auto it = cursor.is_zero ()
-			? nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_v25>{ backend.begin (read_txn, nano::store::table::blocks) }
-			: nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_v25>{ backend.begin (read_txn, nano::store::table::blocks, nano::store::db_val{ cursor }) };
+			? backend.begin (read_txn, nano::store::table::blocks)
+			: backend.begin (read_txn, nano::store::table::blocks, nano::store::db_val{ cursor });
 
 			// Skip the cursor key itself (already processed in previous batch)
-			if (!cursor.is_zero () && !it.is_end () && (*it).first == cursor)
+			if (!cursor.is_zero () && !it.is_end ())
 			{
-				++it;
+				auto const & [key_span, value_span] = *it;
+				nano::block_hash key{ nano::store::db_val{ key_span } };
+				if (key == cursor)
+				{
+					++it;
+				}
 			}
 
 			size_t batch_count = 0;
 			for (; !it.is_end () && batch_count < batch_size; ++it, ++batch_count)
 			{
-				auto const & [hash, block_w_sideband] = *it;
+				auto const & [key_span, value_span] = *it;
 
-				// Rewrite block with new sideband format (no successor)
-				std::vector<uint8_t> data;
+				nano::block_hash hash{ nano::store::db_val{ key_span } };
+
+				// Deserialize the block to determine its type and data size
+				nano::bufferstream stream{ value_span.data (), value_span.size () };
+				auto block = nano::deserialize_block (stream);
+				release_assert (block != nullptr, "failed to deserialize block during v25->v26 upgrade");
+
+				auto const remaining = static_cast<size_t> (stream.in_avail ());
+				auto const expected_v25_size = nano::block_sideband_v25::size (block->type ());
+				auto const expected_v26_size = nano::block_sideband::size (block->type ());
+
+				if (remaining == expected_v26_size)
 				{
-					nano::vectorstream stream{ data };
-					nano::serialize_block (stream, *block_w_sideband.block);
-					nano::block_sideband current_sideband{
-						block_w_sideband.sideband.account,
-						nano::block_hash{ 0 },
-						block_w_sideband.sideband.balance,
-						block_w_sideband.sideband.height,
-						block_w_sideband.sideband.timestamp,
-						block_w_sideband.sideband.details,
-						block_w_sideband.sideband.source_epoch
-					};
-					current_sideband.serialize (stream, block_w_sideband.block->type ());
+					// Block already in v26 format (from a previous interrupted upgrade), skip
+					skipped++;
+				}
+				else
+				{
+					release_assert (remaining == expected_v25_size, "unexpected sideband size during v25->v26 upgrade");
+
+					// Deserialize v25 sideband
+					nano::block_sideband_v25 sideband_v25;
+					auto error = sideband_v25.deserialize (stream, block->type ());
+					release_assert (!error, "failed to deserialize v25 sideband during upgrade");
+
+					// Rewrite block with new sideband format (no successor)
+					std::vector<uint8_t> data;
+					{
+						nano::vectorstream out_stream{ data };
+						nano::serialize_block (out_stream, *block);
+						nano::block_sideband current_sideband{
+							sideband_v25.account,
+							nano::block_hash{ 0 },
+							sideband_v25.balance,
+							sideband_v25.height,
+							sideband_v25.timestamp,
+							sideband_v25.details,
+							sideband_v25.source_epoch
+						};
+						current_sideband.serialize (out_stream, block->type ());
+					}
+
+					nano::store::db_val value{ data.size (), data.data () };
+					auto status = backend.put (transaction, nano::store::table::blocks, hash, value);
+					backend.release_assert_success (status);
+
+					processed++;
 				}
 
-				nano::store::db_val value{ data.size (), data.data () };
-				auto status = backend.put (transaction, nano::store::table::blocks, hash, value);
-				backend.release_assert_success (status);
-
 				cursor = hash;
-				processed++;
 			}
 
 			if (batch_count == 0)
@@ -522,12 +557,12 @@ void ledger_store::upgrade_v25_to_v26 ()
 				break;
 			}
 
-			double const percentage = total_blocks > 0 ? (static_cast<double> (processed) / total_blocks * 100.0) : 0.0;
-			logger.info (nano::log::type::ledger_upgrade, "Processed {} blocks ({:.1f}%)", processed, percentage);
+			double const percentage = total_blocks > 0 ? (static_cast<double> (processed + skipped) / total_blocks * 100.0) : 0.0;
+			logger.info (nano::log::type::ledger_upgrade, "Processed {} blocks ({:.1f}%)", processed + skipped, percentage);
 			transaction.refresh ();
 		}
 
-		logger.info (nano::log::type::ledger_upgrade, "Done processing {} blocks", processed);
+		logger.info (nano::log::type::ledger_upgrade, "Done processing {} blocks ({} converted, {} already upgraded)", processed + skipped, processed, skipped);
 		version.put (transaction, 26);
 	}
 

--- a/nano/store/ledger_store.cpp
+++ b/nano/store/ledger_store.cpp
@@ -467,100 +467,98 @@ void ledger_store::upgrade_v25_to_v26 ()
 		auto transaction = backend.tx_begin_write ();
 
 		// Smaller batch size for dev runs to potentially trigger edge cases
-		const size_t batch_size = nano::is_dev_run () ? 2 : 250000;
-		size_t processed = 0;
-		size_t skipped = 0;
+		size_t const batch_size = nano::is_dev_run () ? 2 : 250000;
+
 		auto const total_blocks = backend.count (backend.tx_begin_read (), nano::store::table::blocks);
 
-		// Use cursor-based iteration with short-lived read transactions
-		// This allows LMDB to reuse old pages between batches, preventing database bloat during migration
-		// Raw iterators are used instead of typed_iterator to avoid eager deserialization at the cursor position,
-		// since blocks at the cursor have already been rewritten in v26 format
-		nano::block_hash cursor{ 0 };
-		while (true)
+		size_t processed = 0;
+		size_t skipped = 0;
+
+		// View for raw block table iteration (preserves raw bytes for mixed v25/v26 format detection)
+		struct raw_blocks_view
 		{
-			auto read_txn = backend.tx_begin_read ();
-			auto it = cursor.is_zero ()
-			? backend.begin (read_txn, nano::store::table::blocks)
-			: backend.begin (read_txn, nano::store::table::blocks, nano::store::db_val{ cursor });
+			using iterator = nano::store::typed_iterator<nano::block_hash, nano::store::db_val>;
 
-			// Skip the cursor key itself (already processed in previous batch)
-			if (!cursor.is_zero () && !it.is_end ())
+			nano::store::backend & backend;
+
+			iterator begin (nano::store::transaction const & txn, nano::block_hash const & key) const
 			{
-				auto const & [key_span, value_span] = *it;
-				nano::block_hash key{ nano::store::db_val{ key_span } };
-				if (key == cursor)
-				{
-					++it;
-				}
+				return iterator{ backend.begin (txn, nano::store::table::blocks, nano::store::db_val{ key }) };
 			}
-
-			size_t batch_count = 0;
-			for (; !it.is_end () && batch_count < batch_size; ++it, ++batch_count)
+			iterator end (nano::store::transaction const & txn) const
 			{
-				auto const & [key_span, value_span] = *it;
+				return iterator{ backend.end (txn, nano::store::table::blocks) };
+			}
+		} raw_view{ backend };
 
-				nano::block_hash hash{ nano::store::db_val{ key_span } };
+		nano::store::crawler crawler{ raw_view, transaction };
 
-				// Deserialize the block to determine its type and data size
-				nano::bufferstream stream{ value_span.data (), value_span.size () };
-				auto block = nano::deserialize_block (stream);
-				release_assert (block != nullptr, "failed to deserialize block during v25->v26 upgrade");
+		size_t batch_count = 0;
+		for (; crawler; ++crawler)
+		{
+			auto const & [hash, raw_val] = *crawler;
 
-				auto const remaining = static_cast<size_t> (stream.in_avail ());
-				auto const expected_v25_size = nano::block_sideband_v25::size (block->type ());
-				auto const expected_v26_size = nano::block_sideband::size (block->type ());
+			// Deserialize the block to determine its type and detect sideband format by remaining size
+			nano::bufferstream stream{ raw_val.span_view.data (), raw_val.span_view.size () };
+			auto block = nano::deserialize_block (stream);
+			release_assert (block, "failed to deserialize block during v25->v26 upgrade");
 
-				if (remaining == expected_v26_size)
+			auto const remaining = static_cast<size_t> (stream.in_avail ());
+			auto const expected_v25_size = nano::block_sideband_v25::size (block->type ());
+			auto const expected_v26_size = nano::block_sideband::size (block->type ());
+
+			if (remaining == expected_v26_size)
+			{
+				// Block already in v26 format (from a previous interrupted upgrade), skip
+				skipped++;
+			}
+			else
+			{
+				release_assert (remaining == expected_v25_size, "unexpected sideband size during v25->v26 upgrade", std::to_string (remaining));
+
+				// Deserialize v25 sideband
+				nano::block_sideband_v25 sideband_v25;
+				auto error = sideband_v25.deserialize (stream, block->type ());
+				release_assert (!error, "failed to deserialize v25 sideband during upgrade");
+
+				// Rewrite block with new sideband format (no successor)
+				std::vector<uint8_t> data;
 				{
-					// Block already in v26 format (from a previous interrupted upgrade), skip
-					skipped++;
-				}
-				else
-				{
-					release_assert (remaining == expected_v25_size, "unexpected sideband size during v25->v26 upgrade");
-
-					// Deserialize v25 sideband
-					nano::block_sideband_v25 sideband_v25;
-					auto error = sideband_v25.deserialize (stream, block->type ());
-					release_assert (!error, "failed to deserialize v25 sideband during upgrade");
-
-					// Rewrite block with new sideband format (no successor)
-					std::vector<uint8_t> data;
-					{
-						nano::vectorstream out_stream{ data };
-						nano::serialize_block (out_stream, *block);
-						nano::block_sideband current_sideband{
-							sideband_v25.account,
-							nano::block_hash{ 0 },
-							sideband_v25.balance,
-							sideband_v25.height,
-							sideband_v25.timestamp,
-							sideband_v25.details,
-							sideband_v25.source_epoch
-						};
-						current_sideband.serialize (out_stream, block->type ());
-					}
-
-					nano::store::db_val value{ data.size (), data.data () };
-					auto status = backend.put (transaction, nano::store::table::blocks, hash, value);
-					backend.release_assert_success (status);
-
-					processed++;
+					nano::vectorstream out_stream{ data };
+					nano::serialize_block (out_stream, *block);
+					nano::block_sideband current_sideband{
+						sideband_v25.account,
+						nano::block_hash{ 0 },
+						sideband_v25.balance,
+						sideband_v25.height,
+						sideband_v25.timestamp,
+						sideband_v25.details,
+						sideband_v25.source_epoch
+					};
+					current_sideband.serialize (out_stream, block->type ());
 				}
 
-				cursor = hash;
+				nano::store::db_val value{ data.size (), data.data () };
+				auto status = backend.put (transaction, nano::store::table::blocks, hash, value);
+				backend.release_assert_success (status);
+
+				processed++;
 			}
 
-			if (batch_count == 0)
+			batch_count++;
+			if (batch_count >= batch_size)
 			{
-				break;
-			}
+				double const percentage = total_blocks > 0 ? (static_cast<double> (processed + skipped) / total_blocks * 100.0) : 0.0;
+				logger.info (nano::log::type::ledger_upgrade, "Processed {} blocks ({:.1f}%)", processed + skipped, percentage);
 
-			double const percentage = total_blocks > 0 ? (static_cast<double> (processed + skipped) / total_blocks * 100.0) : 0.0;
-			logger.info (nano::log::type::ledger_upgrade, "Processed {} blocks ({:.1f}%)", processed + skipped, percentage);
-			transaction.refresh ();
+				// Refresh transaction to commit changes
+				crawler.refresh ();
+
+				batch_count = 0;
+			}
 		}
+
+		crawler.refresh ();
 
 		logger.info (nano::log::type::ledger_upgrade, "Done processing {} blocks ({} converted, {} already upgraded)", processed + skipped, processed, skipped);
 		version.put (transaction, 26);

--- a/nano/store/ledger_store.cpp
+++ b/nano/store/ledger_store.cpp
@@ -205,6 +205,9 @@ void ledger_store::perform_upgrades (nano::store::backend_meta meta)
 			upgrade_v24_to_v25 ();
 			[[fallthrough]];
 		case 25:
+			upgrade_v25_to_v26 ();
+			[[fallthrough]];
+		case 26:
 			break;
 		default:
 			release_assert (false, "invalid ledger database version for upgrade", std::to_string (meta.version));
@@ -263,6 +266,20 @@ nano::store::column_schema const ledger_store::schema_v24{
 	{ nano::store::table::rep_weights, "rep_weights" },
 	{ nano::store::table::online_weight, "online_weight" },
 	{ nano::store::table::pruned, "pruned" },
+	{ nano::store::table::peers, "peers" },
+	{ nano::store::table::confirmation_height, "confirmation_height" },
+	{ nano::store::table::final_votes, "final_votes" },
+	{ nano::store::table::meta, "meta" }
+};
+
+nano::store::column_schema const ledger_store::schema_v25{
+	{ nano::store::table::blocks, "blocks" },
+	{ nano::store::table::accounts, "accounts" },
+	{ nano::store::table::pending, "pending" },
+	{ nano::store::table::rep_weights, "rep_weights" },
+	{ nano::store::table::online_weight, "online_weight" },
+	{ nano::store::table::pruned, "pruned" },
+	{ nano::store::table::successor, "successor" },
 	{ nano::store::table::peers, "peers" },
 	{ nano::store::table::confirmation_height, "confirmation_height" },
 	{ nano::store::table::final_votes, "final_votes" },
@@ -383,8 +400,8 @@ void ledger_store::upgrade_v24_to_v25 ()
 {
 	logger.info (nano::log::type::ledger_upgrade, "Upgrading database from v24 to v25...");
 
-	// Open with schema_current so we have access to the successor table
-	backend.open (schema_current, nano::store::open_mode::read_write);
+	// Open with schema_v25 so we have access to the successor table
+	backend.open (schema_v25, nano::store::open_mode::read_write);
 	{
 		release_assert (backend.get_version (backend.tx_begin_read ()) == 24, "unexpected version during upgrade", std::to_string (backend.get_version (backend.tx_begin_read ())));
 
@@ -400,10 +417,11 @@ void ledger_store::upgrade_v24_to_v25 ()
 		auto const total_blocks = backend.count (backend.tx_begin_read (), nano::store::table::blocks);
 
 		// Iterate all blocks using a separate read transaction
+		// Use block_w_sideband_legacy to read old format with successor in sideband
 		auto iterate_blocks = [this] (auto && func) {
 			auto read_txn = backend.tx_begin_read ();
-			auto it = nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband>{ backend.begin (read_txn, nano::store::table::blocks) };
-			auto const end = nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband>{ backend.end (read_txn, nano::store::table::blocks) };
+			auto it = nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_legacy>{ backend.begin (read_txn, nano::store::table::blocks) };
+			auto const end = nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_legacy>{ backend.end (read_txn, nano::store::table::blocks) };
 			for (; it != end; ++it)
 			{
 				auto const & [hash, block_w_sideband] = *it;
@@ -411,7 +429,7 @@ void ledger_store::upgrade_v24_to_v25 ()
 			}
 		};
 
-		iterate_blocks ([this, &transaction, &processed, batch_size, total_blocks] (nano::block_hash const & hash, nano::store::block_w_sideband const & block_w_sideband) {
+		iterate_blocks ([this, &transaction, &processed, batch_size, total_blocks] (nano::block_hash const & hash, nano::store::block_w_sideband_legacy const & block_w_sideband) {
 			// If successor is non-zero, write to successor table
 			if (!block_w_sideband.sideband.successor.is_zero ())
 			{
@@ -434,6 +452,79 @@ void ledger_store::upgrade_v24_to_v25 ()
 	backend.close ();
 
 	logger.info (nano::log::type::ledger_upgrade, "Upgrading database from v24 to v25 completed");
+}
+
+// Remove successor from block sideband
+void ledger_store::upgrade_v25_to_v26 ()
+{
+	logger.info (nano::log::type::ledger_upgrade, "Upgrading database from v25 to v26...");
+
+	// Open with schema_v25
+	backend.open (schema_v25, nano::store::open_mode::read_write);
+	{
+		release_assert (backend.get_version (backend.tx_begin_read ()) == 25, "unexpected version during upgrade", std::to_string (backend.get_version (backend.tx_begin_read ())));
+
+		auto transaction = backend.tx_begin_write ();
+
+		// Smaller batch size for dev runs to potentially trigger edge cases
+		const size_t batch_size = nano::is_dev_run () ? 2 : 250000;
+		size_t processed = 0;
+		auto const total_blocks = backend.count (backend.tx_begin_read (), nano::store::table::blocks);
+
+		// Use cursor-based iteration with short-lived read transactions
+		// This allows LMDB to reuse old pages between batches, preventing database bloat during migration
+		nano::block_hash cursor{ 0 };
+		while (true)
+		{
+			auto read_txn = backend.tx_begin_read ();
+			auto it = cursor.is_zero ()
+			? nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_legacy>{ backend.begin (read_txn, nano::store::table::blocks) }
+			: nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_legacy>{ backend.begin (read_txn, nano::store::table::blocks, nano::store::db_val{ cursor }) };
+
+			// Skip the cursor key itself (already processed in previous batch)
+			if (!cursor.is_zero () && !it.is_end () && (*it).first == cursor)
+			{
+				++it;
+			}
+
+			size_t batch_count = 0;
+			for (; !it.is_end () && batch_count < batch_size; ++it, ++batch_count)
+			{
+				auto const & [hash, block_w_sideband] = *it;
+
+				// Rewrite block with new sideband format (no successor)
+				std::vector<uint8_t> data;
+				{
+					nano::vectorstream stream{ data };
+					nano::serialize_block (stream, *block_w_sideband.block);
+					block_w_sideband.sideband.serialize (stream, block_w_sideband.block->type ());
+				}
+
+				nano::store::db_val value{ data.size (), data.data () };
+				auto status = backend.put (transaction, nano::store::table::blocks, hash, value);
+				backend.release_assert_success (status);
+
+				cursor = hash;
+				processed++;
+			}
+
+			if (batch_count == 0)
+			{
+				break;
+			}
+
+			double const percentage = total_blocks > 0 ? (static_cast<double> (processed) / total_blocks * 100.0) : 0.0;
+			logger.info (nano::log::type::ledger_upgrade, "Processed {} blocks ({:.1f}%)", processed, percentage);
+			transaction.refresh ();
+		}
+
+		logger.info (nano::log::type::ledger_upgrade, "Done processing {} blocks", processed);
+		version.put (transaction, 26);
+	}
+
+	backend.close ();
+
+	logger.info (nano::log::type::ledger_upgrade, "Upgrading database from v25 to v26 completed");
 }
 
 std::string ledger_store::vendor_get () const

--- a/nano/store/ledger_store.cpp
+++ b/nano/store/ledger_store.cpp
@@ -528,7 +528,6 @@ void ledger_store::upgrade_v25_to_v26 ()
 					nano::serialize_block (out_stream, *block);
 					nano::block_sideband current_sideband{
 						sideband_v25.account,
-						nano::block_hash{ 0 },
 						sideband_v25.balance,
 						sideband_v25.height,
 						sideband_v25.timestamp,

--- a/nano/store/ledger_store.cpp
+++ b/nano/store/ledger_store.cpp
@@ -417,11 +417,11 @@ void ledger_store::upgrade_v24_to_v25 ()
 		auto const total_blocks = backend.count (backend.tx_begin_read (), nano::store::table::blocks);
 
 		// Iterate all blocks using a separate read transaction
-		// Use block_w_sideband_legacy to read old format with successor in sideband
+		// Use block_w_sideband_v25 to read old format with successor in sideband
 		auto iterate_blocks = [this] (auto && func) {
 			auto read_txn = backend.tx_begin_read ();
-			auto it = nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_legacy>{ backend.begin (read_txn, nano::store::table::blocks) };
-			auto const end = nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_legacy>{ backend.end (read_txn, nano::store::table::blocks) };
+			auto it = nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_v25>{ backend.begin (read_txn, nano::store::table::blocks) };
+			auto const end = nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_v25>{ backend.end (read_txn, nano::store::table::blocks) };
 			for (; it != end; ++it)
 			{
 				auto const & [hash, block_w_sideband] = *it;
@@ -429,7 +429,7 @@ void ledger_store::upgrade_v24_to_v25 ()
 			}
 		};
 
-		iterate_blocks ([this, &transaction, &processed, batch_size, total_blocks] (nano::block_hash const & hash, nano::store::block_w_sideband_legacy const & block_w_sideband) {
+		iterate_blocks ([this, &transaction, &processed, batch_size, total_blocks] (nano::block_hash const & hash, nano::store::block_w_sideband_v25 const & block_w_sideband) {
 			// If successor is non-zero, write to successor table
 			if (!block_w_sideband.sideband.successor.is_zero ())
 			{
@@ -478,8 +478,8 @@ void ledger_store::upgrade_v25_to_v26 ()
 		{
 			auto read_txn = backend.tx_begin_read ();
 			auto it = cursor.is_zero ()
-			? nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_legacy>{ backend.begin (read_txn, nano::store::table::blocks) }
-			: nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_legacy>{ backend.begin (read_txn, nano::store::table::blocks, nano::store::db_val{ cursor }) };
+			? nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_v25>{ backend.begin (read_txn, nano::store::table::blocks) }
+			: nano::store::typed_iterator<nano::block_hash, nano::store::block_w_sideband_v25>{ backend.begin (read_txn, nano::store::table::blocks, nano::store::db_val{ cursor }) };
 
 			// Skip the cursor key itself (already processed in previous batch)
 			if (!cursor.is_zero () && !it.is_end () && (*it).first == cursor)
@@ -497,7 +497,16 @@ void ledger_store::upgrade_v25_to_v26 ()
 				{
 					nano::vectorstream stream{ data };
 					nano::serialize_block (stream, *block_w_sideband.block);
-					block_w_sideband.sideband.serialize (stream, block_w_sideband.block->type ());
+					nano::block_sideband current_sideband{
+						block_w_sideband.sideband.account,
+						nano::block_hash{ 0 },
+						block_w_sideband.sideband.balance,
+						block_w_sideband.sideband.height,
+						block_w_sideband.sideband.timestamp,
+						block_w_sideband.sideband.details,
+						block_w_sideband.sideband.source_epoch
+					};
+					current_sideband.serialize (stream, block_w_sideband.block->type ());
 				}
 
 				nano::store::db_val value{ data.size (), data.data () };

--- a/nano/store/ledger_store.hpp
+++ b/nano/store/ledger_store.hpp
@@ -41,6 +41,7 @@ public: // Upgrades
 	void upgrade_v22_to_v23 ();
 	void upgrade_v23_to_v24 ();
 	void upgrade_v24_to_v25 ();
+	void upgrade_v25_to_v26 ();
 
 public:
 	nano::store::write_queue write_queue; // TODO: Shouldn't be public
@@ -79,7 +80,7 @@ public:
 
 public:
 	static nano::store::backend_version_t constexpr version_minimum{ 21 };
-	static nano::store::backend_version_t constexpr version_current{ 25 };
+	static nano::store::backend_version_t constexpr version_current{ 26 };
 
 public:
 	static nano::store::column_schema const schema_current;
@@ -87,5 +88,6 @@ public:
 	static nano::store::column_schema const schema_v22;
 	static nano::store::column_schema const schema_v23;
 	static nano::store::column_schema const schema_v24;
+	static nano::store::column_schema const schema_v25;
 };
 };

--- a/nano/store/versioning.hpp
+++ b/nano/store/versioning.hpp
@@ -7,4 +7,4 @@ struct MDB_val;
 namespace nano::store
 {
 // Holds historical verisons of classes used when upgrading database stores.
-} // namespace nano::store
+}


### PR DESCRIPTION
This V26 database migration rewrites all blocks to remove the 32-byte successor field from block. The successor data has already been copied to the successor table in migration V24
Serialize_v25, deserialize_v25 and size_v25 methods has been added to block_sideband to preserve the ability to read the legacy format during migrations
The migration uses cursor-based iteration with short-lived read transactions to prevent LMDB database bloat during migration.
From my testing, ledger db size increased by only one gb during migration