### PR TITLE
Rocksdb logging configuration

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -604,6 +604,8 @@ TEST (toml_config, daemon_config_deserialize_no_defaults)
 	io_threads = 99
 	read_cache = 99
 	write_cache = 99
+	max_log_files = 99
+	log_level = "debug"
 
 	[node.experimental]
 	secondary_work_peers = ["dev.org:998"]
@@ -797,6 +799,8 @@ TEST (toml_config, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.rocksdb_config.io_threads, defaults.node.rocksdb_config.io_threads);
 	ASSERT_NE (conf.node.rocksdb_config.read_cache, defaults.node.rocksdb_config.read_cache);
 	ASSERT_NE (conf.node.rocksdb_config.write_cache, defaults.node.rocksdb_config.write_cache);
+	ASSERT_NE (conf.node.rocksdb_config.max_log_files, defaults.node.rocksdb_config.max_log_files);
+	ASSERT_NE (conf.node.rocksdb_config.log_level, defaults.node.rocksdb_config.log_level);
 
 	ASSERT_NE (conf.node.optimistic_scheduler.enable, defaults.node.optimistic_scheduler.enable);
 	ASSERT_NE (conf.node.optimistic_scheduler.gap_threshold, defaults.node.optimistic_scheduler.gap_threshold);

--- a/nano/lib/rocksdbconfig.cpp
+++ b/nano/lib/rocksdbconfig.cpp
@@ -7,6 +7,8 @@ nano::error nano::rocksdb_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("io_threads", io_threads, "Number of threads to use with the background compaction and flushing.\ntype:uint32");
 	toml.put ("read_cache", read_cache, "Amount of megabytes per table allocated to read cache. Valid range is 1 - 1024. Default is 32.\nCarefully monitor memory usage if non-default values are used\ntype:long");
 	toml.put ("write_cache", write_cache, "Total amount of megabytes allocated to write cache. Valid range is 1 - 256. Default is 64.\nCarefully monitor memory usage if non-default values are used\ntype:long");
+	toml.put ("max_log_files", max_log_files, "Maximum number of RocksDB info log files to keep. Default is 100.\ntype:uint32");
+	toml.put ("log_level", log_level, "RocksDB log level. One of: debug, info, warn, error, fatal. Default is warn.\ntype:string");
 
 	return toml.get_error ();
 }
@@ -17,11 +19,23 @@ nano::error nano::rocksdb_config::deserialize_toml (nano::tomlconfig & toml)
 	toml.get_optional<unsigned> ("io_threads", io_threads);
 	toml.get_optional<long> ("read_cache", read_cache);
 	toml.get_optional<long> ("write_cache", write_cache);
+	toml.get_optional<unsigned> ("max_log_files", max_log_files);
+	toml.get_optional<std::string> ("log_level", log_level);
 
 	// Validate ranges
 	if (io_threads == 0)
 	{
 		toml.get_error ().set ("io_threads must be non-zero");
+	}
+
+	if (max_log_files == 0)
+	{
+		toml.get_error ().set ("max_log_files must be greater than 0");
+	}
+
+	if (log_level != "debug" && log_level != "info" && log_level != "warn" && log_level != "error" && log_level != "fatal")
+	{
+		toml.get_error ().set ("log_level must be one of: debug, info, warn, error, fatal");
 	}
 
 	if (read_cache < 1 || read_cache > 1024)

--- a/nano/lib/rocksdbconfig.hpp
+++ b/nano/lib/rocksdbconfig.hpp
@@ -3,6 +3,7 @@
 #include <nano/lib/errors.hpp>
 #include <nano/lib/threading.hpp>
 
+#include <string>
 #include <thread>
 
 namespace nano
@@ -20,5 +21,7 @@ public:
 	unsigned io_threads{ std::max (nano::hardware_concurrency () / 2, 1u) };
 	long read_cache{ 32 };
 	long write_cache{ 64 };
+	unsigned max_log_files{ 100 };
+	std::string log_level{ "warn" };
 };
 }

--- a/nano/store/rocksdb/backend_rocksdb.cpp
+++ b/nano/store/rocksdb/backend_rocksdb.cpp
@@ -185,6 +185,29 @@ void backend_rocksdb::open_db (std::filesystem::path const & path, nano::store::
 	db_options.IncreaseParallelism (config.io_threads);
 	db_options.compression = ::rocksdb::kNoCompression;
 
+	db_options.keep_log_file_num = config.max_log_files;
+
+	if (config.log_level == "debug")
+	{
+		db_options.info_log_level = ::rocksdb::InfoLogLevel::DEBUG_LEVEL;
+	}
+	else if (config.log_level == "info")
+	{
+		db_options.info_log_level = ::rocksdb::InfoLogLevel::INFO_LEVEL;
+	}
+	else if (config.log_level == "warn")
+	{
+		db_options.info_log_level = ::rocksdb::InfoLogLevel::WARN_LEVEL;
+	}
+	else if (config.log_level == "error")
+	{
+		db_options.info_log_level = ::rocksdb::InfoLogLevel::ERROR_LEVEL;
+	}
+	else if (config.log_level == "fatal")
+	{
+		db_options.info_log_level = ::rocksdb::InfoLogLevel::FATAL_LEVEL;
+	}
+
 	auto event_listener_l = new event_listener ([this] (::rocksdb::FlushJobInfo const & flush_job_info) {
 		this->on_flush (flush_job_info);
 	});


### PR DESCRIPTION
A node operator has reported several gigabytes of RocksDb log files. 
The default number of archived logfiles is 1000. This means that log files are deleted after 1000 days (one log file per day)
The current default log level for RocksDb is "info" which is quite verbose.
This PR lets the node operator set the log level and the maximum number of archived logs. 
New default values are:
max_log_files 100
log_level "warn"