### PR TITLE
Lazy formatting for logger calls

### DIFF
--- a/nano/core_test/enums.cpp
+++ b/nano/core_test/enums.cpp
@@ -11,32 +11,32 @@
 
 TEST (enums, stat_type)
 {
-	ASSERT_FALSE (nano::to_string (static_cast<nano::stat::type> (0)).empty ());
-	ASSERT_NO_THROW (std::string{ nano::to_string (static_cast<nano::stat::type> (0)) });
+	ASSERT_FALSE (to_string (static_cast<nano::stat::type> (0)).empty ());
+	ASSERT_NO_THROW (std::string{ to_string (static_cast<nano::stat::type> (0)) });
 
-	ASSERT_FALSE (nano::to_string (nano::stat::type::_last).empty ());
-	ASSERT_NO_THROW (std::string{ nano::to_string (nano::stat::type::_last) });
-	ASSERT_EQ (nano::to_string (nano::stat::type::_last), "_last");
+	ASSERT_FALSE (to_string (nano::stat::type::_last).empty ());
+	ASSERT_NO_THROW (std::string{ to_string (nano::stat::type::_last) });
+	ASSERT_EQ (to_string (nano::stat::type::_last), "_last");
 }
 
 TEST (enums, stat_detail)
 {
-	ASSERT_FALSE (nano::to_string (static_cast<nano::stat::detail> (0)).empty ());
-	ASSERT_NO_THROW (std::string{ nano::to_string (static_cast<nano::stat::detail> (0)) });
+	ASSERT_FALSE (to_string (static_cast<nano::stat::detail> (0)).empty ());
+	ASSERT_NO_THROW (std::string{ to_string (static_cast<nano::stat::detail> (0)) });
 
-	ASSERT_FALSE (nano::to_string (nano::stat::detail::_last).empty ());
-	ASSERT_NO_THROW (std::string{ nano::to_string (nano::stat::detail::_last) });
-	ASSERT_EQ (nano::to_string (nano::stat::detail::_last), "_last");
+	ASSERT_FALSE (to_string (nano::stat::detail::_last).empty ());
+	ASSERT_NO_THROW (std::string{ to_string (nano::stat::detail::_last) });
+	ASSERT_EQ (to_string (nano::stat::detail::_last), "_last");
 }
 
 TEST (enums, stat_dir)
 {
-	ASSERT_FALSE (nano::to_string (static_cast<nano::stat::dir> (0)).empty ());
-	ASSERT_NO_THROW (std::string{ nano::to_string (static_cast<nano::stat::dir> (0)) });
+	ASSERT_FALSE (to_string (static_cast<nano::stat::dir> (0)).empty ());
+	ASSERT_NO_THROW (std::string{ to_string (static_cast<nano::stat::dir> (0)) });
 
-	ASSERT_FALSE (nano::to_string (nano::stat::dir::_last).empty ());
-	ASSERT_NO_THROW (std::string{ nano::to_string (nano::stat::dir::_last) });
-	ASSERT_EQ (nano::to_string (nano::stat::dir::_last), "_last");
+	ASSERT_FALSE (to_string (nano::stat::dir::_last).empty ());
+	ASSERT_NO_THROW (std::string{ to_string (nano::stat::dir::_last) });
+	ASSERT_EQ (to_string (nano::stat::dir::_last), "_last");
 }
 
 TEST (enums, log_type)

--- a/nano/core_test/numbers.cpp
+++ b/nano/core_test/numbers.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/balance_formatting.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/numbers_templ.hpp>
 #include <nano/secure/common.hpp>
@@ -254,7 +255,7 @@ struct test_punct : std::moneypunct<char>
 	}
 };
 
-TEST (uint128_union, balance_format)
+TEST (uint128_union, format_balance)
 {
 	ASSERT_EQ ("0", nano::amount (nano::uint128_t ("0")).format_balance (nano::nano_ratio, 0, false));
 	ASSERT_EQ ("0", nano::amount (nano::uint128_t ("0")).format_balance (nano::nano_ratio, 2, true));
@@ -274,6 +275,32 @@ TEST (uint128_union, balance_format)
 	ASSERT_EQ ("1", nano::amount (nano::uint128_t ("1230000000000000000000000000000")).format_balance (nano::nano_ratio, 0, true));
 	ASSERT_EQ ("123456789", nano::amount (nano::nano_ratio * 123456789).format_balance (nano::nano_ratio, 2, false));
 	ASSERT_EQ ("123,456,789", nano::amount (nano::nano_ratio * 123456789).format_balance (nano::nano_ratio, 2, true));
+	ASSERT_EQ ("0.5", nano::amount (nano::nano_ratio / 2).format_balance (nano::nano_ratio, 1, true));
+	ASSERT_EQ ("< 0.01", nano::amount (1).format_balance (nano::nano_ratio, 2, true));
+}
+
+TEST (uint128_union, encode_balance)
+{
+	auto encode = [] (nano::uint128_t value, nano::uint128_t scale, int precision, bool group_digits) {
+		std::ostringstream stream;
+		nano::uint128_union{ value }.encode_balance (stream, scale, precision, group_digits);
+		return stream.str ();
+	};
+	ASSERT_EQ ("0", encode (0, nano::nano_ratio, 0, false));
+	ASSERT_EQ ("0", encode (0, nano::nano_ratio, 2, true));
+	ASSERT_EQ ("340,282,366", encode (nano::uint128_t ("0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"), nano::nano_ratio, 0, true));
+	ASSERT_EQ ("1", encode (nano::uint128_t ("1000000000000000000000000000000"), nano::nano_ratio, 2, true));
+	ASSERT_EQ ("1.2", encode (nano::uint128_t ("1200000000000000000000000000000"), nano::nano_ratio, 2, true));
+	ASSERT_EQ ("1.23", encode (nano::uint128_t ("1230000000000000000000000000000"), nano::nano_ratio, 2, true));
+	ASSERT_EQ ("1.2", encode (nano::uint128_t ("1230000000000000000000000000000"), nano::nano_ratio, 1, true));
+	ASSERT_EQ ("1", encode (nano::uint128_t ("1230000000000000000000000000000"), nano::nano_ratio, 0, true));
+	ASSERT_EQ ("123,456,789", encode (nano::nano_ratio * 123456789, nano::nano_ratio, 2, true));
+	ASSERT_EQ ("123456789", encode (nano::nano_ratio * 123456789, nano::nano_ratio, 2, false));
+	ASSERT_EQ ("< 0.01", encode (nano::nano_ratio / 1000, nano::nano_ratio, 2, true));
+	ASSERT_EQ ("< 0.1", encode (nano::nano_ratio / 1000, nano::nano_ratio, 1, true));
+	ASSERT_EQ ("< 1", encode (nano::nano_ratio / 1000, nano::nano_ratio, 0, true));
+	ASSERT_EQ ("0.5", encode (nano::nano_ratio / 2, nano::nano_ratio, 1, true));
+	ASSERT_EQ ("< 0.01", encode (1, nano::nano_ratio, 2, true));
 }
 
 TEST (uint128_union, decode_decimal)
@@ -862,4 +889,20 @@ TEST (account, known_addresses)
 
 	nano::account account5{ "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF" };
 	ASSERT_EQ (account5.to_account (), "nano_3zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzc3yoon41");
+}
+
+TEST (balance_formatting, encode_balance)
+{
+	auto encode = [] (nano::uint128_t value, nano::uint128_t scale, int precision) {
+		std::ostringstream stream;
+		std::string grouping = "\3";
+		nano::encode_balance (stream, value, scale, precision, true, ',', '.', grouping);
+		return stream.str ();
+	};
+	ASSERT_EQ ("0", encode (0, nano::nano_ratio, 0));
+	ASSERT_EQ ("1", encode (nano::nano_ratio, nano::nano_ratio, 0));
+	ASSERT_EQ ("1.5", encode (nano::nano_ratio + nano::nano_ratio / 2, nano::nano_ratio, 1));
+	ASSERT_EQ ("1,000", encode (nano::nano_ratio * 1000, nano::nano_ratio, 0));
+	ASSERT_EQ ("< 0.01", encode (nano::nano_ratio / 1000, nano::nano_ratio, 2));
+	ASSERT_EQ ("< 0.000001", encode (1, nano::nano_ratio, 6));
 }

--- a/nano/core_test/object_stream.cpp
+++ b/nano/core_test/object_stream.cpp
@@ -513,8 +513,7 @@ TEST (object_stream, ostream_adapter)
 TEST (object_stream, fmt_adapter)
 {
 	streamable_object test_object;
-	auto str1 = fmt::format ("{}", test_object); // Using automatic fmt adapter
-	auto str2 = fmt::format ("{}", nano::streamed (test_object)); // Using explicit fmt adapter
+	auto str = fmt::format ("{}", nano::streamed (test_object)); // Using explicit fmt adapter
 
 	auto expected = trim (R"(
 {
@@ -523,8 +522,7 @@ TEST (object_stream, fmt_adapter)
 }
 )");
 
-	ASSERT_EQ (str1, expected);
-	ASSERT_EQ (str2, expected);
+	ASSERT_EQ (str, expected);
 }
 
 TEST (object_stream, to_string)

--- a/nano/core_test/vote_cache.cpp
+++ b/nano/core_test/vote_cache.cpp
@@ -21,7 +21,7 @@ std::function<nano::uint128_t (nano::account const & rep)> rep_weight_query ()
 	return [] (nano::account const & rep) { return rep_to_weight_map ()[rep]; };
 }
 
-void register_rep (nano::account & rep, nano::uint128_t weight)
+void register_rep (nano::account const & rep, nano::uint128_t weight)
 {
 	auto & map = rep_to_weight_map ();
 	map[rep] = weight;

--- a/nano/lib/balance_formatting.hpp
+++ b/nano/lib/balance_formatting.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+
+#include <string>
+
+namespace nano
+{
+template <typename Value>
+void encode_balance_frac (std::ostream & stream, Value value, Value scale, int precision)
+{
+	auto reduce = scale;
+	auto rem = value;
+	while (reduce > 1 && rem > 0 && precision > 0)
+	{
+		reduce /= 10;
+		auto val = rem / reduce;
+		rem -= val * reduce;
+		stream << val;
+		precision--;
+	}
+}
+
+template <typename Value>
+void encode_balance_int (std::ostream & stream, Value value, char group_sep, std::string const & groupings)
+{
+	auto largestPow10 = nano::uint256_t (1);
+	int dec_count = 1;
+	while (1)
+	{
+		auto next = largestPow10 * 10;
+		if (next > value)
+		{
+			break;
+		}
+		largestPow10 = next;
+		dec_count++;
+	}
+
+	if (dec_count > 39)
+	{
+		return;
+	}
+
+	bool emit_group[39];
+	if (group_sep != 0)
+	{
+		int group_index = 0;
+		int group_count = 0;
+		for (int i = 0; i < dec_count; i++)
+		{
+			group_count++;
+			if (group_count > groupings[group_index])
+			{
+				group_index = std::min (group_index + 1, (int)groupings.length () - 1);
+				group_count = 1;
+				emit_group[i] = true;
+			}
+			else
+			{
+				emit_group[i] = false;
+			}
+		}
+	}
+
+	auto reduce = Value (largestPow10);
+	Value rem = value;
+	while (reduce > 0)
+	{
+		auto val = rem / reduce;
+		rem -= val * reduce;
+		stream << val;
+		dec_count--;
+		if (group_sep != 0 && emit_group[dec_count] && reduce > 1)
+		{
+			stream << group_sep;
+		}
+		reduce /= 10;
+	}
+}
+
+template <typename Value>
+void encode_balance (std::ostream & stream, Value balance, Value scale, int precision, bool group_digits, char thousands_sep, char decimal_point, std::string const & grouping)
+{
+	auto int_part = balance / scale;
+	auto frac_part = balance % scale;
+	auto prec_scale = scale;
+	for (int i = 0; i < precision; i++)
+	{
+		prec_scale /= 10;
+	}
+	if (int_part == 0 && frac_part > 0 && frac_part / prec_scale == 0)
+	{
+		stream << "< ";
+		if (precision > 0)
+		{
+			stream << "0";
+			stream << decimal_point;
+			for (int i = 0; i < precision - 1; i++)
+			{
+				stream << "0";
+			}
+		}
+		stream << "1";
+	}
+	else
+	{
+		encode_balance_int (stream, int_part, group_digits && grouping.length () > 0 ? thousands_sep : 0, grouping);
+		if (precision > 0 && frac_part > 0)
+		{
+			stream << decimal_point;
+			encode_balance_frac (stream, frac_part, scale, precision);
+		}
+	}
+}
+}

--- a/nano/lib/formatting.hpp
+++ b/nano/lib/formatting.hpp
@@ -134,23 +134,23 @@ struct as_node_id_formatter
 
 struct as_nano_formatter
 {
-	nano::uint128_t const value;
+	nano::uint128_t const & value;
 	int precision{ 1 };
 
 	friend std::ostream & operator<< (std::ostream & os, as_nano_formatter const & wrapper)
 	{
-		nano::uint128_union{ wrapper.value }.encode_balance (os, nano::nano_ratio, wrapper.precision, true);
+		nano::encode_balance (os, wrapper.value, nano::nano_ratio, wrapper.precision, true);
 		return os;
 	}
 };
 
 struct as_raw_nano_formatter
 {
-	nano::uint128_t const value;
+	nano::uint128_t const & value;
 
 	friend std::ostream & operator<< (std::ostream & os, as_raw_nano_formatter const & wrapper)
 	{
-		nano::uint128_union{ wrapper.value }.encode_dec (os);
+		os << wrapper.value;
 		return os;
 	}
 };
@@ -163,11 +163,11 @@ inline auto as_node_id (nano::public_key const & key)
 {
 	return as_node_id_formatter{ key };
 }
-inline auto as_nano (nano::uint128_t value, int precision = 1)
+inline auto as_nano (nano::uint128_t const & value, int precision = 1)
 {
 	return as_nano_formatter{ value, precision };
 }
-inline auto as_raw_nano (nano::uint128_t value)
+inline auto as_raw_nano (nano::uint128_t const & value)
 {
 	return as_raw_nano_formatter{ value };
 }

--- a/nano/lib/formatting.hpp
+++ b/nano/lib/formatting.hpp
@@ -92,3 +92,38 @@ struct fmt::formatter<boost::system::error_code> : fmt::formatter<std::string>
 		return fmt::format_to (ctx.out (), "{} {}:{}", ec.message (), ec.value (), ec.category ().name ());
 	}
 };
+
+// Lazy formatting wrappers for public_key alternative representations
+namespace nano::log
+{
+struct as_account
+{
+	nano::public_key const & key;
+
+	friend std::ostream & operator<< (std::ostream & os, as_account const & wrapper)
+	{
+		wrapper.key.encode_account (os);
+		return os;
+	}
+};
+
+struct as_node_id
+{
+	nano::public_key const & key;
+
+	friend std::ostream & operator<< (std::ostream & os, as_node_id const & wrapper)
+	{
+		wrapper.key.encode_node_id (os);
+		return os;
+	}
+};
+}
+
+template <>
+struct fmt::formatter<nano::log::as_account> : fmt::ostream_formatter
+{
+};
+template <>
+struct fmt::formatter<nano::log::as_node_id> : fmt::ostream_formatter
+{
+};

--- a/nano/lib/formatting.hpp
+++ b/nano/lib/formatting.hpp
@@ -104,65 +104,82 @@ struct fmt::formatter<boost::system::error_code> : fmt::formatter<std::string>
 // Lazy formatting wrappers for public_key alternative representations
 namespace nano::log
 {
-struct as_account
+struct as_account_formatter
 {
 	nano::public_key const & key;
 
-	friend std::ostream & operator<< (std::ostream & os, as_account const & wrapper)
+	friend std::ostream & operator<< (std::ostream & os, as_account_formatter const & wrapper)
 	{
 		wrapper.key.encode_account (os);
 		return os;
 	}
 };
 
-struct as_node_id
+struct as_node_id_formatter
 {
 	nano::public_key const & key;
 
-	friend std::ostream & operator<< (std::ostream & os, as_node_id const & wrapper)
+	friend std::ostream & operator<< (std::ostream & os, as_node_id_formatter const & wrapper)
 	{
 		wrapper.key.encode_node_id (os);
 		return os;
 	}
 };
 
-struct as_nano
+struct as_nano_formatter
 {
 	nano::uint128_t const value;
 	int precision{ 1 };
 
-	friend std::ostream & operator<< (std::ostream & os, as_nano const & wrapper)
+	friend std::ostream & operator<< (std::ostream & os, as_nano_formatter const & wrapper)
 	{
 		nano::uint128_union{ wrapper.value }.encode_balance (os, nano::nano_ratio, wrapper.precision, true);
 		return os;
 	}
 };
 
-struct as_raw_nano
+struct as_raw_nano_formatter
 {
 	nano::uint128_t const value;
 
-	friend std::ostream & operator<< (std::ostream & os, as_raw_nano const & wrapper)
+	friend std::ostream & operator<< (std::ostream & os, as_raw_nano_formatter const & wrapper)
 	{
 		nano::uint128_union{ wrapper.value }.encode_dec (os);
 		return os;
 	}
 };
+
+inline auto as_account (nano::public_key const & key)
+{
+	return as_account_formatter{ key };
+}
+inline auto as_node_id (nano::public_key const & key)
+{
+	return as_node_id_formatter{ key };
+}
+inline auto as_nano (nano::uint128_t value, int precision = 1)
+{
+	return as_nano_formatter{ value, precision };
+}
+inline auto as_raw_nano (nano::uint128_t value)
+{
+	return as_raw_nano_formatter{ value };
+}
 }
 
 template <>
-struct fmt::formatter<nano::log::as_account> : fmt::ostream_formatter
+struct fmt::formatter<nano::log::as_account_formatter> : fmt::ostream_formatter
 {
 };
 template <>
-struct fmt::formatter<nano::log::as_node_id> : fmt::ostream_formatter
+struct fmt::formatter<nano::log::as_node_id_formatter> : fmt::ostream_formatter
 {
 };
 template <>
-struct fmt::formatter<nano::log::as_nano> : fmt::ostream_formatter
+struct fmt::formatter<nano::log::as_nano_formatter> : fmt::ostream_formatter
 {
 };
 template <>
-struct fmt::formatter<nano::log::as_raw_nano> : fmt::ostream_formatter
+struct fmt::formatter<nano::log::as_raw_nano_formatter> : fmt::ostream_formatter
 {
 };

--- a/nano/lib/formatting.hpp
+++ b/nano/lib/formatting.hpp
@@ -129,13 +129,7 @@ struct as_node_id
 struct as_nano
 {
 	nano::uint128_t const value;
-	int precision;
-
-	as_nano (nano::uint128_t value_a, int precision_a = 0) :
-		value{ value_a },
-		precision{ precision_a }
-	{
-	}
+	int precision{ 1 };
 
 	friend std::ostream & operator<< (std::ostream & os, as_nano const & wrapper)
 	{

--- a/nano/lib/formatting.hpp
+++ b/nano/lib/formatting.hpp
@@ -72,6 +72,10 @@ struct fmt::formatter<nano::public_key> : fmt::formatter<nano::uint256_union>
 {
 };
 template <>
+struct fmt::formatter<nano::account> : fmt::ostream_formatter
+{
+};
+template <>
 struct fmt::formatter<nano::qualified_root> : fmt::formatter<nano::uint512_union>
 {
 };

--- a/nano/lib/formatting.hpp
+++ b/nano/lib/formatting.hpp
@@ -5,7 +5,25 @@
 
 #include <boost/system/error_code.hpp>
 
+#include <concepts>
+
+#include <fmt/format.h>
 #include <fmt/ostream.h>
+
+// Generic formatter for enums with an ADL-findable to_string() returning string_view
+template <typename T>
+	requires (std::is_enum_v<T> && requires (T const & t) {
+		{
+			to_string (t)
+		} -> std::same_as<std::string_view>;
+	})
+struct fmt::formatter<T> : fmt::formatter<std::string_view>
+{
+	auto format (T const & value, format_context & ctx) const
+	{
+		return fmt::formatter<std::string_view>::format (to_string (value), ctx);
+	}
+};
 
 template <>
 struct fmt::formatter<nano::endpoint> : fmt::ostream_formatter
@@ -61,17 +79,15 @@ template <>
 struct fmt::formatter<nano::root> : fmt::formatter<nano::hash_or_account>
 {
 };
+template <>
+struct fmt::formatter<nano::wallet_id> : fmt::formatter<nano::uint256_union>
+{
+};
 
 template <>
-struct fmt::formatter<boost::system::error_code>
+struct fmt::formatter<boost::system::error_code> : fmt::formatter<std::string>
 {
-	constexpr auto parse (format_parse_context & ctx)
-	{
-		return ctx.begin (); // No format specifiers supported
-	}
-
-	template <typename FormatContext>
-	auto format (const boost::system::error_code & ec, FormatContext & ctx)
+	auto format (const boost::system::error_code & ec, format_context & ctx)
 	{
 		return fmt::format_to (ctx.out (), "{} {}:{}", ec.message (), ec.value (), ec.category ().name ());
 	}

--- a/nano/lib/formatting.hpp
+++ b/nano/lib/formatting.hpp
@@ -139,7 +139,8 @@ struct as_nano
 
 	friend std::ostream & operator<< (std::ostream & os, as_nano const & wrapper)
 	{
-		return os << nano::uint128_union{ wrapper.value }.format_balance (nano::nano_ratio, wrapper.precision, true);
+		nano::uint128_union{ wrapper.value }.encode_balance (os, nano::nano_ratio, wrapper.precision, true);
+		return os;
 	}
 };
 

--- a/nano/lib/formatting.hpp
+++ b/nano/lib/formatting.hpp
@@ -33,6 +33,10 @@ template <>
 struct fmt::formatter<nano::ip_address> : fmt::ostream_formatter
 {
 };
+template <>
+struct fmt::formatter<boost::asio::ip::address_v4> : fmt::ostream_formatter
+{
+};
 
 template <>
 struct fmt::formatter<nano::uint128_t> : fmt::ostream_formatter

--- a/nano/lib/formatting.hpp
+++ b/nano/lib/formatting.hpp
@@ -19,7 +19,7 @@ template <typename T>
 	})
 struct fmt::formatter<T> : fmt::formatter<std::string_view>
 {
-	auto format (T const & value, format_context & ctx) const
+	auto format (T const & value, fmt::format_context & ctx) const
 	{
 		return fmt::formatter<std::string_view>::format (to_string (value), ctx);
 	}
@@ -95,7 +95,7 @@ struct fmt::formatter<nano::wallet_id> : fmt::formatter<nano::uint256_union>
 template <>
 struct fmt::formatter<boost::system::error_code> : fmt::formatter<std::string>
 {
-	auto format (const boost::system::error_code & ec, format_context & ctx)
+	auto format (const boost::system::error_code & ec, fmt::format_context & ctx)
 	{
 		return fmt::format_to (ctx.out (), "{} {}:{}", ec.message (), ec.value (), ec.category ().name ());
 	}

--- a/nano/lib/formatting.hpp
+++ b/nano/lib/formatting.hpp
@@ -92,9 +92,15 @@ struct fmt::formatter<nano::wallet_id> : fmt::formatter<nano::uint256_union>
 {
 };
 
+// Custom formatter for boost::system::error_code for more informative logging
 template <>
-struct fmt::formatter<boost::system::error_code> : fmt::formatter<std::string>
+struct fmt::formatter<boost::system::error_code>
 {
+	auto parse (fmt::format_parse_context & ctx)
+	{
+		return ctx.begin ();
+	}
+
 	auto format (const boost::system::error_code & ec, fmt::format_context & ctx)
 	{
 		return fmt::format_to (ctx.out (), "{} {}:{}", ec.message (), ec.value (), ec.category ().name ());

--- a/nano/lib/formatting.hpp
+++ b/nano/lib/formatting.hpp
@@ -121,6 +121,34 @@ struct as_node_id
 		return os;
 	}
 };
+
+struct as_nano
+{
+	nano::uint128_t const value;
+	int precision;
+
+	as_nano (nano::uint128_t value_a, int precision_a = 0) :
+		value{ value_a },
+		precision{ precision_a }
+	{
+	}
+
+	friend std::ostream & operator<< (std::ostream & os, as_nano const & wrapper)
+	{
+		return os << nano::uint128_union{ wrapper.value }.format_balance (nano::nano_ratio, wrapper.precision, true);
+	}
+};
+
+struct as_raw_nano
+{
+	nano::uint128_t const value;
+
+	friend std::ostream & operator<< (std::ostream & os, as_raw_nano const & wrapper)
+	{
+		nano::uint128_union{ wrapper.value }.encode_dec (os);
+		return os;
+	}
+};
 }
 
 template <>
@@ -129,5 +157,13 @@ struct fmt::formatter<nano::log::as_account> : fmt::ostream_formatter
 };
 template <>
 struct fmt::formatter<nano::log::as_node_id> : fmt::ostream_formatter
+{
+};
+template <>
+struct fmt::formatter<nano::log::as_nano> : fmt::ostream_formatter
+{
+};
+template <>
+struct fmt::formatter<nano::log::as_raw_nano> : fmt::ostream_formatter
 {
 };

--- a/nano/lib/fwd.hpp
+++ b/nano/lib/fwd.hpp
@@ -25,7 +25,7 @@ class root;
 class raw_key;
 class signature;
 class qualified_root;
-using account = public_key;
+class account;
 
 class block;
 class block_details;

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -586,16 +586,9 @@ std::string nano::uint128_union::to_string_dec () const
 	return stream.str ();
 }
 
-/*
- *
- */
-
 void nano::uint128_union::encode_balance (std::ostream & os, nano::uint128_t scale, int precision, bool group_digits) const
 {
-	auto thousands_sep = std::use_facet<std::numpunct<char>> (std::locale ()).thousands_sep ();
-	auto decimal_point = std::use_facet<std::numpunct<char>> (std::locale ()).decimal_point ();
-	std::string grouping = "\3";
-	nano::encode_balance (os, number (), scale, precision, group_digits, thousands_sep, decimal_point, grouping);
+	nano::encode_balance (os, number (), scale, precision, group_digits);
 }
 
 std::string nano::uint128_union::format_balance (nano::uint128_t scale, int precision, bool group_digits) const
@@ -638,6 +631,14 @@ std::string nano::hash_or_account::to_account () const
 /*
  *
  */
+
+void nano::encode_balance (std::ostream & os, nano::uint128_t value, nano::uint128_t scale, int precision, bool group_digits)
+{
+	auto thousands_sep = std::use_facet<std::numpunct<char>> (std::locale ()).thousands_sep ();
+	auto decimal_point = std::use_facet<std::numpunct<char>> (std::locale ()).decimal_point ();
+	std::string grouping = "\3";
+	nano::encode_balance (os, value, scale, precision, group_digits, thousands_sep, decimal_point, grouping);
+}
 
 std::string nano::to_string_hex (uint64_t const value_a)
 {

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -598,16 +598,6 @@ std::string nano::uint128_union::format_balance (nano::uint128_t scale, int prec
 	return stream.str ();
 }
 
-std::string nano::uint128_union::format_balance (nano::uint128_t scale, int precision, bool group_digits, std::locale const & locale) const
-{
-	auto thousands_sep = std::use_facet<std::moneypunct<char>> (locale).thousands_sep ();
-	auto decimal_point = std::use_facet<std::moneypunct<char>> (locale).decimal_point ();
-	std::string grouping = std::use_facet<std::moneypunct<char>> (locale).grouping ();
-	std::ostringstream stream;
-	nano::encode_balance (stream, number (), scale, precision, group_digits, thousands_sep, decimal_point, grouping);
-	return stream.str ();
-}
-
 bool nano::hash_or_account::decode_hex (std::string const & text_a)
 {
 	return raw.decode_hex (text_a);

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -97,7 +97,35 @@ nano::public_key const & nano::public_key::null ()
 
 std::string nano::public_key::to_node_id () const
 {
-	return to_account ().replace (0, 4, "node");
+	std::stringstream stream;
+	encode_node_id (stream);
+	return stream.str ();
+}
+
+void nano::public_key::encode_node_id (std::ostream & os) const
+{
+	// Same encoding as account but with "node_" prefix instead of "nano_"
+	uint64_t check = 0;
+
+	blake2b_state hash;
+	blake2b_init (&hash, 5);
+	blake2b_update (&hash, bytes.data (), bytes.size ());
+	blake2b_final (&hash, reinterpret_cast<uint8_t *> (&check), 5);
+
+	nano::uint512_t number_l{ number () };
+	number_l <<= 40;
+	number_l |= nano::uint512_t{ check };
+
+	std::array<char, 60> encoded{};
+	for (auto i (0); i < 60; ++i)
+	{
+		uint8_t r{ number_l & static_cast<uint8_t> (0x1f) };
+		number_l >>= 5;
+		encoded[59 - i] = account_encode (r);
+	}
+
+	os << "node_";
+	os.write (encoded.data (), encoded.size ());
 }
 
 bool nano::public_key::decode_node_id (std::string const & source_a)

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -1,6 +1,7 @@
 #include <nano/crypto/blake2/blake2.h>
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/crypto_lib/secure_memory.hpp>
+#include <nano/lib/balance_formatting.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/secure/common.hpp>
@@ -589,122 +590,19 @@ std::string nano::uint128_union::to_string_dec () const
  *
  */
 
-void format_frac (std::ostringstream & stream, nano::uint128_t value, nano::uint128_t scale, int precision)
-{
-	auto reduce = scale;
-	auto rem = value;
-	while (reduce > 1 && rem > 0 && precision > 0)
-	{
-		reduce /= 10;
-		auto val = rem / reduce;
-		rem -= val * reduce;
-		stream << val;
-		precision--;
-	}
-}
-
-void format_dec (std::ostringstream & stream, nano::uint128_t value, char group_sep, std::string const & groupings)
-{
-	auto largestPow10 = nano::uint256_t (1);
-	int dec_count = 1;
-	while (1)
-	{
-		auto next = largestPow10 * 10;
-		if (next > value)
-		{
-			break;
-		}
-		largestPow10 = next;
-		dec_count++;
-	}
-
-	if (dec_count > 39)
-	{
-		// Impossible.
-		return;
-	}
-
-	// This could be cached per-locale.
-	bool emit_group[39];
-	if (group_sep != 0)
-	{
-		int group_index = 0;
-		int group_count = 0;
-		for (int i = 0; i < dec_count; i++)
-		{
-			group_count++;
-			if (group_count > groupings[group_index])
-			{
-				group_index = std::min (group_index + 1, (int)groupings.length () - 1);
-				group_count = 1;
-				emit_group[i] = true;
-			}
-			else
-			{
-				emit_group[i] = false;
-			}
-		}
-	}
-
-	auto reduce = nano::uint128_t (largestPow10);
-	nano::uint128_t rem = value;
-	while (reduce > 0)
-	{
-		auto val = rem / reduce;
-		rem -= val * reduce;
-		stream << val;
-		dec_count--;
-		if (group_sep != 0 && emit_group[dec_count] && reduce > 1)
-		{
-			stream << group_sep;
-		}
-		reduce /= 10;
-	}
-}
-
-std::string format_balance (nano::uint128_t balance, nano::uint128_t scale, int precision, bool group_digits, char thousands_sep, char decimal_point, std::string & grouping)
-{
-	std::ostringstream stream;
-	auto int_part = balance / scale;
-	auto frac_part = balance % scale;
-	auto prec_scale = scale;
-	for (int i = 0; i < precision; i++)
-	{
-		prec_scale /= 10;
-	}
-	if (int_part == 0 && frac_part > 0 && frac_part / prec_scale == 0)
-	{
-		// Display e.g. "< 0.01" rather than 0.
-		stream << "< ";
-		if (precision > 0)
-		{
-			stream << "0";
-			stream << decimal_point;
-			for (int i = 0; i < precision - 1; i++)
-			{
-				stream << "0";
-			}
-		}
-		stream << "1";
-	}
-	else
-	{
-		format_dec (stream, int_part, group_digits && grouping.length () > 0 ? thousands_sep : 0, grouping);
-		if (precision > 0 && frac_part > 0)
-		{
-			stream << decimal_point;
-			format_frac (stream, frac_part, scale, precision);
-		}
-	}
-	return stream.str ();
-}
-
-std::string nano::uint128_union::format_balance (nano::uint128_t scale, int precision, bool group_digits) const
+void nano::uint128_union::encode_balance (std::ostream & os, nano::uint128_t scale, int precision, bool group_digits) const
 {
 	auto thousands_sep = std::use_facet<std::numpunct<char>> (std::locale ()).thousands_sep ();
 	auto decimal_point = std::use_facet<std::numpunct<char>> (std::locale ()).decimal_point ();
 	std::string grouping = "\3";
-	return ::format_balance (number (), scale, precision, group_digits, thousands_sep, decimal_point, grouping);
+	nano::encode_balance (os, number (), scale, precision, group_digits, thousands_sep, decimal_point, grouping);
+}
+
+std::string nano::uint128_union::format_balance (nano::uint128_t scale, int precision, bool group_digits) const
+{
+	std::ostringstream stream;
+	encode_balance (stream, scale, precision, group_digits);
+	return stream.str ();
 }
 
 std::string nano::uint128_union::format_balance (nano::uint128_t scale, int precision, bool group_digits, std::locale const & locale) const
@@ -712,7 +610,9 @@ std::string nano::uint128_union::format_balance (nano::uint128_t scale, int prec
 	auto thousands_sep = std::use_facet<std::moneypunct<char>> (locale).thousands_sep ();
 	auto decimal_point = std::use_facet<std::moneypunct<char>> (locale).decimal_point ();
 	std::string grouping = std::use_facet<std::moneypunct<char>> (locale).grouping ();
-	return ::format_balance (number (), scale, precision, group_digits, thousands_sep, decimal_point, grouping);
+	std::ostringstream stream;
+	nano::encode_balance (stream, number (), scale, precision, group_digits, thousands_sep, decimal_point, grouping);
+	return stream.str ();
 }
 
 bool nano::hash_or_account::decode_hex (std::string const & text_a)

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -229,7 +229,7 @@ public: // Keep operators inlined
 	}
 };
 
-class public_key final : public uint256_union
+class public_key : public uint256_union
 {
 public:
 	using uint256_union::uint256_union;
@@ -278,13 +278,20 @@ public: // Keep operators inlined
 	}
 };
 
-class wallet_id : public uint256_union
+class wallet_id final : public uint256_union
 {
 	using uint256_union::uint256_union;
 };
 
-// These are synonymous
-using account = public_key;
+class account final : public public_key
+{
+public:
+	using public_key::public_key;
+
+	account () = default;
+	account (nano::public_key const & key) :
+		public_key{ key } {};
+};
 
 class hash_or_account
 {

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -241,6 +241,7 @@ public:
 
 	bool decode_node_id (std::string const &);
 	void encode_account (std::ostream &) const;
+	void encode_node_id (std::ostream &) const;
 	bool decode_account (std::string const &);
 
 	std::string to_node_id () const;

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -534,11 +534,13 @@ std::ostream & operator<< (std::ostream &, const uint512_union &);
 std::ostream & operator<< (std::ostream &, const hash_or_account &);
 std::ostream & operator<< (std::ostream &, const account &);
 
+void encode_balance (std::ostream &, nano::uint128_t value, nano::uint128_t scale, int precision, bool group_digits);
+
 /**
  * Convert a double to string in fixed format
- * @param precision_a (optional) use a specific precision (default is the maximum)
+ * @param precision (optional) use a specific precision (default is the maximum)
  */
-std::string to_string (double const, int const precision_a = std::numeric_limits<double>::digits10);
+std::string to_string (double const, int const precision = std::numeric_limits<double>::digits10);
 
 namespace difficulty
 {

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -60,7 +60,6 @@ public:
 
 	void encode_balance (std::ostream &, nano::uint128_t scale, int precision, bool group_digits) const;
 	std::string format_balance (nano::uint128_t scale, int precision, bool group_digits) const;
-	std::string format_balance (nano::uint128_t scale, int precision, bool group_digits, std::locale const & locale) const;
 
 	void clear ()
 	{

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -58,6 +58,7 @@ public:
 	bool decode_dec (std::string const &, bool = false);
 	bool decode_dec (std::string const &, nano::uint128_t);
 
+	void encode_balance (std::ostream &, nano::uint128_t scale, int precision, bool group_digits) const;
 	std::string format_balance (nano::uint128_t scale, int precision, bool group_digits) const;
 	std::string format_balance (nano::uint128_t scale, int precision, bool group_digits, std::locale const & locale) const;
 

--- a/nano/lib/numbers_templ.hpp
+++ b/nano/lib/numbers_templ.hpp
@@ -31,6 +31,14 @@ struct hash<::nano::public_key>
 	}
 };
 template <>
+struct hash<::nano::account>
+{
+	size_t operator() (::nano::account const & value) const noexcept
+	{
+		return hash<::nano::uint256_union>{}(value);
+	}
+};
+template <>
 struct hash<::nano::block_hash>
 {
 	size_t operator() (::nano::block_hash const & value) const noexcept
@@ -128,6 +136,14 @@ struct hash<::nano::public_key>
 	size_t operator() (::nano::public_key const & value) const noexcept
 	{
 		return std::hash<::nano::public_key> () (value);
+	}
+};
+template <>
+struct hash<::nano::account>
+{
+	size_t operator() (::nano::account const & value) const noexcept
+	{
+		return std::hash<::nano::account> () (value);
 	}
 };
 template <>

--- a/nano/lib/object_stream_adapters.hpp
+++ b/nano/lib/object_stream_adapters.hpp
@@ -143,7 +143,7 @@ std::string to_json (Value const & value)
 template <nano::object_or_array_streamable Streamable>
 struct fmt::formatter<Streamable> : fmt::ostream_formatter
 {
-	auto format (Streamable const & value, format_context & ctx)
+	auto format (Streamable const & value, fmt::format_context & ctx)
 	{
 		return fmt::ostream_formatter::format (nano::streamed (value), ctx);
 	}

--- a/nano/lib/object_stream_adapters.hpp
+++ b/nano/lib/object_stream_adapters.hpp
@@ -136,15 +136,3 @@ std::string to_json (Value const & value)
 	return ss.str ();
 }
 }
-
-/*
- * Adapter that allows for printing using fmt library for all classes that implement object streaming
- */
-template <nano::object_or_array_streamable Streamable>
-struct fmt::formatter<Streamable> : fmt::ostream_formatter
-{
-	auto format (Streamable const & value, fmt::format_context & ctx)
-	{
-		return fmt::ostream_formatter::format (nano::streamed (value), ctx);
-	}
-};

--- a/nano/lib/stats.cpp
+++ b/nano/lib/stats.cpp
@@ -172,7 +172,7 @@ void nano::stats::sample (stat::sample sample, nano::stats::sampler_value_t valu
 
 	if (enable_logging)
 	{
-		logger.debug (nano::log::type::stats, "Sample: {} -> {}", to_string (sample), value);
+		logger.debug (nano::log::type::stats, "Sample: {} -> {}", sample, value);
 	}
 
 	// Updates need to happen while holding the mutex

--- a/nano/lib/stats_enums.cpp
+++ b/nano/lib/stats_enums.cpp
@@ -1,22 +1,22 @@
 #include <nano/lib/enum_util.hpp>
 #include <nano/lib/stats_enums.hpp>
 
-std::string_view nano::to_string (nano::stat::type type)
+std::string_view nano::stat::to_string (nano::stat::type type)
 {
 	return nano::enum_to_string (type);
 }
 
-std::string_view nano::to_string (nano::stat::detail detail)
+std::string_view nano::stat::to_string (nano::stat::detail detail)
 {
 	return nano::enum_to_string (detail);
 }
 
-std::string_view nano::to_string (nano::stat::dir dir)
+std::string_view nano::stat::to_string (nano::stat::dir dir)
 {
 	return nano::enum_to_string (dir);
 }
 
-std::string_view nano::to_string (nano::stat::sample sample)
+std::string_view nano::stat::to_string (nano::stat::sample sample)
 {
 	return nano::enum_to_string (sample);
 }

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -770,6 +770,12 @@ std::string_view to_string (stat::dir);
 std::string_view to_string (stat::sample);
 }
 
+// Make to_string overloads ADL-findable for stat enums
+namespace nano::stat
+{
+using nano::to_string;
+}
+
 // Ensure that the enum_range is large enough to hold all values (including future ones)
 template <>
 struct magic_enum::customize::enum_range<nano::stat::type>

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -762,18 +762,12 @@ enum class sample
 };
 }
 
-namespace nano
-{
-std::string_view to_string (stat::type);
-std::string_view to_string (stat::detail);
-std::string_view to_string (stat::dir);
-std::string_view to_string (stat::sample);
-}
-
-// Make to_string overloads ADL-findable for stat enums
 namespace nano::stat
 {
-using nano::to_string;
+std::string_view to_string (type);
+std::string_view to_string (detail);
+std::string_view to_string (dir);
+std::string_view to_string (sample);
 }
 
 // Ensure that the enum_range is large enough to hold all values (including future ones)

--- a/nano/lib/thread_runner.cpp
+++ b/nano/lib/thread_runner.cpp
@@ -26,7 +26,7 @@ nano::thread_runner::~thread_runner ()
 
 void nano::thread_runner::start ()
 {
-	logger.debug (nano::log::type::thread_runner, "Starting threads: {} ({})", num_threads, to_string (role));
+	logger.debug (nano::log::type::thread_runner, "Starting threads: {} ({})", num_threads, role);
 
 	for (auto i = 0; i < num_threads; ++i)
 	{
@@ -71,7 +71,7 @@ void nano::thread_runner::join ()
 
 	threads.clear ();
 
-	logger.debug (nano::log::type::thread_runner, "Stopped all threads ({})", to_string (role));
+	logger.debug (nano::log::type::thread_runner, "Stopped all threads ({})", role);
 
 	io_ctx.reset (); // Release shared_ptr to io_context
 }

--- a/nano/nano_node/benchmarks/benchmark_block_processing.cpp
+++ b/nano/nano_node/benchmarks/benchmark_block_processing.cpp
@@ -76,9 +76,9 @@ void run_block_processing_benchmark (boost::program_options::variables_map const
 
 	std::cout << "=== BENCHMARK: Block Processing ===\n";
 	std::cout << "Configuration:\n";
-	std::cout << fmt::format ("  Accounts: {}\n", config.num_accounts);
-	std::cout << fmt::format ("  Iterations: {}\n", config.num_iterations);
-	std::cout << fmt::format ("  Batch size: {}\n", config.batch_size);
+	fmt::print ("  Accounts: {}\n", config.num_accounts);
+	fmt::print ("  Iterations: {}\n", config.num_iterations);
+	fmt::print ("  Batch size: {}\n", config.batch_size);
 
 	// Setup node directly in run method
 	nano::set_active_network (nano::network_type::nano_dev_network);
@@ -104,9 +104,9 @@ void run_block_processing_benchmark (boost::program_options::variables_map const
 	nano::thread_runner runner (io_ctx, nano::default_logger (), node->config.io_threads);
 
 	std::cout << "\nSystem Info:\n";
-	std::cout << fmt::format ("  Backend: {}\n", node->store.vendor_get ());
-	std::cout << fmt::format ("  Block processor threads: {}\n", 1); // TODO: Log number of block processor threads when upstreamed
-	std::cout << fmt::format ("  Block processor batch size: {}\n", node->config.block_processor.batch_size);
+	fmt::print ("  Backend: {}\n", node->store.vendor_get ());
+	fmt::print ("  Block processor threads: {}\n", 1); // TODO: Log number of block processor threads when upstreamed
+	fmt::print ("  Block processor batch size: {}\n", node->config.block_processor.batch_size);
 	std::cout << "\n";
 
 	// Wait for node to be ready
@@ -149,7 +149,7 @@ block_processing_benchmark::block_processing_benchmark (std::shared_ptr<nano::no
 						gap_source_count++;
 						break;
 					default:
-						std::cout << fmt::format ("Block processing failed: {} for block {}\n", to_string (status), context.block->hash ().to_string ());
+						fmt::print ("Block processing failed: {} for block {}\n", to_string (status), context.block->hash ().to_string ());
 						failed_blocks_count++;
 						break;
 				}
@@ -161,7 +161,7 @@ block_processing_benchmark::block_processing_benchmark (std::shared_ptr<nano::no
 void block_processing_benchmark::run ()
 {
 	// Create account pool and distribute genesis funds to a random account
-	std::cout << fmt::format ("Generating {} accounts...\n", config.num_accounts);
+	fmt::print ("Generating {} accounts...\n", config.num_accounts);
 	pool.generate_accounts (config.num_accounts);
 
 	setup_genesis_distribution ();
@@ -169,11 +169,11 @@ void block_processing_benchmark::run ()
 	// Run multiple iterations to measure consistent performance
 	for (size_t iteration = 0; iteration < config.num_iterations; ++iteration)
 	{
-		std::cout << fmt::format ("\n--- Iteration {}/{} --------------------------------------------------------------\n", iteration + 1, config.num_iterations);
-		std::cout << fmt::format ("Generating {} random transfers...\n", config.batch_size / 2);
+		fmt::print ("\n--- Iteration {}/{} --------------------------------------------------------------\n", iteration + 1, config.num_iterations);
+		fmt::print ("Generating {} random transfers...\n", config.batch_size / 2);
 		auto blocks = generate_random_transfers ();
 
-		std::cout << fmt::format ("Processing {} blocks...\n", blocks.size ());
+		fmt::print ("Processing {} blocks...\n", blocks.size ());
 		run_iteration (blocks);
 	}
 
@@ -213,7 +213,7 @@ void block_processing_benchmark::run_iteration (std::deque<std::shared_ptr<nano:
 			auto current_l = current_blocks.lock ();
 			if (current_l->empty () || progress_interval.elapse (3s))
 			{
-				std::cout << fmt::format ("Blocks remaining: {:>9} (block processor: {:>9} | unchecked: {:>5})\n",
+				fmt::print ("Blocks remaining: {:>9} (block processor: {:>9} | unchecked: {:>5})\n",
 				current_l->size (),
 				node->block_processor.size (),
 				node->unchecked.count ());
@@ -230,7 +230,7 @@ void block_processing_benchmark::run_iteration (std::deque<std::shared_ptr<nano:
 	auto const time_end = std::chrono::high_resolution_clock::now ();
 	auto const time_us = std::chrono::duration_cast<std::chrono::microseconds> (time_end - time_begin).count ();
 
-	std::cout << fmt::format ("\nPerformance: {} blocks/sec [{:.2f}s] {} blocks processed\n",
+	fmt::print ("\nPerformance: {} blocks/sec [{:.2f}s] {} blocks processed\n",
 	total_blocks * 1000000 / time_us, time_us / 1000000.0, total_blocks);
 	std::cout << "─────────────────────────────────────────────────────────────────\n";
 
@@ -240,14 +240,14 @@ void block_processing_benchmark::run_iteration (std::deque<std::shared_ptr<nano:
 void block_processing_benchmark::print_statistics ()
 {
 	std::cout << "\n--- SUMMARY ---------------------------------------------------------------------\n\n";
-	std::cout << fmt::format ("Blocks processed:        {:>10}\n", processed_blocks_count.load ());
-	std::cout << fmt::format ("Blocks failed:           {:>10}\n", failed_blocks_count.load ());
-	std::cout << fmt::format ("Blocks old:              {:>10}\n", old_blocks_count.load ());
-	std::cout << fmt::format ("Blocks gap_previous:     {:>10}\n", gap_previous_count.load ());
-	std::cout << fmt::format ("Blocks gap_source:       {:>10}\n", gap_source_count.load ());
-	std::cout << fmt::format ("\n");
-	std::cout << fmt::format ("Accounts total:          {:>10}\n", pool.total_accounts ());
-	std::cout << fmt::format ("Accounts with balance:   {:>10} ({:.1f}%)\n",
+	fmt::print ("Blocks processed:        {:>10}\n", processed_blocks_count.load ());
+	fmt::print ("Blocks failed:           {:>10}\n", failed_blocks_count.load ());
+	fmt::print ("Blocks old:              {:>10}\n", old_blocks_count.load ());
+	fmt::print ("Blocks gap_previous:     {:>10}\n", gap_previous_count.load ());
+	fmt::print ("Blocks gap_source:       {:>10}\n", gap_source_count.load ());
+	fmt::print ("\n");
+	fmt::print ("Accounts total:          {:>10}\n", pool.total_accounts ());
+	fmt::print ("Accounts with balance:   {:>10} ({:.1f}%)\n",
 	pool.accounts_with_balance_count (),
 	100.0 * pool.accounts_with_balance_count () / pool.total_accounts ());
 }

--- a/nano/nano_node/benchmarks/benchmark_cementing.cpp
+++ b/nano/nano_node/benchmarks/benchmark_cementing.cpp
@@ -14,7 +14,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <thread>
@@ -74,12 +73,12 @@ void run_cementing_benchmark (boost::program_options::variables_map const & vm, 
 {
 	auto config = benchmark_config::parse (vm);
 
-	std::cout << "=== BENCHMARK: Cementing ===\n";
-	std::cout << "Configuration:\n";
-	std::cout << fmt::format ("  Mode: {}\n", config.cementing_mode == cementing_mode::root ? "root" : "sequential");
-	std::cout << fmt::format ("  Accounts: {}\n", config.num_accounts);
-	std::cout << fmt::format ("  Iterations: {}\n", config.num_iterations);
-	std::cout << fmt::format ("  Batch size: {}\n", config.batch_size);
+	fmt::print ("=== BENCHMARK: Cementing ===\n");
+	fmt::print ("Configuration:\n");
+	fmt::print ("  Mode: {}\n", config.cementing_mode == cementing_mode::root ? "root" : "sequential");
+	fmt::print ("  Accounts: {}\n", config.num_accounts);
+	fmt::print ("  Iterations: {}\n", config.num_iterations);
+	fmt::print ("  Batch size: {}\n", config.batch_size);
 
 	// Setup node directly in run method
 	nano::set_active_network (nano::network_type::nano_dev_network);
@@ -104,9 +103,9 @@ void run_cementing_benchmark (boost::program_options::variables_map const & vm, 
 	node->start ();
 	nano::thread_runner runner (io_ctx, nano::default_logger (), node->config.io_threads);
 
-	std::cout << "\nSystem Info:\n";
-	std::cout << fmt::format ("  Backend: {}\n", node->store.vendor_get ());
-	std::cout << "\n";
+	fmt::print ("\nSystem Info:\n");
+	fmt::print ("  Backend: {}\n", node->store.vendor_get ());
+	fmt::print ("\n");
 
 	// Wait for node to be ready
 	std::this_thread::sleep_for (500ms);
@@ -145,30 +144,30 @@ cementing_benchmark::cementing_benchmark (std::shared_ptr<nano::node> node_a, be
 
 void cementing_benchmark::run ()
 {
-	std::cout << fmt::format ("Generating {} accounts...\n", config.num_accounts);
+	fmt::print ("Generating {} accounts...\n", config.num_accounts);
 	pool.generate_accounts (config.num_accounts);
 
 	setup_genesis_distribution ();
 
-	std::cout << fmt::format ("Cementing mode: {}\n", config.cementing_mode == cementing_mode::root ? "root" : "sequential");
+	fmt::print ("Cementing mode: {}\n", config.cementing_mode == cementing_mode::root ? "root" : "sequential");
 
 	for (size_t iteration = 0; iteration < config.num_iterations; ++iteration)
 	{
-		std::cout << fmt::format ("\n--- Iteration {}/{} --------------------------------------------------------------\n", iteration + 1, config.num_iterations);
+		fmt::print ("\n--- Iteration {}/{} --------------------------------------------------------------\n", iteration + 1, config.num_iterations);
 
 		std::deque<std::shared_ptr<nano::block>> blocks;
 		if (config.cementing_mode == cementing_mode::root)
 		{
-			std::cout << fmt::format ("Generating dependent chain topology...\n");
+			fmt::print ("Generating dependent chain topology...\n");
 			blocks = generate_dependent_chain ();
 		}
 		else
 		{
-			std::cout << fmt::format ("Generating {} random transfers...\n", config.batch_size / 2);
+			fmt::print ("Generating {} random transfers...\n", config.batch_size / 2);
 			blocks = generate_random_transfers ();
 		}
 
-		std::cout << fmt::format ("Cementing {} blocks...\n", blocks.size ());
+		fmt::print ("Cementing {} blocks...\n", blocks.size ());
 		run_iteration (blocks);
 	}
 
@@ -189,7 +188,7 @@ void cementing_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 		}
 	}
 
-	std::cout << fmt::format ("Processing {} blocks directly into the ledger...\n", blocks.size ());
+	fmt::print ("Processing {} blocks directly into the ledger...\n", blocks.size ());
 
 	// Process all blocks directly into the ledger
 	{
@@ -201,7 +200,7 @@ void cementing_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 		}
 	}
 
-	std::cout << "All blocks processed, starting cementing...\n";
+	fmt::print ("All blocks processed, starting cementing...\n");
 
 	auto const time_begin = std::chrono::high_resolution_clock::now ();
 
@@ -217,7 +216,7 @@ void cementing_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 			release_assert (added, "failed to add final block to cementing set");
 			blocks_submitted = 1;
 
-			std::cout << fmt::format ("Submitted 1 root block to cement {} dependent blocks\n",
+			fmt::print ("Submitted 1 root block to cement {} dependent blocks\n",
 			total_blocks);
 		}
 	}
@@ -234,7 +233,7 @@ void cementing_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 			blocks_submitted++;
 		}
 
-		std::cout << fmt::format ("Submitted {} blocks to cementing set\n",
+		fmt::print ("Submitted {} blocks to cementing set\n",
 		blocks_submitted);
 	}
 
@@ -246,7 +245,7 @@ void cementing_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 			auto pending_l = pending_cementing.lock ();
 			if (pending_l->empty () || progress_interval.elapse (3s))
 			{
-				std::cout << fmt::format ("Blocks remaining: {:>9} (cementing set: {:>5} | deferred: {:>5})\n",
+				fmt::print ("Blocks remaining: {:>9} (cementing set: {:>5} | deferred: {:>5})\n",
 				pending_l->size (),
 				node->cementing_set.size (),
 				node->cementing_set.deferred_size ());
@@ -263,22 +262,22 @@ void cementing_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 	auto const time_end = std::chrono::high_resolution_clock::now ();
 	auto const time_us = std::chrono::duration_cast<std::chrono::microseconds> (time_end - time_begin).count ();
 
-	std::cout << fmt::format ("\nPerformance: {} blocks/sec [{:.2f}s] {} blocks processed\n",
+	fmt::print ("\nPerformance: {} blocks/sec [{:.2f}s] {} blocks processed\n",
 	total_blocks * 1000000 / time_us, time_us / 1000000.0, total_blocks);
-	std::cout << "─────────────────────────────────────────────────────────────────\n";
+	fmt::print ("─────────────────────────────────────────────────────────────────\n");
 
 	node->stats.clear ();
 }
 
 void cementing_benchmark::print_statistics ()
 {
-	std::cout << "\n--- SUMMARY ---------------------------------------------------------------------\n\n";
-	std::cout << fmt::format ("Mode:                    {:>10}\n", config.cementing_mode == cementing_mode::root ? "root" : "sequential");
-	std::cout << fmt::format ("Blocks processed:        {:>10}\n", processed_blocks_count.load ());
-	std::cout << fmt::format ("Blocks cemented:         {:>10}\n", cemented_blocks_count.load ());
-	std::cout << fmt::format ("\n");
-	std::cout << fmt::format ("Accounts total:          {:>10}\n", pool.total_accounts ());
-	std::cout << fmt::format ("Accounts with balance:   {:>10} ({:.1f}%)\n",
+	fmt::print ("\n--- SUMMARY ---------------------------------------------------------------------\n\n");
+	fmt::print ("Mode:                    {:>10}\n", config.cementing_mode == cementing_mode::root ? "root" : "sequential");
+	fmt::print ("Blocks processed:        {:>10}\n", processed_blocks_count.load ());
+	fmt::print ("Blocks cemented:         {:>10}\n", cemented_blocks_count.load ());
+	fmt::print ("\n");
+	fmt::print ("Accounts total:          {:>10}\n", pool.total_accounts ());
+	fmt::print ("Accounts with balance:   {:>10} ({:.1f}%)\n",
 	pool.accounts_with_balance_count (),
 	100.0 * pool.accounts_with_balance_count () / pool.total_accounts ());
 }

--- a/nano/nano_node/benchmarks/benchmark_elections.cpp
+++ b/nano/nano_node/benchmarks/benchmark_elections.cpp
@@ -16,7 +16,6 @@
 #include <boost/asio/io_context.hpp>
 
 #include <chrono>
-#include <iostream>
 #include <limits>
 #include <thread>
 
@@ -86,11 +85,11 @@ void run_elections_benchmark (boost::program_options::variables_map const & vm, 
 {
 	auto config = benchmark_config::parse (vm);
 
-	std::cout << "=== BENCHMARK: Elections ===\n";
-	std::cout << "Configuration:\n";
-	std::cout << fmt::format ("  Accounts: {}\n", config.num_accounts);
-	std::cout << fmt::format ("  Iterations: {}\n", config.num_iterations);
-	std::cout << fmt::format ("  Batch size: {}\n", config.batch_size);
+	fmt::print ("=== BENCHMARK: Elections ===\n");
+	fmt::print ("Configuration:\n");
+	fmt::print ("  Accounts: {}\n", config.num_accounts);
+	fmt::print ("  Iterations: {}\n", config.num_iterations);
+	fmt::print ("  Batch size: {}\n", config.batch_size);
 
 	// Setup node directly in run method
 	nano::set_active_network (nano::network_type::nano_dev_network);
@@ -124,9 +123,9 @@ void run_elections_benchmark (boost::program_options::variables_map const & vm, 
 	node->start ();
 	nano::thread_runner runner (io_ctx, nano::default_logger (), node->config.io_threads);
 
-	std::cout << "\nSystem Info:\n";
-	std::cout << fmt::format ("  Backend: {}\n", node->store.vendor_get ());
-	std::cout << "\n";
+	fmt::print ("\nSystem Info:\n");
+	fmt::print ("  Backend: {}\n", node->store.vendor_get ());
+	fmt::print ("\n");
 
 	// Insert dev genesis representative key for voting
 	auto wallet = node->wallets.create (nano::random_wallet_id ());
@@ -199,18 +198,18 @@ elections_benchmark::elections_benchmark (std::shared_ptr<nano::node> node_a, be
 
 void elections_benchmark::run ()
 {
-	std::cout << fmt::format ("Generating {} accounts...\n", config.num_accounts);
+	fmt::print ("Generating {} accounts...\n", config.num_accounts);
 	pool.generate_accounts (config.num_accounts);
 
 	setup_genesis_distribution (0.1); // Only distribute 10%, keep 90% for voting weight
 
 	for (size_t iteration = 0; iteration < config.num_iterations; ++iteration)
 	{
-		std::cout << fmt::format ("\n--- Iteration {}/{} --------------------------------------------------------------\n", iteration + 1, config.num_iterations);
-		std::cout << fmt::format ("Generating independent blocks...\n");
+		fmt::print ("\n--- Iteration {}/{} --------------------------------------------------------------\n", iteration + 1, config.num_iterations);
+		fmt::print ("Generating independent blocks...\n");
 		auto [sends, opens] = generate_independent_blocks ();
 
-		std::cout << fmt::format ("Measuring elections performance for {} opens...\n", opens.size ());
+		fmt::print ("Measuring elections performance for {} opens...\n", opens.size ());
 		run_iteration (sends, opens);
 	}
 
@@ -222,7 +221,7 @@ void elections_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 	auto const total_opens = opens.size ();
 
 	// Process and cement all send blocks directly
-	std::cout << fmt::format ("Processing and cementing {} send blocks...\n", sends.size ());
+	fmt::print ("Processing and cementing {} send blocks...\n", sends.size ());
 	{
 		auto transaction = node->ledger.tx_begin_write ();
 		for (auto const & send : sends)
@@ -237,7 +236,7 @@ void elections_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 	}
 
 	// Process open blocks into ledger without confirming
-	std::cout << fmt::format ("Processing {} open blocks into ledger...\n", opens.size ());
+	fmt::print ("Processing {} open blocks into ledger...\n", opens.size ());
 	{
 		auto transaction = node->ledger.tx_begin_write ();
 		for (auto const & open : opens)
@@ -264,7 +263,7 @@ void elections_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 	auto const time_begin = std::chrono::high_resolution_clock::now ();
 
 	// Manually start elections for open blocks only
-	std::cout << fmt::format ("Starting elections manually for {} open blocks...\n", opens.size ());
+	fmt::print ("Starting elections manually for {} open blocks...\n", opens.size ());
 	for (auto const & open : opens)
 	{
 		// Use manual scheduler to start election
@@ -281,7 +280,7 @@ void elections_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 
 			if ((pending_cementing_l->empty () && pending_confirmation_l->empty ()) || progress_interval.elapse (3s))
 			{
-				std::cout << fmt::format ("Confirming elections: {:>9} remaining | cementing: {:>9} remaining (active: {:>5} | cementing: {:>5} | deferred: {:>5})\n",
+				fmt::print ("Confirming elections: {:>9} remaining | cementing: {:>9} remaining (active: {:>5} | cementing: {:>5} | deferred: {:>5})\n",
 				pending_confirmation_l->size (),
 				pending_cementing_l->size (),
 				node->active.size (),
@@ -300,20 +299,20 @@ void elections_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>
 	auto const time_end = std::chrono::high_resolution_clock::now ();
 	auto const time_us = std::chrono::duration_cast<std::chrono::microseconds> (time_end - time_begin).count ();
 
-	std::cout << fmt::format ("\nPerformance: {} blocks/sec [{:.2f}s] {} blocks processed\n",
+	fmt::print ("\nPerformance: {} blocks/sec [{:.2f}s] {} blocks processed\n",
 	total_opens * 1000000 / time_us, time_us / 1000000.0, total_opens);
-	std::cout << "─────────────────────────────────────────────────────────────────\n";
+	fmt::print ("─────────────────────────────────────────────────────────────────\n");
 
 	node->stats.clear ();
 }
 
 void elections_benchmark::print_statistics ()
 {
-	std::cout << "\n--- SUMMARY ---------------------------------------------------------------------\n\n";
-	std::cout << fmt::format ("Elections started:       {:>10}\n", elections_started.load ());
-	std::cout << fmt::format ("Elections stopped:       {:>10}\n", elections_stopped.load ());
-	std::cout << fmt::format ("Elections confirmed:     {:>10}\n", elections_confirmed.load ());
-	std::cout << fmt::format ("\n");
+	fmt::print ("\n--- SUMMARY ---------------------------------------------------------------------\n\n");
+	fmt::print ("Elections started:       {:>10}\n", elections_started.load ());
+	fmt::print ("Elections stopped:       {:>10}\n", elections_stopped.load ());
+	fmt::print ("Elections confirmed:     {:>10}\n", elections_confirmed.load ());
+	fmt::print ("\n");
 
 	// Calculate timing statistics from raw data
 	auto timings_l = block_timings.lock ();
@@ -336,9 +335,9 @@ void elections_benchmark::print_statistics ()
 		confirmed_count++;
 	}
 
-	std::cout << "\n";
+	fmt::print ("\n");
 
-	std::cout << fmt::format ("Election time (activated > confirmed): {:>8.2f} ms/block avg\n", total_election_time / (election_count * 1000.0));
-	std::cout << fmt::format ("Total time (activated > cemented):     {:>8.2f} ms/block avg\n", total_confirmation_time / (confirmed_count * 1000.0));
+	fmt::print ("Election time (activated > confirmed): {:>8.2f} ms/block avg\n", total_election_time / (election_count * 1000.0));
+	fmt::print ("Total time (activated > cemented):     {:>8.2f} ms/block avg\n", total_confirmation_time / (confirmed_count * 1000.0));
 }
 }

--- a/nano/nano_node/benchmarks/benchmark_pipeline.cpp
+++ b/nano/nano_node/benchmarks/benchmark_pipeline.cpp
@@ -15,7 +15,6 @@
 #include <boost/asio/io_context.hpp>
 
 #include <chrono>
-#include <iostream>
 #include <limits>
 #include <thread>
 
@@ -91,11 +90,11 @@ void run_pipeline_benchmark (boost::program_options::variables_map const & vm, s
 {
 	auto config = benchmark_config::parse (vm);
 
-	std::cout << "=== BENCHMARK: Full Pipeline ===\n";
-	std::cout << "Configuration:\n";
-	std::cout << fmt::format ("  Accounts: {}\n", config.num_accounts);
-	std::cout << fmt::format ("  Iterations: {}\n", config.num_iterations);
-	std::cout << fmt::format ("  Batch size: {}\n", config.batch_size);
+	fmt::print ("=== BENCHMARK: Full Pipeline ===\n");
+	fmt::print ("Configuration:\n");
+	fmt::print ("  Accounts: {}\n", config.num_accounts);
+	fmt::print ("  Iterations: {}\n", config.num_iterations);
+	fmt::print ("  Batch size: {}\n", config.batch_size);
 
 	// Setup node directly in run method
 	nano::set_active_network (nano::network_type::nano_dev_network);
@@ -126,18 +125,18 @@ void run_pipeline_benchmark (boost::program_options::variables_map const & vm, s
 	node->start ();
 	nano::thread_runner runner (io_ctx, nano::default_logger (), node->config.io_threads);
 
-	std::cout << "\nSystem Info:\n";
-	std::cout << fmt::format ("  Backend: {}\n", node->store.vendor_get ());
-	std::cout << fmt::format ("  Block processor threads: {}\n", 1); // TODO: Log number of block processor threads when upstreamed
-	std::cout << fmt::format ("  Vote processor threads: {}\n", node->config.vote_processor.threads);
-	std::cout << fmt::format ("  Active elections limit: {}\n", node->config.active_elections.size);
-	std::cout << fmt::format ("  Priority pool max blocks: {}\n", node->config.priority_scheduler.max_blocks);
-	std::cout << fmt::format ("  Priority bucket max elections: {}\n", node->config.priority_scheduler.max_elections);
-	std::cout << fmt::format ("  Block processor max peer queue: {}\n", node->config.block_processor.max_peer_queue);
-	std::cout << fmt::format ("  Block processor max system queue: {}\n", node->config.block_processor.max_system_queue);
-	std::cout << fmt::format ("  Vote processor max pr queue: {}\n", node->config.vote_processor.max_pr_queue);
-	std::cout << fmt::format ("  Max unchecked blocks: {}\n", node->config.max_unchecked_blocks);
-	std::cout << "\n";
+	fmt::print ("\nSystem Info:\n");
+	fmt::print ("  Backend: {}\n", node->store.vendor_get ());
+	fmt::print ("  Block processor threads: {}\n", 1); // TODO: Log number of block processor threads when upstreamed
+	fmt::print ("  Vote processor threads: {}\n", node->config.vote_processor.threads);
+	fmt::print ("  Active elections limit: {}\n", node->config.active_elections.size);
+	fmt::print ("  Priority pool max blocks: {}\n", node->config.priority_scheduler.max_blocks);
+	fmt::print ("  Priority bucket max elections: {}\n", node->config.priority_scheduler.max_elections);
+	fmt::print ("  Block processor max peer queue: {}\n", node->config.block_processor.max_peer_queue);
+	fmt::print ("  Block processor max system queue: {}\n", node->config.block_processor.max_system_queue);
+	fmt::print ("  Vote processor max pr queue: {}\n", node->config.vote_processor.max_pr_queue);
+	fmt::print ("  Max unchecked blocks: {}\n", node->config.max_unchecked_blocks);
+	fmt::print ("\n");
 
 	// Insert dev genesis representative key for voting
 	auto wallet = node->wallets.create (nano::random_wallet_id ());
@@ -226,18 +225,18 @@ pipeline_benchmark::pipeline_benchmark (std::shared_ptr<nano::node> node_a, benc
 
 void pipeline_benchmark::run ()
 {
-	std::cout << fmt::format ("Generating {} accounts...\n", config.num_accounts);
+	fmt::print ("Generating {} accounts...\n", config.num_accounts);
 	pool.generate_accounts (config.num_accounts);
 
 	setup_genesis_distribution (0.1); // Only distribute 10%, keep 90% for voting weight
 
 	for (size_t iteration = 0; iteration < config.num_iterations; ++iteration)
 	{
-		std::cout << fmt::format ("\n--- Iteration {}/{} --------------------------------------------------------------\n", iteration + 1, config.num_iterations);
-		std::cout << fmt::format ("Generating {} random transfers...\n", config.batch_size / 2);
+		fmt::print ("\n--- Iteration {}/{} --------------------------------------------------------------\n", iteration + 1, config.num_iterations);
+		fmt::print ("Generating {} random transfers...\n", config.batch_size / 2);
 		auto blocks = generate_random_transfers ();
 
-		std::cout << fmt::format ("Measuring full confirmation pipeline for {} blocks...\n", blocks.size ());
+		fmt::print ("Measuring full confirmation pipeline for {} blocks...\n", blocks.size ());
 		run_iteration (blocks);
 	}
 
@@ -280,7 +279,7 @@ void pipeline_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>>
 			auto pending_l = pending_cementing.lock ();
 			if (pending_l->empty () || progress_interval.elapse (3s))
 			{
-				std::cout << fmt::format ("Blocks remaining: {:>9} (block processor: {:>9} | active: {:>5} | cementing: {:>5} | pool: {:>5})\n",
+				fmt::print ("Blocks remaining: {:>9} (block processor: {:>9} | active: {:>5} | cementing: {:>5} | pool: {:>5})\n",
 				pending_l->size (),
 				node->block_processor.size (),
 				node->active.size (),
@@ -299,23 +298,23 @@ void pipeline_benchmark::run_iteration (std::deque<std::shared_ptr<nano::block>>
 	auto const time_end = std::chrono::high_resolution_clock::now ();
 	auto const time_us = std::chrono::duration_cast<std::chrono::microseconds> (time_end - time_begin).count ();
 
-	std::cout << fmt::format ("\nPerformance: {} blocks/sec [{:.2f}s] {} blocks processed\n",
+	fmt::print ("\nPerformance: {} blocks/sec [{:.2f}s] {} blocks processed\n",
 	total_blocks * 1000000 / time_us, time_us / 1000000.0, total_blocks);
-	std::cout << "─────────────────────────────────────────────────────────────────\n";
+	fmt::print ("─────────────────────────────────────────────────────────────────\n");
 
 	node->stats.clear ();
 }
 
 void pipeline_benchmark::print_statistics ()
 {
-	std::cout << "\n--- SUMMARY ---------------------------------------------------------------------\n\n";
-	std::cout << fmt::format ("Blocks processed:        {:>10}\n", processed_blocks_count.load ());
-	std::cout << fmt::format ("Elections started:       {:>10}\n", elections_started.load ());
-	std::cout << fmt::format ("Elections stopped:       {:>10}\n", elections_stopped.load ());
-	std::cout << fmt::format ("Elections confirmed:     {:>10}\n", elections_confirmed.load ());
-	std::cout << fmt::format ("\n");
-	std::cout << fmt::format ("Accounts total:          {:>10}\n", pool.total_accounts ());
-	std::cout << fmt::format ("Accounts with balance:   {:>10} ({:.1f}%)\n",
+	fmt::print ("\n--- SUMMARY ---------------------------------------------------------------------\n\n");
+	fmt::print ("Blocks processed:        {:>10}\n", processed_blocks_count.load ());
+	fmt::print ("Elections started:       {:>10}\n", elections_started.load ());
+	fmt::print ("Elections stopped:       {:>10}\n", elections_stopped.load ());
+	fmt::print ("Elections confirmed:     {:>10}\n", elections_confirmed.load ());
+	fmt::print ("\n");
+	fmt::print ("Accounts total:          {:>10}\n", pool.total_accounts ());
+	fmt::print ("Accounts with balance:   {:>10} ({:.1f}%)\n",
 	pool.accounts_with_balance_count (),
 	100.0 * pool.accounts_with_balance_count () / pool.total_accounts ());
 
@@ -351,10 +350,10 @@ void pipeline_benchmark::print_statistics ()
 		cemented_count++;
 	}
 
-	std::cout << "\n";
-	std::cout << fmt::format ("Block processing (submitted > processed):    {:>8.2f} ms/block avg\n", total_processing_time / (processed_count * 1000.0));
-	std::cout << fmt::format ("Election activation (processed > activated): {:>8.2f} ms/block avg\n", total_activation_time / (activation_count * 1000.0));
-	std::cout << fmt::format ("Election time (activated > confirmed):       {:>8.2f} ms/block avg\n", total_election_time / (election_count * 1000.0));
-	std::cout << fmt::format ("Total pipeline (submitted > cemented):       {:>8.2f} ms/block avg\n", total_cementing_time / (cemented_count * 1000.0));
+	fmt::print ("\n");
+	fmt::print ("Block processing (submitted > processed):    {:>8.2f} ms/block avg\n", total_processing_time / (processed_count * 1000.0));
+	fmt::print ("Election activation (processed > activated): {:>8.2f} ms/block avg\n", total_activation_time / (activation_count * 1000.0));
+	fmt::print ("Election time (activated > confirmed):       {:>8.2f} ms/block avg\n", total_election_time / (election_count * 1000.0));
+	fmt::print ("Total pipeline (submitted > cemented):       {:>8.2f} ms/block avg\n", total_cementing_time / (cemented_count * 1000.0));
 }
 }

--- a/nano/nano_node/benchmarks/benchmarks.cpp
+++ b/nano/nano_node/benchmarks/benchmarks.cpp
@@ -250,7 +250,7 @@ void benchmark_base::setup_genesis_distribution (double distribution_percentage)
 	// Initialize frontier for target account
 	pool.set_frontier (target_account, open->hash ());
 
-	std::cout << fmt::format ("Genesis distribution complete: {:.1f}% distributed, {:.1f}% retained for voting\n",
+	fmt::print ("Genesis distribution complete: {:.1f}% distributed, {:.1f}% retained for voting\n",
 	distribution_percentage * 100.0, (1.0 - distribution_percentage) * 100.0);
 }
 
@@ -367,7 +367,7 @@ std::deque<std::shared_ptr<nano::block>> benchmark_base::generate_random_transfe
 		transfers_generated++;
 	}
 
-	std::cout << fmt::format ("Generated {} blocks\n", blocks.size ());
+	fmt::print ("Generated {} blocks\n", blocks.size ());
 
 	return blocks;
 }
@@ -399,7 +399,7 @@ std::deque<std::shared_ptr<nano::block>> benchmark_base::generate_dependent_chai
 	size_t random_transfer_blocks = config.batch_size * 0.8;
 	size_t transfers_to_generate = random_transfer_blocks / 2; // Each transfer creates 2 blocks
 
-	std::cout << fmt::format ("Generating dependent chain: {} random transfers, then convergence\n",
+	fmt::print ("Generating dependent chain: {} random transfers, then convergence\n",
 	transfers_to_generate);
 
 	// Phase 1: Generate random transfers (same logic as generate_random_transfers)
@@ -464,7 +464,7 @@ std::deque<std::shared_ptr<nano::block>> benchmark_base::generate_dependent_chai
 	}
 
 	// Phase 2: Convergence - all accounts with balance send to a collector
-	std::cout << fmt::format ("Converging {} accounts to collector account\n",
+	fmt::print ("Converging {} accounts to collector account\n",
 	pool.accounts_with_balance_count ());
 
 	// Select a collector account (can be new or existing)
@@ -535,7 +535,7 @@ std::deque<std::shared_ptr<nano::block>> benchmark_base::generate_dependent_chai
 	pool.set_frontier (collector, collector_frontier);
 	pool.update_balance (collector, collector_balance);
 
-	std::cout << fmt::format ("Generated {} blocks in dependent chain topology\n", blocks.size ());
+	fmt::print ("Generated {} blocks in dependent chain topology\n", blocks.size ());
 
 	return blocks;
 }
@@ -609,7 +609,7 @@ std::pair<std::deque<std::shared_ptr<nano::block>>, std::deque<std::shared_ptr<n
 		pool.update_balance (sender, new_sender_balance);
 	}
 
-	std::cout << fmt::format ("Generated {} sends and {} opens\n", sends.size (), opens.size ());
+	fmt::print ("Generated {} sends and {} opens\n", sends.size (), opens.size ());
 
 	return { sends, opens };
 }

--- a/nano/node/block_processor.cpp
+++ b/nano/node/block_processor.cpp
@@ -9,6 +9,7 @@
 #include <nano/node/ledger_notifications.hpp>
 #include <nano/node/local_vote_history.hpp>
 #include <nano/node/node.hpp>
+#include <nano/node/transport/formatting.hpp>
 #include <nano/node/unchecked_map.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
@@ -116,10 +117,7 @@ bool nano::block_processor::add (std::shared_ptr<nano::block> const & block, blo
 	}
 
 	stats.inc (nano::stat::type::block_processor, nano::stat::detail::process);
-	logger.debug (nano::log::type::block_processor, "Processing block (async): {} (source: {} {})",
-	block->hash ().to_string (),
-	to_string (source),
-	channel ? channel->to_string () : "<unknown>"); // TODO: Lazy eval
+	logger.debug (nano::log::type::block_processor, "Processing block (async): {} (source: {} {})", block->hash (), source, channel);
 
 	return add_impl ({ block, source, std::move (callback) }, channel);
 }
@@ -127,7 +125,7 @@ bool nano::block_processor::add (std::shared_ptr<nano::block> const & block, blo
 std::optional<nano::block_status> nano::block_processor::add_blocking (std::shared_ptr<nano::block> const & block, block_source const source)
 {
 	stats.inc (nano::stat::type::block_processor, nano::stat::detail::process_blocking);
-	logger.debug (nano::log::type::block_processor, "Processing block (blocking): {} (source: {})", block->hash ().to_string (), to_string (source));
+	logger.debug (nano::log::type::block_processor, "Processing block (blocking): {} (source: {})", block->hash (), source);
 
 	nano::block_context ctx{ block, source };
 	auto future = ctx.get_future ();
@@ -141,7 +139,7 @@ std::optional<nano::block_status> nano::block_processor::add_blocking (std::shar
 	catch (std::future_error const &)
 	{
 		stats.inc (nano::stat::type::block_processor, nano::stat::detail::process_blocking_timeout);
-		logger.error (nano::log::type::block_processor, "Block dropped when processing: {}", block->hash ().to_string ());
+		logger.error (nano::log::type::block_processor, "Block dropped when processing: {}", block->hash ());
 	}
 
 	return std::nullopt;
@@ -150,7 +148,7 @@ std::optional<nano::block_status> nano::block_processor::add_blocking (std::shar
 void nano::block_processor::force (std::shared_ptr<nano::block> const & block_a)
 {
 	stats.inc (nano::stat::type::block_processor, nano::stat::detail::force);
-	logger.debug (nano::log::type::block_processor, "Forcing block: {}", block_a->hash ().to_string ());
+	logger.debug (nano::log::type::block_processor, "Forcing block: {}", block_a->hash ());
 
 	add_impl ({ block_a, block_source::forced });
 }
@@ -183,19 +181,19 @@ void nano::block_processor::rollback_competitor (secure::write_transaction & tra
 	if (successor != nullptr && successor->hash () != hash)
 	{
 		// Replace our block with the winner and roll back any dependent blocks
-		logger.debug (nano::log::type::block_processor, "Rolling back: {} and replacing with: {}", successor->hash ().to_string (), hash.to_string ());
+		logger.debug (nano::log::type::block_processor, "Rolling back: {} and replacing with: {}", successor->hash (), hash);
 
 		std::deque<std::shared_ptr<nano::block>> rollback_list;
 		bool error = ledger.rollback (transaction, successor->hash (), rollback_list);
 		if (error)
 		{
 			stats.inc (nano::stat::type::ledger, nano::stat::detail::rollback_failed);
-			logger.warn (nano::log::type::block_processor, "Failed to roll back: {} (succeeded with {} dependents)", successor->hash ().to_string (), rollback_list.size ());
+			logger.warn (nano::log::type::block_processor, "Failed to roll back: {} (succeeded with {} dependents)", successor->hash (), rollback_list.size ());
 		}
 		else
 		{
 			stats.inc (nano::stat::type::ledger, nano::stat::detail::rollback);
-			logger.debug (nano::log::type::block_processor, "Rolled back {} with {} dependents", successor->hash ().to_string (), rollback_list.size ());
+			logger.debug (nano::log::type::block_processor, "Rolled back {} with {} dependents", successor->hash (), rollback_list.size ());
 		}
 
 		if (!rollback_list.empty ())
@@ -376,7 +374,10 @@ void nano::block_processor::process_batch (nano::unique_lock<nano::mutex> & lock
 
 	if (number_of_blocks_processed != 0 && timer.stop () > std::chrono::milliseconds (100))
 	{
-		logger.debug (nano::log::type::block_processor, "Processed {} blocks ({} forced) in {} {}", number_of_blocks_processed, number_of_forced_processed, timer.value ().count (), timer.unit ());
+		logger.debug (nano::log::type::block_processor, "Processed {} blocks ({} forced) in {} {}",
+		number_of_blocks_processed,
+		number_of_forced_processed,
+		timer.value ().count (), timer.unit ());
 	}
 
 	// Queue notifications to be dispatched in the background

--- a/nano/node/bootstrap/bootstrap_context.cpp
+++ b/nano/node/bootstrap/bootstrap_context.cpp
@@ -13,6 +13,7 @@
 #include <nano/node/ledger_notifications.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
+#include <nano/node/transport/formatting.hpp>
 #include <nano/node/transport/transport.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
@@ -294,7 +295,7 @@ bool bootstrap_context::request (nano::account account, size_t count, std::share
 				account,
 				payload.start,
 				optimistic_request,
-				channel->to_string ());
+				channel);
 			}
 			else // Pessimistic (safe) request case
 			{
@@ -310,7 +311,7 @@ bool bootstrap_context::request (nano::account account, size_t count, std::share
 					account,
 					payload.start,
 					optimistic_request,
-					channel->to_string ());
+					channel);
 				}
 				else
 				{
@@ -320,7 +321,7 @@ bool bootstrap_context::request (nano::account account, size_t count, std::share
 					logger.debug (nano::log::type::bootstrap, "Requesting blocks for {} starting from account root (optimistic: {}) from: {}",
 					account,
 					optimistic_request,
-					channel->to_string ());
+					channel);
 				}
 			}
 		}
@@ -331,7 +332,7 @@ bool bootstrap_context::request (nano::account account, size_t count, std::share
 			tag.type = query_type::blocks_by_account;
 			payload.start = account;
 
-			logger.debug (nano::log::type::bootstrap, "Requesting blocks for {} from: {}", account, channel->to_string ());
+			logger.debug (nano::log::type::bootstrap, "Requesting blocks for {} from: {}", account, channel);
 		}
 	}
 

--- a/nano/node/bootstrap/dependency_strategy.cpp
+++ b/nano/node/bootstrap/dependency_strategy.cpp
@@ -2,6 +2,7 @@
 #include <nano/lib/thread_roles.hpp>
 #include <nano/node/bootstrap/dependency_strategy.hpp>
 #include <nano/node/nodeconfig.hpp>
+#include <nano/node/transport/formatting.hpp>
 
 using namespace std::chrono_literals;
 
@@ -112,7 +113,7 @@ bool dependency_strategy::request_info (nano::block_hash hash, std::shared_ptr<n
 	message.payload = msg_pld;
 	message.update_header ();
 
-	ctx.logger.debug (nano::log::type::bootstrap, "Requesting account info for: {} from: {}", hash, channel->to_string ());
+	ctx.logger.debug (nano::log::type::bootstrap, "Requesting account info for: {} from: {}", hash, channel);
 
 	return ctx.send (channel, std::move (message), tag);
 }

--- a/nano/node/bootstrap/frontier_strategy.cpp
+++ b/nano/node/bootstrap/frontier_strategy.cpp
@@ -3,6 +3,7 @@
 #include <nano/node/bootstrap/frontier_strategy.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
+#include <nano/node/transport/formatting.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
@@ -106,7 +107,7 @@ bool frontier_strategy::request_frontiers (nano::account start, std::shared_ptr<
 	message.payload = msg_pld;
 	message.update_header ();
 
-	ctx.logger.debug (nano::log::type::bootstrap, "Requesting frontiers starting from: {} from: {}", start, channel->to_string ());
+	ctx.logger.debug (nano::log::type::bootstrap, "Requesting frontiers starting from: {} from: {}", start, channel);
 
 	return ctx.send (channel, std::move (message), tag);
 }

--- a/nano/node/bounded_backlog.cpp
+++ b/nano/node/bounded_backlog.cpp
@@ -319,12 +319,12 @@ std::deque<nano::block_hash> nano::bounded_backlog::perform_rollbacks (std::dequ
 			if (error)
 			{
 				stats.inc (nano::stat::type::bounded_backlog, nano::stat::detail::rollback_failed);
-				logger.warn (nano::log::type::bounded_backlog, "Failed to roll back: {} (succeeded with {} dependents)", hash.to_string (), rollback_list.size ());
+				logger.warn (nano::log::type::bounded_backlog, "Failed to roll back: {} (succeeded with {} dependents)", hash, rollback_list.size ());
 			}
 			else
 			{
 				stats.inc (nano::stat::type::bounded_backlog, nano::stat::detail::rollback);
-				logger.debug (nano::log::type::bounded_backlog, "Rolled back {} with {} dependents", hash.to_string (), rollback_list.size ());
+				logger.debug (nano::log::type::bounded_backlog, "Rolled back {} with {} dependents", hash, rollback_list.size ());
 			}
 
 			for (auto const & rollback : rollback_list)

--- a/nano/node/monitor.cpp
+++ b/nano/node/monitor.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/formatting.hpp>
 #include <nano/lib/thread_roles.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/monitor.hpp>
@@ -97,9 +98,9 @@ void nano::monitor::run_one ()
 	auto const stake_peered = node.rep_crawler.total_weight ();
 
 	logger.info (nano::log::type::monitor, "Quorum: {} (stake peered: {} | stake online: {})",
-	nano::uint128_union{ quorum }.format_balance (nano_ratio, 1, true),
-	nano::uint128_union{ stake_peered }.format_balance (nano_ratio, 1, true),
-	nano::uint128_union{ stake_online }.format_balance (nano_ratio, 1, true));
+	nano::log::as_nano{ quorum, 1 },
+	nano::log::as_nano{ stake_peered, 1 },
+	nano::log::as_nano{ stake_online, 1 });
 
 	logger.info (nano::log::type::monitor, "Elections active: {} (priority: {} | hinted: {} | optimistic: {}) of which stale: {}",
 	node.active.size (),
@@ -113,8 +114,8 @@ void nano::monitor::run_one ()
 	if (!sufficient_stake && node.warmed_up ())
 	{
 		logger.warn (nano::log::type::monitor, "Peered stake ({}) is below quorum threshold ({}). The node may not be able to confirm transactions. This is usually caused by NAT, firewall rules, or internet connectivity issues.",
-		nano::uint128_union{ stake_peered }.format_balance (nano_ratio, 1, true),
-		nano::uint128_union{ quorum }.format_balance (nano_ratio, 1, true));
+		nano::log::as_nano{ stake_peered, 1 },
+		nano::log::as_nano{ quorum, 1 });
 	}
 
 	last_time = now;

--- a/nano/node/monitor.cpp
+++ b/nano/node/monitor.cpp
@@ -98,9 +98,9 @@ void nano::monitor::run_one ()
 	auto const stake_peered = node.rep_crawler.total_weight ();
 
 	logger.info (nano::log::type::monitor, "Quorum: {} (stake peered: {} | stake online: {})",
-	nano::log::as_nano{ quorum },
-	nano::log::as_nano{ stake_peered },
-	nano::log::as_nano{ stake_online });
+	nano::log::as_nano (quorum),
+	nano::log::as_nano (stake_peered),
+	nano::log::as_nano (stake_online));
 
 	logger.info (nano::log::type::monitor, "Elections active: {} (priority: {} | hinted: {} | optimistic: {}) of which stale: {}",
 	node.active.size (),
@@ -114,8 +114,8 @@ void nano::monitor::run_one ()
 	if (!sufficient_stake && node.warmed_up ())
 	{
 		logger.warn (nano::log::type::monitor, "Peered stake ({}) is below quorum threshold ({}). The node may not be able to confirm transactions. This is usually caused by NAT, firewall rules, or internet connectivity issues.",
-		nano::log::as_nano{ stake_peered },
-		nano::log::as_nano{ quorum });
+		nano::log::as_nano (stake_peered),
+		nano::log::as_nano (quorum));
 	}
 
 	last_time = now;

--- a/nano/node/monitor.cpp
+++ b/nano/node/monitor.cpp
@@ -98,9 +98,9 @@ void nano::monitor::run_one ()
 	auto const stake_peered = node.rep_crawler.total_weight ();
 
 	logger.info (nano::log::type::monitor, "Quorum: {} (stake peered: {} | stake online: {})",
-	nano::log::as_nano{ quorum, 1 },
-	nano::log::as_nano{ stake_peered, 1 },
-	nano::log::as_nano{ stake_online, 1 });
+	nano::log::as_nano{ quorum },
+	nano::log::as_nano{ stake_peered },
+	nano::log::as_nano{ stake_online });
 
 	logger.info (nano::log::type::monitor, "Elections active: {} (priority: {} | hinted: {} | optimistic: {}) of which stale: {}",
 	node.active.size (),
@@ -114,8 +114,8 @@ void nano::monitor::run_one ()
 	if (!sufficient_stake && node.warmed_up ())
 	{
 		logger.warn (nano::log::type::monitor, "Peered stake ({}) is below quorum threshold ({}). The node may not be able to confirm transactions. This is usually caused by NAT, firewall rules, or internet connectivity issues.",
-		nano::log::as_nano{ stake_peered, 1 },
-		nano::log::as_nano{ quorum, 1 });
+		nano::log::as_nano{ stake_peered },
+		nano::log::as_nano{ quorum });
 	}
 
 	last_time = now;

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -7,6 +7,7 @@
 #include <nano/node/node.hpp>
 #include <nano/node/portmapping.hpp>
 #include <nano/node/telemetry.hpp>
+#include <nano/node/transport/formatting.hpp>
 
 using namespace std::chrono_literals;
 
@@ -30,7 +31,7 @@ nano::network::network (nano::node & node_a, uint16_t port_a) :
 {
 	node.observers.channel_connected.add ([this] (std::shared_ptr<nano::transport::channel> const & channel) {
 		node.stats.inc (nano::stat::type::network, nano::stat::detail::connected);
-		node.logger.debug (nano::log::type::network, "Connected to: {}", channel->to_string ());
+		node.logger.debug (nano::log::type::network, "Connected to: {}", channel);
 	});
 }
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -322,7 +322,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	logger.info (nano::log::type::node, "Work peers: {}", config.work_peers.size ());
 	logger.info (nano::log::type::node, "Node ID: {}", node_id.pub.to_node_id ());
 	logger.info (nano::log::type::node, "Number of buckets: {}", bucketing.size ());
-	logger.info (nano::log::type::node, "Genesis block: {}", config.network_params.ledger.genesis->hash ().to_string ());
+	logger.info (nano::log::type::node, "Genesis block: {}", config.network_params.ledger.genesis->hash ());
 	logger.info (nano::log::type::node, "Genesis account: {}", config.network_params.ledger.genesis->account ().to_account ());
 
 	if (!work_generation_enabled ())
@@ -474,7 +474,7 @@ void nano::node::process_active (std::shared_ptr<nano::vote> const & vote)
 [[nodiscard]] nano::block_status nano::node::process (secure::write_transaction const & transaction, std::shared_ptr<nano::block> block)
 {
 	auto status = ledger.process (transaction, block);
-	logger.debug (nano::log::type::node, "Directly processed block: {} (status: {})", block->hash (), to_string (status));
+	logger.debug (nano::log::type::node, "Directly processed block: {} (status: {})", block->hash (), status);
 	return status;
 }
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -321,7 +321,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	logger.info (nano::log::type::node, "Ledger path: {}", store.get_database_path ().string ());
 	logger.info (nano::log::type::node, "Work pool threads: {} ({})", work.threads.size (), (work.opencl ? "OpenCL" : "CPU"));
 	logger.info (nano::log::type::node, "Work peers: {}", config.work_peers.size ());
-	logger.info (nano::log::type::node, "Node ID: {}", nano::log::as_node_id{ node_id.pub });
+	logger.info (nano::log::type::node, "Node ID: {}", nano::log::as_node_id (node_id.pub));
 	logger.info (nano::log::type::node, "Number of buckets: {}", bucketing.size ());
 	logger.info (nano::log::type::node, "Genesis block: {}", config.network_params.ledger.genesis->hash ());
 	logger.info (nano::log::type::node, "Genesis account: {}", config.network_params.ledger.genesis->account ());
@@ -408,7 +408,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 			{
 				logger.info (nano::log::type::node, "Using bootstrap rep weight: {} -> {}",
 				rep.first,
-				nano::log::as_nano{ rep.second });
+				nano::log::as_nano (rep.second));
 			}
 
 			logger.info (nano::log::type::node, "******************************************** ================= ********************************************");

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -324,7 +324,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	logger.info (nano::log::type::node, "Node ID: {}", nano::log::as_node_id{ node_id.pub });
 	logger.info (nano::log::type::node, "Number of buckets: {}", bucketing.size ());
 	logger.info (nano::log::type::node, "Genesis block: {}", config.network_params.ledger.genesis->hash ());
-	logger.info (nano::log::type::node, "Genesis account: {}", nano::log::as_account{ config.network_params.ledger.genesis->account () });
+	logger.info (nano::log::type::node, "Genesis account: {}", config.network_params.ledger.genesis->account ());
 
 	if (!work_generation_enabled ())
 	{
@@ -357,7 +357,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 
 		for (auto const & account : reps.accounts)
 		{
-			logger.info (nano::log::type::node, "Local representative: {}", nano::log::as_account{ account });
+			logger.info (nano::log::type::node, "Local representative: {}", account);
 		}
 	}
 
@@ -407,7 +407,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 			for (auto const & rep : sorted_weights)
 			{
 				logger.info (nano::log::type::node, "Using bootstrap rep weight: {} -> {}",
-				nano::log::as_account{ rep.first },
+				rep.first,
 				nano::uint128_union (rep.second).format_balance (nano_ratio, 0, true));
 			}
 

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -408,7 +408,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 			{
 				logger.info (nano::log::type::node, "Using bootstrap rep weight: {} -> {}",
 				rep.first,
-				nano::uint128_union (rep.second).format_balance (nano_ratio, 0, true));
+				nano::log::as_nano{ rep.second });
 			}
 
 			logger.info (nano::log::type::node, "******************************************** ================= ********************************************");

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/block_type.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/files.hpp>
+#include <nano/lib/formatting.hpp>
 #include <nano/lib/stream.hpp>
 #include <nano/lib/thread_pool.hpp>
 #include <nano/lib/thread_runner.hpp>
@@ -320,10 +321,10 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 	logger.info (nano::log::type::node, "Ledger path: {}", store.get_database_path ().string ());
 	logger.info (nano::log::type::node, "Work pool threads: {} ({})", work.threads.size (), (work.opencl ? "OpenCL" : "CPU"));
 	logger.info (nano::log::type::node, "Work peers: {}", config.work_peers.size ());
-	logger.info (nano::log::type::node, "Node ID: {}", node_id.pub.to_node_id ());
+	logger.info (nano::log::type::node, "Node ID: {}", nano::log::as_node_id{ node_id.pub });
 	logger.info (nano::log::type::node, "Number of buckets: {}", bucketing.size ());
 	logger.info (nano::log::type::node, "Genesis block: {}", config.network_params.ledger.genesis->hash ());
-	logger.info (nano::log::type::node, "Genesis account: {}", config.network_params.ledger.genesis->account ().to_account ());
+	logger.info (nano::log::type::node, "Genesis account: {}", nano::log::as_account{ config.network_params.ledger.genesis->account () });
 
 	if (!work_generation_enabled ())
 	{
@@ -356,7 +357,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 
 		for (auto const & account : reps.accounts)
 		{
-			logger.info (nano::log::type::node, "Local representative: {}", account.to_account ());
+			logger.info (nano::log::type::node, "Local representative: {}", nano::log::as_account{ account });
 		}
 	}
 
@@ -406,7 +407,7 @@ nano::node::node (std::shared_ptr<boost::asio::io_context> io_ctx_a, std::filesy
 			for (auto const & rep : sorted_weights)
 			{
 				logger.info (nano::log::type::node, "Using bootstrap rep weight: {} -> {}",
-				rep.first.to_account (),
+				nano::log::as_account{ rep.first },
 				nano::uint128_union (rep.second).format_balance (nano_ratio, 0, true));
 			}
 

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -36,7 +36,7 @@ void nano::online_reps::start ()
 		cached_trended = trended_result.trended;
 
 		logger.info (nano::log::type::online_reps, "Initial trended weight: {} (samples: {})",
-		nano::log::as_nano{ trended_result.trended, 1 },
+		nano::log::as_nano{ trended_result.trended },
 		trended_result.samples);
 	}
 
@@ -160,8 +160,8 @@ bool nano::online_reps::sample ()
 		if (node.warmed_up () && low_weight_warning_interval.elapse (1min))
 		{
 			logger.warn (nano::log::type::online_reps, "Current online weight {} is below minimum threshold {}. This often occurs when the node cannot reach enough peers; check network connectivity and peer count.",
-			nano::log::as_nano{ current_online, 1 },
-			nano::log::as_nano{ config.online_weight_minimum.number (), 1 });
+			nano::log::as_nano{ current_online },
+			nano::log::as_nano{ config.online_weight_minimum.number () });
 		}
 
 		return false; // Skipped
@@ -185,7 +185,7 @@ bool nano::online_reps::sample ()
 	}
 
 	logger.info (nano::log::type::online_reps, "Updated trended weight: {} (samples: {})",
-	nano::log::as_nano{ trended_result.trended, 1 },
+	nano::log::as_nano{ trended_result.trended },
 	trended_result.samples);
 
 	return true; // Sampled

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -73,7 +73,7 @@ void nano::online_reps::observe (nano::account const & rep)
 
 		if (new_insert)
 		{
-			logger.debug (nano::log::type::online_reps, "Observed new representative: {}", nano::log::as_account{ rep });
+			logger.debug (nano::log::type::online_reps, "Observed new representative: {}", rep);
 			update_online ();
 		}
 	}
@@ -93,7 +93,7 @@ void nano::online_reps::trim ()
 		{
 			stats.inc (nano::stat::type::online_reps, nano::stat::detail::rep_trim);
 			logger.debug (nano::log::type::online_reps, "Removing representative: {}, last observed: {}s ago",
-			nano::log::as_account{ oldest->account },
+			oldest->account,
 			nano::log::seconds_delta (oldest->time, now));
 
 			reps.get<tag_time> ().erase (oldest);

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -1,4 +1,5 @@
 #include <nano/lib/config.hpp>
+#include <nano/lib/formatting.hpp>
 #include <nano/lib/thread_roles.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/node/node.hpp>
@@ -72,7 +73,7 @@ void nano::online_reps::observe (nano::account const & rep)
 
 		if (new_insert)
 		{
-			logger.debug (nano::log::type::online_reps, "Observed new representative: {}", rep.to_account ());
+			logger.debug (nano::log::type::online_reps, "Observed new representative: {}", nano::log::as_account{ rep });
 			update_online ();
 		}
 	}
@@ -92,7 +93,7 @@ void nano::online_reps::trim ()
 		{
 			stats.inc (nano::stat::type::online_reps, nano::stat::detail::rep_trim);
 			logger.debug (nano::log::type::online_reps, "Removing representative: {}, last observed: {}s ago",
-			oldest->account.to_account (),
+			nano::log::as_account{ oldest->account },
 			nano::log::seconds_delta (oldest->time, now));
 
 			reps.get<tag_time> ().erase (oldest);

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -36,7 +36,7 @@ void nano::online_reps::start ()
 		cached_trended = trended_result.trended;
 
 		logger.info (nano::log::type::online_reps, "Initial trended weight: {} (samples: {})",
-		nano::uint128_union{ trended_result.trended }.format_balance (nano_ratio, 1, true),
+		nano::log::as_nano{ trended_result.trended, 1 },
 		trended_result.samples);
 	}
 
@@ -160,8 +160,8 @@ bool nano::online_reps::sample ()
 		if (node.warmed_up () && low_weight_warning_interval.elapse (1min))
 		{
 			logger.warn (nano::log::type::online_reps, "Current online weight {} is below minimum threshold {}. This often occurs when the node cannot reach enough peers; check network connectivity and peer count.",
-			nano::uint128_union{ current_online }.format_balance (nano_ratio, 1, true),
-			nano::uint128_union{ config.online_weight_minimum.number () }.format_balance (nano_ratio, 1, true));
+			nano::log::as_nano{ current_online, 1 },
+			nano::log::as_nano{ config.online_weight_minimum.number (), 1 });
 		}
 
 		return false; // Skipped
@@ -185,7 +185,7 @@ bool nano::online_reps::sample ()
 	}
 
 	logger.info (nano::log::type::online_reps, "Updated trended weight: {} (samples: {})",
-	nano::uint128_union{ trended_result.trended }.format_balance (nano_ratio, 1, true),
+	nano::log::as_nano{ trended_result.trended, 1 },
 	trended_result.samples);
 
 	return true; // Sampled

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -161,7 +161,7 @@ bool nano::online_reps::sample ()
 		{
 			logger.warn (nano::log::type::online_reps, "Current online weight {} is below minimum threshold {}. This often occurs when the node cannot reach enough peers; check network connectivity and peer count.",
 			nano::log::as_nano (current_online),
-			nano::log::as_nano (config.online_weight_minimum.number ()));
+			nano::log::as_nano (config.online_weight_minimum));
 		}
 
 		return false; // Skipped

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -36,7 +36,7 @@ void nano::online_reps::start ()
 		cached_trended = trended_result.trended;
 
 		logger.info (nano::log::type::online_reps, "Initial trended weight: {} (samples: {})",
-		nano::log::as_nano{ trended_result.trended },
+		nano::log::as_nano (trended_result.trended),
 		trended_result.samples);
 	}
 
@@ -160,8 +160,8 @@ bool nano::online_reps::sample ()
 		if (node.warmed_up () && low_weight_warning_interval.elapse (1min))
 		{
 			logger.warn (nano::log::type::online_reps, "Current online weight {} is below minimum threshold {}. This often occurs when the node cannot reach enough peers; check network connectivity and peer count.",
-			nano::log::as_nano{ current_online },
-			nano::log::as_nano{ config.online_weight_minimum.number () });
+			nano::log::as_nano (current_online),
+			nano::log::as_nano (config.online_weight_minimum.number ()));
 		}
 
 		return false; // Skipped
@@ -185,7 +185,7 @@ bool nano::online_reps::sample ()
 	}
 
 	logger.info (nano::log::type::online_reps, "Updated trended weight: {} (samples: {})",
-	nano::log::as_nano{ trended_result.trended },
+	nano::log::as_nano (trended_result.trended),
 	trended_result.samples);
 
 	return true; // Sampled

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -95,7 +95,7 @@ void nano::port_mapping::shutdown ()
 			{
 				node.logger.info (nano::log::type::upnp, "UPnP shutdown {} port mapping successful: {}:{}",
 				protocol.name,
-				protocol.external_address.to_string (),
+				protocol.external_address,
 				protocol.external_port);
 			}
 		}
@@ -192,7 +192,7 @@ void nano::port_mapping::refresh_mapping ()
 
 			node.logger.info (nano::log::type::upnp, "UPnP {} {}:{} mapped to: {}",
 			protocol.name,
-			protocol.external_address.to_string (),
+			protocol.external_address,
 			config_port_l,
 			node_port_l);
 		}
@@ -202,7 +202,7 @@ void nano::port_mapping::refresh_mapping ()
 
 			node.logger.warn (nano::log::type::upnp, "UPnP {} {}:{} failed: {} ({})",
 			protocol.name,
-			protocol.external_address.to_string (),
+			protocol.external_address,
 			config_port_l,
 			add_port_mapping_error_l,
 			strupnperror (add_port_mapping_error_l));

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -3,6 +3,7 @@
 #include <nano/node/node.hpp>
 #include <nano/node/online_reps.hpp>
 #include <nano/node/repcrawler.hpp>
+#include <nano/node/transport/formatting.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_cemented.hpp>
 
@@ -130,14 +131,14 @@ void nano::rep_crawler::validate_and_process (nano::unique_lock<nano::mutex> & l
 		{
 			logger.info (nano::log::type::rep_crawler, "Found representative: {} at: {}",
 			vote->account.to_account (),
-			channel->to_string ());
+			channel);
 		}
 		if (updated)
 		{
 			logger.warn (nano::log::type::rep_crawler, "Updated representative: {} at: {} (was at: {})",
 			vote->account.to_account (),
-			channel->to_string (),
-			prev_channel->to_string ());
+			channel,
+			prev_channel);
 		}
 	}
 }
@@ -226,7 +227,7 @@ void nano::rep_crawler::cleanup ()
 		if (!rep.channel->alive ())
 		{
 			stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::channel_dead);
-			logger.info (nano::log::type::rep_crawler, "Evicting representative: {} with dead channel at: {}", rep.account, rep.channel->to_string ());
+			logger.info (nano::log::type::rep_crawler, "Evicting representative: {} with dead channel at: {}", rep.account, rep.channel);
 			return true; // Erase
 		}
 		return false;
@@ -239,12 +240,12 @@ void nano::rep_crawler::cleanup ()
 			if (query.replies == 0)
 			{
 				stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::query_timeout);
-				logger.debug (nano::log::type::rep_crawler, "Aborting unresponsive query for block: {} from: {}", query.hash, query.channel->to_string ());
+				logger.debug (nano::log::type::rep_crawler, "Aborting unresponsive query for block: {} from: {}", query.hash, query.channel);
 			}
 			else
 			{
 				stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::query_completion);
-				logger.debug (nano::log::type::rep_crawler, "Completion of query with: {} replies for block: {} from: {}", query.replies, query.hash, query.channel->to_string ());
+				logger.debug (nano::log::type::rep_crawler, "Completion of query with: {} replies for block: {} from: {}", query.replies, query.hash, query.channel);
 			}
 			return true; // Erase
 		}
@@ -354,7 +355,7 @@ void nano::rep_crawler::query (std::deque<std::shared_ptr<nano::transport::chann
 		if (tracked)
 		{
 			stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::query_sent);
-			logger.debug (nano::log::type::rep_crawler, "Sending query for block: {} to: {}", hash_root.first, channel->to_string ());
+			logger.debug (nano::log::type::rep_crawler, "Sending query for block: {} to: {}", hash_root.first, channel);
 
 			lock.unlock ();
 
@@ -370,7 +371,7 @@ void nano::rep_crawler::query (std::deque<std::shared_ptr<nano::transport::chann
 		else
 		{
 			stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::query_duplicate);
-			logger.debug (nano::log::type::rep_crawler, "Ignoring duplicate query for block: {} to: {}", hash_root.first, channel->to_string ());
+			logger.debug (nano::log::type::rep_crawler, "Ignoring duplicate query for block: {} to: {}", hash_root.first, channel);
 		}
 	}
 }
@@ -406,7 +407,7 @@ bool nano::rep_crawler::process (std::shared_ptr<nano::vote> const & vote, std::
 		if (found)
 		{
 			stats.inc (nano::stat::type::rep_crawler, nano::stat::detail::response);
-			logger.debug (nano::log::type::rep_crawler, "Processing response for block: {} from: {}", target_hash, channel->to_string ());
+			logger.debug (nano::log::type::rep_crawler, "Processing response for block: {} from: {}", target_hash, channel);
 
 			// Track response time
 			stats.sample (nano::stat::sample::rep_response_time, nano::log::milliseconds_delta (it->time), { 0, config.query_timeout.count () });

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -131,13 +131,13 @@ void nano::rep_crawler::validate_and_process (nano::unique_lock<nano::mutex> & l
 		if (inserted)
 		{
 			logger.info (nano::log::type::rep_crawler, "Found representative: {} at: {}",
-			nano::log::as_account{ vote->account },
+			vote->account,
 			channel);
 		}
 		if (updated)
 		{
 			logger.warn (nano::log::type::rep_crawler, "Updated representative: {} at: {} (was at: {})",
-			nano::log::as_account{ vote->account },
+			vote->account,
 			channel,
 			prev_channel);
 		}

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/formatting.hpp>
 #include <nano/lib/vote.hpp>
 #include <nano/node/active_elections.hpp>
 #include <nano/node/node.hpp>
@@ -130,13 +131,13 @@ void nano::rep_crawler::validate_and_process (nano::unique_lock<nano::mutex> & l
 		if (inserted)
 		{
 			logger.info (nano::log::type::rep_crawler, "Found representative: {} at: {}",
-			vote->account.to_account (),
+			nano::log::as_account{ vote->account },
 			channel);
 		}
 		if (updated)
 		{
 			logger.warn (nano::log::type::rep_crawler, "Updated representative: {} at: {} (was at: {})",
-			vote->account.to_account (),
+			nano::log::as_account{ vote->account },
 			channel,
 			prev_channel);
 		}

--- a/nano/node/request_aggregator.cpp
+++ b/nano/node/request_aggregator.cpp
@@ -7,6 +7,7 @@
 #include <nano/node/node.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/request_aggregator.hpp>
+#include <nano/node/transport/formatting.hpp>
 #include <nano/node/vote_generator.hpp>
 #include <nano/node/vote_router.hpp>
 #include <nano/node/wallet.hpp>
@@ -278,14 +279,14 @@ auto nano::request_aggregator::aggregate (nano::secure::transaction const & tran
 				stats.inc (nano::stat::type::requests, nano::stat::detail::requests_final);
 
 				logger.debug (nano::log::type::request_aggregator, "Replying with final vote for: {} to: {}",
-				block->hash (), channel_a->to_string ()); // TODO: Lazy eval
+				block->hash (), channel_a);
 			}
 			else
 			{
 				stats.inc (nano::stat::type::requests, nano::stat::detail::requests_non_final);
 
 				logger.debug (nano::log::type::request_aggregator, "Skipping reply with normal vote for: {} (requested by: {})",
-				block->hash (), channel_a->to_string ()); // TODO: Lazy eval
+				block->hash (), channel_a);
 			}
 		}
 		else
@@ -293,7 +294,7 @@ auto nano::request_aggregator::aggregate (nano::secure::transaction const & tran
 			stats.inc (nano::stat::type::requests, nano::stat::detail::requests_unknown);
 
 			logger.debug (nano::log::type::request_aggregator, "Cannot reply, block not found: {} with root: {} (requested by: {})",
-			hash, root, channel_a->to_string ()); // TODO: Lazy eval
+			hash, root, channel_a);
 		}
 	}
 

--- a/nano/node/transport/formatting.hpp
+++ b/nano/node/transport/formatting.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <nano/node/transport/channel.hpp>
+
+#include <concepts>
+#include <memory>
+
+#include <fmt/format.h>
+
+template <>
+struct fmt::formatter<nano::transport::channel> : fmt::formatter<std::string>
+{
+	auto format (nano::transport::channel const & channel, format_context & ctx) const
+	{
+		return fmt::formatter<std::string>::format (channel.to_string (), ctx);
+	}
+};
+
+template <typename T>
+	requires std::derived_from<T, nano::transport::channel>
+struct fmt::formatter<std::shared_ptr<T>> : fmt::formatter<std::string>
+{
+	auto format (std::shared_ptr<T> const & channel, format_context & ctx) const
+	{
+		if (channel)
+		{
+			return fmt::formatter<std::string>::format (channel->to_string (), ctx);
+		}
+		else
+		{
+			return fmt::formatter<std::string>::format ("<null>", ctx);
+		}
+	}
+};

--- a/nano/node/transport/formatting.hpp
+++ b/nano/node/transport/formatting.hpp
@@ -10,7 +10,7 @@
 template <>
 struct fmt::formatter<nano::transport::channel> : fmt::formatter<std::string>
 {
-	auto format (nano::transport::channel const & channel, format_context & ctx) const
+	auto format (nano::transport::channel const & channel, fmt::format_context & ctx) const
 	{
 		return fmt::formatter<std::string>::format (channel.to_string (), ctx);
 	}
@@ -20,7 +20,7 @@ template <typename T>
 	requires std::derived_from<T, nano::transport::channel>
 struct fmt::formatter<std::shared_ptr<T>> : fmt::formatter<std::string>
 {
-	auto format (std::shared_ptr<T> const & channel, format_context & ctx) const
+	auto format (std::shared_ptr<T> const & channel, fmt::format_context & ctx) const
 	{
 		if (channel)
 		{

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -1,4 +1,5 @@
 #include <nano/node/node.hpp>
+#include <nano/node/transport/formatting.hpp>
 #include <nano/node/transport/tcp_channels.hpp>
 
 #include <ranges>
@@ -110,7 +111,7 @@ std::shared_ptr<nano::transport::tcp_channel> nano::transport::tcp_channels::cre
 	node.stats.inc (nano::stat::type::tcp_channels, nano::stat::detail::channel_accepted);
 	node.logger.debug (nano::log::type::tcp_channels, "Accepted channel: {} ({}) ({})",
 	socket->get_remote_endpoint (),
-	to_string (socket->get_endpoint_type ()),
+	socket->get_endpoint_type (),
 	node_id.to_node_id ());
 
 	// This should be the only place in node where channels are created
@@ -319,7 +320,7 @@ void nano::transport::tcp_channels::purge (std::chrono::steady_clock::time_point
 		{
 			node.stats.inc (nano::stat::type::tcp_channels_purge, nano::stat::detail::idle);
 			node.logger.debug (nano::log::type::tcp_channels, "Closing idle channel: {} (idle for {}s)",
-			channel->to_string (),
+			channel,
 			nano::log::seconds_delta (last));
 
 			return true; // Close
@@ -328,7 +329,7 @@ void nano::transport::tcp_channels::purge (std::chrono::steady_clock::time_point
 		if (channel->get_network_version () < node.network_params.network.protocol_version_min)
 		{
 			node.stats.inc (nano::stat::type::tcp_channels_purge, nano::stat::detail::outdated);
-			node.logger.debug (nano::log::type::tcp_channels, "Closing channel with old protocol version: {}", channel->to_string ());
+			node.logger.debug (nano::log::type::tcp_channels, "Closing channel with old protocol version: {}", channel);
 
 			return true; // Close
 		}
@@ -360,7 +361,7 @@ void nano::transport::tcp_channels::purge (std::chrono::steady_clock::time_point
 	for (auto const & connection : erased_connections)
 	{
 		node.stats.inc (nano::stat::type::tcp_channels, nano::stat::detail::erase_dead);
-		node.logger.debug (nano::log::type::tcp_channels, "Removing dead channel: {}", connection.channel->to_string ());
+		node.logger.debug (nano::log::type::tcp_channels, "Removing dead channel: {}", connection.channel);
 
 		connection.channel->close ();
 	}

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/formatting.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/transport/formatting.hpp>
 #include <nano/node/transport/tcp_channels.hpp>
@@ -79,7 +80,7 @@ bool nano::transport::tcp_channels::check (const nano::tcp_endpoint & endpoint, 
 	if (has_duplicate)
 	{
 		node.stats.inc (nano::stat::type::tcp_channels_rejected, nano::stat::detail::channel_duplicate);
-		node.logger.debug (nano::log::type::tcp_channels, "Rejected duplicate channel: {} ({})", endpoint, node_id.to_node_id ());
+		node.logger.debug (nano::log::type::tcp_channels, "Rejected duplicate channel: {} ({})", endpoint, nano::log::as_node_id{ node_id });
 
 		return false; // Reject
 	}
@@ -102,7 +103,7 @@ std::shared_ptr<nano::transport::tcp_channel> nano::transport::tcp_channels::cre
 	if (!check (endpoint, node_id))
 	{
 		node.stats.inc (nano::stat::type::tcp_channels, nano::stat::detail::channel_rejected);
-		node.logger.debug (nano::log::type::tcp_channels, "Rejected channel: {} ({})", endpoint, node_id.to_node_id ());
+		node.logger.debug (nano::log::type::tcp_channels, "Rejected channel: {} ({})", endpoint, nano::log::as_node_id{ node_id });
 		// Rejection reason should be logged earlier
 
 		return nullptr;
@@ -112,7 +113,7 @@ std::shared_ptr<nano::transport::tcp_channel> nano::transport::tcp_channels::cre
 	node.logger.debug (nano::log::type::tcp_channels, "Accepted channel: {} ({}) ({})",
 	socket->get_remote_endpoint (),
 	socket->get_endpoint_type (),
-	node_id.to_node_id ());
+	nano::log::as_node_id{ node_id });
 
 	// This should be the only place in node where channels are created
 	auto channel = std::make_shared<nano::transport::tcp_channel> (node, socket);

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -80,7 +80,7 @@ bool nano::transport::tcp_channels::check (const nano::tcp_endpoint & endpoint, 
 	if (has_duplicate)
 	{
 		node.stats.inc (nano::stat::type::tcp_channels_rejected, nano::stat::detail::channel_duplicate);
-		node.logger.debug (nano::log::type::tcp_channels, "Rejected duplicate channel: {} ({})", endpoint, nano::log::as_node_id{ node_id });
+		node.logger.debug (nano::log::type::tcp_channels, "Rejected duplicate channel: {} ({})", endpoint, nano::log::as_node_id (node_id));
 
 		return false; // Reject
 	}
@@ -103,7 +103,7 @@ std::shared_ptr<nano::transport::tcp_channel> nano::transport::tcp_channels::cre
 	if (!check (endpoint, node_id))
 	{
 		node.stats.inc (nano::stat::type::tcp_channels, nano::stat::detail::channel_rejected);
-		node.logger.debug (nano::log::type::tcp_channels, "Rejected channel: {} ({})", endpoint, nano::log::as_node_id{ node_id });
+		node.logger.debug (nano::log::type::tcp_channels, "Rejected channel: {} ({})", endpoint, nano::log::as_node_id (node_id));
 		// Rejection reason should be logged earlier
 
 		return nullptr;
@@ -113,7 +113,7 @@ std::shared_ptr<nano::transport::tcp_channel> nano::transport::tcp_channels::cre
 	node.logger.debug (nano::log::type::tcp_channels, "Accepted channel: {} ({}) ({})",
 	socket->get_remote_endpoint (),
 	socket->get_endpoint_type (),
-	nano::log::as_node_id{ node_id });
+	nano::log::as_node_id (node_id));
 
 	// This should be the only place in node where channels are created
 	auto channel = std::make_shared<nano::transport::tcp_channel> (node, socket);

--- a/nano/node/transport/tcp_listener.cpp
+++ b/nano/node/transport/tcp_listener.cpp
@@ -437,7 +437,7 @@ auto nano::transport::tcp_listener::accept_one (asio::ip::tcp::socket raw_socket
 	}
 
 	stats.inc (nano::stat::type::tcp_listener, nano::stat::detail::accept_success, to_stat_dir (type));
-	logger.debug (nano::log::type::tcp_listener, "Accepted connection: {} ({})", remote_endpoint, to_string (type));
+	logger.debug (nano::log::type::tcp_listener, "Accepted connection: {} ({})", remote_endpoint, type);
 
 	auto socket = std::make_shared<nano::transport::tcp_socket> (node, std::move (raw_socket), to_socket_endpoint (type));
 	auto server = std::make_shared<nano::transport::tcp_server> (node, socket);
@@ -464,7 +464,7 @@ auto nano::transport::tcp_listener::check_limits (asio::ip::address const & ip, 
 	if (node.network.excluded_peers.check (ip)) // true => error
 	{
 		stats.inc (nano::stat::type::tcp_listener_rejected, nano::stat::detail::excluded, to_stat_dir (type));
-		logger.debug (nano::log::type::tcp_listener, "Rejected connection from excluded peer: {} ({})", ip, to_string (type));
+		logger.debug (nano::log::type::tcp_listener, "Rejected connection from excluded peer: {} ({})", ip, type);
 
 		return accept_result::rejected_excluded;
 	}

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -915,7 +915,7 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 				if (!store.fetch (transaction, account_a, prv))
 				{
 					logger.info (nano::log::type::wallet, "Receiving block: {} from account: {}, amount: {}",
-					send_hash_a.to_string (),
+					send_hash_a,
 					account_a.to_account (),
 					pending_info->amount.number ().convert_to<std::string> ());
 
@@ -938,26 +938,26 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 				else
 				{
 					logger.warn (nano::log::type::wallet, "Unable to receive, wallet locked, block: {} to account: {}",
-					send_hash_a.to_string (),
+					send_hash_a,
 					account_a.to_account ());
 				}
 			}
 			else
 			{
 				// Ledger doesn't have this marked as available to receive anymore
-				logger.warn (nano::log::type::wallet, "Not receiving block: {}, block already received", send_hash_a.to_string ());
+				logger.warn (nano::log::type::wallet, "Not receiving block: {}, block already received", send_hash_a);
 			}
 		}
 		else
 		{
 			// Ledger doesn't have this block anymore.
-			logger.warn (nano::log::type::wallet, "Not receiving block: {}, block no longer exists or pruned", send_hash_a.to_string ());
+			logger.warn (nano::log::type::wallet, "Not receiving block: {}, block no longer exists or pruned", send_hash_a);
 		}
 	}
 	else
 	{
 		// Someone sent us something below the threshold of receiving
-		logger.warn (nano::log::type::wallet, "Not receiving block: {} due to minimum receive threshold", send_hash_a.to_string ());
+		logger.warn (nano::log::type::wallet, "Not receiving block: {} due to minimum receive threshold", send_hash_a);
 	}
 	if (block != nullptr)
 	{
@@ -1051,7 +1051,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 				{
 					logger.warn (nano::log::type::wallet, "Block already exists for send action with id: {}, existing hash: {}",
 					id_a.value (),
-					hash.to_string ());
+					hash);
 
 					cached_block = true;
 					wallets.network.flood_block (block, nano::transport::traffic_type::block_broadcast_initial);
@@ -1060,7 +1060,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 				{
 					logger.warn (nano::log::type::wallet, "Block was not found in ledger for send action with id: {}, hash: {}",
 					id_a.value (),
-					hash.to_string ());
+					hash);
 				}
 			}
 			else if (status != MDB_NOTFOUND)
@@ -1160,7 +1160,7 @@ bool nano::wallet::action_complete (std::shared_ptr<nano::block> const & block_a
 		if (wallets.network_params.work.difficulty (*block_a) < required_difficulty)
 		{
 			logger.info (nano::log::type::wallet, "Cached or provided work for block: {}, account {}: is invalid, regenerating...",
-			block_a->hash ().to_string (),
+			block_a->hash (),
 			account_a.to_account ());
 
 			debug_assert (required_difficulty <= wallets.node.max_work_generate_difficulty (block_a->work_version ()));
@@ -1316,7 +1316,7 @@ bool nano::wallet::search_receivable_impl (nano::store::transaction const & wall
 						bool const confirmed = wallets.ledger.cemented.block_exists_or_pruned (ledger_txn, hash);
 
 						logger.info (nano::log::type::wallet, "Found a receivable block: {} ({}) for account: {} from: {}",
-						hash.to_string (),
+						hash,
 						confirmed ? "confirmed" : "unconfirmed",
 						key.account.to_account (),
 						pending.source.to_account ());
@@ -1557,7 +1557,7 @@ void nano::wallet::work_cache_blocking (nano::account const & account_a, nano::r
 		}
 		else if (!wallets.node.stopped)
 		{
-			logger.warn (nano::log::type::wallet, "Could not precache work for root: {} due to work generation failure", root_a.to_string ());
+			logger.warn (nano::log::type::wallet, "Could not precache work for root: {} due to work generation failure", root_a);
 		}
 	}
 }
@@ -1631,7 +1631,7 @@ nano::logger & logger_a) :
 	logger.info (nano::log::type::wallet, "Found {} wallet(s)", items.size ());
 	for (auto const & item : items)
 	{
-		logger.info (nano::log::type::wallet, "Wallet: {}", item.first.to_string ());
+		logger.info (nano::log::type::wallet, "Wallet: {}", item.first);
 	}
 
 	// Backup before upgrade wallets
@@ -1744,7 +1744,7 @@ std::shared_ptr<nano::wallet> nano::wallets::create (nano::wallet_id const & id_
 		}
 		catch (std::exception const & ex)
 		{
-			logger.error (nano::log::type::wallet, "Failed to create wallet {}: {}", id_a.to_string (), ex.what ());
+			logger.error (nano::log::type::wallet, "Failed to create wallet {}: {}", id_a, ex.what ());
 		}
 	}
 	return nullptr;
@@ -1764,7 +1764,7 @@ std::shared_ptr<nano::wallet> nano::wallets::create_from_json (nano::wallet_id c
 		}
 		catch (std::exception const & ex)
 		{
-			logger.error (nano::log::type::wallet, "Failed to create wallet {} from JSON: {}", id_a.to_string (), ex.what ());
+			logger.error (nano::log::type::wallet, "Failed to create wallet {} from JSON: {}", id_a, ex.what ());
 		}
 	}
 	return nullptr;
@@ -1897,7 +1897,7 @@ void nano::wallets::foreach_representative (std::function<void (nano::public_key
 								{
 									last_log = std::chrono::steady_clock::now ();
 
-									logger.warn (nano::log::type::wallet, "Representative locked inside wallet: {}", i->first.to_string ());
+									logger.warn (nano::log::type::wallet, "Representative locked inside wallet: {}", i->first);
 								}
 							}
 						}
@@ -2083,12 +2083,12 @@ void nano::wallets::receive_confirmed (nano::block_hash const & hash_a, nano::ac
 			{
 				if (!ledger.cemented.block_exists_or_pruned (ledger.tx_begin_read (), hash_a))
 				{
-					logger.warn (nano::log::type::wallet, "Confirmed block is missing: {}", hash_a.to_string ());
+					logger.warn (nano::log::type::wallet, "Confirmed block is missing: {}", hash_a);
 					debug_assert (false, "confirmed block is missing");
 				}
 				else
 				{
-					logger.warn (nano::log::type::wallet, "Block has already been received: {}", hash_a.to_string ());
+					logger.warn (nano::log::type::wallet, "Block has already been received: {}", hash_a);
 				}
 			}
 		}

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -372,7 +372,7 @@ bool nano::wallet_store::valid_public_key (nano::public_key const & pub) const
 	return pub.number () >= special_count;
 }
 
-bool nano::wallet_store::exists (nano::store::transaction const & transaction_a, nano::public_key const & pub) const
+bool nano::wallet_store::exists (nano::store::transaction const & transaction_a, nano::account const & pub) const
 {
 	return valid_public_key (pub) && find (transaction_a, pub) != end (transaction_a);
 }

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -915,10 +915,10 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 				nano::raw_key prv;
 				if (!store.fetch (transaction, account_a, prv))
 				{
-					logger.info (nano::log::type::wallet, "Receiving block: {} from account: {}, amount: {}",
+					logger.info (nano::log::type::wallet, "Receiving block: {} from account: {}, amount: {} raw",
 					send_hash_a,
 					account_a,
-					pending_info->amount.number ().convert_to<std::string> ());
+					nano::log::as_raw_nano{ pending_info->amount.number () });
 
 					if (work_a == 0)
 					{
@@ -1077,10 +1077,10 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 					auto balance (wallets.ledger.any.account_balance (ledger_txn, source_a));
 					if (balance && balance.value ().number () >= amount_a)
 					{
-						logger.info (nano::log::type::wallet, "Sending from account: {} to: {}, amount: {}",
+						logger.info (nano::log::type::wallet, "Sending from account: {} to: {}, amount: {} raw",
 						source_a,
 						account_a,
-						amount_a.convert_to<std::string> ());
+						nano::log::as_raw_nano{ amount_a });
 
 						auto info = wallets.ledger.any.account_get (ledger_txn, source_a);
 						release_assert (info, "could not find account info for account in wallet send_action", source_a.to_account ());
@@ -1108,10 +1108,19 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 					}
 					else
 					{
-						logger.warn (nano::log::type::wallet, "Insufficient balance for send from: {}, required: {} but available: {}",
-						account_a,
-						amount_a.convert_to<std::string> (),
-						balance ? balance.value ().number ().convert_to<std::string> () : "unknown");
+						if (balance)
+						{
+							logger.warn (nano::log::type::wallet, "Insufficient balance for send from: {}, required: {} raw, available: {} raw",
+							account_a,
+							nano::log::as_raw_nano{ amount_a },
+							nano::log::as_raw_nano{ balance.value ().number () });
+						}
+						else
+						{
+							logger.warn (nano::log::type::wallet, "Insufficient balance for send from: {}, required: {} raw, available: unknown",
+							account_a,
+							nano::log::as_raw_nano{ amount_a });
+						}
 					}
 				}
 			}

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1,6 +1,7 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/files.hpp>
+#include <nano/lib/formatting.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
@@ -776,7 +777,7 @@ nano::public_key nano::wallet::deterministic_insert_impl (nano::store::write_tra
 	{
 		key = store.deterministic_insert (transaction_a);
 
-		logger.info (nano::log::type::wallet, "Deterministically inserted new account: {}", key.to_account ());
+		logger.info (nano::log::type::wallet, "Deterministically inserted new account: {}", nano::log::as_account{ key });
 
 		if (generate_work_a)
 		{
@@ -785,7 +786,7 @@ nano::public_key nano::wallet::deterministic_insert_impl (nano::store::write_tra
 
 		if (wallets.check_rep (key))
 		{
-			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", key.to_account ());
+			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", nano::log::as_account{ key });
 			representatives.lock ()->insert (key);
 		}
 	}
@@ -800,7 +801,7 @@ nano::public_key nano::wallet::deterministic_insert (uint32_t const index, bool 
 	{
 		key = store.deterministic_insert (transaction, index);
 
-		logger.info (nano::log::type::wallet, "Deterministically inserted new account: {}", key.to_account ());
+		logger.info (nano::log::type::wallet, "Deterministically inserted new account: {}", nano::log::as_account{ key });
 
 		if (generate_work_a)
 		{
@@ -825,7 +826,7 @@ nano::public_key nano::wallet::insert_adhoc (nano::raw_key const & key_a, bool g
 	{
 		key = store.insert_adhoc (transaction, key_a);
 
-		logger.info (nano::log::type::wallet, "Ad-hoc inserted new account: {}", key.to_account ());
+		logger.info (nano::log::type::wallet, "Ad-hoc inserted new account: {}", nano::log::as_account{ key });
 
 		auto ledger_txn = wallets.ledger.tx_begin_read ();
 		if (generate_work_a)
@@ -839,7 +840,7 @@ nano::public_key nano::wallet::insert_adhoc (nano::raw_key const & key_a, bool g
 
 		if (wallets.check_rep (key))
 		{
-			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", key.to_account ());
+			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", nano::log::as_account{ key });
 			representatives.lock ()->insert (key);
 		}
 	}
@@ -916,7 +917,7 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 				{
 					logger.info (nano::log::type::wallet, "Receiving block: {} from account: {}, amount: {}",
 					send_hash_a,
-					account_a.to_account (),
+					nano::log::as_account{ account_a },
 					pending_info->amount.number ().convert_to<std::string> ());
 
 					if (work_a == 0)
@@ -939,7 +940,7 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 				{
 					logger.warn (nano::log::type::wallet, "Unable to receive, wallet locked, block: {} to account: {}",
 					send_hash_a,
-					account_a.to_account ());
+					nano::log::as_account{ account_a });
 				}
 			}
 			else
@@ -983,8 +984,8 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 			if (existing != store.end (transaction) && !wallets.ledger.any.account_head (ledger_txn, source_a).is_zero ())
 			{
 				logger.info (nano::log::type::wallet, "Changing representative for account: {} to: {}",
-				source_a.to_account (),
-				representative_a.to_account ());
+				nano::log::as_account{ source_a },
+				nano::log::as_account{ representative_a });
 
 				auto info = wallets.ledger.any.account_get (ledger_txn, source_a);
 				release_assert (info, "could not find account info for account in wallet change_action", source_a.to_account ());
@@ -1000,14 +1001,12 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 			}
 			else
 			{
-				logger.warn (nano::log::type::wallet, "Changing representative for account: {} failed, wallet locked or account not found",
-				source_a.to_account ());
+				logger.warn (nano::log::type::wallet, "Changing representative for account: {} failed, wallet locked or account not found", nano::log::as_account{ source_a });
 			}
 		}
 		else
 		{
-			logger.warn (nano::log::type::wallet, "Changing representative for account: {} failed, wallet locked",
-			source_a.to_account ());
+			logger.warn (nano::log::type::wallet, "Changing representative for account: {} failed, wallet locked", nano::log::as_account{ source_a });
 		}
 	}
 	if (block != nullptr)
@@ -1079,8 +1078,8 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 					if (balance && balance.value ().number () >= amount_a)
 					{
 						logger.info (nano::log::type::wallet, "Sending from account: {} to: {}, amount: {}",
-						source_a.to_account (),
-						account_a.to_account (),
+						nano::log::as_account{ source_a },
+						nano::log::as_account{ account_a },
 						amount_a.convert_to<std::string> ());
 
 						auto info = wallets.ledger.any.account_get (ledger_txn, source_a);
@@ -1110,7 +1109,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 					else
 					{
 						logger.warn (nano::log::type::wallet, "Insufficient balance for send from: {}, required: {} but available: {}",
-						account_a.to_account (),
+						nano::log::as_account{ account_a },
 						amount_a.convert_to<std::string> (),
 						balance ? balance.value ().number ().convert_to<std::string> () : "unknown");
 					}
@@ -1161,7 +1160,7 @@ bool nano::wallet::action_complete (std::shared_ptr<nano::block> const & block_a
 		{
 			logger.info (nano::log::type::wallet, "Cached or provided work for block: {}, account {}: is invalid, regenerating...",
 			block_a->hash (),
-			account_a.to_account ());
+			nano::log::as_account{ account_a });
 
 			debug_assert (required_difficulty <= wallets.node.max_work_generate_difficulty (block_a->work_version ()));
 			error = !wallets.node.work_generate_blocking (*block_a, required_difficulty).has_value ();
@@ -1318,8 +1317,8 @@ bool nano::wallet::search_receivable_impl (nano::store::transaction const & wall
 						logger.info (nano::log::type::wallet, "Found a receivable block: {} ({}) for account: {} from: {}",
 						hash,
 						confirmed ? "confirmed" : "unconfirmed",
-						key.account.to_account (),
-						pending.source.to_account ());
+						nano::log::as_account{ key.account },
+						nano::log::as_account{ pending.source });
 
 						if (confirmed)
 						{

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -917,7 +917,7 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 				{
 					logger.info (nano::log::type::wallet, "Receiving block: {} from account: {}, amount: {}",
 					send_hash_a,
-					nano::log::as_account{ account_a },
+					account_a,
 					pending_info->amount.number ().convert_to<std::string> ());
 
 					if (work_a == 0)
@@ -940,7 +940,7 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 				{
 					logger.warn (nano::log::type::wallet, "Unable to receive, wallet locked, block: {} to account: {}",
 					send_hash_a,
-					nano::log::as_account{ account_a });
+					account_a);
 				}
 			}
 			else
@@ -984,8 +984,8 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 			if (existing != store.end (transaction) && !wallets.ledger.any.account_head (ledger_txn, source_a).is_zero ())
 			{
 				logger.info (nano::log::type::wallet, "Changing representative for account: {} to: {}",
-				nano::log::as_account{ source_a },
-				nano::log::as_account{ representative_a });
+				source_a,
+				representative_a);
 
 				auto info = wallets.ledger.any.account_get (ledger_txn, source_a);
 				release_assert (info, "could not find account info for account in wallet change_action", source_a.to_account ());
@@ -1001,12 +1001,12 @@ std::shared_ptr<nano::block> nano::wallet::change_action (nano::account const & 
 			}
 			else
 			{
-				logger.warn (nano::log::type::wallet, "Changing representative for account: {} failed, wallet locked or account not found", nano::log::as_account{ source_a });
+				logger.warn (nano::log::type::wallet, "Changing representative for account: {} failed, wallet locked or account not found", source_a);
 			}
 		}
 		else
 		{
-			logger.warn (nano::log::type::wallet, "Changing representative for account: {} failed, wallet locked", nano::log::as_account{ source_a });
+			logger.warn (nano::log::type::wallet, "Changing representative for account: {} failed, wallet locked", source_a);
 		}
 	}
 	if (block != nullptr)
@@ -1078,8 +1078,8 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 					if (balance && balance.value ().number () >= amount_a)
 					{
 						logger.info (nano::log::type::wallet, "Sending from account: {} to: {}, amount: {}",
-						nano::log::as_account{ source_a },
-						nano::log::as_account{ account_a },
+						source_a,
+						account_a,
 						amount_a.convert_to<std::string> ());
 
 						auto info = wallets.ledger.any.account_get (ledger_txn, source_a);
@@ -1109,7 +1109,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 					else
 					{
 						logger.warn (nano::log::type::wallet, "Insufficient balance for send from: {}, required: {} but available: {}",
-						nano::log::as_account{ account_a },
+						account_a,
 						amount_a.convert_to<std::string> (),
 						balance ? balance.value ().number ().convert_to<std::string> () : "unknown");
 					}
@@ -1160,7 +1160,7 @@ bool nano::wallet::action_complete (std::shared_ptr<nano::block> const & block_a
 		{
 			logger.info (nano::log::type::wallet, "Cached or provided work for block: {}, account {}: is invalid, regenerating...",
 			block_a->hash (),
-			nano::log::as_account{ account_a });
+			account_a);
 
 			debug_assert (required_difficulty <= wallets.node.max_work_generate_difficulty (block_a->work_version ()));
 			error = !wallets.node.work_generate_blocking (*block_a, required_difficulty).has_value ();
@@ -1317,8 +1317,8 @@ bool nano::wallet::search_receivable_impl (nano::store::transaction const & wall
 						logger.info (nano::log::type::wallet, "Found a receivable block: {} ({}) for account: {} from: {}",
 						hash,
 						confirmed ? "confirmed" : "unconfirmed",
-						nano::log::as_account{ key.account },
-						nano::log::as_account{ pending.source });
+						key.account,
+						pending.source);
 
 						if (confirmed)
 						{

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -777,7 +777,7 @@ nano::public_key nano::wallet::deterministic_insert_impl (nano::store::write_tra
 	{
 		key = store.deterministic_insert (transaction_a);
 
-		logger.info (nano::log::type::wallet, "Deterministically inserted new account: {}", nano::log::as_account{ key });
+		logger.info (nano::log::type::wallet, "Deterministically inserted new account: {}", nano::log::as_account (key));
 
 		if (generate_work_a)
 		{
@@ -786,7 +786,7 @@ nano::public_key nano::wallet::deterministic_insert_impl (nano::store::write_tra
 
 		if (wallets.check_rep (key))
 		{
-			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", nano::log::as_account{ key });
+			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", nano::log::as_account (key));
 			representatives.lock ()->insert (key);
 		}
 	}
@@ -801,7 +801,7 @@ nano::public_key nano::wallet::deterministic_insert (uint32_t const index, bool 
 	{
 		key = store.deterministic_insert (transaction, index);
 
-		logger.info (nano::log::type::wallet, "Deterministically inserted new account: {}", nano::log::as_account{ key });
+		logger.info (nano::log::type::wallet, "Deterministically inserted new account: {}", nano::log::as_account (key));
 
 		if (generate_work_a)
 		{
@@ -826,7 +826,7 @@ nano::public_key nano::wallet::insert_adhoc (nano::raw_key const & key_a, bool g
 	{
 		key = store.insert_adhoc (transaction, key_a);
 
-		logger.info (nano::log::type::wallet, "Ad-hoc inserted new account: {}", nano::log::as_account{ key });
+		logger.info (nano::log::type::wallet, "Ad-hoc inserted new account: {}", nano::log::as_account (key));
 
 		auto ledger_txn = wallets.ledger.tx_begin_read ();
 		if (generate_work_a)
@@ -840,7 +840,7 @@ nano::public_key nano::wallet::insert_adhoc (nano::raw_key const & key_a, bool g
 
 		if (wallets.check_rep (key))
 		{
-			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", nano::log::as_account{ key });
+			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", nano::log::as_account (key));
 			representatives.lock ()->insert (key);
 		}
 	}
@@ -918,7 +918,7 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 					logger.info (nano::log::type::wallet, "Receiving block: {} from account: {}, amount: {} raw",
 					send_hash_a,
 					account_a,
-					nano::log::as_raw_nano{ pending_info->amount.number () });
+					nano::log::as_raw_nano (pending_info->amount.number ()));
 
 					if (work_a == 0)
 					{
@@ -1080,7 +1080,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 						logger.info (nano::log::type::wallet, "Sending from account: {} to: {}, amount: {} raw",
 						source_a,
 						account_a,
-						nano::log::as_raw_nano{ amount_a });
+						nano::log::as_raw_nano (amount_a));
 
 						auto info = wallets.ledger.any.account_get (ledger_txn, source_a);
 						release_assert (info, "could not find account info for account in wallet send_action", source_a.to_account ());
@@ -1112,14 +1112,14 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 						{
 							logger.warn (nano::log::type::wallet, "Insufficient balance for send from: {}, required: {} raw, available: {} raw",
 							account_a,
-							nano::log::as_raw_nano{ amount_a },
-							nano::log::as_raw_nano{ balance.value ().number () });
+							nano::log::as_raw_nano (amount_a),
+							nano::log::as_raw_nano (balance.value ().number ()));
 						}
 						else
 						{
 							logger.warn (nano::log::type::wallet, "Insufficient balance for send from: {}, required: {} raw, available: unknown",
 							account_a,
-							nano::log::as_raw_nano{ amount_a });
+							nano::log::as_raw_nano (amount_a));
 						}
 					}
 				}

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -918,7 +918,7 @@ std::shared_ptr<nano::block> nano::wallet::receive_action (nano::block_hash cons
 					logger.info (nano::log::type::wallet, "Receiving block: {} from account: {}, amount: {} raw",
 					send_hash_a,
 					account_a,
-					nano::log::as_raw_nano (pending_info->amount.number ()));
+					nano::log::as_raw_nano (pending_info->amount));
 
 					if (work_a == 0)
 					{
@@ -1113,7 +1113,7 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 							logger.warn (nano::log::type::wallet, "Insufficient balance for send from: {}, required: {} raw, available: {} raw",
 							source_a,
 							nano::log::as_raw_nano (amount_a),
-							nano::log::as_raw_nano (balance.value ().number ()));
+							nano::log::as_raw_nano (balance.value ()));
 						}
 						else
 						{

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1111,14 +1111,14 @@ std::shared_ptr<nano::block> nano::wallet::send_action (nano::account const & so
 						if (balance)
 						{
 							logger.warn (nano::log::type::wallet, "Insufficient balance for send from: {}, required: {} raw, available: {} raw",
-							account_a,
+							source_a,
 							nano::log::as_raw_nano (amount_a),
 							nano::log::as_raw_nano (balance.value ().number ()));
 						}
 						else
 						{
 							logger.warn (nano::log::type::wallet, "Insufficient balance for send from: {}, required: {} raw, available: unknown",
-							account_a,
+							source_a,
 							nano::log::as_raw_nano (amount_a));
 						}
 					}

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1064,7 +1064,7 @@ std::string nano_qt::status::color ()
 	return result;
 }
 
-nano_qt::wallet::wallet (QApplication & application_a, nano_qt::eventloop_processor & processor_a, nano::node & node_a, std::shared_ptr<nano::wallet> const & wallet_a, nano::account & account_a) :
+nano_qt::wallet::wallet (QApplication & application_a, nano_qt::eventloop_processor & processor_a, nano::node & node_a, std::shared_ptr<nano::wallet> const & wallet_a, nano::public_key const & account_a) :
 	rendering_ratio (nano::nano_ratio),
 	node (node_a),
 	wallet_m (wallet_a),

--- a/nano/qt/qt.hpp
+++ b/nano/qt/qt.hpp
@@ -219,7 +219,7 @@ public:
 	QLabel * tx_label;
 	QSpinBox * tx_count;
 	nano::ledger & ledger;
-	nano::account const & account;
+	nano::account account;
 	nano_qt::wallet & wallet;
 };
 class block_viewer

--- a/nano/qt/qt.hpp
+++ b/nano/qt/qt.hpp
@@ -297,7 +297,7 @@ public:
 class wallet : public std::enable_shared_from_this<nano_qt::wallet>
 {
 public:
-	wallet (QApplication &, nano_qt::eventloop_processor &, nano::node &, std::shared_ptr<nano::wallet> const &, nano::account &);
+	wallet (QApplication &, nano_qt::eventloop_processor &, nano::node &, std::shared_ptr<nano::wallet> const &, nano::public_key const &);
 	void start ();
 	void refresh ();
 	void update_connected ();
@@ -307,7 +307,7 @@ public:
 	nano::uint128_t rendering_ratio;
 	nano::node & node;
 	std::shared_ptr<nano::wallet> wallet_m;
-	nano::account & account;
+	nano::account account;
 	nano_qt::eventloop_processor & processor;
 	nano_qt::history history;
 	nano_qt::accounts accounts;

--- a/nano/rpc/rpc.cpp
+++ b/nano/rpc/rpc.cpp
@@ -32,7 +32,7 @@ void nano::rpc::start ()
 	bool const is_loopback = (endpoint.address ().is_loopback () || (endpoint.address ().to_v6 ().is_v4_mapped () && boost::asio::ip::make_address_v4 (boost::asio::ip::v4_mapped, endpoint.address ().to_v6 ()).is_loopback ()));
 	if (!is_loopback && config.enable_control)
 	{
-		logger.warn (nano::log::type::rpc, "WARNING: Control-level RPCs are enabled on non-local address {}, potentially allowing wallet access outside local computer", endpoint.address ().to_string ());
+		logger.warn (nano::log::type::rpc, "WARNING: Control-level RPCs are enabled on non-local address {}, potentially allowing wallet access outside local computer", endpoint.address ());
 	}
 
 	acceptor.open (endpoint.protocol ());

--- a/nano/rpc_test/common.hpp
+++ b/nano/rpc_test/common.hpp
@@ -8,7 +8,7 @@ class node;
 class node_config;
 class node_flags;
 class public_key;
-using account = public_key;
+class account;
 
 namespace store
 {

--- a/nano/rpc_test/rpc_context.hpp
+++ b/nano/rpc_test/rpc_context.hpp
@@ -8,8 +8,8 @@ class ipc_rpc_processor;
 class node;
 class node_rpc_config;
 class public_key;
+class account;
 class rpc;
-using account = public_key;
 
 namespace ipc
 {

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -245,12 +245,12 @@ void nano::ledger::initialize (nano::generate_cache_flags const & generate_cache
 	logger.info (nano::log::type::ledger, "Pruned count:   {:>11}", cache.pruned_count.load ());
 	logger.info (nano::log::type::ledger, "Representative count: {:>5}", rep_weights.size ());
 	logger.info (nano::log::type::ledger, "Active balance: {} | pending: {} | burned: {}",
-	nano::log::as_nano{ static_cast<nano::uint128_t> (active_balance) },
-	nano::log::as_nano{ static_cast<nano::uint128_t> (pending_balance) },
-	nano::log::as_nano{ static_cast<nano::uint128_t> (burned_balance) });
+	nano::log::as_nano (static_cast<nano::uint128_t> (active_balance)),
+	nano::log::as_nano (static_cast<nano::uint128_t> (pending_balance)),
+	nano::log::as_nano (static_cast<nano::uint128_t> (burned_balance)));
 	logger.info (nano::log::type::ledger, "Weight committed: {} | unused: {}",
-	nano::log::as_nano{ rep_weights.get_weight_committed () },
-	nano::log::as_nano{ rep_weights.get_weight_unused () });
+	nano::log::as_nano (rep_weights.get_weight_committed ()),
+	nano::log::as_nano (rep_weights.get_weight_unused ()));
 }
 
 void nano::ledger::verify_consistency (secure::transaction const & transaction) const

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -636,21 +636,21 @@ std::optional<nano::account> nano::ledger::linked_account (secure::transaction c
 	{
 		return block.destination ();
 	}
-	else if (block.is_receive ())
+	if (block.is_receive ())
 	{
 		return any.block_account (transaction, block.source ());
 	}
 	return std::nullopt;
 }
 
-nano::account const & nano::ledger::epoch_signer (nano::link const & link_a) const
+nano::account nano::ledger::epoch_signer (nano::link const & link) const
 {
-	return constants.epochs.signer (constants.epochs.epoch (link_a));
+	return constants.epochs.signer (constants.epochs.epoch (link));
 }
 
-nano::link const & nano::ledger::epoch_link (nano::epoch epoch_a) const
+nano::link nano::ledger::epoch_link (nano::epoch epoch) const
 {
-	return constants.epochs.link (epoch_a);
+	return constants.epochs.link (epoch);
 }
 
 void nano::ledger::update_account (secure::write_transaction const & transaction_a, nano::account const & account_a, nano::account_info const & old_a, nano::account_info const & new_a)

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -3,6 +3,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/bounded_dfs.hpp>
 #include <nano/lib/files.hpp>
+#include <nano/lib/formatting.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/stats.hpp>
@@ -244,12 +245,12 @@ void nano::ledger::initialize (nano::generate_cache_flags const & generate_cache
 	logger.info (nano::log::type::ledger, "Pruned count:   {:>11}", cache.pruned_count.load ());
 	logger.info (nano::log::type::ledger, "Representative count: {:>5}", rep_weights.size ());
 	logger.info (nano::log::type::ledger, "Active balance: {} | pending: {} | burned: {}",
-	nano::uint128_union{ static_cast<nano::uint128_t> (active_balance) }.format_balance (nano::nano_ratio, 0, true),
-	nano::uint128_union{ static_cast<nano::uint128_t> (pending_balance) }.format_balance (nano::nano_ratio, 0, true),
-	nano::uint128_union{ static_cast<nano::uint128_t> (burned_balance) }.format_balance (nano::nano_ratio, 0, true));
+	nano::log::as_nano{ static_cast<nano::uint128_t> (active_balance) },
+	nano::log::as_nano{ static_cast<nano::uint128_t> (pending_balance) },
+	nano::log::as_nano{ static_cast<nano::uint128_t> (burned_balance) });
 	logger.info (nano::log::type::ledger, "Weight committed: {} | unused: {}",
-	nano::uint128_union{ rep_weights.get_weight_committed () }.format_balance (nano::nano_ratio, 0, true),
-	nano::uint128_union{ rep_weights.get_weight_unused () }.format_balance (nano::nano_ratio, 0, true));
+	nano::log::as_nano{ rep_weights.get_weight_committed () },
+	nano::log::as_nano{ rep_weights.get_weight_unused () });
 }
 
 void nano::ledger::verify_consistency (secure::transaction const & transaction) const

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -73,8 +73,8 @@ public:
 	bool is_epoch_link (nano::link const &) const;
 	std::shared_ptr<nano::block> find_receive_block_by_send_hash (secure::transaction const &, nano::account const & destination, nano::block_hash const & send_block_hash);
 	std::optional<nano::account> linked_account (secure::transaction const &, nano::block const &);
-	nano::account const & epoch_signer (nano::link const &) const;
-	nano::link const & epoch_link (nano::epoch) const;
+	nano::account epoch_signer (nano::link const &) const;
+	nano::link epoch_link (nano::epoch) const;
 	bool bootstrap_height_reached () const;
 	std::unordered_map<nano::account, nano::uint128_t> rep_weights_snapshot () const;
 

--- a/nano/store/db_val.hpp
+++ b/nano/store/db_val.hpp
@@ -74,6 +74,7 @@ public:
 	explicit operator nano::amount () const;
 	explicit operator nano::block_hash () const;
 	explicit operator nano::public_key () const;
+	explicit operator nano::account () const;
 	explicit operator std::array<char, 64> () const;
 	explicit operator block_w_sideband () const;
 	explicit operator std::shared_ptr<nano::vote> () const;

--- a/nano/store/db_val_templ.hpp
+++ b/nano/store/db_val_templ.hpp
@@ -218,6 +218,11 @@ inline db_val::operator nano::public_key () const
 	return read_as_bytes<nano::public_key> ();
 }
 
+inline db_val::operator nano::account () const
+{
+	return read_as_bytes<nano::account> ();
+}
+
 inline db_val::operator std::array<char, 64> () const
 {
 	nano::bufferstream stream{ span_view.data (), span_view.size () };

--- a/nano/test_common/rate_observer.cpp
+++ b/nano/test_common/rate_observer.cpp
@@ -98,7 +98,7 @@ void nano::test::rate_observer::observe (std::string name, std::function<int64_t
 
 void nano::test::rate_observer::observe (nano::node & node, nano::stat::type type, nano::stat::detail detail, nano::stat::dir dir)
 {
-	auto name = std::string{ nano::to_string (type) } + "::" + std::string{ nano::to_string (detail) } + "::" + std::string{ nano::to_string (dir) };
+	auto name = std::string{ to_string (type) } + "::" + std::string{ to_string (detail) } + "::" + std::string{ to_string (dir) };
 	observe (name, [&node, type, detail, dir] () {
 		return node.stats.count (type, detail, dir);
 	});

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -157,7 +157,7 @@ std::shared_ptr<nano::node> nano::test::system::add_node (nano::node_config cons
 		debug_assert (!ec);
 	}
 
-	logger.debug (nano::log::type::system, "Node started: {}", nano::log::as_node_id{ node->get_node_id () });
+	logger.debug (nano::log::type::system, "Node started: {}", nano::log::as_node_id (node->get_node_id ()));
 
 	nodes.push_back (node);
 	return node;
@@ -171,7 +171,7 @@ std::shared_ptr<nano::node> nano::test::system::make_disconnected_node (std::opt
 	setup_node (*node);
 	node->start ();
 
-	logger.debug (nano::log::type::system, "Node started (disconnected): {}", nano::log::as_node_id{ node->get_node_id () });
+	logger.debug (nano::log::type::system, "Node started (disconnected): {}", nano::log::as_node_id (node->get_node_id ()));
 
 	disconnected_nodes.push_back (node);
 	return node;

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -1,5 +1,6 @@
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/blocks.hpp>
+#include <nano/lib/formatting.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/work_version.hpp>
 #include <nano/node/active_elections.hpp>
@@ -156,7 +157,7 @@ std::shared_ptr<nano::node> nano::test::system::add_node (nano::node_config cons
 		debug_assert (!ec);
 	}
 
-	logger.debug (nano::log::type::system, "Node started: {}", node->get_node_id ().to_node_id ());
+	logger.debug (nano::log::type::system, "Node started: {}", nano::log::as_node_id{ node->get_node_id () });
 
 	nodes.push_back (node);
 	return node;
@@ -170,7 +171,7 @@ std::shared_ptr<nano::node> nano::test::system::make_disconnected_node (std::opt
 	setup_node (*node);
 	node->start ();
 
-	logger.debug (nano::log::type::system, "Node started (disconnected): {}", node->get_node_id ().to_node_id ());
+	logger.debug (nano::log::type::system, "Node started (disconnected): {}", nano::log::as_node_id{ node->get_node_id () });
 
 	disconnected_nodes.push_back (node);
 	return node;


### PR DESCRIPTION
Replace eager string conversions in logger call sites with lazy formatting using `fmt::formatter` specializations. This avoids unnecessary string allocations when the log level is disabled. Add lazy wrappers (`nano::log::as_account`, `as_node_id`, `as_nano`, `as_raw_nano`), and channel formatting support. Make `nano::account` a distinct type from `public_key` so it automatically formats in account notation (`nano_...`).