### PR TITLE
Add disable_reachout flag and move preconfigured peer reachout to network layer

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1123,6 +1123,7 @@ TEST (network, disable_reachout)
 	nano::test::system system;
 	nano::node_flags flags;
 	flags.disable_reachout = true;
+	flags.disable_reachout_preconfigured = true;
 	auto & node = *system.add_node (flags);
 
 	// Wait a bit for any background activity
@@ -1132,5 +1133,4 @@ TEST (network, disable_reachout)
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::network, nano::stat::detail::reachout_live));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::network, nano::stat::detail::reachout_cached));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::network, nano::stat::detail::reachout_preconfigured));
-}
 }

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1116,3 +1116,21 @@ TEST (network, flood_vote)
 	ASSERT_EQ (2, node.network.flood_vote_non_pr (vote, 999.0f));
 	ASSERT_EQ (1, node.network.flood_vote_pr (vote));
 }
+
+// Verify that disable_reachout flag prevents all reachout threads from starting
+TEST (network, disable_reachout)
+{
+	nano::test::system system;
+	nano::node_flags flags;
+	flags.disable_reachout = true;
+	auto & node = *system.add_node (flags);
+
+	// Wait a bit for any background activity
+	WAIT (1s);
+
+	// No reachout should have occurred
+	ASSERT_EQ (0, node.stats.count (nano::stat::type::network, nano::stat::detail::reachout_live));
+	ASSERT_EQ (0, node.stats.count (nano::stat::type::network, nano::stat::detail::reachout_cached));
+	ASSERT_EQ (0, node.stats.count (nano::stat::type::network, nano::stat::detail::reachout_preconfigured));
+}
+}

--- a/nano/core_test/utility.cpp
+++ b/nano/core_test/utility.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/files.hpp>
+#include <nano/lib/interval.hpp>
 #include <nano/lib/optional_ptr.hpp>
 #include <nano/lib/rate_limiting.hpp>
 #include <nano/lib/relaxed_atomic.hpp>
@@ -157,6 +158,32 @@ TEST (relaxed_atomic_integral, many_threads)
 
 	// Check values
 	ASSERT_EQ (0, atomic);
+}
+
+TEST (interval, reset)
+{
+	nano::interval interval;
+
+	// First elapse always fires
+	ASSERT_TRUE (interval.elapse (1min));
+
+	// Immediate second call should not fire
+	ASSERT_FALSE (interval.elapse (1min));
+
+	// After reset, next elapse should fire immediately
+	interval.reset ();
+	ASSERT_TRUE (interval.elapse (1min));
+}
+
+TEST (interval_mt, reset)
+{
+	nano::interval_mt interval;
+
+	ASSERT_TRUE (interval.elapse (1min));
+	ASSERT_FALSE (interval.elapse (1min));
+
+	interval.reset ();
+	ASSERT_TRUE (interval.elapse (1min));
 }
 
 TEST (pending_key, sorting)

--- a/nano/lib/constants.hpp
+++ b/nano/lib/constants.hpp
@@ -111,6 +111,8 @@ public:
 			telemetry_broadcast_interval = 500ms;
 			rep_crawler_normal_interval = 500ms;
 			rep_crawler_warmup_interval = 500ms;
+			reachout_preconfigured_period = std::chrono::seconds (1);
+			reachout_preconfigured_warmup_period = std::chrono::seconds (1);
 		}
 	}
 
@@ -134,6 +136,7 @@ public:
 	{
 		return cleanup_period * 5;
 	}
+
 	/** How often to connect to other peers */
 	std::chrono::milliseconds merge_period;
 	/** How often to send keepalive messages */
@@ -161,6 +164,10 @@ public:
 
 	std::chrono::milliseconds rep_crawler_normal_interval{ 1000 * 7 };
 	std::chrono::milliseconds rep_crawler_warmup_interval{ 1000 * 3 };
+
+	/** How often to reach out to preconfigured peers */
+	std::chrono::seconds reachout_preconfigured_period{ 10min };
+	std::chrono::seconds reachout_preconfigured_warmup_period{ 1min };
 
 	/** Returns the network this object contains values for */
 	nano::network_type network () const

--- a/nano/lib/interval.hpp
+++ b/nano/lib/interval.hpp
@@ -19,6 +19,11 @@ public:
 		return false;
 	}
 
+	void reset ()
+	{
+		last = {};
+	}
+
 private:
 	std::chrono::steady_clock::time_point last{};
 };
@@ -36,6 +41,12 @@ public:
 			return true;
 		}
 		return false;
+	}
+
+	void reset ()
+	{
+		std::lock_guard guard{ mutex };
+		last = {};
 	}
 
 private:

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -359,10 +359,13 @@ enum class detail
 	loop_keepalive,
 	loop_reachout,
 	loop_reachout_cached,
+	loop_reachout_preconfigured,
 	merge_peer,
 	merge_peer_failed,
 	reachout_live,
 	reachout_cached,
+	reachout_preconfigured,
+	trigger_reachout,
 	connected,
 
 	// traffic type

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -110,6 +110,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_wallet_bootstrap", "Disables wallet lazy bootstrap")
 		("disable_ongoing_bootstrap", "Disable ongoing bootstrap")
 		("disable_reachout", "Disable peer reachout")
+		("disable_reachout_preconfigured", "Disable preconfigured peer reachout")
 		("disable_rep_crawler", "Disable rep crawler")
 		("disable_request_loop", "Disable request loop")
 		("disable_bootstrap_listener", "Disables bootstrap processing for TCP listener (not including realtime network TCP connections)")
@@ -148,6 +149,7 @@ void nano::update_flags (nano::node_flags & flags_a, boost::program_options::var
 	flags_a.disable_wallet_bootstrap = (vm.count ("disable_wallet_bootstrap") > 0);
 	flags_a.disable_ongoing_bootstrap = (vm.count ("disable_ongoing_bootstrap") > 0);
 	flags_a.disable_reachout = (vm.count ("disable_reachout") > 0);
+	flags_a.disable_reachout_preconfigured = (vm.count ("disable_reachout_preconfigured") > 0);
 	flags_a.disable_rep_crawler = (vm.count ("disable_rep_crawler") > 0);
 	flags_a.disable_request_loop = (vm.count ("disable_request_loop") > 0);
 	flags_a.disable_bootstrap_bulk_pull_server = (vm.count ("disable_bootstrap_bulk_pull_server") > 0);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -109,6 +109,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_legacy_bootstrap", "Disables legacy bootstrap")
 		("disable_wallet_bootstrap", "Disables wallet lazy bootstrap")
 		("disable_ongoing_bootstrap", "Disable ongoing bootstrap")
+		("disable_reachout", "Disable peer reachout")
 		("disable_rep_crawler", "Disable rep crawler")
 		("disable_request_loop", "Disable request loop")
 		("disable_bootstrap_listener", "Disables bootstrap processing for TCP listener (not including realtime network TCP connections)")
@@ -146,6 +147,7 @@ void nano::update_flags (nano::node_flags & flags_a, boost::program_options::var
 	flags_a.disable_legacy_bootstrap = (vm.count ("disable_legacy_bootstrap") > 0);
 	flags_a.disable_wallet_bootstrap = (vm.count ("disable_wallet_bootstrap") > 0);
 	flags_a.disable_ongoing_bootstrap = (vm.count ("disable_ongoing_bootstrap") > 0);
+	flags_a.disable_reachout = (vm.count ("disable_reachout") > 0);
 	flags_a.disable_rep_crawler = (vm.count ("disable_rep_crawler") > 0);
 	flags_a.disable_request_loop = (vm.count ("disable_request_loop") > 0);
 	flags_a.disable_bootstrap_bulk_pull_server = (vm.count ("disable_bootstrap_bulk_pull_server") > 0);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -2725,7 +2725,7 @@ void nano::json_handler::keepalive ()
 		uint16_t port;
 		if (!nano::parse_port (port_text, port))
 		{
-			node.keepalive (address_text, port);
+			node.network.reachout (address_text, port);
 			response_l.put ("started", "1");
 		}
 		else

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -55,7 +55,7 @@ void nano::network::start ()
 		run_keepalive ();
 	});
 
-	if (config.peer_reachout.count () > 0)
+	if (!node.flags.disable_reachout && config.peer_reachout.count () > 0)
 	{
 		reachout_thread = std::thread ([this] () {
 			nano::thread_role::set (nano::thread_role::name::network_reachout);
@@ -67,7 +67,7 @@ void nano::network::start ()
 		node.logger.warn (nano::log::type::network, "Peer reachout is disabled");
 	}
 
-	if (config.cached_peer_reachout.count () > 0)
+	if (!node.flags.disable_reachout && config.cached_peer_reachout.count () > 0)
 	{
 		reachout_cached_thread = std::thread ([this] () {
 			nano::thread_role::set (nano::thread_role::name::network_reachout);

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -41,6 +41,7 @@ nano::network::~network ()
 	debug_assert (!keepalive_thread.joinable ());
 	debug_assert (!reachout_thread.joinable ());
 	debug_assert (!reachout_cached_thread.joinable ());
+	debug_assert (!reachout_preconfigured_thread.joinable ());
 }
 
 void nano::network::start ()
@@ -79,6 +80,14 @@ void nano::network::start ()
 		node.logger.warn (nano::log::type::network, "Cached peer reachout is disabled");
 	}
 
+	if (!node.flags.disable_reachout)
+	{
+		reachout_preconfigured_thread = std::thread ([this] () {
+			nano::thread_role::set (nano::thread_role::name::network_reachout);
+			run_reachout_preconfigured ();
+		});
+	}
+
 	if (!node.flags.disable_tcp_realtime)
 	{
 		tcp_channels.start ();
@@ -104,6 +113,7 @@ void nano::network::stop ()
 	join_or_pass (cleanup_thread);
 	join_or_pass (reachout_thread);
 	join_or_pass (reachout_cached_thread);
+	join_or_pass (reachout_preconfigured_thread);
 
 	port = 0;
 }
@@ -230,6 +240,82 @@ void nano::network::run_reachout_cached ()
 		}
 
 		lock.lock ();
+	}
+}
+
+void nano::network::run_reachout_preconfigured ()
+{
+	nano::unique_lock<nano::mutex> lock{ mutex };
+	while (!stopped)
+	{
+		condition.wait_for (lock, 1s);
+		if (stopped)
+		{
+			return;
+		}
+		lock.unlock ();
+
+		node.stats.inc (nano::stat::type::network, nano::stat::detail::loop_reachout_preconfigured);
+
+		auto const target_interval = empty ()
+		? node.network_params.network.reachout_preconfigured_warmup_period
+		: node.network_params.network.reachout_preconfigured_period;
+
+		if (reachout_preconfigured_interval.elapse (target_interval))
+		{
+			reachout_preconfigured ();
+		}
+
+		lock.lock ();
+	}
+}
+
+void nano::network::trigger_reachout ()
+{
+	node.stats.inc (nano::stat::type::network, nano::stat::detail::trigger_reachout);
+	reachout_preconfigured_interval.reset ();
+	condition.notify_all ();
+}
+
+void nano::network::reachout (std::string const & address_a, uint16_t port_a)
+{
+	auto node_l (node.shared_from_this ());
+	resolver.async_resolve (boost::asio::ip::tcp::resolver::query (address_a, std::to_string (port_a)), [this, node_l, address_a, port_a] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator i_a) {
+		if (!ec)
+		{
+			for (auto i (i_a), n (boost::asio::ip::tcp::resolver::iterator{}); i != n; ++i)
+			{
+				auto endpoint (nano::transport::map_endpoint_to_v6 (i->endpoint ()));
+				auto channel (find_channel (endpoint));
+				if (!channel)
+				{
+					tcp_channels.start_tcp (endpoint);
+				}
+				else
+				{
+					send_keepalive (channel);
+				}
+			}
+		}
+		else
+		{
+			node.logger.error (nano::log::type::network, "Error resolving address for reachout: {}:{} ({})", address_a, port_a, ec.message ());
+		}
+	});
+}
+
+void nano::network::reachout_preconfigured ()
+{
+	if (node.config.preconfigured_peers.empty ())
+	{
+		return;
+	}
+
+	node.stats.inc (nano::stat::type::network, nano::stat::detail::reachout_preconfigured);
+
+	for (auto const & peer : node.config.preconfigured_peers)
+	{
+		reachout (peer, node.network_params.network.default_node_port);
 	}
 }
 

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -80,7 +80,7 @@ void nano::network::start ()
 		node.logger.warn (nano::log::type::network, "Cached peer reachout is disabled");
 	}
 
-	if (!node.flags.disable_reachout)
+	if (!node.flags.disable_reachout_preconfigured)
 	{
 		reachout_preconfigured_thread = std::thread ([this] () {
 			nano::thread_role::set (nano::thread_role::name::network_reachout);

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <nano/lib/interval.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/network_filter.hpp>
 #include <nano/messages/messages.hpp>
@@ -124,6 +125,11 @@ public:
 	void send_keepalive (std::shared_ptr<nano::transport::channel> const &) const;
 	void send_keepalive_self (std::shared_ptr<nano::transport::channel> const &) const;
 
+	// Trigger immediate reachout to preconfigured peers
+	void trigger_reachout ();
+	void reachout (std::string const & address, uint16_t port);
+	void reachout_preconfigured ();
+
 	void merge_peers (std::array<nano::endpoint, 8> const & ips);
 	bool merge_peer (nano::endpoint const & ip);
 
@@ -175,6 +181,7 @@ private:
 	void run_keepalive ();
 	void run_reachout ();
 	void run_reachout_cached ();
+	void run_reachout_preconfigured ();
 
 private: // Dependencies
 	network_config const & config;
@@ -193,6 +200,9 @@ public: // Callbacks
 	std::function<void ()> disconnect_observer{ [] () {} };
 
 private:
+	nano::interval_mt reachout_preconfigured_interval;
+
+private:
 	std::atomic<bool> stopped{ false };
 	mutable nano::mutex mutex;
 	nano::condition_variable condition;
@@ -200,6 +210,7 @@ private:
 	std::thread keepalive_thread;
 	std::thread reachout_thread;
 	std::thread reachout_cached_thread;
+	std::thread reachout_preconfigured_thread;
 
 public:
 	static std::size_t const buffer_size = 512;

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -451,34 +451,6 @@ nano::node::~node ()
 	stop ();
 }
 
-void nano::node::keepalive (std::string const & address_a, uint16_t port_a)
-{
-	auto node_l (shared_from_this ());
-	network.resolver.async_resolve (boost::asio::ip::tcp::resolver::query (address_a, std::to_string (port_a)), [node_l, address_a, port_a] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator i_a) {
-		if (!ec)
-		{
-			for (auto i (i_a), n (boost::asio::ip::tcp::resolver::iterator{}); i != n; ++i)
-			{
-				auto endpoint (nano::transport::map_endpoint_to_v6 (i->endpoint ()));
-				std::weak_ptr<nano::node> node_w (node_l);
-				auto channel (node_l->network.find_channel (endpoint));
-				if (!channel)
-				{
-					node_l->network.tcp_channels.start_tcp (endpoint);
-				}
-				else
-				{
-					node_l->network.send_keepalive (channel);
-				}
-			}
-		}
-		else
-		{
-			node_l->logger.error (nano::log::type::node, "Error resolving address for keepalive: {}:{} ({})", address_a, port_a, ec.message ());
-		}
-	});
-}
-
 void nano::node::inbound (const nano::messages::message & message, const std::shared_ptr<nano::transport::channel> & channel)
 {
 	debug_assert (channel->owner () == shared_from_this ()); // This node should be the channel owner
@@ -652,17 +624,6 @@ void nano::node::stop ()
 	runner.abort (); // TODO: Remove this
 	runner.join ();
 	debug_assert (io_ctx_shared.use_count () == 1); // Node should be the last user of the io_context
-}
-
-void nano::node::keepalive_preconfigured ()
-{
-	for (auto const & peer : config.preconfigured_peers)
-	{
-		// can't use `network.port` here because preconfigured peers are referenced
-		// just by their address, so we rely on them listening on the default port
-		//
-		keepalive (peer, network_params.network.default_node_port);
-	}
 }
 
 nano::block_hash nano::node::latest (nano::account const & account_a)

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -45,14 +45,12 @@ public:
 
 	std::shared_ptr<nano::node> shared ();
 
-	void keepalive (std::string const &, uint16_t);
 	int store_version ();
 	void inbound (nano::messages::message const &, std::shared_ptr<nano::transport::channel> const &);
 	void process_active (std::shared_ptr<nano::block> const &);
 	void process_active (std::shared_ptr<nano::vote> const &);
 	std::optional<nano::block_status> process_local (std::shared_ptr<nano::block> const &);
 	void process_local_async (std::shared_ptr<nano::block> const &);
-	void keepalive_preconfigured ();
 	std::shared_ptr<nano::block> block (nano::block_hash const &);
 	bool block_or_pruned_exists (nano::block_hash const &) const;
 	std::pair<nano::uint128_t, nano::uint128_t> balance_pending (nano::account const &, bool only_confirmed);

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -181,6 +181,7 @@ public:
 	bool disable_bootstrap_bulk_pull_server{ false };
 	bool disable_bootstrap_bulk_push_client{ false };
 	bool disable_ongoing_bootstrap{ false }; // For testing only
+	bool disable_reachout{ false };
 	bool disable_rep_crawler{ false };
 	bool disable_request_loop{ false }; // For testing only
 	bool disable_tcp_realtime{ false };

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -182,6 +182,7 @@ public:
 	bool disable_bootstrap_bulk_push_client{ false };
 	bool disable_ongoing_bootstrap{ false }; // For testing only
 	bool disable_reachout{ false };
+	bool disable_reachout_preconfigured{ false };
 	bool disable_rep_crawler{ false };
 	bool disable_request_loop{ false }; // For testing only
 	bool disable_tcp_realtime{ false };

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -166,7 +166,7 @@ void nano::rep_crawler::run ()
 		if (!sufficient_weight)
 		{
 			stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::keepalive);
-			node.keepalive_preconfigured ();
+			node.network.trigger_reachout ();
 		}
 
 		lock.lock ();


### PR DESCRIPTION
Move preconfigured peer reachout into its own network thread with warmup/normal intervals, add `trigger_reachout()` for rep_crawler, and a `disable_reachout` node flag to gate all reachout threads. `disable_reachout` is useful for test setups with two isolated nodes that shouldn't connect to the wider network.