### PR TITLE
Update Boost from V1.86.0 to 1.87.0

### DIFF
--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -61,7 +61,7 @@ private:
 	http::response<http::dynamic_body> response;
 	std::function<void (bool const)> on_generation;
 	std::function<void ()> on_cancel;
-	asio::deadline_timer timer;
+	asio::steady_timer timer;
 
 	void read_request ()
 	{
@@ -155,7 +155,7 @@ private:
 				ptree::write_json (ostream, message_l);
 				beast::ostream (this_l->response.body ()) << ostream.str ();
 				// Delay response by 500ms as a slow peer, immediate async call for a good peer
-				this_l->timer.expires_from_now (boost::posix_time::milliseconds (this_l->type == fake_work_peer_type::slow ? 500 : 0));
+				this_l->timer.expires_after (std::chrono::milliseconds (this_l->type == fake_work_peer_type::slow ? 500 : 0));
 				this_l->timer.async_wait ([this_l, result] (boost::system::error_code const & ec) {
 					if (this_l->on_generation)
 					{

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -488,7 +488,7 @@ TEST (network, ipv6_from_ipv4)
 {
 	nano::endpoint endpoint1 (boost::asio::ip::address_v4::loopback (), 16000);
 	ASSERT_TRUE (endpoint1.address ().is_v4 ());
-	nano::endpoint endpoint2 (boost::asio::ip::address_v6::v4_mapped (endpoint1.address ().to_v4 ()), 16000);
+	nano::endpoint endpoint2 (boost::asio::ip::make_address_v6 (boost::asio::ip::v4_mapped, endpoint1.address ().to_v4 ()), 16000);
 	ASSERT_TRUE (endpoint2.address ().is_v6 ());
 }
 
@@ -540,7 +540,7 @@ TEST (network, peer_max_tcp_attempts_subnetwork)
 
 	for (auto i (0); i < node->config.network.max_peers_per_subnetwork; ++i)
 	{
-		auto address (boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0x7f000001 + i))); // 127.0.0.1 hex
+		auto address (boost::asio::ip::make_address_v6 (boost::asio::ip::v4_mapped, boost::asio::ip::address_v4 (0x7f000001 + i))); // 127.0.0.1 hex
 		nano::endpoint endpoint (address, system.get_available_port ());
 		ASSERT_TRUE (node->network.tcp_channels.track_reachout (endpoint));
 	}
@@ -782,7 +782,7 @@ TEST (peer_exclusion, validate)
 
 	for (auto i = 0; i < max_size + 1; ++i)
 	{
-		nano::tcp_endpoint endpoint{ boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (i)), 0 };
+		nano::tcp_endpoint endpoint{ boost::asio::ip::make_address_v6 (boost::asio::ip::v4_mapped, boost::asio::ip::address_v4 (i)), 0 };
 		ASSERT_FALSE (excluded_peers.check (endpoint));
 		ASSERT_EQ (1, excluded_peers.add (endpoint));
 		ASSERT_FALSE (excluded_peers.check (endpoint));
@@ -790,7 +790,7 @@ TEST (peer_exclusion, validate)
 
 	// The oldest entry must have been removed, because we just overfilled the container
 	ASSERT_EQ (max_size, excluded_peers.size ());
-	nano::tcp_endpoint oldest{ boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0x0)), 0 };
+	nano::tcp_endpoint oldest{ boost::asio::ip::make_address_v6 (boost::asio::ip::v4_mapped, boost::asio::ip::address_v4 (0x0)), 0 };
 	ASSERT_EQ (excluded_peers.score (oldest), 0);
 
 	auto to_seconds = [] (std::chrono::steady_clock::time_point const & timepoint) {
@@ -798,10 +798,10 @@ TEST (peer_exclusion, validate)
 	};
 
 	// However, the rest of the entries should be present
-	nano::tcp_endpoint first{ boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0x1)), 0 };
+	nano::tcp_endpoint first{ boost::asio::ip::make_address_v6 (boost::asio::ip::v4_mapped, boost::asio::ip::address_v4 (0x1)), 0 };
 	ASSERT_NE (excluded_peers.score (first), 0);
 
-	nano::tcp_endpoint second{ boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (0x2)), 0 };
+	nano::tcp_endpoint second{ boost::asio::ip::make_address_v6 (boost::asio::ip::v4_mapped, boost::asio::ip::address_v4 (0x2)), 0 };
 	ASSERT_NE (excluded_peers.score (second), 0);
 
 	// Check exclusion times

--- a/nano/core_test/network_functions.cpp
+++ b/nano/core_test/network_functions.cpp
@@ -61,74 +61,74 @@ TEST (network_functions, network_range_ipv4)
 TEST (network_functions, ipv4_address_or_ipv6_subnet)
 {
 	// IPv4 mapped as IPv6 address should return the original IPv4 address
-	boost::asio::ip::address addr1 = boost::asio::ip::address::from_string ("192.168.1.1");
-	boost::asio::ip::address addr2 = boost::asio::ip::address::from_string ("::ffff:192.168.1.1");
+	boost::asio::ip::address addr1 = boost::asio::ip::make_address ("192.168.1.1");
+	boost::asio::ip::address addr2 = boost::asio::ip::make_address ("::ffff:192.168.1.1");
 	ASSERT_EQ (nano::transport::ipv4_address_or_ipv6_subnet (addr1), addr2);
 
 	// IPv6 address within the same /48 subnet should return the network prefix
-	boost::asio::ip::address addr3 = boost::asio::ip::address::from_string ("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
-	boost::asio::ip::address addr4 = boost::asio::ip::address::from_string ("2001:0db8:85a3::");
+	boost::asio::ip::address addr3 = boost::asio::ip::make_address ("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+	boost::asio::ip::address addr4 = boost::asio::ip::make_address ("2001:0db8:85a3::");
 	ASSERT_EQ (nano::transport::ipv4_address_or_ipv6_subnet (addr3), addr4);
 
 	// Different IPv6 address outside the /48 subnet should not match
-	boost::asio::ip::address addr5 = boost::asio::ip::address::from_string ("2001:0db8:85a4:0001:0000:8a2e:0370:7334");
+	boost::asio::ip::address addr5 = boost::asio::ip::make_address ("2001:0db8:85a4:0001:0000:8a2e:0370:7334");
 	ASSERT_NE (nano::transport::ipv4_address_or_ipv6_subnet (addr3), nano::transport::ipv4_address_or_ipv6_subnet (addr5));
 }
 
 TEST (network_functions, is_same_ip)
 {
 	// Same IPv4 addresses
-	boost::asio::ip::address ipv4_addr1 = boost::asio::ip::address::from_string ("192.168.1.1");
+	boost::asio::ip::address ipv4_addr1 = boost::asio::ip::make_address ("192.168.1.1");
 	ASSERT_TRUE (nano::transport::is_same_ip (ipv4_addr1, ipv4_addr1));
 
 	// IPv4 and its IPv6 mapped form
-	boost::asio::ip::address ipv6_mapped_ipv4 = boost::asio::ip::address::from_string ("::ffff:192.168.1.1");
+	boost::asio::ip::address ipv6_mapped_ipv4 = boost::asio::ip::make_address ("::ffff:192.168.1.1");
 	ASSERT_TRUE (nano::transport::is_same_ip (ipv4_addr1, ipv6_mapped_ipv4));
 }
 
 TEST (network_functions, is_same_ipv4)
 {
 	// Same IPv4 addresses
-	boost::asio::ip::address ipv4_addr1 = boost::asio::ip::address::from_string ("192.168.1.1");
+	boost::asio::ip::address ipv4_addr1 = boost::asio::ip::make_address ("192.168.1.1");
 	ASSERT_TRUE (nano::transport::is_same_ip (ipv4_addr1, ipv4_addr1));
 
 	// IPv4 and its IPv6 mapped form
-	boost::asio::ip::address ipv6_mapped_ipv4 = boost::asio::ip::address::from_string ("::ffff:192.168.1.1");
+	boost::asio::ip::address ipv6_mapped_ipv4 = boost::asio::ip::make_address ("::ffff:192.168.1.1");
 	ASSERT_TRUE (nano::transport::is_same_ip (ipv4_addr1, ipv6_mapped_ipv4));
 }
 
 TEST (network_functions, is_same_ipv6)
 {
 	// Two different IPv6 addresses within the same /48 subnet
-	boost::asio::ip::address ipv6_addr1 = boost::asio::ip::address::from_string ("2001:db8::1");
-	boost::asio::ip::address ipv6_addr2 = boost::asio::ip::address::from_string ("2001:db8::2");
+	boost::asio::ip::address ipv6_addr1 = boost::asio::ip::make_address ("2001:db8::1");
+	boost::asio::ip::address ipv6_addr2 = boost::asio::ip::make_address ("2001:db8::2");
 	ASSERT_TRUE (nano::transport::is_same_ip (ipv6_addr1, ipv6_addr2));
 
 	// Two different IPv6 addresses in different /48 subnets
-	boost::asio::ip::address ipv6_addr3 = boost::asio::ip::address::from_string ("2001:db8:1::1");
+	boost::asio::ip::address ipv6_addr3 = boost::asio::ip::make_address ("2001:db8:1::1");
 	ASSERT_FALSE (nano::transport::is_same_ip (ipv6_addr1, ipv6_addr3));
 }
 
 TEST (network_functions, is_different_ip_family)
 {
-	boost::asio::ip::address addr1 = boost::asio::ip::address::from_string ("192.168.1.1");
-	boost::asio::ip::address addr2 = boost::asio::ip::address::from_string ("::1");
+	boost::asio::ip::address addr1 = boost::asio::ip::make_address ("192.168.1.1");
+	boost::asio::ip::address addr2 = boost::asio::ip::make_address ("::1");
 	ASSERT_FALSE (nano::transport::is_same_ip (addr1, addr2));
 }
 
 TEST (network_functions, is_same_ip_v4_mapped)
 {
-	boost::asio::ip::address addr1 = boost::asio::ip::address::from_string ("::ffff:192.168.1.1");
-	boost::asio::ip::address addr2 = boost::asio::ip::address::from_string ("192.168.1.1");
+	boost::asio::ip::address addr1 = boost::asio::ip::make_address ("::ffff:192.168.1.1");
+	boost::asio::ip::address addr2 = boost::asio::ip::make_address ("192.168.1.1");
 	ASSERT_TRUE (nano::transport::is_same_ip (addr1, addr2));
 
-	boost::asio::ip::address addr3 = boost::asio::ip::address::from_string ("10.0.0.1");
+	boost::asio::ip::address addr3 = boost::asio::ip::make_address ("10.0.0.1");
 	ASSERT_FALSE (nano::transport::is_same_ip (addr1, addr3));
 }
 
 TEST (network_functions, map_ipv4_address_to_subnetwork)
 {
-	boost::asio::ip::address addr = boost::asio::ip::address::from_string ("192.168.1.100");
+	boost::asio::ip::address addr = boost::asio::ip::make_address ("192.168.1.100");
 	auto subnetwork = nano::transport::map_address_to_subnetwork (addr);
 	// Assuming a /24 subnet mask for IPv4, all addresses in 192.168.1.x should map to the same network
 	// Automatically maps to IPv6
@@ -137,7 +137,7 @@ TEST (network_functions, map_ipv4_address_to_subnetwork)
 
 TEST (network_functions, map_ipv6_address_to_subnetwork)
 {
-	boost::asio::ip::address addr = boost::asio::ip::address::from_string ("2001:db8:abcd:0012::0");
+	boost::asio::ip::address addr = boost::asio::ip::make_address ("2001:db8:abcd:0012::0");
 	auto subnetwork = nano::transport::map_address_to_subnetwork (addr);
 	// Assuming a /32 subnet mask for IPv6
 	ASSERT_EQ (subnetwork.to_string (), "2001:db8::");

--- a/nano/lib/ipc.cpp
+++ b/nano/lib/ipc.cpp
@@ -21,7 +21,7 @@ void nano::ipc::socket_base::timer_start (std::chrono::seconds timeout_a)
 {
 	if (timeout_a < std::chrono::seconds::max ())
 	{
-		io_timer.expires_from_now (boost::posix_time::seconds (static_cast<long> (timeout_a.count ())));
+		io_timer.expires_after (std::chrono::seconds (timeout_a.count ()));
 		io_timer.async_wait ([this] (boost::system::error_code const & ec) {
 			if (!ec)
 			{
@@ -38,9 +38,7 @@ void nano::ipc::socket_base::timer_expired ()
 
 void nano::ipc::socket_base::timer_cancel ()
 {
-	boost::system::error_code ec;
-	io_timer.cancel (ec);
-	debug_assert (!ec);
+	io_timer.cancel ();
 }
 
 /*

--- a/nano/lib/ipc.hpp
+++ b/nano/lib/ipc.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nano/boost/asio/deadline_timer.hpp>
+#include <nano/boost/asio/steady_timer.hpp>
 
 #include <memory>
 #include <string>
@@ -55,7 +55,7 @@ namespace ipc
 		/** Prevent io_context destruction while this socket is alive */
 		std::shared_ptr<boost::asio::io_context> io_ctx_shared;
 		/** IO operation timer */
-		boost::asio::deadline_timer io_timer;
+		boost::asio::steady_timer io_timer;
 	};
 
 	/**

--- a/nano/lib/ipc_client.cpp
+++ b/nano/lib/ipc_client.cpp
@@ -33,12 +33,7 @@ public:
 	virtual void async_read_message (std::shared_ptr<std::vector<uint8_t>> const & buffer_a, std::chrono::seconds timeout_a, std::function<void (boost::system::error_code const &, size_t)> callback_a) = 0;
 };
 
-/* Boost v1.70 introduced breaking changes; the conditional compilation allows 1.6x to be supported as well. */
-#if BOOST_VERSION < 107000
-using socket_type = boost::asio::ip::tcp::socket;
-#else
 using socket_type = boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::executor_type>;
-#endif
 
 /** Domain and TCP client socket */
 template <typename SOCKET_TYPE, typename ENDPOINT_TYPE>
@@ -58,13 +53,12 @@ public:
 	{
 		auto this_l (this->shared_from_this ());
 		this_l->timer_start (io_timeout);
-		resolver.async_resolve (boost::asio::ip::tcp::resolver::query (host_a, std::to_string (port_a)), [this_l, callback = std::move (callback_a)] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator endpoint_iterator_a) {
+		resolver.async_resolve (host_a, std::to_string (port_a), [this_l, callback = std::move (callback_a)] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::results_type results) {
 			this_l->timer_cancel ();
-			boost::asio::ip::tcp::resolver::iterator end;
-			if (!ec && endpoint_iterator_a != end)
+			if (!ec && !results.empty ())
 			{
-				this_l->endpoint = *endpoint_iterator_a;
-				callback (ec, *endpoint_iterator_a);
+				this_l->endpoint = *results.begin ();
+				callback (ec, *results.begin ());
 			}
 			else
 			{

--- a/nano/lib/thread_runner.hpp
+++ b/nano/lib/thread_runner.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <nano/boost/asio/deadline_timer.hpp>
 #include <nano/boost/asio/executor_work_guard.hpp>
 #include <nano/boost/asio/io_context.hpp>
 #include <nano/lib/logging.hpp>

--- a/nano/load_test/entry.cpp
+++ b/nano/load_test/entry.cpp
@@ -24,12 +24,7 @@
 #include <memory>
 #include <random>
 
-/* Boost v1.70 introduced breaking changes; the conditional compilation allows 1.6x to be supported as well. */
-#if BOOST_VERSION < 107000
-using socket_type = boost::asio::ip::tcp::socket;
-#else
 using socket_type = boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::executor_type>;
-#endif
 
 namespace nano
 {
@@ -143,7 +138,7 @@ private:
 	void async_connect ()
 	{
 		boost::asio::async_connect (socket, results.cbegin (), results.cend (),
-		[this_l = shared_from_this ()] (boost::system::error_code const & ec, tcp::resolver::iterator iterator) {
+		[this_l = shared_from_this ()] (boost::system::error_code const & ec, tcp::resolver::results_type::const_iterator iterator) {
 			this_l->request_receive ();
 		});
 	}
@@ -243,7 +238,7 @@ private:
 	void async_connect ()
 	{
 		boost::asio::async_connect (socket, results.cbegin (), results.cend (),
-		[this_l = shared_from_this ()] (boost::system::error_code const & ec, tcp::resolver::iterator iterator) {
+		[this_l = shared_from_this ()] (boost::system::error_code const & ec, tcp::resolver::results_type::const_iterator iterator) {
 			this_l->request_send ();
 		});
 	}
@@ -358,7 +353,7 @@ private:
 	void async_connect ()
 	{
 		boost::asio::async_connect (socket, results.cbegin (), results.cend (),
-		[this_l = shared_from_this ()] (boost::system::error_code const & ec, tcp::resolver::iterator iterator) {
+		[this_l = shared_from_this ()] (boost::system::error_code const & ec, tcp::resolver::results_type::const_iterator iterator) {
 			this_l->request_do ();
 		});
 	}

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -5,7 +5,6 @@
 
 #include <boost/algorithm/string/erase.hpp>
 #include <boost/format.hpp>
-#include <boost/range/iterator_range.hpp>
 
 std::shared_ptr<request_type> nano::distributed_work::peer_request::get_prepared_json_request (std::string const & request_string_a) const
 {
@@ -83,14 +82,17 @@ void nano::distributed_work::start ()
 		else
 		{
 			auto this_l (shared_from_this ());
-			node.network.resolver.async_resolve (boost::asio::ip::tcp::resolver::query (peer.first, std::to_string (peer.second)), [peer, this_l, &extra = resolved_extra] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator i_a) {
+			node.network.resolver.async_resolve (peer.first, std::to_string (peer.second), [peer, this_l, &extra = resolved_extra] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::results_type results) {
 				if (!ec)
 				{
-					this_l->do_request (nano::tcp_endpoint (i_a->endpoint ().address (), i_a->endpoint ().port ()));
-					++i_a;
-					for (auto & i : boost::make_iterator_range (i_a, {}))
+					bool first = true;
+					for (auto const & i : results)
 					{
-						++extra;
+						if (!first)
+						{
+							++extra;
+						}
+						first = false;
 						this_l->do_request (nano::tcp_endpoint (i.endpoint ().address (), i.endpoint ().port ()));
 					}
 				}

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -281,12 +281,12 @@ void nano::network::trigger_reachout ()
 void nano::network::reachout (std::string const & address_a, uint16_t port_a)
 {
 	auto node_l (node.shared_from_this ());
-	resolver.async_resolve (boost::asio::ip::tcp::resolver::query (address_a, std::to_string (port_a)), [this, node_l, address_a, port_a] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::iterator i_a) {
+	resolver.async_resolve (address_a, std::to_string (port_a), [this, node_l, address_a, port_a] (boost::system::error_code const & ec, boost::asio::ip::tcp::resolver::results_type results) {
 		if (!ec)
 		{
-			for (auto i (i_a), n (boost::asio::ip::tcp::resolver::iterator{}); i != n; ++i)
+			for (auto const & i : results)
 			{
-				auto endpoint (nano::transport::map_endpoint_to_v6 (i->endpoint ()));
+				auto endpoint (nano::transport::map_endpoint_to_v6 (i.endpoint ()));
 				auto channel (find_channel (endpoint));
 				if (!channel)
 				{

--- a/nano/node/portmapping.cpp
+++ b/nano/node/portmapping.cpp
@@ -148,7 +148,7 @@ void nano::port_mapping::refresh_devices ()
 	if (igd_error_l == 1 || igd_error_l == 2)
 	{
 		boost::system::error_code ec;
-		address = boost::asio::ip::address_v4::from_string (local_address_l.data (), ec);
+		address = boost::asio::ip::make_address_v4 (local_address_l.data (), ec);
 	}
 }
 
@@ -250,7 +250,7 @@ bool nano::port_mapping::check_lost_or_old_mapping ()
 		if (external_ip_error_l == UPNPCOMMAND_SUCCESS)
 		{
 			boost::system::error_code ec;
-			protocol.external_address = boost::asio::ip::address_v4::from_string (external_address_l.data (), ec);
+			protocol.external_address = boost::asio::ip::make_address_v4 (external_address_l.data (), ec);
 			protocol.external_port = static_cast<uint16_t> (std::atoi (config_port_l.data ()));
 		}
 		else

--- a/nano/node/rpc_callbacks.cpp
+++ b/nano/node/rpc_callbacks.cpp
@@ -114,7 +114,8 @@ void nano::http_callbacks::setup_callbacks ()
 				boost::asio::ip::tcp::resolver::results_type results) {
 					if (!ec)
 					{
-						do_rpc_callback (results.begin (), results.end (), address, port, target, body, resolver);
+						auto results_ptr = std::make_shared<boost::asio::ip::tcp::resolver::results_type> (std::move (results));
+						do_rpc_callback (results_ptr->begin (), results_ptr->end (), address, port, target, body, resolver, results_ptr);
 					}
 					else
 					{
@@ -140,7 +141,8 @@ std::string const & address,
 uint16_t port,
 std::shared_ptr<std::string> const & target,
 std::shared_ptr<std::string> const & body,
-std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
+std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver,
+std::shared_ptr<boost::asio::ip::tcp::resolver::results_type> const & results)
 {
 	// Check if we have more endpoints to try
 	if (i_a != end_a)
@@ -150,7 +152,7 @@ std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 		// Create socket and attempt connection
 		auto sock = std::make_shared<boost::asio::ip::tcp::socket> (node.io_ctx);
 		sock->async_connect (i_a->endpoint (),
-		[this, target, body, sock, address, port, i_a, end_a, resolver] (boost::system::error_code const & ec) mutable {
+		[this, target, body, sock, address, port, i_a, end_a, resolver, results] (boost::system::error_code const & ec) mutable {
 			if (!ec)
 			{
 				// Connection successful, prepare and send HTTP request
@@ -165,7 +167,7 @@ std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 
 				// Send the HTTP request
 				boost::beast::http::async_write (*sock, *req,
-				[this, sock, address, port, req, i_a, end_a, target, body, resolver] (
+				[this, sock, address, port, req, i_a, end_a, target, body, resolver, results] (
 				boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
 					if (!ec)
 					{
@@ -175,7 +177,7 @@ std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 
 						// Read the HTTP response
 						boost::beast::http::async_read (*sock, *sb, *resp,
-						[this, sb, resp, sock, address, port, i_a, end_a, target, body, resolver] (
+						[this, sb, resp, sock, address, port, i_a, end_a, target, body, resolver, results] (
 						boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
 							if (!ec)
 							{
@@ -220,7 +222,7 @@ std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 				address, i_a->endpoint ().address ().to_string (), port, ec.message ());
 
 				++i_a;
-				do_rpc_callback (i_a, end_a, address, port, target, body, resolver);
+				do_rpc_callback (i_a, end_a, address, port, target, body, resolver, results);
 			}
 		});
 	}

--- a/nano/node/rpc_callbacks.cpp
+++ b/nano/node/rpc_callbacks.cpp
@@ -109,12 +109,12 @@ void nano::http_callbacks::setup_callbacks ()
 
 				// Resolve the callback address
 				// Safe to capture 'this' as io_context is stopped before node destruction
-				resolver->async_resolve (boost::asio::ip::tcp::resolver::query{ address, std::to_string (port) },
+				resolver->async_resolve (address, std::to_string (port),
 				[this, address, port, target, body, resolver] (boost::system::error_code const & ec,
-				boost::asio::ip::tcp::resolver::iterator i_a) {
+				boost::asio::ip::tcp::resolver::results_type results) {
 					if (!ec)
 					{
-						do_rpc_callback (i_a, address, port, target, body, resolver);
+						do_rpc_callback (results.begin (), results.end (), address, port, target, body, resolver);
 					}
 					else
 					{
@@ -134,7 +134,8 @@ void nano::http_callbacks::setup_callbacks ()
  * Handles connection establishment, request sending, and response processing
  * Includes retry logic for failed connection attempts
  */
-void nano::http_callbacks::do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a,
+void nano::http_callbacks::do_rpc_callback (boost::asio::ip::tcp::resolver::results_type::iterator i_a,
+boost::asio::ip::tcp::resolver::results_type::iterator end_a,
 std::string const & address,
 uint16_t port,
 std::shared_ptr<std::string> const & target,
@@ -142,14 +143,14 @@ std::shared_ptr<std::string> const & body,
 std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 {
 	// Check if we have more endpoints to try
-	if (i_a != boost::asio::ip::tcp::resolver::iterator{})
+	if (i_a != end_a)
 	{
 		stats.inc (nano::stat::type::http_callbacks, nano::stat::detail::initiate);
 
 		// Create socket and attempt connection
 		auto sock = std::make_shared<boost::asio::ip::tcp::socket> (node.io_ctx);
 		sock->async_connect (i_a->endpoint (),
-		[this, target, body, sock, address, port, i_a, resolver] (boost::system::error_code const & ec) mutable {
+		[this, target, body, sock, address, port, i_a, end_a, resolver] (boost::system::error_code const & ec) mutable {
 			if (!ec)
 			{
 				// Connection successful, prepare and send HTTP request
@@ -164,7 +165,7 @@ std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 
 				// Send the HTTP request
 				boost::beast::http::async_write (*sock, *req,
-				[this, sock, address, port, req, i_a, target, body, resolver] (
+				[this, sock, address, port, req, i_a, end_a, target, body, resolver] (
 				boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
 					if (!ec)
 					{
@@ -174,7 +175,7 @@ std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 
 						// Read the HTTP response
 						boost::beast::http::async_read (*sock, *sb, *resp,
-						[this, sb, resp, sock, address, port, i_a, target, body, resolver] (
+						[this, sb, resp, sock, address, port, i_a, end_a, target, body, resolver] (
 						boost::system::error_code const & ec, std::size_t bytes_transferred) mutable {
 							if (!ec)
 							{
@@ -219,7 +220,7 @@ std::shared_ptr<boost::asio::ip::tcp::resolver> const & resolver)
 				address, i_a->endpoint ().address ().to_string (), port, ec.message ());
 
 				++i_a;
-				do_rpc_callback (i_a, address, port, target, body, resolver);
+				do_rpc_callback (i_a, end_a, address, port, target, body, resolver);
 			}
 		});
 	}

--- a/nano/node/rpc_callbacks.hpp
+++ b/nano/node/rpc_callbacks.hpp
@@ -25,7 +25,7 @@ private: // Dependencies
 
 private:
 	void setup_callbacks ();
-	void do_rpc_callback (boost::asio::ip::tcp::resolver::results_type::iterator i_a, boost::asio::ip::tcp::resolver::results_type::iterator end_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);
+	void do_rpc_callback (boost::asio::ip::tcp::resolver::results_type::iterator i_a, boost::asio::ip::tcp::resolver::results_type::iterator end_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &, std::shared_ptr<boost::asio::ip::tcp::resolver::results_type> const & results);
 
 	nano::thread_pool workers;
 	nano::interval_mt warning_interval;

--- a/nano/node/rpc_callbacks.hpp
+++ b/nano/node/rpc_callbacks.hpp
@@ -25,7 +25,7 @@ private: // Dependencies
 
 private:
 	void setup_callbacks ();
-	void do_rpc_callback (boost::asio::ip::tcp::resolver::iterator i_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);
+	void do_rpc_callback (boost::asio::ip::tcp::resolver::results_type::iterator i_a, boost::asio::ip::tcp::resolver::results_type::iterator end_a, std::string const &, uint16_t, std::shared_ptr<std::string> const &, std::shared_ptr<std::string> const &, std::shared_ptr<boost::asio::ip::tcp::resolver> const &);
 
 	nano::thread_pool workers;
 	nano::interval_mt warning_interval;

--- a/nano/node/transport/fake.cpp
+++ b/nano/node/transport/fake.cpp
@@ -20,7 +20,7 @@ bool nano::transport::fake::channel::send_impl (nano::messages::message const & 
 	auto size = buffer.size ();
 	if (callback)
 	{
-		node.io_ctx.post ([callback, size] () {
+		boost::asio::post (node.io_ctx, [callback, size] () {
 			callback (boost::system::errc::make_error_code (boost::system::errc::success), size);
 		});
 	}

--- a/nano/node/transport/fake.cpp
+++ b/nano/node/transport/fake.cpp
@@ -1,3 +1,4 @@
+#include <nano/boost/asio/post.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/transport/fake.hpp>
 

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -52,7 +52,7 @@ bool nano::transport::inproc::channel::send_impl (nano::messages::message const 
 
 	if (callback)
 	{
-		node.io_ctx.post ([callback_l = std::move (callback), buffer_size = buffer.size ()] () {
+		boost::asio::post (node.io_ctx, [callback_l = std::move (callback), buffer_size = buffer.size ()] () {
 			callback_l (boost::system::errc::make_error_code (boost::system::errc::success), buffer_size);
 		});
 	}

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -1,3 +1,4 @@
+#include <nano/boost/asio/post.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/transport/inproc.hpp>

--- a/nano/node/transport/loopback.cpp
+++ b/nano/node/transport/loopback.cpp
@@ -1,3 +1,4 @@
+#include <nano/boost/asio/post.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/transport/loopback.hpp>

--- a/nano/node/transport/loopback.cpp
+++ b/nano/node/transport/loopback.cpp
@@ -21,7 +21,7 @@ bool nano::transport::loopback_channel::send_impl (nano::messages::message const
 
 	if (callback)
 	{
-		node.io_ctx.post ([callback_l = std::move (callback)] () {
+		boost::asio::post (node.io_ctx, [callback_l = std::move (callback)] () {
 			callback_l (boost::system::errc::make_error_code (boost::system::errc::success), 0);
 		});
 	}

--- a/nano/node/transport/transport.cpp
+++ b/nano/node/transport/transport.cpp
@@ -11,7 +11,7 @@ nano::endpoint nano::transport::map_endpoint_to_v6 (nano::endpoint const & endpo
 	auto endpoint_l (endpoint_a);
 	if (endpoint_l.address ().is_v4 ())
 	{
-		endpoint_l = nano::endpoint (boost::asio::ip::address_v6::v4_mapped (endpoint_l.address ().to_v4 ()), endpoint_l.port ());
+		endpoint_l = nano::endpoint (boost::asio::ip::make_address_v6 (boost::asio::ip::v4_mapped, endpoint_l.address ().to_v4 ()), endpoint_l.port ());
 	}
 	return endpoint_l;
 }
@@ -54,12 +54,12 @@ bool nano::transport::is_same_subnetwork (boost::asio::ip::address const & addre
 
 boost::asio::ip::address_v6 nano::transport::mapped_from_v4_bytes (unsigned long address_a)
 {
-	return boost::asio::ip::address_v6::v4_mapped (boost::asio::ip::address_v4 (address_a));
+	return boost::asio::ip::make_address_v6 (boost::asio::ip::v4_mapped, boost::asio::ip::address_v4 (address_a));
 }
 
 boost::asio::ip::address_v6 nano::transport::mapped_from_v4_or_v6 (boost::asio::ip::address const & address_a)
 {
-	return address_a.is_v4 () ? boost::asio::ip::address_v6::v4_mapped (address_a.to_v4 ()) : address_a.to_v6 ();
+	return address_a.is_v4 () ? boost::asio::ip::make_address_v6 (boost::asio::ip::v4_mapped, address_a.to_v4 ()) : address_a.to_v6 ();
 }
 
 bool nano::transport::is_ipv4_or_v4_mapped_address (boost::asio::ip::address const & address_a)

--- a/nano/node/websocket_stream.hpp
+++ b/nano/node/websocket_stream.hpp
@@ -7,14 +7,8 @@
 
 #include <memory>
 
-/* Boost v1.70 introduced breaking changes; the conditional compilation allows 1.6x to be supported as well. */
-#if BOOST_VERSION < 107000
-using socket_type = boost::asio::ip::tcp::socket;
-#define beast_buffers boost::beast::buffers
-#else
 using socket_type = boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::executor_type>;
 #define beast_buffers boost::beast::make_printable
-#endif
 using ws_type = boost::beast::websocket::stream<socket_type>;
 
 #ifdef NANO_SECURE_RPC

--- a/nano/rpc/rpc_connection.cpp
+++ b/nano/rpc/rpc_connection.cpp
@@ -1,4 +1,5 @@
 #include <nano/boost/asio/bind_executor.hpp>
+#include <nano/boost/asio/post.hpp>
 #include <nano/lib/json_error_response.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/lib/rpcconfig.hpp>

--- a/nano/rpc/rpc_connection.cpp
+++ b/nano/rpc/rpc_connection.cpp
@@ -108,7 +108,7 @@ void nano::rpc_connection::parse_request (STREAM_TYPE & stream, std::shared_ptr<
 	boost::beast::http::async_read (stream, buffer, *body_parser, boost::asio::bind_executor (strand, [this_l, body_parser, header_field_credentials_l, header_corr_id_l, path_l, &stream] (boost::system::error_code const & ec, size_t bytes_transferred) {
 		if (!ec)
 		{
-			this_l->io_ctx.post ([this_l, body_parser, header_field_credentials_l, header_corr_id_l, path_l, &stream] () {
+			boost::asio::post (this_l->io_ctx, [this_l, body_parser, header_field_credentials_l, header_corr_id_l, path_l, &stream] () {
 				auto & req (body_parser->get ());
 				auto start (std::chrono::steady_clock::now ());
 				auto version (req.version ());

--- a/nano/rpc/rpc_connection.hpp
+++ b/nano/rpc/rpc_connection.hpp
@@ -10,12 +10,7 @@
 
 #include <atomic>
 
-/* Boost v1.70 introduced breaking changes; the conditional compilation allows 1.6x to be supported as well. */
-#if BOOST_VERSION < 107000
-using socket_type = boost::asio::ip::tcp::socket;
-#else
 using socket_type = boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::executor_type>;
-#endif
 
 namespace nano
 {


### PR DESCRIPTION
This PR updates Boost from v1.86.0 to v1.87.0
It migrates deprecated Boost.Asio APIs to their new replacements:
- deadline_timer → steady_timer with expires_after() / std::chrono
- resolver::query + iterator → async_resolve(host, service)
- address::from_string() → make_address and make_address_v4()
- address_v6::v4_mapped() → make_address_v6()
- io_context::post() → boost::asio::post()

Also remove pre-Boost 1.70 compatibility checks
Version 1.87.0 release documentation can be found here: https://www.boost.org/releases/1.87.0/