### PR TITLE
Bump docker Ubuntu base images to 24.04

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   prepare_build:
     name: Prepare Build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       ci_tag: ${{ steps.set_vars.outputs.ci_tag }}
       tag_created: ${{ steps.set_vars.outputs.tag_created }}
@@ -78,7 +78,7 @@ jobs:
     name: Linux [${{ matrix.network }}]
     needs: prepare_build
     if: ${{ needs.prepare_build.outputs.tag_created == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
       matrix:
@@ -115,7 +115,7 @@ jobs:
     name: Docker [${{ matrix.network }}]
     needs: prepare_build
     if: ${{ needs.prepare_build.outputs.tag_created == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
       matrix:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   promote_reference:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/docker/ci/Dockerfile-base
+++ b/docker/ci/Dockerfile-base
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS builder
+FROM ubuntu:24.04 AS builder
 
 ARG COMPILER=gcc
 ARG NANO_NETWORK=live
@@ -24,7 +24,7 @@ ARG SANITIZER
 RUN ci/build-node.sh
 RUN echo ${NANO_NETWORK} >/etc/nano-network
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN groupadd --gid 1000 nanocurrency && \
     useradd --uid 1000 --gid nanocurrency --shell /bin/bash --create-home nanocurrency

--- a/docker/tests/Dockerfile-tests
+++ b/docker/tests/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG COMPILER=gcc
 ENV COMPILER=${COMPILER}


### PR DESCRIPTION
Update the CI, node, and test Dockerfiles from Ubuntu 22.04 to Ubuntu 24.04. Also move build and deploy CI workflows to 24.04.