### PR TITLE
Exchange node capabilities when performing network handshake

### DIFF
--- a/nano/core_test/enums.cpp
+++ b/nano/core_test/enums.cpp
@@ -1,9 +1,13 @@
+#include <nano/lib/enum_flags_templ.hpp>
 #include <nano/lib/enum_util.hpp>
+#include <nano/lib/node_capabilities.hpp>
 #include <nano/lib/stats_enums.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
+
+#include <sstream>
 
 TEST (enums, stat_type)
 {
@@ -129,4 +133,137 @@ TEST (enum_util, convert)
 	ASSERT_EQ (nano::enum_convert<test_enum> (test_enum2::one), test_enum::one);
 	ASSERT_EQ (nano::enum_convert<test_enum> (test_enum2::two), test_enum::two);
 	ASSERT_EQ (nano::enum_convert<test_enum> (test_enum2::three), test_enum::three);
+}
+
+namespace
+{
+enum class test_flags : uint8_t
+{
+	none = 0,
+	alpha = 1 << 0,
+	beta = 1 << 1,
+	gamma = 1 << 2,
+};
+
+std::string_view to_string (test_flags value)
+{
+	switch (value)
+	{
+		case test_flags::none:
+			return "none";
+		case test_flags::alpha:
+			return "alpha";
+		case test_flags::beta:
+			return "beta";
+		case test_flags::gamma:
+			return "gamma";
+	}
+	return "unknown";
+}
+
+}
+
+TEST (enum_flags, default_construction)
+{
+	nano::enum_flags<test_flags> flags;
+	ASSERT_TRUE (flags.none ());
+	ASSERT_FALSE (flags.any ());
+	ASSERT_FALSE (static_cast<bool> (flags));
+}
+
+TEST (enum_flags, single_flag_construction)
+{
+	nano::enum_flags<test_flags> flags{ test_flags::alpha };
+	ASSERT_TRUE (flags.test (test_flags::alpha));
+	ASSERT_FALSE (flags.test (test_flags::beta));
+	ASSERT_TRUE (flags.any ());
+	ASSERT_FALSE (flags.none ());
+}
+
+TEST (enum_flags, set_reset)
+{
+	nano::enum_flags<test_flags> flags;
+	flags.set (test_flags::alpha);
+	flags.set (test_flags::gamma);
+	ASSERT_TRUE (flags.test (test_flags::alpha));
+	ASSERT_FALSE (flags.test (test_flags::beta));
+	ASSERT_TRUE (flags.test (test_flags::gamma));
+
+	flags.reset (test_flags::alpha);
+	ASSERT_FALSE (flags.test (test_flags::alpha));
+	ASSERT_TRUE (flags.test (test_flags::gamma));
+}
+
+TEST (enum_flags, operators)
+{
+	nano::enum_flags<test_flags> a{ test_flags::alpha };
+	nano::enum_flags<test_flags> b{ test_flags::beta };
+	auto combined = a | b;
+	ASSERT_TRUE (combined.test (test_flags::alpha));
+	ASSERT_TRUE (combined.test (test_flags::beta));
+	ASSERT_FALSE (combined.test (test_flags::gamma));
+
+	auto masked = combined & a;
+	ASSERT_TRUE (masked.test (test_flags::alpha));
+	ASSERT_FALSE (masked.test (test_flags::beta));
+}
+
+TEST (enum_flags, compound_assignment)
+{
+	nano::enum_flags<test_flags> flags;
+	flags |= test_flags::alpha;
+	flags |= test_flags::beta;
+	ASSERT_TRUE (flags.test (test_flags::alpha));
+	ASSERT_TRUE (flags.test (test_flags::beta));
+
+	flags &= test_flags::alpha;
+	ASSERT_TRUE (flags.test (test_flags::alpha));
+	ASSERT_FALSE (flags.test (test_flags::beta));
+}
+
+TEST (enum_flags, equality)
+{
+	nano::enum_flags<test_flags> a{ test_flags::alpha };
+	nano::enum_flags<test_flags> b{ test_flags::alpha };
+	nano::enum_flags<test_flags> c{ test_flags::beta };
+	ASSERT_EQ (a, b);
+	ASSERT_NE (a, c);
+}
+
+TEST (enum_flags, from_underlying)
+{
+	auto flags = nano::enum_flags<test_flags>::from_underlying (0x03); // alpha | beta
+	ASSERT_TRUE (flags.test (test_flags::alpha));
+	ASSERT_TRUE (flags.test (test_flags::beta));
+	ASSERT_FALSE (flags.test (test_flags::gamma));
+	ASSERT_EQ (flags.underlying (), 0x03);
+}
+
+TEST (enum_flags, to_string_none)
+{
+	nano::enum_flags<test_flags> flags;
+	ASSERT_EQ (to_string (flags), "<none>");
+}
+
+TEST (enum_flags, to_string_single)
+{
+	nano::enum_flags<test_flags> flags{ test_flags::beta };
+	ASSERT_EQ (to_string (flags), "beta");
+}
+
+TEST (enum_flags, to_string_multiple)
+{
+	nano::enum_flags<test_flags> flags;
+	flags.set (test_flags::alpha);
+	flags.set (test_flags::gamma);
+	ASSERT_EQ (to_string (flags), "alpha, gamma");
+}
+
+TEST (enum_flags, to_string_all)
+{
+	nano::enum_flags<test_flags> flags;
+	flags.set (test_flags::alpha);
+	flags.set (test_flags::beta);
+	flags.set (test_flags::gamma);
+	ASSERT_EQ (to_string (flags), "alpha, beta, gamma");
 }

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -786,7 +786,7 @@ TEST (message, node_id_handshake_response_serialization)
 	ASSERT_FALSE (error);
 	ASSERT_FALSE (message.query);
 	ASSERT_TRUE (message.response);
-	ASSERT_FALSE (message.response->v2);
+	ASSERT_TRUE (std::holds_alternative<std::monostate> (message.response->ext));
 
 	ASSERT_EQ (original.response->node_id, message.response->node_id);
 	ASSERT_EQ (original.response->signature, message.response->signature);
@@ -802,7 +802,7 @@ TEST (message, node_id_handshake_response_v2_serialization)
 	nano::messages::node_id_handshake::response_payload::v2_payload v2_pld{};
 	v2_pld.salt = 17;
 	v2_pld.genesis = nano::block_hash{ 13 };
-	response.v2 = v2_pld;
+	response.ext = v2_pld;
 
 	nano::messages::node_id_handshake original{ nano::dev::network_params.network, std::nullopt, response };
 
@@ -825,12 +825,63 @@ TEST (message, node_id_handshake_response_v2_serialization)
 	ASSERT_FALSE (error);
 	ASSERT_FALSE (message.query);
 	ASSERT_TRUE (message.response);
-	ASSERT_TRUE (message.response->v2);
+
+	auto * v2_orig = std::get_if<nano::messages::node_id_handshake::response_payload::v2_payload> (&original.response->ext);
+	auto * v2_msg = std::get_if<nano::messages::node_id_handshake::response_payload::v2_payload> (&message.response->ext);
+	ASSERT_TRUE (v2_orig);
+	ASSERT_TRUE (v2_msg);
 
 	ASSERT_EQ (original.response->node_id, message.response->node_id);
 	ASSERT_EQ (original.response->signature, message.response->signature);
-	ASSERT_EQ (original.response->v2->salt, message.response->v2->salt);
-	ASSERT_EQ (original.response->v2->genesis, message.response->v2->genesis);
+	ASSERT_EQ (v2_orig->salt, v2_msg->salt);
+	ASSERT_EQ (v2_orig->genesis, v2_msg->genesis);
+
+	ASSERT_TRUE (nano::at_end (stream));
+}
+
+TEST (message, node_id_handshake_response_v3_serialization)
+{
+	nano::messages::node_id_handshake::response_payload response{};
+	response.node_id = nano::account{ 7 };
+	response.signature = nano::signature{ 11 };
+	nano::messages::node_id_handshake::response_payload::v3_payload v3_pld{};
+	v3_pld.salt = 17;
+	v3_pld.genesis = nano::block_hash{ 13 };
+	v3_pld.flags = nano::node_capabilities_flags{ nano::node_capabilities::topo_index } | nano::node_capabilities::vote_storage;
+	response.ext = v3_pld;
+
+	nano::messages::node_id_handshake original{ nano::dev::network_params.network, std::nullopt, response };
+
+	// Serialize
+	std::vector<uint8_t> bytes;
+	{
+		nano::vectorstream stream{ bytes };
+		original.serialize (stream);
+	}
+	nano::bufferstream stream{ bytes.data (), bytes.size () };
+
+	// Header
+	bool error = false;
+	nano::messages::message_header header (error, stream);
+	ASSERT_FALSE (error);
+	ASSERT_EQ (nano::messages::message_type::node_id_handshake, header.type);
+
+	// Message
+	nano::messages::node_id_handshake message{ error, stream, header };
+	ASSERT_FALSE (error);
+	ASSERT_FALSE (message.query);
+	ASSERT_TRUE (message.response);
+
+	auto * v3_orig = std::get_if<nano::messages::node_id_handshake::response_payload::v3_payload> (&original.response->ext);
+	auto * v3_msg = std::get_if<nano::messages::node_id_handshake::response_payload::v3_payload> (&message.response->ext);
+	ASSERT_TRUE (v3_orig);
+	ASSERT_TRUE (v3_msg);
+
+	ASSERT_EQ (original.response->node_id, message.response->node_id);
+	ASSERT_EQ (original.response->signature, message.response->signature);
+	ASSERT_EQ (v3_orig->salt, v3_msg->salt);
+	ASSERT_EQ (v3_orig->genesis, v3_msg->genesis);
+	ASSERT_EQ (v3_orig->flags, v3_msg->flags);
 
 	ASSERT_TRUE (nano::at_end (stream));
 }
@@ -864,9 +915,10 @@ TEST (handshake, signature_v2)
 
 	nano::messages::node_id_handshake::response_payload original{};
 	original.node_id = node_id.pub;
-	original.v2 = nano::messages::node_id_handshake::response_payload::v2_payload{};
-	original.v2->genesis = nano::test::random_hash ();
-	original.v2->salt = nano::random_pool::generate<nano::uint256_union> ();
+	nano::messages::node_id_handshake::response_payload::v2_payload v2{};
+	v2.genesis = nano::test::random_hash ();
+	v2.salt = nano::random_pool::generate<nano::uint256_union> ();
+	original.ext = v2;
 	original.sign (cookie, node_id);
 	ASSERT_TRUE (original.validate (cookie));
 
@@ -885,7 +937,7 @@ TEST (handshake, signature_v2)
 	{
 		auto message = original;
 		ASSERT_TRUE (message.validate (cookie));
-		message.v2->genesis = nano::test::random_hash ();
+		std::get<nano::messages::node_id_handshake::response_payload::v2_payload> (message.ext).genesis = nano::test::random_hash ();
 		ASSERT_FALSE (message.validate (cookie));
 	}
 
@@ -893,7 +945,47 @@ TEST (handshake, signature_v2)
 	{
 		auto message = original;
 		ASSERT_TRUE (message.validate (cookie));
-		message.v2->salt = nano::random_pool::generate<nano::uint256_union> ();
+		std::get<nano::messages::node_id_handshake::response_payload::v2_payload> (message.ext).salt = nano::random_pool::generate<nano::uint256_union> ();
+		ASSERT_FALSE (message.validate (cookie));
+	}
+}
+
+TEST (handshake, signature_v3)
+{
+	nano::keypair node_id{};
+	auto cookie = nano::random_pool::generate<nano::uint256_union> ();
+
+	nano::messages::node_id_handshake::response_payload original{};
+	original.node_id = node_id.pub;
+	nano::messages::node_id_handshake::response_payload::v3_payload v3{};
+	v3.genesis = nano::test::random_hash ();
+	v3.salt = nano::random_pool::generate<nano::uint256_union> ();
+	v3.flags = nano::node_capabilities::topo_index;
+	original.ext = v3;
+	original.sign (cookie, node_id);
+	ASSERT_TRUE (original.validate (cookie));
+
+	// Mutate flags -> signature should fail
+	{
+		auto message = original;
+		ASSERT_TRUE (message.validate (cookie));
+		std::get<nano::messages::node_id_handshake::response_payload::v3_payload> (message.ext).flags = {};
+		ASSERT_FALSE (message.validate (cookie));
+	}
+
+	// Mutate genesis -> signature should fail
+	{
+		auto message = original;
+		ASSERT_TRUE (message.validate (cookie));
+		std::get<nano::messages::node_id_handshake::response_payload::v3_payload> (message.ext).genesis = nano::test::random_hash ();
+		ASSERT_FALSE (message.validate (cookie));
+	}
+
+	// Mutate reserved -> signature should fail
+	{
+		auto message = original;
+		ASSERT_TRUE (message.validate (cookie));
+		std::get<nano::messages::node_id_handshake::response_payload::v3_payload> (message.ext).reserved = 42;
 		ASSERT_FALSE (message.validate (cookie));
 	}
 }

--- a/nano/core_test/tcp_server.cpp
+++ b/nano/core_test/tcp_server.cpp
@@ -1,4 +1,5 @@
 #include <nano/crypto_lib/random_pool.hpp>
+#include <nano/lib/node_capabilities.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/transport/tcp_server.hpp>
 #include <nano/node/transport/tcp_socket.hpp>
@@ -196,7 +197,7 @@ TEST (tcp_server, handshake_self_connection_rejected)
 
 	nano::messages::node_id_handshake::response_payload response;
 	response.node_id = node->node_id.pub; // Use our own node ID
-	response.v2 = nano::messages::node_id_handshake::response_payload::v2_payload{
+	response.ext = nano::messages::node_id_handshake::response_payload::v2_payload{
 		nano::random_pool::generate<nano::uint256_union> (), // salt
 		node->network_params.ledger.genesis->hash () // genesis
 	};
@@ -366,4 +367,40 @@ TEST (tcp_server, handshake_wrong_network_id)
 	// Verify the handshake was aborted
 	ASSERT_TIMELY_EQ (5s, node->stats.count (nano::stat::type::tcp_server, nano::stat::detail::handshake_abort), 1);
 	ASSERT_TIMELY_EQ (5s, node->stats.count (nano::stat::type::tcp_server_message_error, nano::stat::detail::invalid_network), 1);
+}
+
+/*
+ * Verify that v3 handshake exchanges node capability flags between peers
+ */
+TEST (tcp_server, handshake_flags_exchanged)
+{
+	nano::test::system system;
+
+	nano::node_flags flags1;
+	flags1.capabilities_override = nano::node_capabilities_flags{ nano::node_capabilities::topo_index };
+	auto node1 = system.add_node (flags1);
+
+	nano::node_flags flags2;
+	flags2.capabilities_override = nano::node_capabilities_flags{ nano::node_capabilities::vote_storage };
+	auto node2 = system.add_node (flags2);
+
+	node1->network.merge_peer (node2->network.endpoint ());
+
+	ASSERT_TIMELY (10s, node1->network.find_node_id (node2->node_id.pub));
+	ASSERT_TIMELY (10s, node2->network.find_node_id (node1->node_id.pub));
+
+	// node1's channel to node2 should carry node2's capabilities (vote_storage)
+	auto chan1 = node1->network.find_node_id (node2->node_id.pub);
+	ASSERT_TRUE (chan1);
+	ASSERT_TRUE (chan1->get_flags ().test (nano::node_capabilities::vote_storage));
+	ASSERT_FALSE (chan1->get_flags ().test (nano::node_capabilities::topo_index));
+
+	// node2's channel to node1 should carry node1's capabilities (topo_index)
+	auto chan2 = node2->network.find_node_id (node1->node_id.pub);
+	ASSERT_TRUE (chan2);
+	ASSERT_TRUE (chan2->get_flags ().test (nano::node_capabilities::topo_index));
+	ASSERT_FALSE (chan2->get_flags ().test (nano::node_capabilities::vote_storage));
+
+	ASSERT_EQ (node1->stats.count (nano::stat::type::tcp_server, nano::stat::detail::handshake_abort), 0);
+	ASSERT_EQ (node2->stats.count (nano::stat::type::tcp_server, nano::stat::detail::handshake_abort), 0);
 }

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -93,6 +93,8 @@ add_library(
   network_filter.cpp
   networks.hpp
   networks.cpp
+  node_capabilities.hpp
+  node_capabilities.cpp
   numbers.hpp
   numbers.cpp
   numbers_templ.hpp

--- a/nano/lib/CMakeLists.txt
+++ b/nano/lib/CMakeLists.txt
@@ -52,6 +52,9 @@ add_library(
   constants.cpp
   container_info.hpp
   container_info.cpp
+  enum_flags.hpp
+  enum_flags_templ.hpp
+  enum_util.hpp
   env.hpp
   env.cpp
   epoch.hpp

--- a/nano/lib/enum_flags.hpp
+++ b/nano/lib/enum_flags.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+#include <iosfwd>
+#include <string>
+#include <type_traits>
+
+namespace nano
+{
+template <typename E>
+class enum_flags;
+
+template <typename E>
+std::ostream & operator<< (std::ostream &, enum_flags<E> const &);
+
+template <typename E>
+std::string to_string (enum_flags<E> const &);
+
+/**
+ * Type-safe wrapper for flag enums (bitfields)
+ * Provides a std::bitset-like API
+ * The underlying enum should define power-of-2 values (1 << 0, 1 << 1, etc.) and a zero value
+ * Stream operator and to_string definitions are in enum_flags_templ.hpp
+ */
+template <typename E>
+class enum_flags
+{
+public:
+	using underlying_t = std::underlying_type_t<E>;
+
+	constexpr enum_flags () = default;
+	constexpr enum_flags (E flag) :
+		value{ static_cast<underlying_t> (flag) }
+	{
+		check_layout ();
+	}
+
+	static constexpr enum_flags from_underlying (underlying_t v)
+	{
+		enum_flags f;
+		f.value = v;
+		return f;
+	}
+
+	bool test (E flag) const
+	{
+		return (value & static_cast<underlying_t> (flag)) != 0;
+	}
+
+	enum_flags & set (E flag)
+	{
+		value |= static_cast<underlying_t> (flag);
+		return *this;
+	}
+
+	enum_flags & reset (E flag)
+	{
+		value &= ~static_cast<underlying_t> (flag);
+		return *this;
+	}
+
+	bool any () const
+	{
+		return value != 0;
+	}
+
+	bool none () const
+	{
+		return value == 0;
+	}
+
+	enum_flags operator| (enum_flags other) const
+	{
+		return from_underlying (value | other.value);
+	}
+
+	enum_flags operator& (enum_flags other) const
+	{
+		return from_underlying (value & other.value);
+	}
+
+	enum_flags & operator|= (enum_flags other)
+	{
+		value |= other.value;
+		return *this;
+	}
+
+	enum_flags & operator&= (enum_flags other)
+	{
+		value &= other.value;
+		return *this;
+	}
+
+	bool operator== (enum_flags other) const
+	{
+		return value == other.value;
+	}
+
+	bool operator!= (enum_flags other) const
+	{
+		return value != other.value;
+	}
+
+	explicit operator bool () const
+	{
+		return any ();
+	}
+
+	underlying_t const & underlying () const
+	{
+		return value;
+	}
+
+	underlying_t & underlying ()
+	{
+		return value;
+	}
+
+private:
+	underlying_t value{ 0 };
+
+	static constexpr void check_layout ()
+	{
+		static_assert (std::is_standard_layout_v<enum_flags>, "Standard layout required for safe underlying type punning");
+		static_assert (std::is_trivially_copyable_v<enum_flags>, "Trivially copyable required for safe underlying type punning");
+		static_assert (sizeof (enum_flags) == sizeof (underlying_t), "Size of enum_flags must be the same as underlying type");
+	}
+};
+}

--- a/nano/lib/enum_flags_templ.hpp
+++ b/nano/lib/enum_flags_templ.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <nano/lib/enum_flags.hpp>
+
+#include <ostream>
+#include <sstream>
+#include <string>
+
+#include <magic_enum.hpp>
+
+namespace nano
+{
+template <typename E>
+std::ostream & operator<< (std::ostream & os, enum_flags<E> const & flags)
+{
+	using underlying_t = typename enum_flags<E>::underlying_t;
+	underlying_t known_bits = 0;
+	bool first = true;
+	// Print names of all known set flags
+	for (auto val : magic_enum::enum_values<E> ())
+	{
+		auto bit = static_cast<underlying_t> (val);
+		if (bit == 0)
+		{
+			continue; // Skip the zero/none value
+		}
+		known_bits |= bit;
+		if (flags.test (val))
+		{
+			if (!first)
+			{
+				os << ", ";
+			}
+			os << magic_enum::enum_name (val);
+			first = false;
+		}
+	}
+	// Print any bits not covered by known enum values (e.g. from a newer peer)
+	auto unknown = flags.underlying () & ~known_bits;
+	if (unknown)
+	{
+		if (!first)
+		{
+			os << ", ";
+		}
+		os << "unknown(0x" << std::hex << unknown << std::dec << ")";
+		first = false;
+	}
+	if (first)
+	{
+		os << "<none>";
+	}
+	return os;
+}
+
+template <typename E>
+std::string to_string (enum_flags<E> const & flags)
+{
+	std::ostringstream ss;
+	ss << flags;
+	return ss.str ();
+}
+}

--- a/nano/lib/node_capabilities.cpp
+++ b/nano/lib/node_capabilities.cpp
@@ -1,0 +1,11 @@
+#include <nano/lib/enum_flags_templ.hpp>
+#include <nano/lib/enum_util.hpp>
+#include <nano/lib/node_capabilities.hpp>
+
+std::string_view nano::to_string (nano::node_capabilities value)
+{
+	return nano::enum_to_string (value);
+}
+
+template std::ostream & nano::operator<< <nano::node_capabilities> (std::ostream &, nano::node_capabilities_flags const &);
+template std::string nano::to_string<nano::node_capabilities> (nano::node_capabilities_flags const &);

--- a/nano/lib/node_capabilities.hpp
+++ b/nano/lib/node_capabilities.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <nano/lib/enum_flags.hpp>
+
+#include <cstdint>
+#include <string_view>
+
+namespace nano
+{
+enum class node_capabilities : uint64_t
+{
+	none = 0,
+	topo_index = 1ULL << 0,
+	vote_storage = 1ULL << 1,
+};
+
+std::string_view to_string (node_capabilities);
+
+using node_capabilities_flags = nano::enum_flags<node_capabilities>;
+}

--- a/nano/lib/utility.hpp
+++ b/nano/lib/utility.hpp
@@ -26,6 +26,15 @@ namespace program_options
 
 namespace nano
 {
+// Helper for std::visit with multiple lambdas
+template <class... Ts>
+struct overloaded : Ts...
+{
+	using Ts::operator()...;
+};
+template <class... Ts>
+overloaded (Ts...) -> overloaded<Ts...>;
+
 // Lower priority of calling work generating thread
 void work_thread_reprioritize ();
 

--- a/nano/messages/node_id_handshake.cpp
+++ b/nano/messages/node_id_handshake.cpp
@@ -26,11 +26,24 @@ node_id_handshake::node_id_handshake (nano::network_constants const & constants,
 	{
 		header.flag_set (query_flag);
 		header.flag_set (v2_flag); // Always indicate support for V2 handshake when querying, old peers will just ignore it
+		header.flag_set (v3_flag); // Always indicate support for V3 handshake when querying, old peers will just ignore it
 	}
 	if (response)
 	{
 		header.flag_set (response_flag);
-		header.flag_set (v2_flag, response->v2.has_value ()); // We only use V2 handshake when replying to peers that indicated support for it
+		// Response version takes precedence over query version flags
+		header.flag_set (v2_flag, false);
+		header.flag_set (v3_flag, false);
+		std::visit (nano::overloaded{
+					[&] (response_payload::v3_payload const &) {
+						header.flag_set (v3_flag);
+					},
+					[&] (response_payload::v2_payload const &) {
+						header.flag_set (v2_flag);
+					},
+					[] (std::monostate) {},
+					},
+		response->ext);
 	}
 }
 
@@ -88,16 +101,23 @@ bool node_id_handshake::is_response (message_header const & header)
 	return result;
 }
 
-bool node_id_handshake::is_v2 (message_header const & header)
+handshake_version node_id_handshake::version (message_header const & header)
 {
 	debug_assert (header.type == message_type::node_id_handshake);
-	bool result = header.extensions.test (v2_flag);
-	return result;
+	if (header.extensions.test (v3_flag))
+	{
+		return handshake_version::v3;
+	}
+	if (header.extensions.test (v2_flag))
+	{
+		return handshake_version::v2;
+	}
+	return handshake_version::v1;
 }
 
-bool node_id_handshake::is_v2 () const
+handshake_version node_id_handshake::version () const
 {
-	return is_v2 (header);
+	return version (header);
 }
 
 void node_id_handshake::visit (message_visitor & visitor_a) const
@@ -157,42 +177,65 @@ void node_id_handshake::query_payload::operator() (nano::object_stream & obs) co
 
 void node_id_handshake::response_payload::serialize (nano::stream & stream) const
 {
-	if (v2)
-	{
-		nano::write (stream, node_id);
-		nano::write (stream, v2->salt);
-		nano::write (stream, v2->genesis);
-		nano::write (stream, signature);
-	}
-	// TODO: Remove legacy handshake
-	else
-	{
-		nano::write (stream, node_id);
-		nano::write (stream, signature);
-	}
+	nano::write (stream, node_id);
+	std::visit (nano::overloaded{
+				[&] (v3_payload const & p) {
+					nano::write (stream, p.salt);
+					nano::write (stream, p.genesis);
+					nano::write_big_endian (stream, p.flags.underlying ());
+					nano::write_big_endian (stream, p.reserved);
+				},
+				[&] (v2_payload const & p) {
+					nano::write (stream, p.salt);
+					nano::write (stream, p.genesis);
+				},
+				[] (std::monostate) {},
+				},
+	ext);
+	nano::write (stream, signature);
 }
 
 void node_id_handshake::response_payload::deserialize (nano::stream & stream, message_header const & header)
 {
-	if (is_v2 (header))
+	nano::read (stream, node_id);
+	switch (version (header))
 	{
-		nano::read (stream, node_id);
-		v2_payload pld{};
-		nano::read (stream, pld.salt);
-		nano::read (stream, pld.genesis);
-		v2 = pld;
-		nano::read (stream, signature);
+		case handshake_version::v3:
+		{
+			v3_payload pld{};
+			nano::read (stream, pld.salt);
+			nano::read (stream, pld.genesis);
+			nano::read_big_endian (stream, pld.flags.underlying ());
+			nano::read_big_endian (stream, pld.reserved);
+			ext = pld;
+		}
+		break;
+		case handshake_version::v2:
+		{
+			v2_payload pld{};
+			nano::read (stream, pld.salt);
+			nano::read (stream, pld.genesis);
+			ext = pld;
+		}
+		break;
+		case handshake_version::v1:
+			break;
 	}
-	else
-	{
-		nano::read (stream, node_id);
-		nano::read (stream, signature);
-	}
+	nano::read (stream, signature);
 }
 
 std::size_t node_id_handshake::response_payload::size (const message_header & header)
 {
-	return is_v2 (header) ? size_v2 : size_v1;
+	switch (node_id_handshake::version (header))
+	{
+		case handshake_version::v3:
+			return size_v3;
+		case handshake_version::v2:
+			return size_v2;
+		case handshake_version::v1:
+			return size_v1;
+	}
+	return size_v1;
 }
 
 std::vector<uint8_t> node_id_handshake::response_payload::data_to_sign (const nano::uint256_union & cookie) const
@@ -200,20 +243,43 @@ std::vector<uint8_t> node_id_handshake::response_payload::data_to_sign (const na
 	std::vector<uint8_t> bytes;
 	{
 		nano::vectorstream stream{ bytes };
+		nano::write (stream, cookie);
 
-		if (v2)
-		{
-			nano::write (stream, cookie);
-			nano::write (stream, v2->salt);
-			nano::write (stream, v2->genesis);
-		}
-		// TODO: Remove legacy handshake
-		else
-		{
-			nano::write (stream, cookie);
-		}
+		std::visit (nano::overloaded{
+					[&] (v3_payload const & p) {
+						nano::write (stream, p.salt);
+						nano::write (stream, p.genesis);
+						nano::write_big_endian (stream, p.flags.underlying ());
+						nano::write_big_endian (stream, p.reserved);
+					},
+					[&] (v2_payload const & p) {
+						nano::write (stream, p.salt);
+						nano::write (stream, p.genesis);
+					},
+					[] (std::monostate) {},
+					},
+		ext);
 	}
 	return bytes;
+}
+
+std::optional<nano::block_hash> node_id_handshake::response_payload::genesis () const
+{
+	return std::visit (nano::overloaded{
+					   [] (v3_payload const & p) -> std::optional<nano::block_hash> { return p.genesis; },
+					   [] (v2_payload const & p) -> std::optional<nano::block_hash> { return p.genesis; },
+					   [] (std::monostate) -> std::optional<nano::block_hash> { return std::nullopt; },
+					   },
+	ext);
+}
+
+nano::node_capabilities_flags node_id_handshake::response_payload::flags () const
+{
+	return std::visit (nano::overloaded{
+					   [] (v3_payload const & p) -> nano::node_capabilities_flags { return p.flags; },
+					   [] (auto const &) -> nano::node_capabilities_flags { return {}; },
+					   },
+	ext);
 }
 
 void node_id_handshake::response_payload::sign (const nano::uint256_union & cookie, nano::keypair const & key)
@@ -239,11 +305,22 @@ void node_id_handshake::response_payload::operator() (nano::object_stream & obs)
 	obs.write ("node_id", node_id);
 	obs.write ("signature", signature);
 
-	obs.write ("v2", v2.has_value ());
-	if (v2)
-	{
-		obs.write ("salt", v2->salt);
-		obs.write ("genesis", v2->genesis);
-	}
+	std::visit (nano::overloaded{
+				[&] (v3_payload const & p) {
+					obs.write ("version", 3);
+					obs.write ("salt", p.salt);
+					obs.write ("genesis", p.genesis);
+					obs.write ("capabilities", p.flags);
+				},
+				[&] (v2_payload const & p) {
+					obs.write ("version", 2);
+					obs.write ("salt", p.salt);
+					obs.write ("genesis", p.genesis);
+				},
+				[&] (std::monostate) {
+					obs.write ("version", 1);
+				},
+				},
+	ext);
 }
 }

--- a/nano/messages/node_id_handshake.hpp
+++ b/nano/messages/node_id_handshake.hpp
@@ -1,14 +1,23 @@
 #pragma once
 
 #include <nano/lib/keypair.hpp>
+#include <nano/lib/node_capabilities.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/messages/message.hpp>
 
 #include <optional>
+#include <variant>
 #include <vector>
 
 namespace nano::messages
 {
+enum class handshake_version
+{
+	v1,
+	v2,
+	v3,
+};
+
 class node_id_handshake final : public message
 {
 public: // Payload definitions
@@ -46,14 +55,27 @@ public: // Payload definitions
 			nano::block_hash genesis;
 		};
 
+		struct v3_payload
+		{
+			nano::uint256_union salt;
+			nano::block_hash genesis;
+			nano::node_capabilities_flags flags;
+			uint64_t reserved{ 0 }; // Reserved for future use
+		};
+
 	public:
 		nano::account node_id;
 		nano::signature signature;
-		std::optional<v2_payload> v2;
+		std::variant<std::monostate, v2_payload, v3_payload> ext;
+
+	public: // Accessors
+		std::optional<nano::block_hash> genesis () const;
+		nano::node_capabilities_flags flags () const;
 
 	public:
 		static std::size_t constexpr size_v1 = sizeof (nano::account) + sizeof (nano::signature);
 		static std::size_t constexpr size_v2 = sizeof (nano::account) + sizeof (nano::signature) + sizeof (v2_payload);
+		static std::size_t constexpr size_v3 = sizeof (nano::account) + sizeof (nano::signature) + sizeof (v3_payload);
 		static std::size_t size (message_header const &);
 
 	public: // Logging
@@ -75,11 +97,12 @@ public: // Header
 	static uint8_t constexpr query_flag = 0;
 	static uint8_t constexpr response_flag = 1;
 	static uint8_t constexpr v2_flag = 2;
+	static uint8_t constexpr v3_flag = 3;
 
 	static bool is_query (message_header const &);
 	static bool is_response (message_header const &);
-	static bool is_v2 (message_header const &);
-	bool is_v2 () const;
+	static handshake_version version (message_header const &);
+	handshake_version version () const;
 
 public: // Payload
 	std::optional<query_payload> query;

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -644,7 +644,8 @@ bool nano::network::verify_handshake_response (const nano::messages::node_id_han
 	}
 
 	// Prevent mismatched genesis
-	if (response.v2 && response.v2->genesis != node.network_params.ledger.genesis->hash ())
+	auto genesis = response.genesis ();
+	if (genesis && *genesis != node.network_params.ledger.genesis->hash ())
 	{
 		node.stats.inc (nano::stat::type::handshake, nano::stat::detail::invalid_genesis);
 		return false; // Fail
@@ -677,16 +678,34 @@ std::optional<nano::messages::node_id_handshake::query_payload> nano::network::p
 	return std::nullopt;
 }
 
-nano::messages::node_id_handshake::response_payload nano::network::prepare_handshake_response (const nano::messages::node_id_handshake::query_payload & query, bool v2) const
+nano::messages::node_id_handshake::response_payload nano::network::prepare_handshake_response (const nano::messages::node_id_handshake::query_payload & query, nano::messages::handshake_version version) const
 {
-	nano::messages::node_id_handshake::response_payload response{};
+	using handshake_version = nano::messages::handshake_version;
+	using response_payload = nano::messages::node_id_handshake::response_payload;
+
+	response_payload response{};
 	response.node_id = node.node_id.pub;
-	if (v2)
+	switch (version)
 	{
-		nano::messages::node_id_handshake::response_payload::v2_payload response_v2{};
-		response_v2.salt = nano::random_pool::generate<uint256_union> ();
-		response_v2.genesis = node.network_params.ledger.genesis->hash ();
-		response.v2 = response_v2;
+		case handshake_version::v3:
+		{
+			response_payload::v3_payload v3{};
+			v3.salt = nano::random_pool::generate<uint256_union> ();
+			v3.genesis = node.network_params.ledger.genesis->hash ();
+			v3.flags = node.get_capabilities ();
+			response.ext = v3;
+			break;
+		}
+		case handshake_version::v2:
+		{
+			response_payload::v2_payload v2{};
+			v2.salt = nano::random_pool::generate<uint256_union> ();
+			v2.genesis = node.network_params.ledger.genesis->hash ();
+			response.ext = v2;
+			break;
+		}
+		case handshake_version::v1:
+			break;
 	}
 	response.sign (query.cookie, node.node_id);
 	return response;

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -168,7 +168,7 @@ public: // Handshake
 	/** Verifies that handshake response matches our query. @returns true if OK */
 	bool verify_handshake_response (nano::messages::node_id_handshake::response_payload const & response, nano::endpoint const & remote_endpoint);
 	std::optional<nano::messages::node_id_handshake::query_payload> prepare_handshake_query (nano::endpoint const & remote_endpoint);
-	nano::messages::node_id_handshake::response_payload prepare_handshake_response (nano::messages::node_id_handshake::query_payload const & query, bool v2) const;
+	nano::messages::node_id_handshake::response_payload prepare_handshake_response (nano::messages::node_id_handshake::query_payload const & query, nano::messages::handshake_version version) const;
 
 private:
 	void run_cleanup ();

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -878,6 +878,17 @@ int nano::node::store_version ()
 	return store.version.get (transaction);
 }
 
+nano::node_capabilities_flags nano::node::get_capabilities () const
+{
+	if (flags.capabilities_override)
+	{
+		return *flags.capabilities_override;
+	}
+	// TODO: Set capabilities flags based on node configuration and state
+	nano::node_capabilities_flags caps;
+	return caps;
+}
+
 nano::bootstrap_weights nano::node::get_bootstrap_weights () const
 {
 	return nano::get_bootstrap_weights (network_params.network.current_network);

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -89,6 +89,7 @@ public:
 	void bootstrap_block (nano::block_hash const &);
 
 	nano::account get_node_id () const;
+	nano::node_capabilities_flags get_capabilities () const;
 	nano::messages::telemetry_data local_telemetry () const;
 	std::string identifier () const;
 

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -4,6 +4,7 @@
 #include <nano/lib/errors.hpp>
 #include <nano/lib/lmdbconfig.hpp>
 #include <nano/lib/logging.hpp>
+#include <nano/lib/node_capabilities.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/rocksdbconfig.hpp>
 #include <nano/lib/stats.hpp>
@@ -204,5 +205,6 @@ public:
 	std::size_t block_processor_verification_size{ 0 };
 	std::size_t vote_processor_capacity{ 144 * 1024 };
 	std::size_t bootstrap_interval{ 0 }; // For testing only
+	std::optional<nano::node_capabilities_flags> capabilities_override; // For testing only
 };
 }

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/locks.hpp>
+#include <nano/lib/node_capabilities.hpp>
 #include <nano/lib/object_stream.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/messages/messages.hpp>
@@ -108,6 +109,17 @@ public:
 		network_version = network_version_a;
 	}
 
+	nano::node_capabilities_flags get_flags () const
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		return flags;
+	}
+	void set_flags (nano::node_capabilities_flags value)
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		flags = value;
+	}
+
 	nano::endpoint get_peering_endpoint () const;
 	void set_peering_endpoint (nano::endpoint endpoint);
 
@@ -129,6 +141,7 @@ private:
 	std::chrono::steady_clock::time_point last_packet_sent{ std::chrono::steady_clock::now () };
 	std::optional<nano::account> node_id{};
 	std::atomic<uint8_t> network_version{ 0 };
+	nano::node_capabilities_flags flags;
 	std::optional<nano::endpoint> peering_endpoint{};
 	std::optional<nano::messages::keepalive> last_keepalive{};
 

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -86,7 +86,7 @@ bool nano::transport::tcp_channels::check (const nano::tcp_endpoint & endpoint, 
 	return true; // OK
 }
 
-std::shared_ptr<nano::transport::tcp_channel> nano::transport::tcp_channels::create (const std::shared_ptr<nano::transport::tcp_socket> & socket, const std::shared_ptr<nano::transport::tcp_server> & server, const nano::account & node_id)
+std::shared_ptr<nano::transport::tcp_channel> nano::transport::tcp_channels::create (const std::shared_ptr<nano::transport::tcp_socket> & socket, const std::shared_ptr<nano::transport::tcp_server> & server, const nano::account & node_id, nano::node_capabilities_flags flags)
 {
 	auto const endpoint = socket->get_remote_endpoint ();
 	debug_assert (endpoint.address ().is_v6 ());
@@ -116,6 +116,7 @@ std::shared_ptr<nano::transport::tcp_channel> nano::transport::tcp_channels::cre
 	// This should be the only place in node where channels are created
 	auto channel = std::make_shared<nano::transport::tcp_channel> (node, socket);
 	channel->set_node_id (node_id);
+	channel->set_flags (flags);
 
 	attempts.get<endpoint_tag> ().erase (endpoint);
 

--- a/nano/node/transport/tcp_channels.hpp
+++ b/nano/node/transport/tcp_channels.hpp
@@ -36,7 +36,7 @@ public:
 	void start ();
 	void stop ();
 
-	std::shared_ptr<nano::transport::tcp_channel> create (std::shared_ptr<nano::transport::tcp_socket> const &, std::shared_ptr<nano::transport::tcp_server> const &, nano::account const & node_id);
+	std::shared_ptr<nano::transport::tcp_channel> create (std::shared_ptr<nano::transport::tcp_socket> const &, std::shared_ptr<nano::transport::tcp_server> const &, nano::account const & node_id, nano::node_capabilities_flags = {});
 	void erase (nano::tcp_endpoint const &);
 	std::size_t size () const;
 	std::shared_ptr<nano::transport::tcp_channel> find_channel (nano::tcp_endpoint const &) const;

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -335,14 +335,14 @@ auto nano::transport::tcp_server::process_handshake (nano::messages::node_id_han
 	if (message.query)
 	{
 		// Sends response + our own query
-		co_await send_handshake_response (*message.query, message.is_v2 ());
+		co_await send_handshake_response (*message.query, message.version ());
 		// Fall through and continue handshake
 	}
 	if (message.response)
 	{
 		if (node.network.verify_handshake_response (*message.response, get_remote_endpoint ()))
 		{
-			bool success = to_realtime_connection (message.response->node_id);
+			bool success = to_realtime_connection (message.response->node_id, message.response->flags ());
 			if (success)
 			{
 				co_return handshake_status::realtime; // Switched to realtime
@@ -392,9 +392,9 @@ auto nano::transport::tcp_server::send_handshake_request () -> asio::awaitable<v
 	}
 }
 
-auto nano::transport::tcp_server::send_handshake_response (nano::messages::node_id_handshake::query_payload const & query, bool v2) -> asio::awaitable<void>
+auto nano::transport::tcp_server::send_handshake_response (nano::messages::node_id_handshake::query_payload const & query, nano::messages::handshake_version version) -> asio::awaitable<void>
 {
-	auto response = node.network.prepare_handshake_response (query, v2);
+	auto response = node.network.prepare_handshake_response (query, version);
 	auto own_query = node.network.prepare_handshake_query (get_remote_endpoint ());
 	nano::messages::node_id_handshake handshake_response{ node.network_params.network, own_query, response };
 
@@ -493,7 +493,7 @@ bool nano::transport::tcp_server::to_bootstrap_connection ()
 	return true;
 }
 
-bool nano::transport::tcp_server::to_realtime_connection (nano::account const & node_id)
+bool nano::transport::tcp_server::to_realtime_connection (nano::account const & node_id, nano::node_capabilities_flags flags)
 {
 	if (node.flags.disable_tcp_realtime)
 	{
@@ -504,7 +504,7 @@ bool nano::transport::tcp_server::to_realtime_connection (nano::account const & 
 		return false;
 	}
 
-	auto channel_l = node.network.tcp_channels.create (socket, shared_from_this (), node_id);
+	auto channel_l = node.network.tcp_channels.create (socket, shared_from_this (), node_id, flags);
 	if (!channel_l)
 	{
 		return false;

--- a/nano/node/transport/tcp_server.hpp
+++ b/nano/node/transport/tcp_server.hpp
@@ -57,7 +57,7 @@ private:
 	asio::awaitable<nano::buffer_view> read_socket (size_t size) const;
 
 	asio::awaitable<handshake_status> process_handshake (nano::messages::node_id_handshake const & message);
-	asio::awaitable<void> send_handshake_response (nano::messages::node_id_handshake::query_payload const & query, bool v2);
+	asio::awaitable<void> send_handshake_response (nano::messages::node_id_handshake::query_payload const & query, nano::messages::handshake_version version);
 	asio::awaitable<void> send_handshake_request ();
 
 private:
@@ -76,7 +76,7 @@ private:
 
 private:
 	bool to_bootstrap_connection ();
-	bool to_realtime_connection (nano::account const & node_id);
+	bool to_realtime_connection (nano::account const & node_id, nano::node_capabilities_flags flags);
 
 private: // Visitors
 	class realtime_message_visitor : public nano::messages::message_visitor


### PR DESCRIPTION
This introduces a V3 node ID handshake that allows nodes to advertise optional capabilities to their peers.
                                                                                                                                                                                  
### Motivation                                                                                                                                                                   
                                                                                                                                                                                  
This is building toward a network of specialized nodes: nodes that opt into providing additional services beyond standard consensus participation. For example, a node with `topo_index` capability can serve topologically ordered block data, enabling dramatically faster bootstrapping for peers. A node with `vote_storage` can relay historical vote data, helping peers that fall behind to catch up quickly without re-requesting votes from representatives.                                                                      
                                                                                                                                                                                  
By advertising these capabilities during the handshake, peers can discover which nodes offer which services and route requests accordingly.