### PR TITLE
Cache representative keys to optimize `wallets::foreach_representative (...)` hot path

### DIFF
--- a/nano/core_test/vote_generator.cpp
+++ b/nano/core_test/vote_generator.cpp
@@ -681,7 +681,7 @@ TEST (vote_generator, multiple_representatives)
 	wallet.insert_adhoc (rep1.prv);
 	wallet.insert_adhoc (rep2.prv);
 	wallet.insert_adhoc (rep3.prv);
-	node.wallets.compute_reps ();
+	node.wallets.refresh_reps ();
 	ASSERT_EQ (4, node.wallets.reps ().voting);
 
 	nano::shared_locked<std::vector<std::shared_ptr<nano::vote>>> votes;

--- a/nano/core_test/vote_replier.cpp
+++ b/nano/core_test/vote_replier.cpp
@@ -117,7 +117,7 @@ TEST (vote_replier, single_hash_reply)
 	config.enable_voting = true;
 	auto & node = *system.add_node (config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	node.wallets.compute_reps ();
+	node.wallets.refresh_reps ();
 
 	auto blocks = nano::test::setup_chain (system, node, 1);
 
@@ -145,7 +145,7 @@ TEST (vote_replier, multiple_hashes_reply)
 	config.enable_voting = true;
 	auto & node = *system.add_node (config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	node.wallets.compute_reps ();
+	node.wallets.refresh_reps ();
 
 	auto blocks = nano::test::setup_chain (system, node, 3);
 
@@ -182,7 +182,7 @@ TEST (vote_replier, mixed_known_unknown)
 	config.enable_voting = true;
 	auto & node = *system.add_node (config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	node.wallets.compute_reps ();
+	node.wallets.refresh_reps ();
 
 	auto blocks = nano::test::setup_chain (system, node, 1);
 
@@ -248,7 +248,7 @@ TEST (vote_replier, per_channel_fairness)
 	config.vote_replier.channel_limit = 1;
 	auto & node = *system.add_node (config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	node.wallets.compute_reps ();
+	node.wallets.refresh_reps ();
 
 	auto blocks = nano::test::setup_chain (system, node, 1);
 
@@ -281,7 +281,7 @@ TEST (vote_replier, integration_confirm_req)
 	config.optimistic_scheduler.enable = false;
 	auto & node = *system.add_node (config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	node.wallets.compute_reps ();
+	node.wallets.refresh_reps ();
 
 	// Create and confirm a block
 	nano::keypair key;
@@ -528,7 +528,7 @@ TEST (vote_replier, multiple_representatives)
 	ASSERT_TIMELY (5s, node.balance (rep2.pub) == amount);
 	wallet.change_sync (rep2.pub, rep2.pub);
 	ASSERT_EQ (node.weight (rep2.pub), amount);
-	node.wallets.compute_reps ();
+	node.wallets.refresh_reps ();
 	ASSERT_EQ (2, node.wallets.reps ().voting);
 
 	auto blocks = nano::test::setup_chain (system, node, 1);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -995,28 +995,6 @@ TEST (wallet, epoch_2_receive_unopened)
 	ASSERT_LT (tries, max_tries);
 }
 
-/**
- * This test checks that wallets::foreach_representative can be used recursively
- */
-TEST (wallet, foreach_representative_deadlock)
-{
-	nano::test::system system (1);
-	auto & node (*system.nodes[0]);
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	node.wallets.compute_reps ();
-	ASSERT_EQ (1, node.wallets.reps ().voting);
-
-	bool set = false;
-	node.wallets.foreach_representative ([&node, &set, &system] (nano::public_key const & pub, nano::raw_key const & prv) {
-		node.wallets.foreach_representative ([&node, &set, &system] (nano::public_key const & pub, nano::raw_key const & prv) {
-			ASSERT_TIMELY (5s, node.wallets.mutex.try_lock () == 1);
-			node.wallets.mutex.unlock ();
-			set = true;
-		});
-	});
-	ASSERT_TRUE (set);
-}
-
 TEST (wallet, search_receivable)
 {
 	nano::test::system system;

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -193,7 +193,7 @@ TEST (wallets, vote_minimum)
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	wallet->insert_adhoc (key1.prv);
 	wallet->insert_adhoc (key2.prv);
-	node1.wallets.compute_reps ();
+	node1.wallets.refresh_reps ();
 	ASSERT_EQ (2, wallet->reps ().size ());
 }
 
@@ -417,7 +417,7 @@ TEST (wallets, signer_multiple)
 	system.wallet (0)->send_sync (nano::dev::genesis_key.pub, rep2.pub, amount);
 	ASSERT_TIMELY (5s, node.balance (rep2.pub) == amount);
 	system.wallet (0)->change_sync (rep2.pub, rep2.pub);
-	node.wallets.compute_reps ();
+	node.wallets.refresh_reps ();
 	ASSERT_EQ (2, node.wallets.reps ().voting);
 
 	auto sign = node.wallets.signer ();
@@ -458,7 +458,7 @@ TEST (wallets, signer_below_weight)
 	ASSERT_TRUE (node.weight (below_minimum.pub) > 0);
 	ASSERT_TRUE (node.weight (below_minimum.pub) < config.vote_minimum.number ());
 
-	node.wallets.compute_reps ();
+	node.wallets.refresh_reps ();
 	ASSERT_EQ (1, node.wallets.reps ().voting);
 
 	auto sign = node.wallets.signer ();

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -474,3 +474,443 @@ TEST (wallets, signer_below_weight)
 	ASSERT_FALSE (accounts.count (zero_weight.pub));
 	ASSERT_FALSE (accounts.count (below_minimum.pub));
 }
+
+/*
+ * rep_keys_cache tests
+ */
+
+/*
+ * Locking a wallet should clear its reps from the cache
+ */
+TEST (wallets, rep_keys_cache_lock_clears)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	node.wallets.refresh_reps ();
+
+	// Pre-condition: genesis key is in cache
+	{
+		auto sign = node.wallets.signer ();
+		int called = 0;
+		sign ([&] (nano::public_key const &, nano::raw_key const &) {
+			++called;
+		});
+		ASSERT_EQ (1, called);
+	}
+
+	// Lock the wallet
+	system.wallet (0)->rekey ("pass");
+	system.wallet (0)->lock ();
+	ASSERT_TRUE (system.wallet (0)->is_locked ());
+
+	// Cache should be empty
+	auto sign = node.wallets.signer ();
+	int called = 0;
+	sign ([&] (nano::public_key const &, nano::raw_key const &) {
+		++called;
+	});
+	ASSERT_EQ (0, called);
+}
+
+/*
+ * Unlocking a wallet should repopulate the cache
+ */
+TEST (wallets, rep_keys_cache_unlock_repopulates)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	node.wallets.refresh_reps ();
+
+	// Lock the wallet
+	system.wallet (0)->rekey ("pass");
+	system.wallet (0)->lock ();
+
+	// Pre-condition: cache is empty
+	{
+		auto sign = node.wallets.signer ();
+		int called = 0;
+		sign ([&] (nano::public_key const &, nano::raw_key const &) {
+			++called;
+		});
+		ASSERT_EQ (0, called);
+	}
+
+	// Unlock the wallet
+	ASSERT_FALSE (system.wallet (0)->enter_password ("pass"));
+	ASSERT_FALSE (system.wallet (0)->is_locked ());
+
+	// Cache should be repopulated
+	auto sign = node.wallets.signer ();
+	std::set<nano::account> accounts;
+	sign ([&] (nano::public_key const & pub, nano::raw_key const &) {
+		accounts.insert (pub);
+	});
+	ASSERT_EQ (1, accounts.size ());
+	ASSERT_TRUE (accounts.count (nano::dev::genesis_key.pub));
+}
+
+/*
+ * Rekeying a wallet should preserve cached keys (wallet stays unlocked)
+ */
+TEST (wallets, rep_keys_cache_rekey_preserves)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	node.wallets.refresh_reps ();
+
+	// Capture key pair before rekey
+	nano::public_key pub_before;
+	nano::raw_key prv_before;
+	{
+		auto sign = node.wallets.signer ();
+		sign ([&] (nano::public_key const & pub, nano::raw_key const & prv) {
+			pub_before = pub;
+			prv_before = prv;
+		});
+	}
+	ASSERT_EQ (nano::dev::genesis_key.pub, pub_before);
+
+	// Rekey
+	ASSERT_FALSE (system.wallet (0)->rekey ("newpass"));
+	ASSERT_FALSE (system.wallet (0)->is_locked ());
+
+	// Capture key pair after rekey — should be identical
+	nano::public_key pub_after;
+	nano::raw_key prv_after;
+	{
+		auto sign = node.wallets.signer ();
+		sign ([&] (nano::public_key const & pub, nano::raw_key const & prv) {
+			pub_after = pub;
+			prv_after = prv;
+		});
+	}
+	ASSERT_EQ (pub_before, pub_after);
+	ASSERT_EQ (prv_before, prv_after);
+	ASSERT_EQ (nano::dev::genesis_key.prv, prv_after);
+}
+
+/*
+ * insert_adhoc of a key with rep-level weight should immediately update the cache
+ * without needing an explicit refresh_reps() call
+ */
+TEST (wallets, rep_keys_cache_insert_adhoc_qualifying)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+
+	// Create a second account with vote_minimum weight
+	nano::keypair rep2;
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - node.config.vote_minimum.number ())
+				.link (rep2.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
+	ASSERT_EQ (nano::block_status::progress, node.process (send));
+
+	auto open = builder
+				.state ()
+				.account (rep2.pub)
+				.previous (0)
+				.representative (rep2.pub)
+				.balance (node.config.vote_minimum.number ())
+				.link (send->hash ())
+				.sign (rep2.prv, rep2.pub)
+				.work (*system.work.generate (rep2.pub))
+				.build ();
+	ASSERT_EQ (nano::block_status::progress, node.process (open));
+
+	node.wallets.refresh_reps ();
+
+	// Pre-condition: only genesis in cache
+	{
+		auto sign = node.wallets.signer ();
+		std::set<nano::account> accounts;
+		sign ([&] (nano::public_key const & pub, nano::raw_key const &) {
+			accounts.insert (pub);
+		});
+		ASSERT_EQ (1, accounts.size ());
+		ASSERT_TRUE (accounts.count (nano::dev::genesis_key.pub));
+	}
+
+	// Insert rep2 — should immediately appear in cache (no refresh_reps needed)
+	system.wallet (0)->insert_adhoc (rep2.prv);
+
+	auto sign = node.wallets.signer ();
+	std::set<nano::account> accounts;
+	sign ([&] (nano::public_key const & pub, nano::raw_key const &) {
+		accounts.insert (pub);
+	});
+	ASSERT_EQ (2, accounts.size ());
+	ASSERT_TRUE (accounts.count (nano::dev::genesis_key.pub));
+	ASSERT_TRUE (accounts.count (rep2.pub));
+}
+
+/*
+ * insert_adhoc of a zero-weight key should not modify the cache
+ */
+TEST (wallets, rep_keys_cache_insert_adhoc_nonqualifying)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	node.wallets.refresh_reps ();
+
+	// Insert a key with no weight
+	nano::keypair nobody;
+	system.wallet (0)->insert_adhoc (nobody.prv);
+
+	// Cache should still contain only genesis
+	auto sign = node.wallets.signer ();
+	std::set<nano::account> accounts;
+	sign ([&] (nano::public_key const & pub, nano::raw_key const &) {
+		accounts.insert (pub);
+	});
+	ASSERT_EQ (1, accounts.size ());
+	ASSERT_TRUE (accounts.count (nano::dev::genesis_key.pub));
+	ASSERT_FALSE (accounts.count (nobody.pub));
+}
+
+/*
+ * With two wallets, locking one should only remove that wallet's reps from cache
+ */
+TEST (wallets, rep_keys_cache_multiple_wallets_partial_lock)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	// Wallet 1: genesis key
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+
+	// Create rep2 with voting weight
+	nano::keypair rep2;
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - node.config.vote_minimum.number ())
+				.link (rep2.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
+	ASSERT_EQ (nano::block_status::progress, node.process (send));
+
+	auto open = builder
+				.state ()
+				.account (rep2.pub)
+				.previous (0)
+				.representative (rep2.pub)
+				.balance (node.config.vote_minimum.number ())
+				.link (send->hash ())
+				.sign (rep2.prv, rep2.pub)
+				.work (*system.work.generate (rep2.pub))
+				.build ();
+	ASSERT_EQ (nano::block_status::progress, node.process (open));
+
+	// Wallet 2: rep2 key
+	auto wallet2 = node.wallets.create (nano::random_wallet_id ());
+	wallet2->insert_adhoc (rep2.prv);
+
+	node.wallets.refresh_reps ();
+
+	// Pre-condition: both reps in cache
+	{
+		auto sign = node.wallets.signer ();
+		std::set<nano::account> accounts;
+		sign ([&] (nano::public_key const & pub, nano::raw_key const &) {
+			accounts.insert (pub);
+		});
+		ASSERT_EQ (2, accounts.size ());
+		ASSERT_TRUE (accounts.count (nano::dev::genesis_key.pub));
+		ASSERT_TRUE (accounts.count (rep2.pub));
+	}
+
+	// Lock wallet2 only
+	wallet2->rekey ("pass");
+	wallet2->lock ();
+
+	// Only wallet1's rep should remain
+	auto sign = node.wallets.signer ();
+	std::set<nano::account> accounts;
+	sign ([&] (nano::public_key const & pub, nano::raw_key const &) {
+		accounts.insert (pub);
+	});
+	ASSERT_EQ (1, accounts.size ());
+	ASSERT_TRUE (accounts.count (nano::dev::genesis_key.pub));
+	ASSERT_FALSE (accounts.count (rep2.pub));
+}
+
+/*
+ * Private keys reconstructed from fan objects should derive to the correct public keys
+ */
+TEST (wallets, rep_keys_cache_key_correctness)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	node.wallets.refresh_reps ();
+
+	auto sign = node.wallets.signer ();
+	std::map<nano::public_key, nano::raw_key> key_pairs;
+	sign ([&] (nano::public_key const & pub, nano::raw_key const & prv) {
+		key_pairs[pub] = prv;
+	});
+
+	ASSERT_EQ (1, key_pairs.size ());
+	ASSERT_TRUE (key_pairs.count (nano::dev::genesis_key.pub));
+
+	// Verify the cached private key matches the original
+	ASSERT_EQ (nano::dev::genesis_key.prv, key_pairs[nano::dev::genesis_key.pub]);
+
+	// Verify the private key derives back to the correct public key
+	ASSERT_EQ (nano::dev::genesis_key.pub, nano::pub_key (key_pairs[nano::dev::genesis_key.pub]));
+}
+
+/*
+ * With voting disabled, foreach_representative should never invoke the callback
+ */
+TEST (wallets, rep_keys_cache_voting_disabled)
+{
+	nano::test::system system;
+	nano::node_config config = system.default_config ();
+	config.enable_voting = false;
+	auto & node = *system.add_node (config);
+
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	node.wallets.refresh_reps ();
+
+	auto sign = node.wallets.signer ();
+	int called = 0;
+	sign ([&] (nano::public_key const &, nano::raw_key const &) {
+		++called;
+	});
+	ASSERT_EQ (0, called);
+}
+
+/*
+ * After removing an account from a wallet, refresh_reps should exclude it from the cache
+ */
+TEST (wallets, rep_keys_cache_account_removed)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+	node.wallets.refresh_reps ();
+
+	// Pre-condition: genesis in cache
+	{
+		auto sign = node.wallets.signer ();
+		int called = 0;
+		sign ([&] (nano::public_key const &, nano::raw_key const &) {
+			++called;
+		});
+		ASSERT_EQ (1, called);
+	}
+
+	// Remove account and refresh
+	system.wallet (0)->remove_account (nano::dev::genesis_key.pub);
+	node.wallets.refresh_reps ();
+
+	// Cache should be empty
+	auto sign = node.wallets.signer ();
+	int called = 0;
+	sign ([&] (nano::public_key const &, nano::raw_key const &) {
+		++called;
+	});
+	ASSERT_EQ (0, called);
+}
+
+/*
+ * A rep that loses all weight should be excluded from the cache on next refresh
+ */
+TEST (wallets, rep_keys_cache_weight_lost)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+
+	// Create rep2 with vote_minimum weight
+	nano::keypair rep2;
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - node.config.vote_minimum.number ())
+				.link (rep2.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
+	ASSERT_EQ (nano::block_status::progress, node.process (send));
+
+	auto open = builder
+				.state ()
+				.account (rep2.pub)
+				.previous (0)
+				.representative (rep2.pub)
+				.balance (node.config.vote_minimum.number ())
+				.link (send->hash ())
+				.sign (rep2.prv, rep2.pub)
+				.work (*system.work.generate (rep2.pub))
+				.build ();
+	ASSERT_EQ (nano::block_status::progress, node.process (open));
+
+	system.wallet (0)->insert_adhoc (rep2.prv);
+	node.wallets.refresh_reps ();
+
+	// Pre-condition: both reps in cache
+	{
+		auto sign = node.wallets.signer ();
+		std::set<nano::account> accounts;
+		sign ([&] (nano::public_key const & pub, nano::raw_key const &) {
+			accounts.insert (pub);
+		});
+		ASSERT_EQ (2, accounts.size ());
+	}
+
+	// rep2 sends all balance back to genesis (weight drops to zero)
+	auto send_back = builder
+					 .state ()
+					 .account (rep2.pub)
+					 .previous (open->hash ())
+					 .representative (rep2.pub)
+					 .balance (0)
+					 .link (nano::dev::genesis_key.pub)
+					 .sign (rep2.prv, rep2.pub)
+					 .work (*system.work.generate (open->hash ()))
+					 .build ();
+	ASSERT_EQ (nano::block_status::progress, node.process (send_back));
+	ASSERT_EQ (0, node.weight (rep2.pub));
+
+	node.wallets.refresh_reps ();
+
+	// Only genesis should remain
+	auto sign = node.wallets.signer ();
+	std::set<nano::account> accounts;
+	sign ([&] (nano::public_key const & pub, nano::raw_key const &) {
+		accounts.insert (pub);
+	});
+	ASSERT_EQ (1, accounts.size ());
+	ASSERT_TRUE (accounts.count (nano::dev::genesis_key.pub));
+	ASSERT_FALSE (accounts.count (rep2.pub));
+}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4743,9 +4743,7 @@ void nano::json_handler::wallet_lock ()
 	auto wallet (wallet_impl ());
 	if (!ec)
 	{
-		nano::raw_key empty;
-		empty.clear ();
-		wallet->store.password.value_set (empty);
+		wallet->lock ();
 		response_l.put ("locked", "1");
 
 		node.logger.warn (nano::log::type::rpc, "Wallet locked");

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1962,7 +1962,7 @@ bool nano::wallets::check_rep_impl (wallet_representatives & reps, nano::account
 	return true;
 }
 
-void nano::wallets::compute_reps ()
+void nano::wallets::refresh_reps ()
 {
 	refresh_rep_index ();
 	refresh_rep_keys_cache ();
@@ -2074,7 +2074,7 @@ void nano::wallets::run_reps_scan ()
 		stats.inc (nano::stat::type::wallet, nano::stat::detail::loop_reps);
 
 		// Recompute local wallet representatives and refresh cached keys
-		compute_reps ();
+		refresh_reps ();
 
 		lock.lock ();
 

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -745,8 +745,16 @@ void nano::wallet::enter_initial_password ()
 
 bool nano::wallet::enter_password (std::string const & password_a)
 {
-	auto transaction = wallets.tx_begin_write ();
-	return enter_password_impl (transaction, password_a);
+	bool result;
+	{
+		auto transaction = wallets.tx_begin_write ();
+		result = enter_password_impl (transaction, password_a);
+	}
+	if (!result)
+	{
+		wallets.refresh_rep_keys_cache ();
+	}
+	return result;
 }
 
 bool nano::wallet::enter_password_impl (nano::store::transaction const & transaction_a, std::string const & password_a)
@@ -755,8 +763,6 @@ bool nano::wallet::enter_password_impl (nano::store::transaction const & transac
 	if (!result)
 	{
 		logger.info (nano::log::type::wallet, "Wallet unlocked");
-
-		wallets.refresh_rep_keys_cache ();
 
 		auto this_l = shared_from_this ();
 		wallets.queue_wallet_action (nano::wallets::high_priority, this_l, [this_l] (nano::wallet & wallet) {
@@ -790,7 +796,6 @@ nano::public_key nano::wallet::deterministic_insert_impl (nano::store::write_tra
 		{
 			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", nano::log::as_account (key));
 			representatives.lock ()->insert (key);
-			wallets.refresh_rep_keys_cache ();
 		}
 	}
 	return key;
@@ -816,8 +821,15 @@ nano::public_key nano::wallet::deterministic_insert (uint32_t const index, bool 
 
 nano::public_key nano::wallet::deterministic_insert (bool generate_work_a)
 {
-	auto transaction (wallets.tx_begin_write ());
-	auto result (deterministic_insert_impl (transaction, generate_work_a));
+	nano::public_key result;
+	{
+		auto transaction (wallets.tx_begin_write ());
+		result = deterministic_insert_impl (transaction, generate_work_a);
+	}
+	if (!result.is_zero ())
+	{
+		wallets.refresh_rep_keys_cache ();
+	}
 	return result;
 }
 
@@ -1409,8 +1421,13 @@ uint32_t nano::wallet::deterministic_check_impl (nano::store::transaction const 
 
 nano::public_key nano::wallet::change_seed (nano::raw_key const & prv_a, uint32_t count)
 {
-	auto transaction = wallets.tx_begin_write ();
-	return change_seed_impl (transaction, prv_a, count);
+	nano::public_key result;
+	{
+		auto transaction = wallets.tx_begin_write ();
+		result = change_seed_impl (transaction, prv_a, count);
+	}
+	wallets.refresh_rep_keys_cache ();
+	return result;
 }
 
 nano::public_key nano::wallet::change_seed_impl (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv_a, uint32_t count)
@@ -1437,8 +1454,11 @@ nano::public_key nano::wallet::change_seed_impl (nano::store::write_transaction 
 
 void nano::wallet::deterministic_restore ()
 {
-	auto transaction = wallets.tx_begin_write ();
-	deterministic_restore_impl (transaction);
+	{
+		auto transaction = wallets.tx_begin_write ();
+		deterministic_restore_impl (transaction);
+	}
+	wallets.refresh_rep_keys_cache ();
 }
 
 void nano::wallet::deterministic_restore_impl (nano::store::write_transaction const & transaction_a)
@@ -1454,8 +1474,11 @@ void nano::wallet::deterministic_restore_impl (nano::store::write_transaction co
 
 bool nano::wallet::rekey (std::string const & password_a)
 {
-	auto transaction = wallets.tx_begin_write ();
-	auto result = store.rekey (transaction, password_a);
+	bool result;
+	{
+		auto transaction = wallets.tx_begin_write ();
+		result = store.rekey (transaction, password_a);
+	}
 	if (!result)
 	{
 		wallets.refresh_rep_keys_cache ();
@@ -1480,8 +1503,11 @@ void nano::wallet::lock ()
 
 void nano::wallet::remove_account (nano::account const & account_a)
 {
-	auto transaction = wallets.tx_begin_write ();
-	store.erase (transaction, account_a);
+	{
+		auto transaction = wallets.tx_begin_write ();
+		store.erase (transaction, account_a);
+	}
+	wallets.refresh_rep_keys_cache ();
 }
 
 std::vector<nano::account> nano::wallet::accounts () const
@@ -1492,8 +1518,13 @@ std::vector<nano::account> nano::wallet::accounts () const
 
 bool nano::wallet::move_accounts (wallet & source, std::vector<nano::public_key> const & accounts_a)
 {
-	auto transaction = wallets.tx_begin_write ();
-	return store.move (transaction, source.store, accounts_a);
+	bool error;
+	{
+		auto transaction = wallets.tx_begin_write ();
+		error = store.move (transaction, source.store, accounts_a);
+	}
+	wallets.refresh_rep_keys_cache ();
+	return error;
 }
 
 nano::key_type nano::wallet::key_type (nano::account const & account_a) const

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -756,6 +756,8 @@ bool nano::wallet::enter_password_impl (nano::store::transaction const & transac
 	{
 		logger.info (nano::log::type::wallet, "Wallet unlocked");
 
+		wallets.refresh_rep_keys_cache ();
+
 		auto this_l = shared_from_this ();
 		wallets.queue_wallet_action (nano::wallets::high_priority, this_l, [this_l] (nano::wallet & wallet) {
 			// Wallets must survive node lifetime
@@ -788,6 +790,7 @@ nano::public_key nano::wallet::deterministic_insert_impl (nano::store::write_tra
 		{
 			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", nano::log::as_account (key));
 			representatives.lock ()->insert (key);
+			wallets.refresh_rep_keys_cache ();
 		}
 	}
 	return key;
@@ -842,6 +845,7 @@ nano::public_key nano::wallet::insert_adhoc (nano::raw_key const & key_a, bool g
 		{
 			logger.info (nano::log::type::wallet, "New account qualified as a representative: {}", nano::log::as_account (key));
 			representatives.lock ()->insert (key);
+			wallets.refresh_rep_keys_cache ();
 		}
 	}
 	return key;
@@ -1451,7 +1455,12 @@ void nano::wallet::deterministic_restore_impl (nano::store::write_transaction co
 bool nano::wallet::rekey (std::string const & password_a)
 {
 	auto transaction = wallets.tx_begin_write ();
-	return store.rekey (transaction, password_a);
+	auto result = store.rekey (transaction, password_a);
+	if (!result)
+	{
+		wallets.refresh_rep_keys_cache ();
+	}
+	return result;
 }
 
 bool nano::wallet::is_locked () const
@@ -1462,9 +1471,11 @@ bool nano::wallet::is_locked () const
 
 void nano::wallet::lock ()
 {
+	logger.info (nano::log::type::wallet, "Wallet locked");
 	nano::raw_key empty;
 	empty.clear ();
 	store.password.value_set (empty);
+	wallets.refresh_rep_keys_cache ();
 }
 
 void nano::wallet::remove_account (nano::account const & account_a)
@@ -1870,61 +1881,6 @@ void nano::wallets::queue_wallet_action (nano::uint128_t const & amount_a, std::
 	condition.notify_all ();
 }
 
-auto nano::wallets::signer () -> signer_t
-{
-	return [this] (auto const & callback) { foreach_representative (callback); };
-}
-
-void nano::wallets::foreach_representative (std::function<void (nano::public_key const & pub_a, nano::raw_key const & prv_a)> const & action_a)
-{
-	if (config.enable_voting)
-	{
-		std::vector<std::pair<nano::public_key const, nano::raw_key const>> action_accounts_l;
-		{
-			auto transaction_l (tx_begin_read ());
-			auto ledger_txn = ledger.tx_begin_read ();
-			nano::lock_guard<nano::mutex> lock{ mutex };
-			for (auto i (items.begin ()), n (items.end ()); i != n; ++i)
-			{
-				auto & wallet (*i->second);
-				nano::lock_guard<std::recursive_mutex> store_lock{ wallet.store.mutex };
-				auto representatives_locked = *wallet.representatives.lock ();
-				for (auto const & account : representatives_locked)
-				{
-					if (wallet.store.exists (transaction_l, account))
-					{
-						if (!ledger.weight_exact (ledger_txn, account).is_zero ())
-						{
-							if (wallet.store.valid_password (transaction_l))
-							{
-								nano::raw_key prv;
-								auto error (wallet.store.fetch (transaction_l, account, prv));
-								release_assert (!error, "failed to fetch private key for representative account", account.to_account ());
-								action_accounts_l.emplace_back (account, prv);
-							}
-							else
-							{
-								// TODO: Better logging interval handling
-								static auto last_log = std::chrono::steady_clock::time_point ();
-								if (last_log < std::chrono::steady_clock::now () - std::chrono::seconds (60))
-								{
-									last_log = std::chrono::steady_clock::now ();
-
-									logger.warn (nano::log::type::wallet, "Representative locked inside wallet: {}", i->first);
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-		for (auto const & representative : action_accounts_l)
-		{
-			action_a (representative.first, representative.second);
-		}
-	}
-}
-
 bool nano::wallets::exists_impl (nano::store::transaction const & transaction_a, nano::account const & account_a)
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
@@ -1970,6 +1926,11 @@ nano::wallet_representatives nano::wallets::reps () const
 	return *representatives.lock ();
 }
 
+auto nano::wallets::signer () -> signer_t
+{
+	return [this] (auto const & callback) { foreach_representative (callback); };
+}
+
 bool nano::wallets::check_rep (nano::account const & account)
 {
 	auto half_principal_weight = node.minimum_principal_weight () / 2;
@@ -2003,25 +1964,95 @@ bool nano::wallets::check_rep_impl (wallet_representatives & reps, nano::account
 
 void nano::wallets::compute_reps ()
 {
+	refresh_rep_index ();
+	refresh_rep_keys_cache ();
+}
+
+void nano::wallets::refresh_rep_index ()
+{
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	auto representatives_locked = representatives.lock ();
-	representatives_locked->clear ();
-	auto half_principal_weight (node.minimum_principal_weight () / 2);
-	auto transaction (tx_begin_read ());
-	for (auto i (items.begin ()), n (items.end ()); i != n; ++i)
+
+	auto reps_locked = representatives.lock ();
+	reps_locked->clear ();
+
+	auto const half_principal_weight = node.minimum_principal_weight () / 2;
+
+	auto wallet_txn = tx_begin_read ();
+
+	for (auto const & [id, wallet] : items)
 	{
-		auto & wallet (*i->second);
-		std::unordered_set<nano::account> representatives_l;
-		for (auto ii (wallet.store.begin (transaction)), nn (wallet.store.end (transaction)); ii != nn; ++ii)
+		std::unordered_set<nano::account> new_representatives;
+		for (auto i = wallet->store.begin (wallet_txn), n = wallet->store.end (wallet_txn); i != n; ++i)
 		{
-			auto account (ii->first);
-			if (check_rep_impl (*representatives_locked, account, half_principal_weight))
+			auto account = i->first;
+			if (check_rep_impl (*reps_locked, account, half_principal_weight))
 			{
-				representatives_l.insert (account);
+				new_representatives.insert (account);
 			}
 		}
-		wallet.representatives.lock ()->swap (representatives_l);
+		wallet->representatives.lock ()->swap (new_representatives);
 	}
+}
+
+void nano::wallets::foreach_representative (std::function<void (nano::public_key const & pub, nano::raw_key const & prv)> const & action)
+{
+	if (config.enable_voting)
+	{
+		// Cache lock is held during callbacks, recursive calls are not allowed
+		auto locked = rep_keys_cache.lock ();
+		for (auto const & [pub, fan_ptr] : *locked)
+		{
+			nano::raw_key prv;
+			fan_ptr->value (prv);
+			action (pub, prv);
+		}
+	}
+}
+
+void nano::wallets::refresh_rep_keys_cache ()
+{
+	if (!config.enable_voting)
+	{
+		return;
+	}
+
+	std::vector<std::pair<nano::public_key, std::unique_ptr<nano::fan>>> new_cache;
+
+	auto wallet_txn = tx_begin_read ();
+
+	nano::lock_guard<nano::mutex> lock{ mutex };
+
+	for (auto const & [id, wallet] : items)
+	{
+		nano::lock_guard<std::recursive_mutex> store_lock{ wallet->store.mutex };
+
+		auto reps_locked = wallet->representatives.lock ();
+		for (auto const & account : *reps_locked)
+		{
+			if (wallet->store.exists (wallet_txn, account))
+			{
+				if (wallet->store.valid_password (wallet_txn))
+				{
+					nano::raw_key prv;
+					auto error = wallet->store.fetch (wallet_txn, account, prv);
+					release_assert (!error, "failed to fetch private key for representative account", account.to_account ());
+
+					// Store private key spread across multiple heap allocations via fan to avoid plaintext keys in memory at rest
+					new_cache.emplace_back (account, std::make_unique<nano::fan> (prv, config.password_fanout));
+				}
+				else
+				{
+					static auto last_log = std::chrono::steady_clock::time_point ();
+					if (last_log < std::chrono::steady_clock::now () - std::chrono::seconds (60))
+					{
+						last_log = std::chrono::steady_clock::now ();
+						logger.warn (nano::log::type::wallet, "Representative locked inside wallet: {}", id);
+					}
+				}
+			}
+		}
+	}
+	rep_keys_cache.lock ()->swap (new_cache);
 }
 
 void nano::wallets::run_reps_scan ()
@@ -2029,7 +2060,7 @@ void nano::wallets::run_reps_scan ()
 	auto delay = [this] () {
 		// Representation drifts quickly on the test network but very slowly on the live network
 		return network_params.network.is_dev_network ()
-		? std::chrono::milliseconds (10)
+		? 100ms
 		: (network_params.network.is_test_network ()
 		? std::chrono::milliseconds (nano::test_scan_wallet_reps_delay ())
 		: std::chrono::minutes (15));
@@ -2042,7 +2073,7 @@ void nano::wallets::run_reps_scan ()
 
 		stats.inc (nano::stat::type::wallet, nano::stat::detail::loop_reps);
 
-		// Recompute local wallet representatives
+		// Recompute local wallet representatives and refresh cached keys
 		compute_reps ();
 
 		lock.lock ();
@@ -2148,6 +2179,7 @@ nano::container_info nano::wallets::container_info () const
 	nano::container_info info;
 	info.put ("items", items.size ());
 	info.put ("actions", actions.size ());
+	info.put ("rep_keys_cache", rep_keys_cache.lock ()->size ());
 	return info;
 }
 

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -326,7 +326,7 @@ public:
 	// Representatives
 	void foreach_representative (std::function<void (nano::public_key const &, nano::raw_key const &)> const & action);
 	bool check_rep (nano::account const &);
-	void compute_reps ();
+	void refresh_reps ();
 	nano::wallet_representatives reps () const;
 
 	/// Returns a signer that iterates over all representatives in the wallet

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -383,9 +383,12 @@ private:
 	void run_receivable_scan ();
 	bool check_rep_impl (wallet_representatives &, nano::account const &, nano::uint128_t const & half_principal_weight);
 	bool exists_impl (nano::store::transaction const &, nano::account const &);
+	void refresh_rep_index ();
+	void refresh_rep_keys_cache ();
 
 private:
 	mutable nano::locked<nano::wallet_representatives> representatives;
+	nano::locked<std::vector<std::pair<nano::public_key, std::unique_ptr<nano::fan>>>> rep_keys_cache;
 
 	friend class wallet;
 };


### PR DESCRIPTION
`foreach_representative` is called on every vote signing. Previously, each call performed redundant DB lookups, lock acquisitions, and key decryption for every representative. This caches decrypted key pairs using `fan` objects (XOR-spread across heap allocations) so the hot path becomes a simple cache read.