### PR TITLE
Add `topo_height` field to block sideband

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -97,6 +97,7 @@ TEST (block_store, sideband_serialization)
 	sideband1.balance = 2;
 	sideband1.height = 3;
 	sideband1.timestamp = 5;
+	sideband1.topo_height = 42;
 	std::vector<uint8_t> vector;
 	{
 		nano::vectorstream stream1 (vector);
@@ -109,6 +110,7 @@ TEST (block_store, sideband_serialization)
 	ASSERT_EQ (sideband1.balance, sideband2.balance);
 	ASSERT_EQ (sideband1.height, sideband2.height);
 	ASSERT_EQ (sideband1.timestamp, sideband2.timestamp);
+	ASSERT_EQ (sideband1.topo_height, sideband2.topo_height);
 }
 
 TEST (block_store, add_item)

--- a/nano/core_test/ledger_upgrades.cpp
+++ b/nano/core_test/ledger_upgrades.cpp
@@ -848,9 +848,9 @@ TEST (ledger_upgrades, upgrade_v25_to_v26)
 	auto const new_size_open = nano::block_sideband::size (nano::block_type::open);
 	auto const new_size_state = nano::block_sideband::size (nano::block_type::state);
 
-	// Verify the new format is 32 bytes smaller (sizeof block_hash)
-	ASSERT_EQ (old_size_open - new_size_open, 32);
-	ASSERT_EQ (old_size_state - new_size_state, 32);
+	// Verify the new format is 24 bytes smaller (removed 32-byte successor, added 8-byte topo_index)
+	ASSERT_EQ (old_size_open - new_size_open, 24);
+	ASSERT_EQ (old_size_state - new_size_state, 24);
 
 	auto const path = nano::unique_path ();
 	{

--- a/nano/lib/block_sideband.cpp
+++ b/nano/lib/block_sideband.cpp
@@ -248,7 +248,25 @@ void nano::block_sideband::operator() (nano::object_stream & obs) const
 
 size_t nano::block_sideband_v25::size (nano::block_type type)
 {
-	return nano::block_sideband::size (type) + sizeof (nano::block_hash);
+	size_t result = sizeof (nano::block_hash); // successor
+	if (nano::block_sideband::includes_account (type))
+	{
+		result += sizeof (nano::account);
+	}
+	if (nano::block_sideband::includes_height (type))
+	{
+		result += sizeof (uint64_t);
+	}
+	if (nano::block_sideband::includes_balance (type))
+	{
+		result += sizeof (nano::amount);
+	}
+	result += sizeof (uint64_t); // timestamp
+	if (nano::block_sideband::includes_details (type))
+	{
+		result += nano::block_details::size () + sizeof (uint8_t); // details + source_epoch
+	}
+	return result;
 }
 
 void nano::block_sideband_v25::serialize (nano::stream & stream_a, nano::block_type type) const

--- a/nano/lib/block_sideband.cpp
+++ b/nano/lib/block_sideband.cpp
@@ -148,6 +148,7 @@ size_t nano::block_sideband::size (nano::block_type type)
 	{
 		result += sizeof (balance);
 	}
+	result += sizeof (topo_height);
 	result += sizeof (timestamp);
 	if (includes_details (type))
 	{
@@ -171,6 +172,7 @@ void nano::block_sideband::serialize (nano::stream & stream_a, nano::block_type 
 	{
 		nano::write (stream_a, balance.bytes);
 	}
+	nano::write (stream_a, boost::endian::native_to_big (topo_height));
 	nano::write (stream_a, boost::endian::native_to_big (timestamp));
 	if (includes_details (type))
 	{
@@ -209,6 +211,8 @@ bool nano::block_sideband::deserialize (nano::stream & stream_a, nano::block_typ
 		{
 			balance.clear ();
 		}
+		nano::read (stream_a, topo_height);
+		boost::endian::big_to_native_inplace (topo_height);
 		nano::read (stream_a, timestamp);
 		boost::endian::big_to_native_inplace (timestamp);
 		if (includes_details (type))
@@ -238,6 +242,7 @@ void nano::block_sideband::operator() (nano::object_stream & obs) const
 	obs.write ("balance", balance);
 	obs.write ("height", height);
 	obs.write ("timestamp", timestamp);
+	obs.write ("topo_height", topo_height);
 	obs.write ("source_epoch", source_epoch);
 	obs.write ("details", details);
 }

--- a/nano/lib/block_sideband.hpp
+++ b/nano/lib/block_sideband.hpp
@@ -66,6 +66,7 @@ public:
 	nano::account account{}; // Not serialized for state/open blocks
 	nano::amount balance{ 0 }; // Serialized only for receive/change/open blocks
 	uint64_t height{ 0 }; // Not serialized for open blocks (deserialized as 1)
+	uint64_t topo_height{ 0 };
 	uint64_t timestamp{ 0 };
 	nano::block_details details; // Serialized only for state blocks
 	nano::epoch source_epoch{ nano::epoch::epoch_0 }; // Serialized only for state blocks


### PR DESCRIPTION
Adds a `topo_height` field to the block sideband, bundled into the existing v25→v26 database upgrade that was introduced recently.
This is a placeholder for future work — the field will be populated and used in upcoming PRs (topological block index). Adding it now avoids a second database migration later.