### PR TITLE
Enable sccache for Linux and Macos CI builds

### DIFF
--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -53,7 +53,7 @@ jobs:
         id: build
         run: ci/build-tests.sh
 
-      - name: sccache stats
+      - name: Build cache stats
         if: always()
         run: sccache --show-stats
 
@@ -120,7 +120,7 @@ jobs:
         id: build
         run: ci/build-tests.sh
 
-      - name: sccache stats
+      - name: Build cache stats
         if: always()
         run: sccache --show-stats
 

--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -32,6 +32,10 @@ jobs:
       ASAN_OPTIONS: log_exe_name=1:log_path=sanitizer_report:suppressions=../asan_suppressions:detect_leaks=${{ matrix.SANITIZER.leak_check && '1' || '0' }}
       TSAN_OPTIONS: log_exe_name=1:log_path=sanitizer_report:suppressions=../tsan_suppressions
       UBSAN_OPTIONS: log_exe_name=1:log_path=sanitizer_report:print_stacktrace=1
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_VERSION: linux-sanitizers-${{ matrix.SANITIZER.name }}-${{ matrix.COMPILER }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
@@ -42,9 +46,16 @@ jobs:
       - name: Prepare
         run: sudo -E ci/prepare/linux/prepare.sh
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Build Tests
         id: build
         run: ci/build-tests.sh
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Core Tests
         if: steps.build.outcome == 'success' && (success() || failure())
@@ -88,6 +99,10 @@ jobs:
       ASAN_OPTIONS: log_exe_name=1:log_path=sanitizer_report:suppressions=../asan_suppressions
       TSAN_OPTIONS: log_exe_name=1:log_path=sanitizer_report:suppressions=../tsan_suppressions
       UBSAN_OPTIONS: log_exe_name=1:log_path=sanitizer_report:print_stacktrace=1
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_VERSION: macos-sanitizers-${{ matrix.SANITIZER.name }}-${{ matrix.COMPILER }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
@@ -98,9 +113,16 @@ jobs:
       - name: Prepare
         run: ci/prepare/macos/prepare.sh
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Build Tests
         id: build
         run: ci/build-tests.sh
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Core Tests
         if: steps.build.outcome == 'success' && (success() || failure())

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -38,7 +38,7 @@ jobs:
         id: build
         run: ci/build-tests.sh
 
-      - name: sccache stats
+      - name: Build cache stats
         if: always()
         run: sccache --show-stats
 
@@ -99,7 +99,7 @@ jobs:
         id: build
         run: ci/build-tests.sh
 
-      - name: sccache stats
+      - name: Build cache stats
         if: always()
         run: sccache --show-stats
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -16,6 +16,10 @@ jobs:
       BUILD_TYPE: ${{ matrix.RELEASE && 'RelWithDebInfo' || 'Debug' }}
       TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}
       DEADLINE_SCALE_FACTOR: ${{ matrix.BACKEND == 'rocksdb' && '2' || '1' }}
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_VERSION: macos-${{ matrix.RELEASE }}
     runs-on: macos-14
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
@@ -27,9 +31,16 @@ jobs:
       - name: Prepare
         run: ci/prepare/macos/prepare.sh
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Build Tests
         id: build
         run: ci/build-tests.sh
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Setup Core Dumps
         if: steps.build.outcome == 'success' && (success() || failure())
@@ -67,6 +78,10 @@ jobs:
       BUILD_TYPE: ${{ matrix.RELEASE && 'RelWithDebInfo' || 'Debug' }}
       TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}
       DEADLINE_SCALE_FACTOR: ${{ matrix.BACKEND == 'rocksdb' && '2' || '1' }}
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      SCCACHE_GHA_VERSION: linux-${{ matrix.COMPILER }}-${{ matrix.RELEASE }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
@@ -77,9 +92,16 @@ jobs:
       - name: Prepare
         run: sudo -E ci/prepare/linux/prepare.sh
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Build Tests
         id: build
         run: ci/build-tests.sh
+
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Setup Core Dumps
         if: steps.build.outcome == 'success' && (success() || failure())


### PR DESCRIPTION
Github offers 10 GB cache storage and we are currently not using it.
This PR introduces compile caching of CI runs on unit tests and code sanitizer running Linux and MacOs. Most of the submodules in this project changes rarely (like Boost, Rocksdb, spdlog etc).
MSVC caching needs some additional changes, so caching on Windows builds are skipped in this PR. I can look into that later.
The first run will populate the cache and give zero cache hits. Subsequent pushes will use cached versions for any unchanged code. 
Each CI job will print cache hit rates to the logs.
From my testing, this reduces build times from 20-30 minutes to 3-10 minutes
https://github.com/mozilla/sccache