### PR TITLE
Extract vote eligibility logic into voting_policy

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -82,6 +82,7 @@ add_executable(
   unchecked_map.cpp
   utility.cpp
   vote_cache.cpp
+  voting_policy.cpp
   vote_processor.cpp
   vote_rebroadcaster.cpp
   voting.cpp

--- a/nano/core_test/voting_policy.cpp
+++ b/nano/core_test/voting_policy.cpp
@@ -1,0 +1,1458 @@
+#include <nano/lib/blocks.hpp>
+#include <nano/lib/files.hpp>
+#include <nano/lib/vote.hpp>
+#include <nano/node/make_store.hpp>
+#include <nano/secure/ledger.hpp>
+#include <nano/secure/ledger_set_any.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
+#include <nano/secure/voting_policy.hpp>
+#include <nano/store/ledger/final_vote.hpp>
+#include <nano/test_common/ledger_context.hpp>
+#include <nano/test_common/testutil.hpp>
+
+#include <gtest/gtest.h>
+
+/*
+ * vote_normal
+ */
+
+// Genesis block has zero dependencies — always eligible
+TEST (voting_policy, vote_normal_genesis)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	nano::voting_policy policy{ ledger };
+
+	auto txn = ledger.tx_begin_read ();
+	auto result = policy.vote_normal (txn, *nano::dev::genesis);
+	ASSERT_TRUE (result);
+	ASSERT_EQ (result->qualified_root (), nano::dev::genesis->qualified_root ());
+	ASSERT_EQ (result->hash (), nano::dev::genesis->hash ());
+	ASSERT_EQ (result->type (), nano::vote_type::normal);
+}
+
+// Send from genesis — previous (genesis) is cemented at init
+TEST (voting_policy, vote_normal_send)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (ledger.tx_begin_write (), send1));
+
+	auto txn = ledger.tx_begin_read ();
+	auto result = policy.vote_normal (txn, *send1);
+	ASSERT_TRUE (result);
+	ASSERT_EQ (result->qualified_root (), send1->qualified_root ());
+	ASSERT_EQ (result->hash (), send1->hash ());
+	ASSERT_EQ (result->type (), nano::vote_type::normal);
+}
+
+// Second send fails — previous (send1) is not cemented
+TEST (voting_policy, vote_normal_send_previous_not_cemented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto send2 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 200)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send2));
+
+	ASSERT_FALSE (policy.vote_normal (txn, *send2));
+	ASSERT_FALSE (policy.vote_final (txn, *send2));
+	ASSERT_FALSE (policy.reply_final (txn, *send2));
+}
+
+// Open block receiving from uncemented send — source dependency not met
+TEST (voting_policy, vote_normal_open_source_not_cemented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto open1 = builder.state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (100)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, open1));
+
+	// send1 is not cemented so open1's source dependency fails
+	ASSERT_FALSE (policy.vote_normal (txn, *open1));
+	ASSERT_FALSE (policy.vote_final (txn, *open1));
+	ASSERT_FALSE (policy.reply_final (txn, *open1));
+}
+
+// Open block receiving from cemented send — previous is zero (trivial), source cemented
+TEST (voting_policy, vote_normal_open_source_cemented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto open1 = builder.state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (100)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ledger.cement (txn, send1->hash ());
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, open1));
+
+	auto result = policy.vote_normal (txn, *open1);
+	ASSERT_TRUE (result);
+	ASSERT_EQ (result->qualified_root (), open1->qualified_root ());
+	ASSERT_EQ (result->hash (), open1->hash ());
+}
+
+// Receive where previous is cemented but source send is not
+TEST (voting_policy, vote_normal_receive_previous_cemented_source_not)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	// send1 to key1 — cement it so open1 can be cemented
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	// send2 to key1 — do NOT cement
+	auto send2 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 200)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	// open1 for key1 receiving send1
+	auto open1 = builder.state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (100)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	// receive2 on key1 receiving send2 (previous=open1, source=send2)
+	auto receive2 = builder.state ()
+					.account (key1.pub)
+					.previous (open1->hash ())
+					.representative (nano::dev::genesis_key.pub)
+					.balance (200)
+					.link (send2->hash ())
+					.sign (key1.prv, key1.pub)
+					.work (*pool.generate (open1->hash ()))
+					.build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ledger.cement (txn, send1->hash ());
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send2));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, open1));
+	ledger.cement (txn, open1->hash ());
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, receive2));
+
+	// previous (open1) is cemented, but source (send2) is not
+	ASSERT_FALSE (policy.vote_normal (txn, *receive2));
+	ASSERT_FALSE (policy.vote_final (txn, *receive2));
+	ASSERT_FALSE (policy.reply_final (txn, *receive2));
+}
+
+// Receive where source is cemented but previous is not
+TEST (voting_policy, vote_normal_receive_source_cemented_previous_not)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	// Two sends from genesis
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto send2 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 200)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	// open1 for key1 receiving send1 — do NOT cement
+	auto open1 = builder.state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (100)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	// receive2 on key1 receiving send2
+	auto receive2 = builder.state ()
+					.account (key1.pub)
+					.previous (open1->hash ())
+					.representative (nano::dev::genesis_key.pub)
+					.balance (200)
+					.link (send2->hash ())
+					.sign (key1.prv, key1.pub)
+					.work (*pool.generate (open1->hash ()))
+					.build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send2));
+	ledger.cement (txn, send2->hash ()); // cements send1 and send2
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, open1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, receive2));
+
+	// source (send2) is cemented, but previous (open1) is not
+	ASSERT_FALSE (policy.vote_normal (txn, *receive2));
+	ASSERT_FALSE (policy.vote_final (txn, *receive2));
+	ASSERT_FALSE (policy.reply_final (txn, *receive2));
+}
+
+// Receive with both previous and source cemented — eligible
+TEST (voting_policy, vote_normal_receive_both_cemented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto send2 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 200)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	auto open1 = builder.state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (100)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	auto receive2 = builder.state ()
+					.account (key1.pub)
+					.previous (open1->hash ())
+					.representative (nano::dev::genesis_key.pub)
+					.balance (200)
+					.link (send2->hash ())
+					.sign (key1.prv, key1.pub)
+					.work (*pool.generate (open1->hash ()))
+					.build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send2));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, open1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, receive2));
+
+	// Cement all dependencies
+	ledger.cement (txn, send2->hash ()); // cements genesis, send1, send2
+	ledger.cement (txn, open1->hash ()); // cements open1
+
+	auto result = policy.vote_normal (txn, *receive2);
+	ASSERT_TRUE (result);
+	ASSERT_EQ (result->hash (), receive2->hash ());
+}
+
+// Change block with cemented previous — eligible (no source dependency)
+TEST (voting_policy, vote_normal_change_cemented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair new_rep;
+	nano::block_builder builder;
+
+	auto change1 = builder.state ()
+				   .account (nano::dev::genesis_key.pub)
+				   .previous (nano::dev::genesis->hash ())
+				   .representative (new_rep.pub)
+				   .balance (nano::dev::constants.genesis_amount)
+				   .link (0)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (nano::dev::genesis->hash ()))
+				   .build ();
+
+	ASSERT_EQ (nano::block_status::progress, ledger.process (ledger.tx_begin_write (), change1));
+
+	auto txn = ledger.tx_begin_read ();
+	auto result = policy.vote_normal (txn, *change1);
+	ASSERT_TRUE (result);
+	ASSERT_EQ (result->hash (), change1->hash ());
+}
+
+// Change block with uncemented previous — not eligible
+TEST (voting_policy, vote_normal_change_not_cemented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1, new_rep;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto change1 = builder.state ()
+				   .account (nano::dev::genesis_key.pub)
+				   .previous (send1->hash ())
+				   .representative (new_rep.pub)
+				   .balance (nano::dev::constants.genesis_amount - 100)
+				   .link (0)
+				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				   .work (*pool.generate (send1->hash ()))
+				   .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, change1));
+
+	// send1 not cemented, so change1 fails
+	ASSERT_FALSE (policy.vote_normal (txn, *change1));
+	ASSERT_FALSE (policy.vote_final (txn, *change1));
+	ASSERT_FALSE (policy.reply_final (txn, *change1));
+}
+
+// Epoch block with cemented previous — eligible (link is epoch link, not a block hash)
+TEST (voting_policy, vote_normal_epoch_cemented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::block_builder builder;
+
+	auto epoch1 = builder.state ()
+				  .account (nano::dev::genesis_key.pub)
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis_key.pub)
+				  .balance (nano::dev::constants.genesis_amount)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, epoch1));
+
+	auto result = policy.vote_normal (txn, *epoch1);
+	ASSERT_TRUE (result);
+	ASSERT_EQ (result->hash (), epoch1->hash ());
+
+	auto final_result = policy.vote_final (txn, *epoch1);
+	ASSERT_TRUE (final_result);
+	ASSERT_EQ (final_result->type (), nano::vote_type::final);
+}
+
+// Epoch block with uncemented previous — not eligible
+TEST (voting_policy, vote_normal_epoch_not_cemented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto epoch1 = builder.state ()
+				  .account (nano::dev::genesis_key.pub)
+				  .previous (send1->hash ())
+				  .representative (nano::dev::genesis_key.pub)
+				  .balance (nano::dev::constants.genesis_amount - 100)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (send1->hash ()))
+				  .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, epoch1));
+
+	// send1 not cemented
+	ASSERT_FALSE (policy.vote_normal (txn, *epoch1));
+	ASSERT_FALSE (policy.vote_final (txn, *epoch1));
+	ASSERT_FALSE (policy.reply_final (txn, *epoch1));
+}
+
+// Epoch open block — dependencies are [0, 0], always eligible
+TEST (voting_policy, vote_normal_epoch_open_cemented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	// Send to key1 so there's a pending entry (required for epoch open)
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	// Epoch open for key1 — previous=0, balance=0, signed by epoch signer
+	auto epoch_open = builder.state ()
+					  .account (key1.pub)
+					  .previous (0)
+					  .representative (0)
+					  .balance (0)
+					  .link (ledger.epoch_link (nano::epoch::epoch_1))
+					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					  .work (*pool.generate (key1.pub))
+					  .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, epoch_open));
+
+	// Epoch open has deps [0, 0] — always eligible regardless of send1 cementing status
+	auto result = policy.vote_normal (txn, *epoch_open);
+	ASSERT_TRUE (result);
+	ASSERT_EQ (result->hash (), epoch_open->hash ());
+
+	auto final_result = policy.vote_final (txn, *epoch_open);
+	ASSERT_TRUE (final_result);
+	ASSERT_EQ (final_result->hash (), epoch_open->hash ());
+	ASSERT_EQ (final_result->qualified_root (), epoch_open->qualified_root ());
+	ASSERT_EQ (final_result->type (), nano::vote_type::final);
+}
+
+// Epoch open block with uncemented send — eligible because deps are [0, 0]
+TEST (voting_policy, vote_normal_epoch_open_send_not_cemented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto epoch_open = builder.state ()
+					  .account (key1.pub)
+					  .previous (0)
+					  .representative (0)
+					  .balance (0)
+					  .link (ledger.epoch_link (nano::epoch::epoch_1))
+					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					  .work (*pool.generate (key1.pub))
+					  .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, epoch_open));
+
+	// send1 is NOT cemented, but epoch open deps are [0, 0] — eligible
+	ASSERT_TRUE (policy.vote_normal (txn, *epoch_open));
+	ASSERT_TRUE (policy.vote_final (txn, *epoch_open));
+}
+
+/*
+ * vote_final
+ */
+
+// Dependencies cemented — permit granted and final_vote record written
+TEST (voting_policy, vote_final_eligible)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+
+	ASSERT_FALSE (policy.reply_final (txn, *send1)); // vote_final must be called before reply_final
+
+	auto result = policy.vote_final (txn, *send1);
+	ASSERT_TRUE (result);
+	ASSERT_EQ (result->type (), nano::vote_type::final);
+	ASSERT_EQ (result->hash (), send1->hash ());
+
+	// Verify the final_vote record was persisted
+	auto stored = ledger.store.final_vote.get (txn, send1->qualified_root ());
+	ASSERT_TRUE (stored);
+	ASSERT_EQ (*stored, send1->hash ());
+
+	ASSERT_TRUE (policy.reply_final (txn, *send1));
+}
+
+// Dependencies not cemented — no permit, no record written
+TEST (voting_policy, vote_final_not_eligible)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto send2 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 200)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send2));
+
+	// send1 not cemented, so send2 not eligible
+	ASSERT_FALSE (policy.vote_final (txn, *send2));
+	ASSERT_FALSE (policy.reply_final (txn, *send2));
+
+	// No record should have been written (short-circuit evaluation)
+	auto stored = ledger.store.final_vote.get (txn, send2->qualified_root ());
+	ASSERT_FALSE (stored);
+}
+
+// Calling vote_final twice for the same block — idempotent (put returns true for same hash)
+TEST (voting_policy, vote_final_idempotent)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+
+	auto result1 = policy.vote_final (txn, *send1);
+	auto result2 = policy.vote_final (txn, *send1);
+	ASSERT_TRUE (result1);
+	ASSERT_TRUE (result2);
+}
+
+// Final vote for fork is prevented — different block at same qualified_root is rejected
+TEST (voting_policy, vote_final_fork_prevented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1, key2;
+	nano::block_builder builder;
+
+	// Process send1A and record final vote
+	auto send1a = builder.state ()
+				  .account (nano::dev::genesis_key.pub)
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis_key.pub)
+				  .balance (nano::dev::constants.genesis_amount - 100)
+				  .link (key1.pub)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	// Fork: different send from same previous (different destination/amount)
+	auto send1b = builder.state ()
+				  .account (nano::dev::genesis_key.pub)
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis_key.pub)
+				  .balance (nano::dev::constants.genesis_amount - 200)
+				  .link (key2.pub)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1a));
+
+	// Record final vote for send1a
+	ASSERT_TRUE (policy.vote_final (txn, *send1a));
+	ASSERT_TRUE (policy.reply_final (txn, *send1a));
+
+	// Rollback send1a and process fork send1b
+	ASSERT_FALSE (ledger.rollback (txn, send1a->hash ()));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1b));
+
+	// Final vote for fork must be denied — the record already has send1a's hash
+	ASSERT_FALSE (policy.vote_final (txn, *send1b));
+	// Reply returns permit with the originally recorded hash, not the fork's
+	auto reply = policy.reply_final (txn, *send1b);
+	ASSERT_TRUE (reply);
+	ASSERT_EQ (reply->hash (), send1a->hash ());
+}
+
+/*
+ * reply_final
+ */
+
+// Read-only final reply check — eligible when dependencies cemented and block is final-votable
+TEST (voting_policy, reply_final_eligible)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+
+	// Record final vote so reply_final returns true
+	auto final_permit = policy.vote_final (txn, *send1);
+	ASSERT_TRUE (final_permit);
+
+	// Read-only reply check should succeed
+	auto result = policy.reply_final (txn, *send1);
+	ASSERT_TRUE (result);
+	ASSERT_EQ (result->type (), nano::vote_type::final);
+	ASSERT_EQ (result->hash (), send1->hash ());
+
+	// Sign with the reply permit and verify the vote
+	nano::keypair rep;
+	nano::voting_policy::vote_signer_t signer = [&rep] (auto const & callback) { callback (rep.pub, rep.prv); };
+	auto votes = policy.sign (nano::vote_type::final, { *result }, signer);
+	ASSERT_EQ (votes.size (), 1);
+	ASSERT_TRUE (votes[0]->is_final ());
+	ASSERT_EQ (votes[0]->hashes.size (), 1);
+	ASSERT_EQ (votes[0]->hashes[0], send1->hash ());
+	ASSERT_EQ (votes[0]->account, rep.pub);
+	ASSERT_FALSE (votes[0]->validate ());
+}
+
+// No final vote record and block not cemented — no reply
+TEST (voting_policy, reply_final_no_record_not_cemented)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+
+	ASSERT_EQ (nano::block_status::progress, ledger.process (ledger.tx_begin_write (), send1));
+
+	auto txn = ledger.tx_begin_read ();
+	ASSERT_FALSE (policy.reply_final (txn, *send1));
+}
+
+// Fork query returns permit with the originally recorded hash, not the fork's hash
+TEST (voting_policy, reply_final_fork_returns_recorded_hash)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1, key2, rep;
+	nano::block_builder builder;
+
+	auto send1a = builder.state ()
+				  .account (nano::dev::genesis_key.pub)
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis_key.pub)
+				  .balance (nano::dev::constants.genesis_amount - 100)
+				  .link (key1.pub)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	auto send1b = builder.state ()
+				  .account (nano::dev::genesis_key.pub)
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis_key.pub)
+				  .balance (nano::dev::constants.genesis_amount - 200)
+				  .link (key2.pub)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1a));
+
+	// Record final vote for send1a
+	ASSERT_TRUE (policy.vote_final (txn, *send1a));
+
+	// Replace with fork
+	ASSERT_FALSE (ledger.rollback (txn, send1a->hash ()));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1b));
+
+	// Querying the fork returns a permit with the RECORDED hash (send1a), not the fork's hash
+	auto result = policy.reply_final (txn, *send1b);
+	ASSERT_TRUE (result);
+	ASSERT_EQ (result->hash (), send1a->hash ());
+	ASSERT_NE (result->hash (), send1b->hash ());
+	ASSERT_EQ (result->type (), nano::vote_type::final);
+
+	// Signing with this permit produces a vote for the originally committed block
+	nano::voting_policy::vote_signer_t signer = [&rep] (auto const & callback) { callback (rep.pub, rep.prv); };
+	auto votes = policy.sign (nano::vote_type::final, { *result }, signer);
+	ASSERT_EQ (votes.size (), 1);
+	ASSERT_TRUE (votes[0]->is_final ());
+	ASSERT_EQ (votes[0]->hashes[0], send1a->hash ());
+	ASSERT_FALSE (votes[0]->validate ());
+}
+
+// No final vote record but block is cemented — reply with block's hash
+TEST (voting_policy, reply_final_cemented_fallback)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ledger.cement (txn, send1->hash ());
+
+	auto result = policy.reply_final (txn, *send1);
+	ASSERT_TRUE (result);
+	ASSERT_EQ (result->type (), nano::vote_type::final);
+	ASSERT_EQ (result->hash (), send1->hash ());
+}
+
+/*
+ * signing
+ */
+
+// Mixing normal and final permits in sign() triggers release_assert
+TEST (voting_policy_DeathTest, sign_type_mismatch)
+{
+	testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1, rep;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+
+	auto normal_permit = policy.vote_normal (txn, *send1);
+	ASSERT_TRUE (normal_permit);
+
+	nano::voting_policy::vote_signer_t signer = [&rep] (auto const & callback) { callback (rep.pub, rep.prv); };
+
+	// Passing normal permits with vote_type::final must crash
+	ASSERT_DEATH_IF_SUPPORTED (policy.sign (nano::vote_type::final, { *normal_permit }, signer), "");
+}
+
+// Empty permits returns empty votes — signer is not called
+TEST (voting_policy, sign_empty)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	nano::voting_policy policy{ ledger };
+
+	bool signer_called = false;
+	nano::voting_policy::vote_signer_t signer = [&signer_called] (auto const & callback) {
+		signer_called = true;
+		nano::keypair key;
+		callback (key.pub, key.prv);
+	};
+
+	auto votes = policy.sign (nano::vote_type::normal, {}, signer);
+	ASSERT_TRUE (votes.empty ());
+	ASSERT_FALSE (signer_called);
+}
+
+// Single permit, single signer — produces one vote with correct fields and valid signature
+TEST (voting_policy, sign_single_permit)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1, rep;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (ledger.tx_begin_write (), send1));
+
+	auto txn = ledger.tx_begin_read ();
+	auto permit = policy.vote_normal (txn, *send1);
+	ASSERT_TRUE (permit);
+
+	nano::voting_policy::vote_signer_t signer = [&rep] (auto const & callback) { callback (rep.pub, rep.prv); };
+	nano::millis_t ts = 99008; // 16-byte aligned for clean assertion
+	auto votes = policy.sign (nano::vote_type::normal, { *permit }, signer, ts);
+
+	ASSERT_EQ (votes.size (), 1);
+	ASSERT_EQ (votes[0]->hashes.size (), 1);
+	ASSERT_EQ (votes[0]->hashes[0], send1->hash ());
+	ASSERT_EQ (votes[0]->account, rep.pub);
+	ASSERT_EQ (votes[0]->timestamp (), ts & nano::vote::timestamp_mask);
+	ASSERT_EQ (votes[0]->duration_bits (), 0x9);
+	ASSERT_FALSE (votes[0]->is_final ());
+	ASSERT_FALSE (votes[0]->validate ()); // validate() returns false when signature is valid
+}
+
+// Multiple permits batched into a single vote with all hashes
+TEST (voting_policy, sign_multiple_permits)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1, rep;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto send2 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 200)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ledger.cement (txn, send1->hash ());
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send2));
+
+	auto permit1 = policy.vote_normal (txn, *send1);
+	auto permit2 = policy.vote_normal (txn, *send2);
+	ASSERT_TRUE (permit1);
+	ASSERT_TRUE (permit2);
+
+	nano::voting_policy::vote_signer_t signer = [&rep] (auto const & callback) { callback (rep.pub, rep.prv); };
+	auto votes = policy.sign (nano::vote_type::normal, { *permit1, *permit2 }, signer, 99008);
+
+	ASSERT_EQ (votes.size (), 1);
+	ASSERT_EQ (votes[0]->hashes.size (), 2);
+	ASSERT_EQ (votes[0]->hashes[0], send1->hash ());
+	ASSERT_EQ (votes[0]->hashes[1], send2->hash ());
+	ASSERT_FALSE (votes[0]->validate ());
+}
+
+// Multiple signers produce one vote per representative
+TEST (voting_policy, sign_multiple_signers)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1, rep1, rep2;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (ledger.tx_begin_write (), send1));
+
+	auto txn = ledger.tx_begin_read ();
+	auto permit = policy.vote_normal (txn, *send1);
+	ASSERT_TRUE (permit);
+
+	nano::voting_policy::vote_signer_t signer = [&rep1, &rep2] (auto const & callback) {
+		callback (rep1.pub, rep1.prv);
+		callback (rep2.pub, rep2.prv);
+	};
+	auto votes = policy.sign (nano::vote_type::normal, { *permit }, signer, 99008);
+
+	ASSERT_EQ (votes.size (), 2);
+	ASSERT_EQ (votes[0]->account, rep1.pub);
+	ASSERT_EQ (votes[1]->account, rep2.pub);
+	ASSERT_FALSE (votes[0]->validate ());
+	ASSERT_FALSE (votes[1]->validate ());
+}
+
+// Final vote type produces max timestamp and max duration
+TEST (voting_policy, sign_final_type)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1, rep;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	auto permit = policy.vote_final (txn, *send1);
+	ASSERT_TRUE (permit);
+
+	nano::voting_policy::vote_signer_t signer = [&rep] (auto const & callback) { callback (rep.pub, rep.prv); };
+	auto votes = policy.sign (nano::vote_type::final, { *permit }, signer);
+
+	ASSERT_EQ (votes.size (), 1);
+	ASSERT_TRUE (votes[0]->is_final ());
+	ASSERT_EQ (votes[0]->duration_bits (), nano::vote::duration_max);
+	ASSERT_FALSE (votes[0]->validate ());
+}
+
+// Custom timestamp is forwarded correctly for normal votes
+TEST (voting_policy, sign_normal_custom_timestamp)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1, rep;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (ledger.tx_begin_write (), send1));
+
+	auto txn = ledger.tx_begin_read ();
+	auto permit = policy.vote_normal (txn, *send1);
+	ASSERT_TRUE (permit);
+
+	nano::voting_policy::vote_signer_t signer = [&rep] (auto const & callback) { callback (rep.pub, rep.prv); };
+
+	// Test with a non-aligned timestamp to verify masking behavior
+	nano::millis_t ts = 12345;
+	auto votes = policy.sign (nano::vote_type::normal, { *permit }, signer, ts);
+
+	ASSERT_EQ (votes.size (), 1);
+	ASSERT_EQ (votes[0]->timestamp (), ts & nano::vote::timestamp_mask);
+	ASSERT_FALSE (votes[0]->is_final ());
+}
+
+// Empty signer (no representatives) produces no votes
+TEST (voting_policy, sign_no_signers)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (ledger.tx_begin_write (), send1));
+
+	auto txn = ledger.tx_begin_read ();
+	auto permit = policy.vote_normal (txn, *send1);
+	ASSERT_TRUE (permit);
+
+	nano::voting_policy::vote_signer_t empty_signer = [] (auto const &) {};
+	auto votes = policy.sign (nano::vote_type::normal, { *permit }, empty_signer, 99008);
+
+	ASSERT_TRUE (votes.empty ());
+}
+
+/*
+ * Integration / cross-cutting
+ */
+
+// Incrementally cement dependencies and verify eligibility changes at each step
+TEST (voting_policy, progressive_cementing)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	// Build chain: genesis → send1 → send2 (genesis account)
+	//              send1 → open1 (key1 account)
+	//              send2 → receive2 (key1 account, previous=open1)
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto send2 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 200)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	auto open1 = builder.state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (100)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	auto receive2 = builder.state ()
+					.account (key1.pub)
+					.previous (open1->hash ())
+					.representative (nano::dev::genesis_key.pub)
+					.balance (200)
+					.link (send2->hash ())
+					.sign (key1.prv, key1.pub)
+					.work (*pool.generate (open1->hash ()))
+					.build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send2));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, open1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, receive2));
+
+	// Phase 1: Nothing cemented beyond genesis — receive2 not eligible
+	ASSERT_FALSE (policy.vote_normal (txn, *receive2));
+	ASSERT_FALSE (policy.vote_normal (txn, *open1));
+
+	// Phase 2: Cement send1 — open1 now eligible (source cemented), receive2 still not
+	ledger.cement (txn, send1->hash ());
+	ASSERT_TRUE (policy.vote_normal (txn, *open1));
+	ASSERT_FALSE (policy.vote_normal (txn, *receive2));
+
+	// Phase 3: Cement open1 — receive2 still not eligible (send2 not cemented)
+	ledger.cement (txn, open1->hash ());
+	ASSERT_FALSE (policy.vote_normal (txn, *receive2));
+
+	// Phase 4: Cement send2 — receive2 now eligible (both deps cemented)
+	ledger.cement (txn, send2->hash ());
+	ASSERT_TRUE (policy.vote_normal (txn, *receive2));
+}
+
+// Complete flow: check eligibility, get permits, sign votes, verify signatures
+TEST (voting_policy, full_send_receive_sign)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1, rep;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto open1 = builder.state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (100)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ledger.cement (txn, send1->hash ());
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, open1));
+
+	// Check normal eligibility
+	auto normal_permit = policy.vote_normal (txn, *open1);
+	ASSERT_TRUE (normal_permit);
+
+	// Check final eligibility
+	auto final_permit = policy.vote_final (txn, *open1);
+	ASSERT_TRUE (final_permit);
+
+	// reply_final should also return true
+	ASSERT_TRUE (policy.reply_final (txn, *open1));
+
+	nano::voting_policy::vote_signer_t signer = [&rep] (auto const & callback) { callback (rep.pub, rep.prv); };
+
+	// Sign normal vote
+	auto normal_votes = policy.sign (nano::vote_type::normal, { *normal_permit }, signer, 99008);
+	ASSERT_EQ (normal_votes.size (), 1);
+	ASSERT_FALSE (normal_votes[0]->is_final ());
+	ASSERT_FALSE (normal_votes[0]->validate ());
+
+	// Sign final vote
+	auto final_votes = policy.sign (nano::vote_type::final, { *final_permit }, signer);
+	ASSERT_EQ (final_votes.size (), 1);
+	ASSERT_TRUE (final_votes[0]->is_final ());
+	ASSERT_FALSE (final_votes[0]->validate ());
+}
+
+// Pruned source dependency counts as cemented
+TEST (voting_policy, pruned_dependency)
+{
+	nano::logger logger;
+	nano::stats stats{ logger };
+	auto store = nano::make_store (logger, stats, nano::unique_path (), nano::dev::constants);
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger);
+	ledger.pruning = true;
+	nano::voting_policy policy{ ledger };
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	nano::keypair key1;
+	nano::block_builder builder;
+
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto send2 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - 200)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send2));
+	ledger.cement (txn, send2->hash ());
+
+	// Prune send1 (it's cemented, so prunable)
+	ASSERT_EQ (2, ledger.pruning_action (txn, send2->hash (), 1));
+
+	// open1 receiving from pruned send1
+	auto open1 = builder.state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (100)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, open1));
+
+	// Pruned source should satisfy dependency check
+	ASSERT_TRUE (policy.vote_normal (txn, *open1));
+	ASSERT_TRUE (policy.vote_final (txn, *open1));
+	ASSERT_TRUE (policy.reply_final (txn, *open1));
+}
+
+// Final vote record prevents voting on competing fork across all methods
+TEST (voting_policy, final_vote_fork_safety)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::voting_policy policy{ ledger };
+	nano::keypair key1, key2, rep;
+	nano::block_builder builder;
+
+	auto send1a = builder.state ()
+				  .account (nano::dev::genesis_key.pub)
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis_key.pub)
+				  .balance (nano::dev::constants.genesis_amount - 100)
+				  .link (key1.pub)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+	auto send1b = builder.state ()
+				  .account (nano::dev::genesis_key.pub)
+				  .previous (nano::dev::genesis->hash ())
+				  .representative (nano::dev::genesis_key.pub)
+				  .balance (nano::dev::constants.genesis_amount - 200)
+				  .link (key2.pub)
+				  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				  .work (*pool.generate (nano::dev::genesis->hash ()))
+				  .build ();
+
+	auto txn = ledger.tx_begin_write ();
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1a));
+
+	// Commit final vote for send1a
+	auto permit_a = policy.vote_final (txn, *send1a);
+	ASSERT_TRUE (permit_a);
+
+	// Sign the final vote successfully
+	nano::voting_policy::vote_signer_t signer = [&rep] (auto const & callback) { callback (rep.pub, rep.prv); };
+	auto votes_a = policy.sign (nano::vote_type::final, { *permit_a }, signer);
+	ASSERT_EQ (votes_a.size (), 1);
+	ASSERT_TRUE (votes_a[0]->is_final ());
+
+	// reply_final confirms send1a
+	ASSERT_TRUE (policy.reply_final (txn, *send1a));
+
+	// Replace with fork
+	ASSERT_FALSE (ledger.rollback (txn, send1a->hash ()));
+	ASSERT_EQ (nano::block_status::progress, ledger.process (txn, send1b));
+
+	// vote_final denies the fork
+	ASSERT_FALSE (policy.vote_final (txn, *send1b));
+	// reply_final returns permit with the originally recorded hash
+	auto fork_reply = policy.reply_final (txn, *send1b);
+	ASSERT_TRUE (fork_reply);
+	ASSERT_EQ (fork_reply->hash (), send1a->hash ());
+
+	// Normal vote is also denied for the fork
+	ASSERT_FALSE (policy.vote_normal (txn, *send1b));
+
+	// Rollback fork and confirm original block is still votable
+	ASSERT_FALSE (ledger.rollback (txn, send1b->hash ()));
+	ASSERT_TRUE (policy.reply_final (txn, *send1a));
+	ASSERT_TRUE (policy.vote_final (txn, *send1a));
+}

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -53,6 +53,7 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_cemented.hpp>
+#include <nano/secure/voting_policy.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/block.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>
@@ -174,13 +175,15 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	vote_processor{ *vote_processor_impl },
 	vote_cache_processor_impl{ std::make_unique<nano::vote_cache_processor> (config.vote_processor, vote_router, vote_cache, stats, logger) },
 	vote_cache_processor{ *vote_cache_processor_impl },
-	generator_impl{ std::make_unique<nano::vote_generator> (config.vote_generator, *this, ledger, wallets, vote_processor, history, network, stats, logger, /* non-final */ false, loopback_channel) },
+	voting_policy_impl{ std::make_unique<nano::voting_policy> (ledger) },
+	voting_policy{ *voting_policy_impl },
+	generator_impl{ std::make_unique<nano::vote_generator> (config.vote_generator, *this, voting_policy, ledger, wallets, vote_processor, history, network, stats, logger, /* non-final */ false, loopback_channel) },
 	generator{ *generator_impl },
-	final_generator_impl{ std::make_unique<nano::vote_generator> (config.vote_generator, *this, ledger, wallets, vote_processor, history, network, stats, logger, /* final */ true, loopback_channel) },
+	final_generator_impl{ std::make_unique<nano::vote_generator> (config.vote_generator, *this, voting_policy, ledger, wallets, vote_processor, history, network, stats, logger, /* final */ true, loopback_channel) },
 	final_generator{ *final_generator_impl },
 	scheduler_impl{ std::make_unique<nano::scheduler::component> (config, *this, ledger, ledger_notifications, bucketing, active, online_reps, vote_cache, cementing_set, stats, logger) },
 	scheduler{ *scheduler_impl },
-	aggregator_impl{ std::make_unique<nano::request_aggregator> (config.request_aggregator, *this, generator, final_generator, history, ledger, wallets, vote_router) },
+	aggregator_impl{ std::make_unique<nano::request_aggregator> (config.request_aggregator, *this, voting_policy, generator, final_generator, history, ledger, wallets, vote_router) },
 	aggregator{ *aggregator_impl },
 	backlog_scan_impl{ std::make_unique<nano::backlog_scan> (config.backlog_scan, ledger, stats) },
 	backlog_scan{ *backlog_scan_impl },

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -178,6 +178,8 @@ public:
 	nano::vote_processor & vote_processor;
 	std::unique_ptr<nano::vote_cache_processor> vote_cache_processor_impl;
 	nano::vote_cache_processor & vote_cache_processor;
+	std::unique_ptr<nano::voting_policy> voting_policy_impl;
+	nano::voting_policy & voting_policy;
 	std::unique_ptr<nano::vote_generator> generator_impl;
 	nano::vote_generator & generator;
 	std::unique_ptr<nano::vote_generator> final_generator_impl;

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -12,13 +12,13 @@
 #include <nano/node/wallet.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/secure/ledger_set_cemented.hpp>
-#include <nano/store/ledger/final_vote.hpp>
+#include <nano/secure/voting_policy.hpp>
 
-nano::request_aggregator::request_aggregator (request_aggregator_config const & config_a, nano::node & node_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_router & vote_router_a) :
+nano::request_aggregator::request_aggregator (request_aggregator_config const & config_a, nano::node & node_a, nano::voting_policy & policy_a, nano::vote_generator & generator_a, nano::vote_generator & final_generator_a, nano::local_vote_history & history_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_router & vote_router_a) :
 	config{ config_a },
 	node_config{ node_a.config },
 	network_constants{ node_a.network_params.network },
+	policy (policy_a),
 	local_votes (history_a),
 	ledger (ledger_a),
 	wallets (wallets_a),
@@ -254,24 +254,9 @@ auto nano::request_aggregator::aggregate (nano::secure::transaction const & tran
 
 		auto block = search_for_block ();
 
-		auto should_generate_final_vote = [&] (auto const & block) {
-			release_assert (block);
-
-			// Check if final vote is set for this block
-			if (auto final_hash = ledger.store.final_vote.get (transaction, block->qualified_root ()))
-			{
-				return final_hash == block->hash ();
-			}
-			// If the final vote is not set, generate vote if the block is confirmed
-			else
-			{
-				return ledger.cemented.block_exists (transaction, block->hash ());
-			}
-		};
-
 		if (block)
 		{
-			if (should_generate_final_vote (block))
+			if (policy.reply_final (transaction, *block))
 			{
 				to_generate_final.push_back (block);
 

--- a/nano/node/request_aggregator.hpp
+++ b/nano/node/request_aggregator.hpp
@@ -40,7 +40,7 @@ public:
 class request_aggregator final
 {
 public:
-	request_aggregator (request_aggregator_config const &, nano::node &, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::vote_router &);
+	request_aggregator (request_aggregator_config const &, nano::node &, nano::voting_policy &, nano::vote_generator &, nano::vote_generator &, nano::local_vote_history &, nano::ledger &, nano::wallets &, nano::vote_router &);
 	~request_aggregator ();
 
 	void start ();
@@ -80,6 +80,7 @@ private: // Dependencies
 	request_aggregator_config const & config;
 	nano::node_config const & node_config;
 	nano::network_constants const & network_constants;
+	nano::voting_policy & policy;
 	nano::local_vote_history & local_votes;
 	nano::ledger & ledger;
 	nano::wallets & wallets;

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -13,13 +13,14 @@
 #include <nano/node/wallet.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
-#include <nano/store/ledger/final_vote.hpp>
+#include <nano/secure/voting_policy.hpp>
 
 #include <chrono>
 
-nano::vote_generator::vote_generator (vote_generator_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_processor & vote_processor_a, nano::local_vote_history & history_a, nano::network & network_a, nano::stats & stats_a, nano::logger & logger_a, bool is_final_a, std::shared_ptr<nano::transport::channel> inproc_channel_a) :
+nano::vote_generator::vote_generator (vote_generator_config const & config_a, nano::node & node_a, nano::voting_policy & policy_a, nano::ledger & ledger_a, nano::wallets & wallets_a, nano::vote_processor & vote_processor_a, nano::local_vote_history & history_a, nano::network & network_a, nano::stats & stats_a, nano::logger & logger_a, bool is_final_a, std::shared_ptr<nano::transport::channel> inproc_channel_a) :
 	config (config_a),
 	node (node_a),
+	policy (policy_a),
 	ledger (ledger_a),
 	wallets (wallets_a),
 	vote_processor (vote_processor_a),
@@ -42,36 +43,6 @@ nano::vote_generator::~vote_generator ()
 {
 	debug_assert (stopped);
 	debug_assert (!thread.joinable ());
-}
-
-bool nano::vote_generator::should_vote (transaction_variant_t const & transaction_variant, nano::root const & root_a, nano::block_hash const & hash_a) const
-{
-	bool should_vote = false;
-	std::shared_ptr<nano::block> block;
-	if (is_final)
-	{
-		debug_assert (std::holds_alternative<nano::secure::write_transaction> (transaction_variant));
-		auto const & transaction = std::get<nano::secure::write_transaction> (transaction_variant);
-
-		block = ledger.any.block_get (transaction, hash_a);
-		should_vote = block != nullptr && ledger.dependencies_cemented (transaction, *block) && ledger.store.final_vote.put (transaction, block->qualified_root (), hash_a);
-		debug_assert (block == nullptr || root_a == block->root ());
-	}
-	else
-	{
-		debug_assert (std::holds_alternative<nano::secure::read_transaction> (transaction_variant));
-		auto const & transaction = std::get<nano::secure::read_transaction> (transaction_variant);
-
-		block = ledger.any.block_get (transaction, hash_a);
-		should_vote = block != nullptr && ledger.dependencies_cemented (transaction, *block);
-	}
-
-	logger.trace (log_type (), nano::log::detail::should_vote,
-	nano::log::arg{ "should_vote", should_vote },
-	nano::log::arg{ "block", block },
-	nano::log::arg{ "is_final", is_final });
-
-	return should_vote;
 }
 
 void nano::vote_generator::start ()
@@ -106,34 +77,40 @@ void nano::vote_generator::add (const root & root, const block_hash & hash)
 
 void nano::vote_generator::process_batch (std::deque<queue_entry_t> & batch)
 {
-	std::deque<candidate_t> verified;
-
-	auto refresh_if_needed = [] (auto && transaction_variant) {
-		std::visit ([&] (auto && transaction) { transaction.refresh_if_needed (); }, transaction_variant);
-	};
-
-	auto verify_batch = [this, &verified, &refresh_if_needed] (auto && transaction_variant, auto && batch) {
-		for (auto & [root, hash] : batch)
-		{
-			refresh_if_needed (transaction_variant);
-
-			if (should_vote (transaction_variant, root, hash))
-			{
-				verified.emplace_back (root, hash);
-			}
-		}
-	};
+	std::deque<nano::vote_permit> verified;
 
 	if (is_final)
 	{
-		transaction_variant_t transaction_variant{ ledger.tx_begin_write (nano::store::writer::voting_final) };
-		verify_batch (transaction_variant, batch);
+		auto transaction = ledger.tx_begin_write (nano::store::writer::voting_final);
+		for (auto & [root, hash] : batch)
+		{
+			transaction.refresh_if_needed ();
+			auto block = ledger.any.block_get (transaction, hash);
+			if (block)
+			{
+				if (auto permit = policy.vote_final (transaction, *block))
+				{
+					verified.push_back (*permit);
+				}
+			}
+		}
 		// Commit write transaction
 	}
 	else
 	{
-		transaction_variant_t transaction_variant{ ledger.tx_begin_read () };
-		verify_batch (transaction_variant, batch);
+		auto transaction = ledger.tx_begin_read ();
+		for (auto & [root, hash] : batch)
+		{
+			transaction.refresh_if_needed ();
+			auto block = ledger.any.block_get (transaction, hash);
+			if (block)
+			{
+				if (auto permit = policy.vote_normal (transaction, *block))
+				{
+					verified.push_back (*permit);
+				}
+			}
+		}
 	}
 
 	// Submit verified candidates to the main processing thread
@@ -154,13 +131,16 @@ std::size_t nano::vote_generator::generate (std::vector<std::shared_ptr<nano::bl
 	request_t::first_type req_candidates;
 	{
 		auto transaction = ledger.tx_begin_read ();
-		auto dependencies_cemented = [&transaction, this] (auto const & block_a) {
-			return this->ledger.dependencies_cemented (transaction, *block_a);
-		};
-		auto as_candidate = [] (auto const & block_a) {
-			return candidate_t{ block_a->root (), block_a->hash () };
-		};
-		nano::transform_if (blocks_a.begin (), blocks_a.end (), std::back_inserter (req_candidates), dependencies_cemented, as_candidate);
+		for (auto const & block : blocks_a)
+		{
+			auto permit = is_final
+			? policy.reply_final (transaction, *block)
+			: policy.vote_normal (transaction, *block);
+			if (permit)
+			{
+				req_candidates.push_back (*permit);
+			}
+		}
 	}
 	auto const result = req_candidates.size ();
 	nano::lock_guard<nano::mutex> guard{ mutex };
@@ -178,35 +158,43 @@ void nano::vote_generator::broadcast (nano::unique_lock<nano::mutex> & lock_a)
 {
 	debug_assert (lock_a.owns_lock ());
 
-	std::vector<nano::block_hash> hashes;
-	std::vector<nano::root> roots;
-	hashes.reserve (nano::network::confirm_ack_hashes_max);
-	roots.reserve (nano::network::confirm_ack_hashes_max);
-	while (!candidates.empty () && hashes.size () < nano::network::confirm_ack_hashes_max)
+	std::vector<nano::vote_permit> permits;
+	permits.reserve (nano::network::confirm_ack_hashes_max);
+	std::vector<nano::root> seen_roots;
+	seen_roots.reserve (nano::network::confirm_ack_hashes_max);
+	while (!candidates.empty () && permits.size () < nano::network::confirm_ack_hashes_max)
 	{
-		auto const & [root, hash] = candidates.front ();
-		if (std::find (roots.begin (), roots.end (), root) == roots.end ())
+		auto permit = std::move (candidates.front ());
+		candidates.pop_front ();
+		if (std::find (seen_roots.begin (), seen_roots.end (), permit.root ()) == seen_roots.end ())
 		{
-			if (spacing.votable (root, hash))
+			if (spacing.votable (permit.root (), permit.hash ()))
 			{
-				roots.push_back (root);
-				hashes.push_back (hash);
+				seen_roots.push_back (permit.root ());
+				permits.push_back (std::move (permit));
 			}
 			else
 			{
 				stats.inc (stat_type (), nano::stat::detail::generator_spacing);
 			}
 		}
-		candidates.pop_front ();
 	}
-	if (!hashes.empty ())
+	if (!permits.empty ())
 	{
 		lock_a.unlock ();
-		vote (hashes, roots, [this] (auto const & generated_vote) {
+		auto signer = [this] (auto const & callback) { wallets.foreach_representative (callback); };
+		auto votes = policy.sign (is_final ? nano::vote_type::final : nano::vote_type::normal, permits, signer);
+		for (auto const & vote : votes)
+		{
+			for (auto const & permit : permits)
+			{
+				history.add (permit.root (), permit.hash (), vote);
+				spacing.flag (permit.root (), permit.hash ());
+			}
 			stats.inc (stat_type (), nano::stat::detail::generator_broadcasts);
-			stats.sample (is_final ? nano::stat::sample::vote_generator_final_hashes : nano::stat::sample::vote_generator_hashes, generated_vote->hashes.size (), { 0, nano::network::confirm_ack_hashes_max });
-			broadcast_action (generated_vote);
-		});
+			stats.sample (is_final ? nano::stat::sample::vote_generator_final_hashes : nano::stat::sample::vote_generator_hashes, vote->hashes.size (), { 0, nano::network::confirm_ack_hashes_max });
+			broadcast_action (vote);
+		}
 		lock_a.lock ();
 	}
 }
@@ -222,19 +210,19 @@ void nano::vote_generator::reply (nano::unique_lock<nano::mutex> & lock_a, reque
 	auto n (request_a.first.cend ());
 	while (i != n && !stopped)
 	{
-		std::vector<nano::block_hash> hashes;
-		std::vector<nano::root> roots;
-		hashes.reserve (nano::network::confirm_ack_hashes_max);
-		roots.reserve (nano::network::confirm_ack_hashes_max);
-		for (; i != n && hashes.size () < nano::network::confirm_ack_hashes_max; ++i)
+		std::vector<nano::vote_permit> permits;
+		permits.reserve (nano::network::confirm_ack_hashes_max);
+		std::vector<nano::root> seen_roots;
+		seen_roots.reserve (nano::network::confirm_ack_hashes_max);
+		for (; i != n && permits.size () < nano::network::confirm_ack_hashes_max; ++i)
 		{
-			auto const & [root, hash] = *i;
-			if (std::find (roots.begin (), roots.end (), root) == roots.end ())
+			auto const & permit = *i;
+			if (std::find (seen_roots.begin (), seen_roots.end (), permit.root ()) == seen_roots.end ())
 			{
-				if (spacing.votable (root, hash))
+				if (spacing.votable (permit.root (), permit.hash ()))
 				{
-					roots.push_back (root);
-					hashes.push_back (hash);
+					seen_roots.push_back (permit.root ());
+					permits.push_back (permit);
 				}
 				else
 				{
@@ -242,39 +230,27 @@ void nano::vote_generator::reply (nano::unique_lock<nano::mutex> & lock_a, reque
 				}
 			}
 		}
-		if (!hashes.empty ())
+		if (!permits.empty ())
 		{
-			stats.add (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes, stat::dir::in, hashes.size ());
+			stats.add (nano::stat::type::requests, nano::stat::detail::requests_generated_hashes, stat::dir::in, permits.size ());
 
-			vote (hashes, roots, [this, channel = request_a.second] (std::shared_ptr<nano::vote> const & vote_a) {
-				nano::messages::confirm_ack confirm{ node.network_params.network, vote_a };
-				channel->send (confirm, nano::transport::traffic_type::vote_reply);
+			auto signer = [this] (auto const & callback) { wallets.foreach_representative (callback); };
+			auto votes = policy.sign (is_final ? nano::vote_type::final : nano::vote_type::normal, permits, signer);
+			for (auto const & vote : votes)
+			{
+				for (auto const & permit : permits)
+				{
+					history.add (permit.root (), permit.hash (), vote);
+					spacing.flag (permit.root (), permit.hash ());
+				}
+				nano::messages::confirm_ack confirm{ node.network_params.network, vote };
+				request_a.second->send (confirm, nano::transport::traffic_type::vote_reply);
 				stats.inc (nano::stat::type::requests, nano::stat::detail::requests_generated_votes, stat::dir::in);
-			});
+			}
 		}
 	}
 	stats.inc (stat_type (), nano::stat::detail::generator_replies);
 	lock_a.lock ();
-}
-
-void nano::vote_generator::vote (std::vector<nano::block_hash> const & hashes_a, std::vector<nano::root> const & roots_a, std::function<void (std::shared_ptr<nano::vote> const &)> const & action_a)
-{
-	debug_assert (hashes_a.size () == roots_a.size ());
-	std::vector<std::shared_ptr<nano::vote>> votes_l;
-	wallets.foreach_representative ([this, &hashes_a, &votes_l] (nano::public_key const & pub_a, nano::raw_key const & prv_a) {
-		auto timestamp = this->is_final ? nano::vote::timestamp_max : nano::milliseconds_since_epoch ();
-		uint8_t duration = this->is_final ? nano::vote::duration_max : /*8192ms*/ 0x9;
-		votes_l.emplace_back (std::make_shared<nano::vote> (pub_a, prv_a, timestamp, duration, hashes_a));
-	});
-	for (auto const & vote_l : votes_l)
-	{
-		for (std::size_t i (0), n (hashes_a.size ()); i != n; ++i)
-		{
-			history.add (roots_a[i], hashes_a[i], vote_l);
-			spacing.flag (roots_a[i], hashes_a[i]);
-		}
-		action_a (vote_l);
-	}
 }
 
 void nano::vote_generator::broadcast_action (std::shared_ptr<nano::vote> const & vote_a) const

--- a/nano/node/vote_generator.hpp
+++ b/nano/node/vote_generator.hpp
@@ -8,6 +8,7 @@
 #include <nano/lib/utility.hpp>
 #include <nano/node/fwd.hpp>
 #include <nano/secure/common.hpp>
+#include <nano/secure/voting_policy.hpp>
 
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
@@ -18,7 +19,6 @@
 #include <condition_variable>
 #include <deque>
 #include <thread>
-#include <variant>
 
 namespace mi = boost::multi_index;
 
@@ -39,13 +39,12 @@ public:
 class vote_generator final
 {
 private:
-	using candidate_t = std::pair<nano::root, nano::block_hash>;
-	using request_t = std::pair<std::vector<candidate_t>, std::shared_ptr<nano::transport::channel>>;
+	using request_t = std::pair<std::vector<nano::vote_permit>, std::shared_ptr<nano::transport::channel>>;
 	using queue_entry_t = std::pair<nano::root, nano::block_hash>;
 	std::chrono::steady_clock::time_point next_broadcast = { std::chrono::steady_clock::now () };
 
 public:
-	vote_generator (vote_generator_config const &, nano::node &, nano::ledger &, nano::wallets &, nano::vote_processor &, nano::local_vote_history &, nano::network &, nano::stats &, nano::logger &, bool is_final, std::shared_ptr<nano::transport::channel> inproc_channel);
+	vote_generator (vote_generator_config const &, nano::node &, nano::voting_policy &, nano::ledger &, nano::wallets &, nano::vote_processor &, nano::local_vote_history &, nano::network &, nano::stats &, nano::logger &, bool is_final, std::shared_ptr<nano::transport::channel> inproc_channel);
 	~vote_generator ();
 
 	/** Queue items for vote generation, or broadcast votes already in cache */
@@ -59,15 +58,11 @@ public:
 	nano::container_info container_info () const;
 
 private:
-	using transaction_variant_t = std::variant<nano::secure::read_transaction, nano::secure::write_transaction>;
-
 	void run ();
 	void broadcast (nano::unique_lock<nano::mutex> &);
 	void reply (nano::unique_lock<nano::mutex> &, request_t &&);
-	void vote (std::vector<nano::block_hash> const &, std::vector<nano::root> const &, std::function<void (std::shared_ptr<nano::vote> const &)> const &);
 	void broadcast_action (std::shared_ptr<nano::vote> const &) const;
 	void process_batch (std::deque<queue_entry_t> & batch);
-	bool should_vote (transaction_variant_t const &, nano::root const &, nano::block_hash const &) const;
 	bool broadcast_predicate () const;
 
 	nano::stat::type stat_type () const;
@@ -76,6 +71,7 @@ private:
 private: // Dependencies
 	vote_generator_config const & config;
 	nano::node & node;
+	nano::voting_policy & policy;
 	nano::ledger & ledger;
 	nano::wallets & wallets;
 	nano::vote_processor & vote_processor;
@@ -92,7 +88,7 @@ private:
 	nano::condition_variable condition;
 	static std::size_t constexpr max_requests{ 2048 };
 	std::deque<request_t> requests;
-	std::deque<candidate_t> candidates;
+	std::deque<nano::vote_permit> candidates;
 	std::atomic<bool> stopped{ false };
 	std::thread thread;
 	std::shared_ptr<nano::transport::channel> inproc_channel;

--- a/nano/secure/CMakeLists.txt
+++ b/nano/secure/CMakeLists.txt
@@ -26,7 +26,9 @@ add_library(
   receivable_iterator_impl.hpp
   rep_weights.hpp
   rep_weights.cpp
-  transaction.hpp)
+  transaction.hpp
+  voting_policy.hpp
+  voting_policy.cpp)
 
 target_link_libraries(secure nano_lib ed25519 crypto_lib Boost::system)
 

--- a/nano/secure/fwd.hpp
+++ b/nano/secure/fwd.hpp
@@ -12,8 +12,11 @@ class ledger_constants;
 class network_params;
 class pending_info;
 class pending_key;
+class vote_permit;
+class voting_policy;
 
 enum class block_status;
+enum class vote_type;
 }
 
 namespace nano::secure

--- a/nano/secure/voting_policy.cpp
+++ b/nano/secure/voting_policy.cpp
@@ -1,0 +1,118 @@
+#include <nano/lib/blocks.hpp>
+#include <nano/lib/vote.hpp>
+#include <nano/secure/ledger.hpp>
+#include <nano/secure/ledger_set_any.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
+#include <nano/secure/voting_policy.hpp>
+#include <nano/store/ledger/final_vote.hpp>
+
+/*
+ * vote_permit
+ */
+
+nano::vote_permit::vote_permit (nano::qualified_root qualified_root, nano::block_hash hash, nano::vote_type type) :
+	qualified_root_m{ qualified_root },
+	hash_m{ hash },
+	type_m{ type }
+{
+}
+
+nano::qualified_root const & nano::vote_permit::qualified_root () const
+{
+	return qualified_root_m;
+}
+
+nano::root nano::vote_permit::root () const
+{
+	return qualified_root_m.root ();
+}
+
+nano::block_hash const & nano::vote_permit::hash () const
+{
+	return hash_m;
+}
+
+nano::vote_type nano::vote_permit::type () const
+{
+	return type_m;
+}
+
+/*
+ * voting_policy
+ */
+
+nano::voting_policy::voting_policy (nano::ledger & ledger) :
+	ledger{ ledger }
+{
+}
+
+std::optional<nano::vote_permit> nano::voting_policy::vote_normal (nano::secure::transaction const & txn, nano::block const & block) const
+{
+	if (ledger.dependencies_cemented (txn, block))
+	{
+		// If a final vote was already committed for a different block at this root, refuse to vote
+		if (auto final_hash = ledger.store.final_vote.get (txn, block.qualified_root ()))
+		{
+			if (*final_hash != block.hash ())
+			{
+				return std::nullopt;
+			}
+		}
+		return nano::vote_permit{ block.qualified_root (), block.hash (), vote_type::normal };
+	}
+	return std::nullopt;
+}
+
+std::optional<nano::vote_permit> nano::voting_policy::vote_final (nano::secure::write_transaction const & txn, nano::block const & block) const
+{
+	if (ledger.dependencies_cemented (txn, block))
+	{
+		// This checks for existing final vote and only inserts if no record exists, or if the same hash is already recorded for this root
+		if (ledger.store.final_vote.put (txn, block.qualified_root (), block.hash ()))
+		{
+			return nano::vote_permit{ block.qualified_root (), block.hash (), vote_type::final };
+		}
+	}
+	return std::nullopt;
+}
+
+std::optional<nano::vote_permit> nano::voting_policy::reply_final (nano::secure::transaction const & txn, nano::block const & block) const
+{
+	// If a final vote was already committed for this root, allow voting for the recorded hash
+	if (auto final_hash = ledger.store.final_vote.get (txn, block.qualified_root ()))
+	{
+		return nano::vote_permit{ block.qualified_root (), *final_hash, vote_type::final };
+	}
+	// If no final vote recorded but block is already cemented, allow voting for this hash
+	if (ledger.cemented.block_exists (txn, block.hash ()))
+	{
+		return nano::vote_permit{ block.qualified_root (), block.hash (), vote_type::final };
+	}
+	return std::nullopt;
+}
+
+std::vector<std::shared_ptr<nano::vote>> nano::voting_policy::sign (nano::vote_type type, std::vector<nano::vote_permit> const & permits, vote_signer_t const & signer, nano::millis_t timestamp) const
+{
+	if (permits.empty ())
+	{
+		return {};
+	}
+
+	release_assert (std::all_of (permits.begin (), permits.end (), [type] (auto const & p) { return p.type () == type; }), "vote permit type mismatch");
+
+	std::vector<nano::block_hash> hashes;
+	hashes.reserve (permits.size ());
+	for (auto const & permit : permits)
+	{
+		hashes.push_back (permit.hash ());
+	}
+
+	nano::millis_t const effective_timestamp = (type == vote_type::final) ? nano::vote::timestamp_max : timestamp;
+	uint8_t const effective_duration = (type == vote_type::final) ? nano::vote::duration_max : /*8192ms*/ 0x9;
+
+	std::vector<std::shared_ptr<nano::vote>> votes;
+	signer ([&] (nano::public_key const & pub, nano::raw_key const & prv) {
+		votes.emplace_back (std::make_shared<nano::vote> (pub, prv, effective_timestamp, effective_duration, hashes));
+	});
+	return votes;
+}

--- a/nano/secure/voting_policy.hpp
+++ b/nano/secure/voting_policy.hpp
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+#include <nano/lib/timer.hpp>
+#include <nano/secure/fwd.hpp>
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace nano
+{
+class vote;
+
+enum class vote_type
+{
+	normal,
+	final
+};
+
+/**
+ * Proof that a vote eligibility check was performed.
+ * Can only be created by voting_policy — private constructor ensures callers cannot bypass the policy.
+ */
+class vote_permit
+{
+	friend class voting_policy;
+	vote_permit (nano::qualified_root qualified_root, nano::block_hash hash, nano::vote_type type);
+
+	nano::qualified_root qualified_root_m;
+	nano::block_hash hash_m;
+	nano::vote_type type_m;
+
+public:
+	nano::qualified_root const & qualified_root () const;
+	nano::root root () const;
+	nano::block_hash const & hash () const;
+	nano::vote_type type () const;
+};
+
+/**
+ * Centralizes vote eligibility decisions and signing.
+ * Single source of truth for whether a block should be voted on.
+ * Vote construction must only be handled here.
+ */
+class voting_policy
+{
+public:
+	explicit voting_policy (nano::ledger &);
+
+	/**
+	 * Check normal vote eligibility for an already-fetched block.
+	 * Returns a permit if the block's dependencies are cemented and no conflicting final vote exists.
+	 */
+	std::optional<vote_permit> vote_normal (
+	nano::secure::transaction const &,
+	nano::block const & block) const;
+
+	/**
+	 * Check final vote eligibility for an already-fetched block.
+	 * Returns a permit if dependencies are cemented and the final vote slot can be claimed (final_vote.put).
+	 * Requires a write transaction because it persists the final vote decision.
+	 */
+	std::optional<vote_permit> vote_final (
+	nano::secure::write_transaction const &,
+	nano::block const & block) const;
+
+	/**
+	 * Read-only final vote eligibility for the reply path.
+	 * If a final vote was previously recorded for this root, returns a permit for the *recorded* hash
+	 * (which may differ from the queried block's hash in the case of forks).
+	 * Falls back to allowing the block's own hash if the block is cemented.
+	 * Does not persist any state.
+	 */
+	std::optional<vote_permit> reply_final (
+	nano::secure::transaction const &,
+	nano::block const & block) const;
+
+	/**
+	 * Signer iterates representative key pairs and calls the provided callback for each.
+	 */
+	using vote_signer_t = std::function<void (
+	std::function<void (nano::public_key const &, nano::raw_key const &)> const &)>;
+
+	/**
+	 * Sign votes for the given permits.
+	 * All permit hashes are batched into a single vote per representative.
+	 * The signer provides representative key pairs via callback.
+	 * Timestamp and duration are controlled based on vote type.
+	 */
+	std::vector<std::shared_ptr<nano::vote>> sign (
+	nano::vote_type type,
+	std::vector<vote_permit> const & permits,
+	vote_signer_t const & signer,
+	nano::millis_t timestamp = nano::milliseconds_since_epoch ()) const;
+
+private:
+	nano::ledger & ledger;
+};
+}


### PR DESCRIPTION
Vote eligibility checks were previously scattered across `vote_generator` and `request_aggregator`, with each component independently deciding whether a block should receive a normal or final vote. This made it difficult to reason about vote safety as a whole, and easy to introduce inconsistencies when modifying one path but not the other.

This PR introduces a `voting_policy` class that serves as the single source of truth for all vote eligibility decisions and vote construction. The class exposes three eligibility methods (`vote_normal`, `vote_final`, `reply_final`) and a `sign` method that constructs and signs votes. A `vote_permit` type with a private constructor ensures that callers cannot bypass the policy.

The key safety invariants enforced by the policy are: normal votes require all block dependencies to be cemented and refuse to vote if a conflicting final vote record exists for the same root, final votes additionally claim a persistent slot via `final_vote.put` to prevent double-voting on forks, and the reply path (`reply_final`) is read-only and returns the recorded hash rather than the queried block's hash to avoid accidentally endorsing a fork during vote replies.

`vote_generator` and `request_aggregator` are updated to delegate all eligibility and signing decisions to `voting_policy`, removing their duplicated logic. The vote construction code that previously lived inside `vote_generator::broadcast` and `vote_generator::reply` is now handled by `voting_policy::sign`.