### PR TITLE
Added two more maker enums

### DIFF
--- a/nano/messages/telemetry.cpp
+++ b/nano/messages/telemetry.cpp
@@ -423,6 +423,10 @@ std::string to_string (telemetry_maker maker)
 			return "nf_node";
 		case telemetry_maker::nf_pruned_node:
 			return "nf_pruned_node";
+		case telemetry_maker::nano_node_light:
+			return "nano_node_light";
+		case telemetry_maker::rs_nano:
+			return "rs_nano";
 	}
 	return "invalid";
 }
@@ -461,6 +465,10 @@ telemetry_maker telemetry_maker_from_string (std::string const & str)
 		return telemetry_maker::nf_node;
 	if (str == "nf_pruned_node")
 		return telemetry_maker::nf_pruned_node;
+	if (str == "nano_node_light")
+		return telemetry_maker::nano_node_light;
+	if (str == "rs_nano")
+		return telemetry_maker::rs_nano;
 	return telemetry_maker::nf_node;
 }
 

--- a/nano/messages/telemetry.hpp
+++ b/nano/messages/telemetry.hpp
@@ -17,7 +17,9 @@ namespace nano::messages
 enum class telemetry_maker : uint8_t
 {
 	nf_node = 0,
-	nf_pruned_node = 1
+	nf_pruned_node = 1,
+	nano_node_light = 2,
+	rs_nano = 3
 };
 
 enum class telemetry_database_backend : uint8_t


### PR DESCRIPTION
This adds two more telemetry enums for the maker fields so the complete list is:
NfNode = 0
NfPrunedNode = 1
NanoNodeLight = 2
RsNano = 3

They are copied directly from the RS nano implementation.
I have tested it and it detected two RSNano nodes in telemetry