### PR TITLE
Add `--enable_rpc` flag

### DIFF
--- a/nano/core_test/cli.cpp
+++ b/nano/core_test/cli.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/cli.hpp>
 #include <nano/lib/files.hpp>
 #include <nano/node/cli.hpp>
+#include <nano/node/nodeconfig.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
@@ -67,6 +68,22 @@ TEST (cli, config_override_parsing)
 	config_overrides = nano::config_overrides (key_value_pairs);
 	ASSERT_EQ (config_overrides[3], "node.work_peers=[\"127.0.0.1:7000\",\"128.0.0.1:50000\"]");
 	ASSERT_EQ (config_overrides.size (), 4);
+}
+
+TEST (cli, enable_rpc_flag)
+{
+	boost::program_options::options_description description;
+	nano::add_node_flag_options (description);
+
+	char const * argv[] = { "nano_node", "--enable_rpc" };
+	boost::program_options::variables_map vm;
+	boost::program_options::store (boost::program_options::parse_command_line (2, argv, description), vm);
+	boost::program_options::notify (vm);
+
+	nano::node_flags flags;
+	nano::update_flags (flags, vm);
+
+	ASSERT_TRUE (flags.enable_rpc);
 }
 
 namespace

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -141,7 +141,8 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 		std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
 		std::shared_ptr<nano::rpc> rpc;
 
-		if (config.rpc_enable)
+		bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
+		if (rpc_enabled)
 		{
 			// In process RPC
 			if (!config.rpc.child_process.enable)
@@ -160,6 +161,8 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 					std::exit (1);
 				}
 
+				logger.debug (nano::log::type::daemon, "Starting in-process RPC server on port {}", rpc_config.port);
+
 				rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, *ipc_server, config.rpc, stop_callback);
 				rpc = nano::get_rpc (io_ctx, rpc_config, *rpc_handler);
 				rpc->start ();
@@ -173,6 +176,8 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 				}
 
 				logger.warn (nano::log::type::daemon, "RPC is configured to run in a separate process, this is experimental and is not recommended for production use. Please consider using the in-process RPC instead.");
+
+				logger.debug (nano::log::type::daemon, "Spawning RPC process with command: {}", config.rpc.child_process.rpc_path);
 
 				std::string network{ node->network_params.network.get_current_network_as_string () };
 				rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path.string (), "--network", network);

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -177,7 +177,8 @@ public:
 				std::unique_ptr<boost::process::child> rpc_process;
 				std::shared_ptr<nano::rpc> rpc;
 				std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
-				if (config.rpc_enable)
+				bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
+				if (rpc_enabled)
 				{
 					if (!config.rpc.child_process.enable)
 					{
@@ -186,10 +187,14 @@ public:
 						error = nano::read_rpc_config_toml (data_path, rpc_config, flags.rpc_config_overrides);
 						if (error)
 						{
+							logger.critical (nano::log::type::daemon, "Error deserializing RPC config: {}", error.get_message ());
 							splash->hide ();
 							show_error (error.get_message ());
 							std::exit (1);
 						}
+
+						logger.debug (nano::log::type::daemon, "Starting in-process RPC server on port {}", rpc_config.port);
+
 						rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, ipc, config.rpc);
 						rpc = nano::get_rpc (io_ctx, rpc_config, *rpc_handler);
 						rpc->start ();
@@ -201,6 +206,10 @@ public:
 						{
 							throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.child_process.rpc_path);
 						}
+
+						logger.warn (nano::log::type::daemon, "RPC is configured to run in a separate process, this is experimental and is not recommended for production use. Please consider using the in-process RPC instead.");
+
+						logger.debug (nano::log::type::daemon, "Spawning RPC process with command: {}", config.rpc.child_process.rpc_path);
 
 						std::string network{ node->network_params.network.get_current_network_as_string () };
 						rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path.string (), "--network", network);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -128,6 +128,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_tcp_realtime", "Disables TCP realtime connections")
 		("disable_search_pending", "Disables the periodic search for pending transactions")
 		("enable_pruning", "Enable experimental ledger pruning")
+		("enable_rpc", "Enable RPC")
 		("enable_voting", "Enable voting")
 		("super_rebroadcaster", "Broadcast all blocks and votes to all peers (high bandwidth usage)")
 		("allow_bootstrap_peers_duplicates", "Allow multiple connections to same peer in bootstrap attempts")
@@ -168,6 +169,7 @@ void nano::update_flags (nano::node_flags & flags_a, boost::program_options::var
 	flags_a.disable_providing_telemetry_metrics = (vm.count ("disable_providing_telemetry_metrics") > 0);
 	flags_a.disable_block_processor_unchecked_deletion = (vm.count ("disable_block_processor_unchecked_deletion") > 0);
 	flags_a.enable_pruning = (vm.count ("enable_pruning") > 0);
+	flags_a.enable_rpc = (vm.count ("enable_rpc") > 0);
 	flags_a.enable_voting = (vm.count ("enable_voting") > 0);
 	flags_a.super_rebroadcaster = (vm.count ("super_rebroadcaster") > 0);
 	flags_a.allow_bootstrap_peers_duplicates = (vm.count ("allow_bootstrap_peers_duplicates") > 0);

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -157,6 +157,7 @@ public:
 	bool disable_max_peers_per_subnetwork{ false };
 	bool disable_search_pending{ false };
 	bool enable_pruning{ false };
+	bool enable_rpc{ false };
 	bool enable_voting{ false };
 	bool super_rebroadcaster{ false };
 	bool fast_bootstrap{ false };

--- a/systest/rpc_stop.sh
+++ b/systest/rpc_stop.sh
@@ -14,9 +14,9 @@ trap cleanup EXIT
 
 # Start the node in daemon mode with ephemeral ports
 $NANO_NODE_EXE --daemon --network dev --data_path "$DATADIR" \
+    --enable_rpc \
     --runtime_info_file "$RUNTIME_INFO" \
     --config node.peering_port=0 \
-    --config rpc.enable=true \
     --rpcconfig port=0 \
     --rpcconfig enable_control=true &
 NODE_PID=$!

--- a/systest/runtime_files.sh
+++ b/systest/runtime_files.sh
@@ -16,10 +16,10 @@ trap cleanup EXIT
 
 # Start the node with both --pid_file and --runtime_info_file using ephemeral ports
 $NANO_NODE_EXE --daemon --network dev --data_path "$DATADIR" \
+    --enable_rpc \
     --pid_file "$PID_FILE" \
     --runtime_info_file "$RUNTIME_INFO" \
     --config node.peering_port=0 \
-    --config rpc.enable=true \
     --rpcconfig port=0 \
     --rpcconfig enable_control=true &
 NODE_PID=$!


### PR DESCRIPTION
Honor `--enable_rpc` in node and wallet startup so RPC can be enabled without a config override. Add CLI coverage, extra RPC startup logging, and switch system tests to the new flag.