### PR TITLE
Add batch add_many method to block processor

### DIFF
--- a/nano/core_test/block_processor.cpp
+++ b/nano/core_test/block_processor.cpp
@@ -1,5 +1,7 @@
 #include <nano/lib/blockbuilders.hpp>
 #include <nano/lib/blocks.hpp>
+#include <nano/lib/stats_enums.hpp>
+#include <nano/node/block_processor.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/secure/common.hpp>
@@ -10,7 +12,302 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+
 using namespace std::chrono_literals;
+
+// Async add of a single block with callback, verifies processing and callback invocation
+TEST (block_processor, add)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+
+	auto latest = nano::dev::genesis->hash ();
+	auto balance = nano::dev::constants.genesis_amount;
+
+	nano::keypair key;
+	nano::block_builder builder;
+	balance -= nano::Knano_ratio;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (latest)
+				.representative (nano::dev::genesis_key.pub)
+				.balance (balance)
+				.link (key.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (latest))
+				.build ();
+
+	std::atomic<bool> callback_called{ false };
+	std::atomic<nano::block_status> callback_status{};
+	auto added = node.block_processor.add (send, nano::block_source::live, nullptr, [&] (nano::block_status status) {
+		callback_status = status;
+		callback_called = true;
+	});
+	ASSERT_TRUE (added);
+
+	// Callback should fire once the block is processed
+	ASSERT_TIMELY (5s, callback_called.load ());
+	ASSERT_EQ (callback_status.load (), nano::block_status::progress);
+	ASSERT_TRUE (node.block_or_pruned_exists (send->hash ()));
+	ASSERT_EQ (node.ledger.block_count (), 2);
+}
+
+// Block with invalid work is rejected before queueing
+TEST (block_processor, add_insufficient_work)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+
+	nano::keypair key;
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Knano_ratio)
+				.link (key.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (0)
+				.build ();
+
+	// Block should be rejected without entering the queue
+	auto added = node.block_processor.add (send, nano::block_source::live);
+	ASSERT_FALSE (added);
+	ASSERT_EQ (node.stats.count (nano::stat::type::block_processor, nano::stat::detail::insufficient_work), 1);
+	ASSERT_EQ (node.ledger.block_count (), 1);
+}
+
+// Synchronous add blocks the caller until processing completes, also verifies duplicate block returns old status
+TEST (block_processor, add_blocking)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+
+	auto latest = nano::dev::genesis->hash ();
+	auto balance = nano::dev::constants.genesis_amount;
+
+	nano::keypair key;
+	nano::block_builder builder;
+	balance -= nano::Knano_ratio;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (latest)
+				.representative (nano::dev::genesis_key.pub)
+				.balance (balance)
+				.link (key.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (latest))
+				.build ();
+
+	// Blocks caller until result is available
+	auto result = node.block_processor.add_blocking (send, nano::block_source::local);
+	ASSERT_TRUE (result.has_value ());
+	ASSERT_EQ (result.value (), nano::block_status::progress);
+	ASSERT_TRUE (node.block_or_pruned_exists (send->hash ()));
+
+	// Processing the same block again should return old
+	auto result2 = node.block_processor.add_blocking (send, nano::block_source::local);
+	ASSERT_TRUE (result2.has_value ());
+	ASSERT_EQ (result2.value (), nano::block_status::old);
+}
+
+// When queue is full, add_blocking returns nullopt because the promise is destroyed unfulfilled
+TEST (block_processor, add_blocking_overfill)
+{
+	nano::test::system system;
+
+	nano::node_config node_config;
+	// Queue size 0 guarantees immediate rejection
+	node_config.block_processor.max_system_queue = 0;
+	auto & node = *system.add_node (node_config);
+
+	nano::keypair key;
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Knano_ratio)
+				.link (key.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
+
+	// Block is dropped due to queue being full, promise is destroyed unfulfilled, add_blocking returns nullopt
+	auto result = node.block_processor.add_blocking (send, nano::block_source::local);
+	ASSERT_FALSE (result.has_value ());
+	ASSERT_EQ (node.stats.count (nano::stat::type::block_processor, nano::stat::detail::overfill), 1);
+}
+
+// Batch add of a block chain with callback on the last block
+TEST (block_processor, add_many)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+
+	auto latest = nano::dev::genesis->hash ();
+	auto balance = nano::dev::constants.genesis_amount;
+
+	std::deque<std::shared_ptr<nano::block>> blocks;
+	for (int n = 0; n < 5; ++n)
+	{
+		nano::keypair key;
+		nano::block_builder builder;
+		balance -= nano::Knano_ratio;
+		auto send = builder
+					.state ()
+					.account (nano::dev::genesis_key.pub)
+					.previous (latest)
+					.representative (nano::dev::genesis_key.pub)
+					.balance (balance)
+					.link (key.pub)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest))
+					.build ();
+		latest = send->hash ();
+		blocks.push_back (send);
+	}
+
+	std::atomic<bool> callback_called{ false };
+	std::atomic<nano::block_status> callback_status{};
+
+	// All blocks queued under a single lock, callback attached to the last block
+	auto added = node.block_processor.add_many (blocks, nano::block_source::live, nullptr, [&] (nano::block_status status) {
+		callback_status = status;
+		callback_called = true;
+	});
+	ASSERT_EQ (added, 5);
+
+	// Callback fires when the last block in the batch is processed
+	ASSERT_TIMELY (5s, callback_called.load ());
+	ASSERT_EQ (callback_status.load (), nano::block_status::progress);
+	ASSERT_EQ (node.ledger.block_count (), 6);
+	for (auto const & block : blocks)
+	{
+		ASSERT_TRUE (node.block_or_pruned_exists (block->hash ()));
+	}
+}
+
+// Batch add with limited queue size, some blocks are dropped due to overfill
+TEST (block_processor, add_many_overfill)
+{
+	nano::test::system system;
+
+	nano::node_config node_config;
+	// Only 4 blocks fit in the system queue, remaining will be dropped
+	node_config.block_processor.max_system_queue = 4;
+	auto & node = *system.add_node (node_config);
+
+	auto latest = nano::dev::genesis->hash ();
+	auto balance = nano::dev::constants.genesis_amount;
+
+	std::deque<std::shared_ptr<nano::block>> blocks;
+	for (int n = 0; n < 8; ++n)
+	{
+		nano::keypair key;
+		nano::block_builder builder;
+		balance -= nano::Knano_ratio;
+		auto send = builder
+					.state ()
+					.account (nano::dev::genesis_key.pub)
+					.previous (latest)
+					.representative (nano::dev::genesis_key.pub)
+					.balance (balance)
+					.link (key.pub)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest))
+					.build ();
+		latest = send->hash ();
+		blocks.push_back (send);
+	}
+
+	// Not all blocks should fit, overfill stat tracks the dropped ones
+	auto added = node.block_processor.add_many (blocks, nano::block_source::local);
+	ASSERT_LT (added, 8);
+	ASSERT_GT (node.stats.count (nano::stat::type::block_processor, nano::stat::detail::overfill), 0);
+}
+
+// Batch add with a mix of valid and invalid work blocks, only valid ones are queued
+TEST (block_processor, add_many_mixed_work)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+
+	auto latest = nano::dev::genesis->hash ();
+	auto balance = nano::dev::constants.genesis_amount;
+
+	// Use deterministic keys so block hashes (and therefore roots) are fixed across runs
+	nano::keypair key1{ "1" };
+	nano::keypair key2{ "2" };
+	nano::keypair key3{ "3" };
+	nano::block_builder builder;
+
+	// Block 1: valid work
+	balance -= nano::Knano_ratio;
+	auto send1 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (latest)
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (balance)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (latest))
+				 .build ();
+
+	// Block 2: invalid work (will be skipped)
+	balance -= nano::Knano_ratio;
+	auto send2 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (balance)
+				 .link (key2.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (0)
+				 .build ();
+
+	// Block 3: valid work (will hit gap_previous since block 2 was skipped)
+	balance -= nano::Knano_ratio;
+	auto send3 = builder
+				 .state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send2->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (balance)
+				 .link (key3.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (send2->hash ()))
+				 .build ();
+
+	auto added = node.block_processor.add_many ({ send1, send2, send3 }, nano::block_source::live);
+
+	// Only 2 blocks should be queued (send2 has invalid work)
+	ASSERT_EQ (added, 2);
+	ASSERT_EQ (node.stats.count (nano::stat::type::block_processor, nano::stat::detail::insufficient_work), 1);
+
+	// Block 1 should be processed, block 2 was never queued
+	ASSERT_TIMELY (5s, node.block_or_pruned_exists (send1->hash ()));
+	ASSERT_FALSE (node.block_or_pruned_exists (send2->hash ()));
+}
+
+// Batch add with empty deque is a no-op
+TEST (block_processor, add_many_empty)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+
+	std::deque<std::shared_ptr<nano::block>> empty;
+	auto added = node.block_processor.add_many (empty, nano::block_source::live);
+	ASSERT_EQ (added, 0);
+	ASSERT_EQ (node.ledger.block_count (), 1);
+}
 
 TEST (block_processor, backlog_throttling)
 {

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -82,7 +82,7 @@ TEST (conflicts, add_existing)
 
 	// the block processor will notice that the block is a fork and it will try to publish it
 	// which will update the election object
-	node1.block_processor.add (send2);
+	node1.block_processor.add (send2, nano::block_source::test);
 
 	ASSERT_TRUE (node1.active.active (*send1));
 	ASSERT_TIMELY (5s, node1.active.active (*send2));

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -4210,7 +4210,7 @@ TEST (ledger, epoch_open_pending)
 					  .build ();
 	auto process_result = node1.ledger.process (node1.ledger.tx_begin_write (), epoch_open);
 	ASSERT_EQ (nano::block_status::gap_epoch_open_pending, process_result);
-	node1.block_processor.add (epoch_open);
+	node1.block_processor.add (epoch_open, nano::block_source::test);
 	// Waits for the block to get saved in the database
 	ASSERT_TIMELY_EQ (10s, 1, node1.unchecked.count ());
 	ASSERT_FALSE (node1.block_or_pruned_exists (epoch_open->hash ()));
@@ -4228,7 +4228,7 @@ TEST (ledger, epoch_open_pending)
 				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				 .work (*pool.generate (nano::dev::genesis->hash ()))
 				 .build ();
-	node1.block_processor.add (send1);
+	node1.block_processor.add (send1, nano::block_source::test);
 	ASSERT_TIMELY (10s, node1.block_or_pruned_exists (epoch_open->hash ()));
 }
 
@@ -4361,15 +4361,15 @@ TEST (ledger, unchecked_epoch)
 				  .work (0)
 				  .build ();
 	node1.work_generate_blocking (*epoch1);
-	node1.block_processor.add (epoch1);
+	node1.block_processor.add (epoch1, nano::block_source::test);
 	{
 		// Waits for the epoch1 block to pass through block_processor and unchecked.put queues
 		ASSERT_TIMELY_EQ (10s, 1, node1.unchecked.count ());
 		auto blocks = node1.unchecked.get (epoch1->previous ());
 		ASSERT_EQ (blocks.size (), 1);
 	}
-	node1.block_processor.add (send1);
-	node1.block_processor.add (open1);
+	node1.block_processor.add (send1, nano::block_source::test);
+	node1.block_processor.add (open1, nano::block_source::test);
 	ASSERT_TIMELY (5s, node1.ledger.any.block_exists (node1.ledger.tx_begin_read (), epoch1->hash ()));
 	{
 		// Waits for the last blocks to pass through block_processor and unchecked.put queues
@@ -4434,16 +4434,16 @@ TEST (ledger, unchecked_epoch_invalid)
 				  .work (0)
 				  .build ();
 	node1.work_generate_blocking (*epoch2);
-	node1.block_processor.add (epoch1);
-	node1.block_processor.add (epoch2);
+	node1.block_processor.add (epoch1, nano::block_source::test);
+	node1.block_processor.add (epoch2, nano::block_source::test);
 	{
 		// Waits for the last blocks to pass through block_processor and unchecked.put queues
 		ASSERT_TIMELY_EQ (10s, 2, node1.unchecked.count ());
 		auto blocks = node1.unchecked.get (epoch1->previous ());
 		ASSERT_EQ (blocks.size (), 2);
 	}
-	node1.block_processor.add (send1);
-	node1.block_processor.add (open1);
+	node1.block_processor.add (send1, nano::block_source::test);
+	node1.block_processor.add (open1, nano::block_source::test);
 	// Waits for the last blocks to pass through block_processor and unchecked.put queues
 	ASSERT_TIMELY (10s, node1.ledger.any.block_exists (node1.ledger.tx_begin_read (), epoch2->hash ()));
 	{
@@ -4501,8 +4501,8 @@ TEST (ledger, unchecked_open)
 				 .build ();
 	node1.work_generate_blocking (*open2);
 	open2->signature.bytes[0] ^= 1;
-	node1.block_processor.add (open2); // Insert open2 in to the queue before open1
-	node1.block_processor.add (open1);
+	node1.block_processor.add (open2, nano::block_source::test); // Insert open2 in to the queue before open1
+	node1.block_processor.add (open1, nano::block_source::test);
 	{
 		// Waits for the last blocks to pass through block_processor and unchecked.put queues
 		ASSERT_TIMELY_EQ (10s, 1, node1.unchecked.count ());
@@ -4510,7 +4510,7 @@ TEST (ledger, unchecked_open)
 		auto blocks = node1.unchecked.get (open1->source_field ().value ());
 		ASSERT_EQ (blocks.size (), 1);
 	}
-	node1.block_processor.add (send1);
+	node1.block_processor.add (send1, nano::block_source::test);
 	// Waits for the send1 block to pass through block_processor and unchecked.put queues
 	ASSERT_TIMELY (5s, node1.ledger.any.block_exists (node1.ledger.tx_begin_read (), open1->hash ()));
 	ASSERT_EQ (0, node1.unchecked.count ());
@@ -4561,8 +4561,8 @@ TEST (ledger, unchecked_receive)
 					.work (0)
 					.build ();
 	node1.work_generate_blocking (*receive1);
-	node1.block_processor.add (send1);
-	node1.block_processor.add (receive1);
+	node1.block_processor.add (send1, nano::block_source::test);
+	node1.block_processor.add (receive1, nano::block_source::test);
 	auto check_block_is_listed = [&] (nano::store::transaction const & transaction_a, nano::block_hash const & block_hash_a) {
 		return !node1.unchecked.get (block_hash_a).empty ();
 	};
@@ -4574,7 +4574,7 @@ TEST (ledger, unchecked_receive)
 		ASSERT_EQ (blocks.size (), 1);
 	}
 	// Waits for the open1 block to pass through block_processor and unchecked.put queues
-	node1.block_processor.add (open1);
+	node1.block_processor.add (open1, nano::block_source::test);
 	ASSERT_TIMELY (15s, check_block_is_listed (node1.store.tx_begin_read (), receive1->source_field ().value ()));
 	// Previous block for receive1 is known, signature was validated
 	{
@@ -4582,7 +4582,7 @@ TEST (ledger, unchecked_receive)
 		auto blocks (node1.unchecked.get (receive1->source_field ().value ()));
 		ASSERT_EQ (blocks.size (), 1);
 	}
-	node1.block_processor.add (send2);
+	node1.block_processor.add (send2, nano::block_source::test);
 	ASSERT_TIMELY (10s, node1.ledger.any.block_exists (node1.ledger.tx_begin_read (), receive1->hash ()));
 	ASSERT_EQ (0, node1.unchecked.count ());
 }

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -1716,8 +1716,8 @@ TEST (node, block_confirm)
 					  .build ();
 	auto hash1 = send1->hash ();
 	auto hash2 = send1_copy->hash ();
-	node1.block_processor.add (send1);
-	node2.block_processor.add (send1_copy);
+	node1.block_processor.add (send1, nano::block_source::test);
+	node2.block_processor.add (send1_copy, nano::block_source::test);
 	ASSERT_TIMELY (5s, node1.block_or_pruned_exists (send1->hash ()) && node2.block_or_pruned_exists (send1_copy->hash ()));
 	ASSERT_TRUE (node1.block_or_pruned_exists (send1->hash ()));
 	ASSERT_TRUE (node2.block_or_pruned_exists (send1_copy->hash ()));

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -241,6 +241,7 @@ enum class detail
 	process_blocking,
 	process_blocking_timeout,
 	force,
+	force_overfill,
 	cooldown_backlog,
 
 	// block source

--- a/nano/nano_node/benchmarks/benchmark_block_processing.cpp
+++ b/nano/nano_node/benchmarks/benchmark_block_processing.cpp
@@ -196,14 +196,9 @@ void block_processing_benchmark::run_iteration (std::deque<std::shared_ptr<nano:
 	auto const time_begin = std::chrono::high_resolution_clock::now ();
 
 	// Process all blocks
-	while (!blocks.empty ())
-	{
-		auto block = blocks.front ();
-		blocks.pop_front ();
-
-		bool added = node->block_processor.add (block, nano::block_source::test);
-		release_assert (added, "failed to add block to processor");
-	}
+	auto added = node->block_processor.add_many (blocks, nano::block_source::test);
+	release_assert (added == blocks.size (), "failed to add all blocks to processor");
+	blocks.clear ();
 
 	// Wait for processing to complete
 	nano::interval progress_interval;

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1240,10 +1240,7 @@ int main (int argc, char * const * argv)
 			nano::thread_runner runner1 (io_ctx1, nano::default_logger (), node1->config.io_threads);
 
 			std::cout << boost::str (boost::format ("Processing %1% blocks\n") % (count * 2));
-			for (auto & block : blocks)
-			{
-				node1->block_processor.add (block);
-			}
+			node1->block_processor.add_many (blocks, nano::block_source::live);
 			auto iteration (0);
 			while (node1->ledger.block_count () != count * 2 + 1)
 			{
@@ -1285,13 +1282,8 @@ int main (int argc, char * const * argv)
 			node2->start ();
 			nano::thread_runner runner2 (io_ctx2, nano::default_logger (), node2->config.io_threads);
 			std::cout << boost::str (boost::format ("Processing %1% blocks (test node)\n") % (count * 2));
-			// Processing block
-			while (!blocks.empty ())
-			{
-				auto block (blocks.front ());
-				node2->block_processor.add (block);
-				blocks.pop_front ();
-			}
+			node2->block_processor.add_many (blocks, nano::block_source::live);
+			blocks.clear ();
 			while (node2->ledger.block_count () != count * 2 + 1)
 			{
 				std::this_thread::sleep_for (std::chrono::milliseconds (500));
@@ -1872,10 +1864,7 @@ int main (int argc, char * const * argv)
 				// Add epoch open blocks again if required
 				if (node.node->block_processor.size () == 0)
 				{
-					for (auto & block : epoch_open_blocks)
-					{
-						node.node->block_processor.add (block);
-					}
+					node.node->block_processor.add_many (epoch_open_blocks, nano::block_source::live);
 				}
 				// Message each 60 seconds
 				if (timer_l.after_deadline (std::chrono::seconds (60)))

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1240,7 +1240,7 @@ int main (int argc, char * const * argv)
 			nano::thread_runner runner1 (io_ctx1, nano::default_logger (), node1->config.io_threads);
 
 			std::cout << boost::str (boost::format ("Processing %1% blocks\n") % (count * 2));
-			node1->block_processor.add_many (blocks, nano::block_source::live);
+			node1->block_processor.add_many (blocks, nano::block_source::test);
 			auto iteration (0);
 			while (node1->ledger.block_count () != count * 2 + 1)
 			{
@@ -1282,7 +1282,7 @@ int main (int argc, char * const * argv)
 			node2->start ();
 			nano::thread_runner runner2 (io_ctx2, nano::default_logger (), node2->config.io_threads);
 			std::cout << boost::str (boost::format ("Processing %1% blocks (test node)\n") % (count * 2));
-			node2->block_processor.add_many (blocks, nano::block_source::live);
+			node2->block_processor.add_many (blocks, nano::block_source::test);
 			blocks.clear ();
 			while (node2->ledger.block_count () != count * 2 + 1)
 			{
@@ -1845,7 +1845,7 @@ int main (int argc, char * const * argv)
 							{
 								std::cout << boost::str (boost::format ("%1% blocks retrieved") % count) << std::endl;
 							}
-							node.node->block_processor.add (block);
+							node.node->block_processor.add (block, nano::block_source::test);
 							if (block->type () == nano::block_type::state && block->previous ().is_zero () && source_node->ledger.is_epoch_link (block->link_field ().value ()))
 							{
 								// Epoch open blocks can be rejected without processed pending blocks to account, push it later again
@@ -1864,7 +1864,7 @@ int main (int argc, char * const * argv)
 				// Add epoch open blocks again if required
 				if (node.node->block_processor.size () == 0)
 				{
-					node.node->block_processor.add_many (epoch_open_blocks, nano::block_source::live);
+					node.node->block_processor.add_many (epoch_open_blocks, nano::block_source::test);
 				}
 				// Message each 60 seconds
 				if (timer_l.after_deadline (std::chrono::seconds (60)))

--- a/nano/node/block_processor.cpp
+++ b/nano/node/block_processor.cpp
@@ -122,6 +122,80 @@ bool nano::block_processor::add (std::shared_ptr<nano::block> const & block, blo
 	return add_impl ({ block, source, std::move (callback) }, channel);
 }
 
+std::size_t nano::block_processor::add_many (std::deque<std::shared_ptr<nano::block>> const & blocks, block_source const source, std::shared_ptr<nano::transport::channel> const & channel, std::function<void (nano::block_status)> last_callback)
+{
+	if (blocks.empty ())
+	{
+		return 0;
+	}
+
+	// Validate work outside the lock, build context objects
+	std::deque<nano::block_context> contexts;
+	std::size_t insufficient_work_count = 0;
+
+	for (auto const & block : blocks)
+	{
+		if (network_params.work.validate_entry (*block)) // true => error
+		{
+			++insufficient_work_count;
+		}
+		else
+		{
+			contexts.emplace_back (block, source);
+		}
+	}
+
+	if (insufficient_work_count > 0)
+	{
+		stats.add (nano::stat::type::block_processor, nano::stat::detail::insufficient_work, insufficient_work_count);
+	}
+
+	if (contexts.empty ())
+	{
+		return 0;
+	}
+
+	// Attach callback to last valid block
+	if (last_callback)
+	{
+		contexts.back ().callback = std::move (last_callback);
+	}
+
+	// Push all contexts under a single lock
+	std::size_t added = 0;
+	std::size_t overfill = 0;
+	{
+		nano::lock_guard<nano::mutex> guard{ mutex };
+		for (auto & ctx : contexts)
+		{
+			if (queue.push (std::move (ctx), { source, channel }))
+			{
+				++added;
+			}
+			else
+			{
+				++overfill;
+			}
+		}
+	}
+
+	if (added > 0)
+	{
+		stats.add (nano::stat::type::block_processor, nano::stat::detail::process, added);
+		condition.notify_all ();
+	}
+	if (overfill > 0)
+	{
+		stats.add (nano::stat::type::block_processor, nano::stat::detail::overfill, overfill);
+		stats.add (nano::stat::type::block_processor_overfill, to_stat_detail (source), overfill);
+	}
+
+	logger.debug (nano::log::type::block_processor, "Processing blocks (async batch): total={}, added={}, overfill={}, invalid_work={} (source: {} {})",
+	blocks.size (), added, overfill, insufficient_work_count, source, channel);
+
+	return added;
+}
+
 std::optional<nano::block_status> nano::block_processor::add_blocking (std::shared_ptr<nano::block> const & block, block_source const source)
 {
 	stats.inc (nano::stat::type::block_processor, nano::stat::detail::process_blocking);

--- a/nano/node/block_processor.cpp
+++ b/nano/node/block_processor.cpp
@@ -116,10 +116,14 @@ bool nano::block_processor::add (std::shared_ptr<nano::block> const & block, blo
 		return false; // Not added
 	}
 
-	stats.inc (nano::stat::type::block_processor, nano::stat::detail::process);
 	logger.debug (nano::log::type::block_processor, "Processing block (async): {} (source: {} {})", block->hash (), source, channel);
 
-	return add_impl ({ block, source, std::move (callback) }, channel);
+	bool added = add_impl ({ block, source, std::move (callback) }, channel);
+	if (added)
+	{
+		stats.inc (nano::stat::type::block_processor, nano::stat::detail::process);
+	}
+	return added;
 }
 
 std::size_t nano::block_processor::add_many (std::deque<std::shared_ptr<nano::block>> const & blocks, block_source const source, std::shared_ptr<nano::transport::channel> const & channel, std::function<void (nano::block_status)> last_callback)
@@ -198,12 +202,15 @@ std::size_t nano::block_processor::add_many (std::deque<std::shared_ptr<nano::bl
 
 std::optional<nano::block_status> nano::block_processor::add_blocking (std::shared_ptr<nano::block> const & block, block_source const source)
 {
-	stats.inc (nano::stat::type::block_processor, nano::stat::detail::process_blocking);
 	logger.debug (nano::log::type::block_processor, "Processing block (blocking): {} (source: {})", block->hash (), source);
 
 	nano::block_context ctx{ block, source };
 	auto future = ctx.get_future ();
-	add_impl (std::move (ctx));
+	bool added = add_impl (std::move (ctx));
+	if (added)
+	{
+		stats.inc (nano::stat::type::block_processor, nano::stat::detail::process_blocking);
+	}
 
 	try
 	{
@@ -219,12 +226,20 @@ std::optional<nano::block_status> nano::block_processor::add_blocking (std::shar
 	return std::nullopt;
 }
 
-void nano::block_processor::force (std::shared_ptr<nano::block> const & block_a)
+void nano::block_processor::force (std::shared_ptr<nano::block> const & block)
 {
-	stats.inc (nano::stat::type::block_processor, nano::stat::detail::force);
-	logger.debug (nano::log::type::block_processor, "Forcing block: {}", block_a->hash ());
+	logger.debug (nano::log::type::block_processor, "Forcing block: {}", block->hash ());
 
-	add_impl ({ block_a, block_source::forced });
+	bool added = add_impl ({ block, block_source::forced });
+	if (added)
+	{
+		stats.inc (nano::stat::type::block_processor, nano::stat::detail::force);
+	}
+	else
+	{
+		stats.inc (nano::stat::type::block_processor, nano::stat::detail::force_overfill);
+		logger.debug (nano::log::type::block_processor, "Failed to force block (queue full): {}", block->hash ());
+	}
 }
 
 bool nano::block_processor::add_impl (nano::block_context ctx, std::shared_ptr<nano::transport::channel> const & channel)

--- a/nano/node/block_processor.hpp
+++ b/nano/node/block_processor.hpp
@@ -10,6 +10,7 @@
 #include <boost/thread.hpp>
 
 #include <chrono>
+#include <deque>
 #include <future>
 #include <memory>
 #include <optional>
@@ -58,11 +59,26 @@ public:
 	void start ();
 	void stop ();
 
+	bool add (
+	std::shared_ptr<nano::block> const & block,
+	nano::block_source source = nano::block_source::live,
+	std::shared_ptr<nano::transport::channel> const & channel = nullptr,
+	std::function<void (nano::block_status)> callback = {});
+
+	std::size_t add_many (
+	std::deque<std::shared_ptr<nano::block>> const & blocks,
+	nano::block_source source,
+	std::shared_ptr<nano::transport::channel> const & channel = nullptr,
+	std::function<void (nano::block_status)> last_callback = {});
+
+	std::optional<nano::block_status> add_blocking (
+	std::shared_ptr<nano::block> const & block,
+	nano::block_source source);
+
+	void force (std::shared_ptr<nano::block> const & block);
+
 	std::size_t size () const;
 	std::size_t size (nano::block_source) const;
-	bool add (std::shared_ptr<nano::block> const &, nano::block_source = nano::block_source::live, std::shared_ptr<nano::transport::channel> const & channel = nullptr, std::function<void (nano::block_status)> callback = {});
-	std::optional<nano::block_status> add_blocking (std::shared_ptr<nano::block> const & block, nano::block_source);
-	void force (std::shared_ptr<nano::block> const &);
 
 	nano::container_info container_info () const;
 

--- a/nano/node/block_processor.hpp
+++ b/nano/node/block_processor.hpp
@@ -61,7 +61,7 @@ public:
 
 	bool add (
 	std::shared_ptr<nano::block> const & block,
-	nano::block_source source = nano::block_source::live,
+	nano::block_source source,
 	std::shared_ptr<nano::transport::channel> const & channel = nullptr,
 	std::function<void (nano::block_status)> callback = {});
 

--- a/nano/node/bootstrap/bootstrap_context.cpp
+++ b/nano/node/bootstrap/bootstrap_context.cpp
@@ -561,25 +561,15 @@ bool bootstrap_context::process (nano::messages::asc_pull_ack::blocks_payload co
 				blocks.pop_front ();
 			}
 
-			for (auto const & block : blocks)
-			{
-				if (block == blocks.back ())
+			block_processor.add_many (blocks, nano::block_source::bootstrap, nullptr, [this, account = tag.account] (auto result) {
+				// It's the last block submitted for this account chain, reset timestamp to allow more requests
+				stats.inc (nano::stat::type::bootstrap, nano::stat::detail::timestamp_reset);
 				{
-					// It's the last block submitted for this account chain, reset timestamp to allow more requests
-					block_processor.add (block, nano::block_source::bootstrap, nullptr, [this, account = tag.account] (auto result) {
-						stats.inc (nano::stat::type::bootstrap, nano::stat::detail::timestamp_reset);
-						{
-							nano::lock_guard<nano::mutex> guard{ mutex };
-							accounts.timestamp_reset (account);
-						}
-						condition.notify_all ();
-					});
+					nano::lock_guard<nano::mutex> guard{ mutex };
+					accounts.timestamp_reset (account);
 				}
-				else
-				{
-					block_processor.add (block, nano::block_source::bootstrap);
-				}
-			}
+				condition.notify_all ();
+			});
 
 			if (tag.source == query_source::database)
 			{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -465,7 +465,7 @@ void nano::node::inbound (const nano::messages::message & message, const std::sh
 
 void nano::node::process_active (std::shared_ptr<nano::block> const & incoming)
 {
-	block_processor.add (incoming);
+	block_processor.add (incoming, nano::block_source::live);
 }
 
 void nano::node::process_active (std::shared_ptr<nano::vote> const & vote)

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -635,7 +635,7 @@ TEST (node, mass_vote_by_hash)
 	}
 	for (auto i (blocks.begin ()), n (blocks.end ()); i != n; ++i)
 	{
-		system.nodes[0]->block_processor.add (*i);
+		system.nodes[0]->block_processor.add (*i, nano::block_source::test);
 	}
 }
 


### PR DESCRIPTION
Add `block_processor::add_many()` that accepts a batch of blocks and inserts them with a single mutex acquisition and one condition variable notification, instead of N lock/unlock cycles.