### PR TITLE
Encapsulate wallet key usage behind wallet_cipher

### DIFF
--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -327,8 +327,8 @@ TEST (wallet_store, serialize_json_empty)
 	zero.clear ();
 	nano::uint128_union iv{ 0 };
 	ASSERT_EQ (cipher1.value ().encrypt (zero, iv), cipher2.value ().encrypt (zero, iv));
-	ASSERT_EQ (wallet1.salt (transaction), wallet2.salt (transaction));
-	ASSERT_EQ (wallet1.check (transaction), wallet2.check (transaction));
+	ASSERT_EQ (wallet1.salt_get (transaction), wallet2.salt_get (transaction));
+	ASSERT_EQ (wallet1.check_value_get (transaction), wallet2.check_value_get (transaction));
 	ASSERT_EQ (wallet1.representative (transaction), wallet2.representative (transaction));
 	ASSERT_EQ (wallet1.end (transaction), wallet1.begin (transaction));
 	ASSERT_EQ (wallet2.end (transaction), wallet2.begin (transaction));
@@ -353,8 +353,8 @@ TEST (wallet_store, serialize_json_one)
 	zero.clear ();
 	nano::uint128_union iv{ 0 };
 	ASSERT_EQ (cipher1.value ().encrypt (zero, iv), cipher2.value ().encrypt (zero, iv));
-	ASSERT_EQ (wallet1.salt (transaction), wallet2.salt (transaction));
-	ASSERT_EQ (wallet1.check (transaction), wallet2.check (transaction));
+	ASSERT_EQ (wallet1.salt_get (transaction), wallet2.salt_get (transaction));
+	ASSERT_EQ (wallet1.check_value_get (transaction), wallet2.check_value_get (transaction));
 	ASSERT_EQ (wallet1.representative (transaction), wallet2.representative (transaction));
 	ASSERT_TRUE (wallet2.exists (transaction, key.pub));
 	auto prv_result = wallet2.fetch (transaction, key.pub);
@@ -385,8 +385,8 @@ TEST (wallet_store, serialize_json_password)
 	zero.clear ();
 	nano::uint128_union iv{ 0 };
 	ASSERT_EQ (cipher1.value ().encrypt (zero, iv), cipher2.value ().encrypt (zero, iv));
-	ASSERT_EQ (wallet1.salt (transaction), wallet2.salt (transaction));
-	ASSERT_EQ (wallet1.check (transaction), wallet2.check (transaction));
+	ASSERT_EQ (wallet1.salt_get (transaction), wallet2.salt_get (transaction));
+	ASSERT_EQ (wallet1.check_value_get (transaction), wallet2.check_value_get (transaction));
 	ASSERT_EQ (wallet1.representative (transaction), wallet2.representative (transaction));
 	ASSERT_TRUE (wallet2.exists (transaction, key.pub));
 	auto prv_result = wallet2.fetch (transaction, key.pub);

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -226,8 +226,7 @@ TEST (wallet_store, rekey)
 	nano::wallet::wallet_store wallet (kdf, transaction, backend, nano::dev::genesis_key.pub, 1, "0");
 	nano::raw_key password;
 	wallet.password.value (password);
-	nano::raw_key default_password_key;
-	wallet.derive_key (default_password_key, transaction, nano::wallet::wallet_store::default_password);
+	auto default_password_key = wallet.derive_key (transaction, nano::wallet::wallet_store::default_password);
 	ASSERT_EQ (default_password_key, password);
 	nano::keypair key1;
 	wallet.insert_adhoc (transaction, key1.prv);
@@ -236,8 +235,7 @@ TEST (wallet_store, rekey)
 	ASSERT_EQ (key1.prv, result1.value ());
 	ASSERT_FALSE (wallet.rekey (transaction, "1"));
 	wallet.password.value (password);
-	nano::raw_key password1;
-	wallet.derive_key (password1, transaction, "1");
+	auto password1 = wallet.derive_key (transaction, "1");
 	ASSERT_EQ (password1, password);
 	auto result2 = wallet.fetch (transaction, key1.pub);
 	ASSERT_TRUE (result2);
@@ -252,13 +250,10 @@ TEST (wallet_store, hash_password)
 	auto transaction (backend.tx_begin_write ());
 	nano::kdf kdf{ nano::dev::network_params.kdf_work };
 	nano::wallet::wallet_store wallet (kdf, transaction, backend, nano::dev::genesis_key.pub, 1, "0");
-	nano::raw_key hash1;
-	wallet.derive_key (hash1, transaction, "");
-	nano::raw_key hash2;
-	wallet.derive_key (hash2, transaction, "");
+	auto hash1 = wallet.derive_key (transaction, "");
+	auto hash2 = wallet.derive_key (transaction, "");
 	ASSERT_EQ (hash1, hash2);
-	nano::raw_key hash3;
-	wallet.derive_key (hash3, transaction, "a");
+	auto hash3 = wallet.derive_key (transaction, "a");
 	ASSERT_NE (hash1, hash3);
 }
 

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -154,10 +154,9 @@ TEST (wallet_store, one_item_iteration)
 	for (auto i (wallet.begin (transaction)), j (wallet.end (transaction)); i != j; ++i)
 	{
 		ASSERT_EQ (key1.pub, nano::uint256_union (i->first));
-		nano::raw_key password;
-		wallet.wallet_key (password, transaction);
-		nano::raw_key key;
-		key.decrypt (nano::wallet::wallet_value (i->second).key, password, (nano::uint256_union (i->first)).owords[0].number ());
+		auto cipher = wallet.unlock (transaction);
+		ASSERT_TRUE (cipher);
+		auto key = cipher.value ().decrypt (nano::wallet::wallet_value (i->second).key, (nano::uint256_union (i->first)).owords[0]);
 		ASSERT_EQ (key1.prv, key);
 	}
 }
@@ -179,10 +178,9 @@ TEST (wallet_store, two_item_iteration)
 		for (auto i (wallet.begin (transaction)), j (wallet.end (transaction)); i != j; ++i)
 		{
 			pubs.insert (i->first);
-			nano::raw_key password;
-			wallet.wallet_key (password, transaction);
-			nano::raw_key key;
-			key.decrypt (nano::wallet::wallet_value (i->second).key, password, (i->first).owords[0].number ());
+			auto cipher = wallet.unlock (transaction);
+			ASSERT_TRUE (cipher);
+			auto key = cipher.value ().decrypt (nano::wallet::wallet_value (i->second).key, (i->first).owords[0]);
 			prvs.insert (key);
 		}
 	}
@@ -321,11 +319,14 @@ TEST (wallet_store, serialize_json_empty)
 	std::string serialized;
 	wallet1.serialize_json (transaction, serialized);
 	nano::wallet::wallet_store wallet2 (kdf, transaction, backend, 1, "1", serialized);
-	nano::raw_key password1;
-	nano::raw_key password2;
-	wallet1.wallet_key (password1, transaction);
-	wallet2.wallet_key (password2, transaction);
-	ASSERT_EQ (password1, password2);
+	auto cipher1 = wallet1.unlock (transaction);
+	auto cipher2 = wallet2.unlock (transaction);
+	ASSERT_TRUE (cipher1);
+	ASSERT_TRUE (cipher2);
+	nano::raw_key zero;
+	zero.clear ();
+	nano::uint128_union iv{ 0 };
+	ASSERT_EQ (cipher1.value ().encrypt (zero, iv), cipher2.value ().encrypt (zero, iv));
 	ASSERT_EQ (wallet1.salt (transaction), wallet2.salt (transaction));
 	ASSERT_EQ (wallet1.check (transaction), wallet2.check (transaction));
 	ASSERT_EQ (wallet1.representative (transaction), wallet2.representative (transaction));
@@ -344,11 +345,14 @@ TEST (wallet_store, serialize_json_one)
 	std::string serialized;
 	wallet1.serialize_json (transaction, serialized);
 	nano::wallet::wallet_store wallet2 (kdf, transaction, backend, 1, "1", serialized);
-	nano::raw_key password1;
-	nano::raw_key password2;
-	wallet1.wallet_key (password1, transaction);
-	wallet2.wallet_key (password2, transaction);
-	ASSERT_EQ (password1, password2);
+	auto cipher1 = wallet1.unlock (transaction);
+	auto cipher2 = wallet2.unlock (transaction);
+	ASSERT_TRUE (cipher1);
+	ASSERT_TRUE (cipher2);
+	nano::raw_key zero;
+	zero.clear ();
+	nano::uint128_union iv{ 0 };
+	ASSERT_EQ (cipher1.value ().encrypt (zero, iv), cipher2.value ().encrypt (zero, iv));
 	ASSERT_EQ (wallet1.salt (transaction), wallet2.salt (transaction));
 	ASSERT_EQ (wallet1.check (transaction), wallet2.check (transaction));
 	ASSERT_EQ (wallet1.representative (transaction), wallet2.representative (transaction));
@@ -373,11 +377,14 @@ TEST (wallet_store, serialize_json_password)
 	ASSERT_FALSE (wallet2.valid_password (transaction));
 	ASSERT_FALSE (wallet2.attempt_password (transaction, "password"));
 	ASSERT_TRUE (wallet2.valid_password (transaction));
-	nano::raw_key password1;
-	nano::raw_key password2;
-	wallet1.wallet_key (password1, transaction);
-	wallet2.wallet_key (password2, transaction);
-	ASSERT_EQ (password1, password2);
+	auto cipher1 = wallet1.unlock (transaction);
+	auto cipher2 = wallet2.unlock (transaction);
+	ASSERT_TRUE (cipher1);
+	ASSERT_TRUE (cipher2);
+	nano::raw_key zero;
+	zero.clear ();
+	nano::uint128_union iv{ 0 };
+	ASSERT_EQ (cipher1.value ().encrypt (zero, iv), cipher2.value ().encrypt (zero, iv));
 	ASSERT_EQ (wallet1.salt (transaction), wallet2.salt (transaction));
 	ASSERT_EQ (wallet1.check (transaction), wallet2.check (transaction));
 	ASSERT_EQ (wallet1.representative (transaction), wallet2.representative (transaction));

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -147,7 +147,6 @@ TEST (wallet_store, unlock_locked)
 	wallet.password.value_set (garbage);
 	auto cipher_locked = wallet.unlock (transaction);
 	ASSERT_FALSE (cipher_locked);
-	ASSERT_EQ (cipher_locked.error (), nano::error_common::wallet_locked);
 }
 
 TEST (wallet_store, cipher_round_trip)

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -132,6 +132,53 @@ TEST (wallet_store, retrieval)
 	ASSERT_FALSE (wallet.valid_password (transaction));
 }
 
+TEST (wallet_store, unlock_locked)
+{
+	nano::wallet::lmdb::wallets_backend_lmdb backend (nano::unique_path () / "wallet.ldb");
+	auto transaction (backend.tx_begin_write ());
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
+	nano::wallet::wallet_store wallet (kdf, transaction, backend, nano::dev::genesis_key.pub, 1, "0");
+	// Fresh wallet unlocks under the default password
+	auto cipher_unlocked = wallet.unlock (transaction);
+	ASSERT_TRUE (cipher_unlocked);
+	// Corrupt the live password fan to simulate a locked / wrong-password state
+	nano::raw_key garbage;
+	garbage = 1;
+	wallet.password.value_set (garbage);
+	auto cipher_locked = wallet.unlock (transaction);
+	ASSERT_FALSE (cipher_locked);
+	ASSERT_EQ (cipher_locked.error (), nano::error_common::wallet_locked);
+}
+
+TEST (wallet_store, cipher_round_trip)
+{
+	nano::wallet::lmdb::wallets_backend_lmdb backend (nano::unique_path () / "wallet.ldb");
+	auto transaction (backend.tx_begin_write ());
+	nano::kdf kdf{ nano::dev::network_params.kdf_work };
+	nano::wallet::wallet_store wallet (kdf, transaction, backend, nano::dev::genesis_key.pub, 1, "0");
+	auto cipher = wallet.unlock (transaction);
+	ASSERT_TRUE (cipher);
+	// Random non-zero plaintext: covers the non-zero encrypt case
+	nano::raw_key plaintext;
+	nano::random_pool::generate_block (plaintext.bytes.data (), plaintext.bytes.size ());
+	ASSERT_FALSE (plaintext.is_zero ());
+	nano::uint128_union iv{ 42 };
+	auto ciphertext = cipher.value ().encrypt (plaintext, iv);
+	// Encryption should actually transform the data
+	ASSERT_NE (plaintext, ciphertext);
+	// Round-trip: decrypt with the same IV recovers the plaintext
+	auto recovered = cipher.value ().decrypt (ciphertext, iv);
+	ASSERT_EQ (plaintext, recovered);
+	// Sanity: a different IV does not recover the plaintext
+	nano::uint128_union iv_other{ 43 };
+	ASSERT_NE (plaintext, cipher.value ().decrypt (ciphertext, iv_other));
+	// Encrypting different plaintexts under the same IV produces different ciphertexts
+	nano::raw_key plaintext_other;
+	nano::random_pool::generate_block (plaintext_other.bytes.data (), plaintext_other.bytes.size ());
+	auto ciphertext_other = cipher.value ().encrypt (plaintext_other, iv);
+	ASSERT_NE (ciphertext, ciphertext_other);
+}
+
 TEST (wallet_store, empty_iteration)
 {
 	nano::wallet::lmdb::wallets_backend_lmdb backend (nano::unique_path () / "wallet.ldb");

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -483,8 +483,7 @@ nano::uint256_union wallet_store::salt_get (nano::store::transaction const & tra
 
 nano::result<wallet_cipher> wallet_store::unlock (nano::store::transaction const & transaction_a) const
 {
-	nano::raw_key wallet_key_l;
-	wallet_key (wallet_key_l, transaction_a);
+	auto const wallet_key_l = wallet_key_decrypt (transaction_a);
 	nano::raw_key zero{};
 	zero.clear ();
 	nano::uint256_union check_l{};
@@ -496,14 +495,16 @@ nano::result<wallet_cipher> wallet_store::unlock (nano::store::transaction const
 	return wallet_cipher{ wallet_key_l };
 }
 
-void wallet_store::wallet_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a) const
+nano::raw_key wallet_store::wallet_key_decrypt (nano::store::transaction const & transaction_a) const
 {
 	nano::lock_guard<std::recursive_mutex> lock{ mutex };
 	nano::raw_key wallet_l;
 	wallet_key_mem.value (wallet_l);
 	nano::raw_key password_l;
 	password.value (password_l);
-	prv_a.decrypt (wallet_l, password_l, salt_get (transaction_a).owords[0]);
+	nano::raw_key result;
+	result.decrypt (wallet_l, password_l, salt_get (transaction_a).owords[0]);
+	return result;
 }
 
 nano::raw_key wallet_store::seed (nano::store::transaction const & transaction) const

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -317,7 +317,7 @@ nano::result<nano::raw_key> wallet_store::fetch (nano::store::transaction const 
 		case key_type::deterministic:
 		{
 			auto encrypted_seed = entry_get_raw (transaction, wallet_store::seed_special).key;
-			auto seed_l = cipher.value ().decrypt (encrypted_seed, salt (transaction).owords[seed_iv_index]);
+			auto seed_l = cipher.value ().decrypt (encrypted_seed, salt_get (transaction).owords[seed_iv_index]);
 			auto index = static_cast<uint32_t> (value.key.number () & static_cast<uint32_t> (-1));
 			prv = nano::deterministic_key (seed_l, index);
 			break;
@@ -469,15 +469,15 @@ void wallet_store::version_put (nano::store::write_transaction const & transacti
 	entry_put_raw (transaction_a, wallet_store::version_special, nano::wallet::wallet_value (entry, 0));
 }
 
-nano::uint256_union wallet_store::check (nano::store::transaction const & transaction_a) const
+nano::uint256_union wallet_store::check_value_get (nano::store::transaction const & transaction_a) const
 {
-	nano::wallet::wallet_value value (entry_get_raw (transaction_a, wallet_store::check_special));
+	auto value = entry_get_raw (transaction_a, wallet_store::check_special);
 	return value.key;
 }
 
-nano::uint256_union wallet_store::salt (nano::store::transaction const & transaction_a) const
+nano::uint256_union wallet_store::salt_get (nano::store::transaction const & transaction_a) const
 {
-	nano::wallet::wallet_value value (entry_get_raw (transaction_a, wallet_store::salt_special));
+	auto value = entry_get_raw (transaction_a, wallet_store::salt_special);
 	return value.key;
 }
 
@@ -488,8 +488,8 @@ nano::result<wallet_cipher> wallet_store::unlock (nano::store::transaction const
 	nano::raw_key zero{};
 	zero.clear ();
 	nano::uint256_union check_l{};
-	check_l.encrypt (zero, wallet_key_l, salt (transaction_a).owords[check_iv_index]);
-	if (check (transaction_a) != check_l)
+	check_l.encrypt (zero, wallet_key_l, salt_get (transaction_a).owords[check_iv_index]);
+	if (check_value_get (transaction_a) != check_l)
 	{
 		return nano::error (nano::error_common::wallet_locked);
 	}
@@ -503,7 +503,7 @@ void wallet_store::wallet_key (nano::raw_key & prv_a, nano::store::transaction c
 	wallet_key_mem.value (wallet_l);
 	nano::raw_key password_l;
 	password.value (password_l);
-	prv_a.decrypt (wallet_l, password_l, salt (transaction_a).owords[0]);
+	prv_a.decrypt (wallet_l, password_l, salt_get (transaction_a).owords[0]);
 }
 
 nano::raw_key wallet_store::seed (nano::store::transaction const & transaction) const
@@ -511,14 +511,14 @@ nano::raw_key wallet_store::seed (nano::store::transaction const & transaction) 
 	auto cipher = unlock (transaction);
 	release_assert (cipher, "wallet is locked or password is invalid");
 	nano::wallet::wallet_value value (entry_get_raw (transaction, wallet_store::seed_special));
-	return cipher.value ().decrypt (value.key, salt (transaction).owords[seed_iv_index]);
+	return cipher.value ().decrypt (value.key, salt_get (transaction).owords[seed_iv_index]);
 }
 
 void wallet_store::seed_set (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv_a)
 {
 	auto cipher = unlock (transaction_a);
 	release_assert (cipher, "wallet is locked or password is invalid");
-	auto ciphertext = cipher.value ().encrypt (prv_a, salt (transaction_a).owords[seed_iv_index]);
+	auto ciphertext = cipher.value ().encrypt (prv_a, salt_get (transaction_a).owords[seed_iv_index]);
 	entry_put_raw (transaction_a, wallet_store::seed_special, nano::wallet::wallet_value (ciphertext, 0));
 	deterministic_clear (transaction_a);
 }
@@ -559,7 +559,7 @@ nano::raw_key wallet_store::deterministic_key (nano::store::transaction const & 
 	auto cipher = unlock (transaction);
 	release_assert (cipher, "wallet is locked or password is invalid");
 	auto encrypted_seed = entry_get_raw (transaction, wallet_store::seed_special).key;
-	auto wallet_seed = cipher.value ().decrypt (encrypted_seed, salt (transaction).owords[seed_iv_index]);
+	auto wallet_seed = cipher.value ().decrypt (encrypted_seed, salt_get (transaction).owords[seed_iv_index]);
 	return nano::deterministic_key (wallet_seed, index);
 }
 
@@ -638,7 +638,7 @@ bool wallet_store::rekey (nano::store::write_transaction const & transaction_a, 
 	}
 	nano::raw_key password_new;
 	derive_key (password_new, transaction_a, password_a);
-	auto encrypted = cipher.value ().reseal (password_new, salt (transaction_a).owords[0]);
+	auto encrypted = cipher.value ().reseal (password_new, salt_get (transaction_a).owords[0]);
 	password.value_set (password_new);
 	wallet_key_mem.value_set (encrypted);
 	entry_put_raw (transaction_a, wallet_store::wallet_key_special, nano::wallet::wallet_value (encrypted, 0));
@@ -647,7 +647,7 @@ bool wallet_store::rekey (nano::store::write_transaction const & transaction_a, 
 
 void wallet_store::derive_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a, std::string const & password_a) const
 {
-	auto salt_l (salt (transaction_a));
+	auto salt_l (salt_get (transaction_a));
 	kdf.phs (prv_a, password_a, salt_l);
 }
 

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -162,8 +162,7 @@ wallet_store::wallet_store (nano::kdf & kdf_a, nano::store::write_transaction & 
 			// Wallet key is a fixed random key that encrypts all entries
 			nano::raw_key wallet_key;
 			random_pool::generate_block (wallet_key.bytes.data (), sizeof (wallet_key.bytes));
-			nano::raw_key password_l;
-			derive_key (password_l, transaction_a, default_password);
+			auto password_l = derive_key (transaction_a, default_password);
 			password.value_set (password_l);
 			// Wallet key is encrypted by the user's password
 			nano::raw_key encrypted;
@@ -611,8 +610,7 @@ bool wallet_store::attempt_password (nano::store::transaction const & transactio
 	bool result = false;
 	{
 		nano::lock_guard<std::recursive_mutex> lock{ mutex };
-		nano::raw_key password_l;
-		derive_key (password_l, transaction_a, password_a);
+		auto password_l = derive_key (transaction_a, password_a);
 		password.value_set (password_l);
 		result = !valid_password (transaction_a);
 	}
@@ -637,8 +635,7 @@ bool wallet_store::rekey (nano::store::write_transaction const & transaction_a, 
 	{
 		return true;
 	}
-	nano::raw_key password_new;
-	derive_key (password_new, transaction_a, password_a);
+	auto password_new = derive_key (transaction_a, password_a);
 	auto encrypted = cipher.value ().reseal (password_new, salt_get (transaction_a).owords[0]);
 	password.value_set (password_new);
 	wallet_key_mem.value_set (encrypted);
@@ -646,10 +643,12 @@ bool wallet_store::rekey (nano::store::write_transaction const & transaction_a, 
 	return false;
 }
 
-void wallet_store::derive_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a, std::string const & password_a) const
+nano::raw_key wallet_store::derive_key (nano::store::transaction const & transaction_a, std::string const & password_a) const
 {
-	auto salt_l (salt_get (transaction_a));
-	kdf.phs (prv_a, password_a, salt_l);
+	auto const salt_l = salt_get (transaction_a);
+	nano::raw_key result;
+	kdf.phs (result, password_a, salt_l);
+	return result;
 }
 
 auto wallet_store::begin (nano::store::transaction const & txn) const -> iterator

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -34,6 +34,36 @@ template class nano::store::typed_iterator<nano::account, nano::wallet::wallet_v
 namespace nano::wallet
 {
 /*
+ * wallet_cipher
+ */
+
+wallet_cipher::wallet_cipher (nano::raw_key wallet_key_a) :
+	wallet_key{ wallet_key_a }
+{
+}
+
+nano::raw_key wallet_cipher::encrypt (nano::raw_key const & plaintext, nano::uint128_union const & iv) const
+{
+	nano::raw_key result;
+	result.encrypt (plaintext, wallet_key, iv);
+	return result;
+}
+
+nano::raw_key wallet_cipher::decrypt (nano::uint256_union const & ciphertext, nano::uint128_union const & iv) const
+{
+	nano::raw_key result;
+	result.decrypt (ciphertext, wallet_key, iv);
+	return result;
+}
+
+nano::raw_key wallet_cipher::reseal (nano::raw_key const & new_password_key, nano::uint128_union const & iv) const
+{
+	nano::raw_key result;
+	result.encrypt (wallet_key, new_password_key, iv);
+	return result;
+}
+
+/*
  * wallet_store
  */
 
@@ -203,12 +233,10 @@ nano::account wallet_store::representative (nano::store::transaction const & tra
 
 nano::public_key wallet_store::insert_adhoc (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv)
 {
-	release_assert (valid_password (transaction_a), "wallet is locked or password is invalid");
+	auto cipher = unlock (transaction_a);
+	release_assert (cipher, "wallet is locked or password is invalid");
 	nano::public_key pub (nano::pub_key (prv));
-	nano::raw_key password_l;
-	wallet_key (password_l, transaction_a);
-	nano::raw_key ciphertext;
-	ciphertext.encrypt (prv, password_l, pub.owords[0].number ());
+	auto ciphertext = cipher.value ().encrypt (prv, pub.owords[0]);
 	entry_put_raw (transaction_a, pub, nano::wallet::wallet_value (ciphertext, 0));
 	return pub;
 }
@@ -271,7 +299,8 @@ nano::wallet::key_type wallet_store::key_type (nano::wallet::wallet_value const 
 
 nano::result<nano::raw_key> wallet_store::fetch (nano::store::transaction const & transaction, nano::account const & pub) const
 {
-	if (!valid_password (transaction))
+	auto cipher = unlock (transaction);
+	if (!cipher)
 	{
 		return nano::error (nano::error_common::wallet_locked);
 	}
@@ -287,16 +316,15 @@ nano::result<nano::raw_key> wallet_store::fetch (nano::store::transaction const 
 	{
 		case key_type::deterministic:
 		{
-			auto seed_l = seed (transaction);
+			auto encrypted_seed = entry_get_raw (transaction, wallet_store::seed_special).key;
+			auto seed_l = cipher.value ().decrypt (encrypted_seed, salt (transaction).owords[seed_iv_index]);
 			auto index = static_cast<uint32_t> (value.key.number () & static_cast<uint32_t> (-1));
-			prv = deterministic_key (transaction, index);
+			prv = nano::deterministic_key (seed_l, index);
 			break;
 		}
 		case key_type::adhoc:
 		{
-			nano::raw_key password_l;
-			wallet_key (password_l, transaction);
-			prv.decrypt (value.key, password_l, pub.owords[0].number ());
+			prv = cipher.value ().decrypt (value.key, pub.owords[0]);
 			break;
 		}
 		default:
@@ -453,6 +481,21 @@ nano::uint256_union wallet_store::salt (nano::store::transaction const & transac
 	return value.key;
 }
 
+nano::result<wallet_cipher> wallet_store::unlock (nano::store::transaction const & transaction_a) const
+{
+	nano::raw_key wallet_key_l;
+	wallet_key (wallet_key_l, transaction_a);
+	nano::raw_key zero{};
+	zero.clear ();
+	nano::uint256_union check_l{};
+	check_l.encrypt (zero, wallet_key_l, salt (transaction_a).owords[check_iv_index]);
+	if (check (transaction_a) != check_l)
+	{
+		return nano::error (nano::error_common::wallet_locked);
+	}
+	return wallet_cipher{ wallet_key_l };
+}
+
 void wallet_store::wallet_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a) const
 {
 	nano::lock_guard<std::recursive_mutex> lock{ mutex };
@@ -465,21 +508,17 @@ void wallet_store::wallet_key (nano::raw_key & prv_a, nano::store::transaction c
 
 nano::raw_key wallet_store::seed (nano::store::transaction const & transaction) const
 {
-	release_assert (valid_password (transaction), "wallet is locked or password is invalid");
+	auto cipher = unlock (transaction);
+	release_assert (cipher, "wallet is locked or password is invalid");
 	nano::wallet::wallet_value value (entry_get_raw (transaction, wallet_store::seed_special));
-	nano::raw_key password;
-	wallet_key (password, transaction);
-	nano::raw_key result;
-	result.decrypt (value.key, password, salt (transaction).owords[seed_iv_index]);
-	return result;
+	return cipher.value ().decrypt (value.key, salt (transaction).owords[seed_iv_index]);
 }
 
 void wallet_store::seed_set (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv_a)
 {
-	nano::raw_key password_l;
-	wallet_key (password_l, transaction_a);
-	nano::raw_key ciphertext;
-	ciphertext.encrypt (prv_a, password_l, salt (transaction_a).owords[seed_iv_index]);
+	auto cipher = unlock (transaction_a);
+	release_assert (cipher, "wallet is locked or password is invalid");
+	auto ciphertext = cipher.value ().encrypt (prv_a, salt (transaction_a).owords[seed_iv_index]);
 	entry_put_raw (transaction_a, wallet_store::seed_special, nano::wallet::wallet_value (ciphertext, 0));
 	deterministic_clear (transaction_a);
 }
@@ -517,8 +556,10 @@ nano::public_key wallet_store::deterministic_insert (nano::store::write_transact
 
 nano::raw_key wallet_store::deterministic_key (nano::store::transaction const & transaction, uint32_t index) const
 {
-	release_assert (valid_password (transaction), "wallet is locked or password is invalid");
-	auto wallet_seed = seed (transaction);
+	auto cipher = unlock (transaction);
+	release_assert (cipher, "wallet is locked or password is invalid");
+	auto encrypted_seed = entry_get_raw (transaction, wallet_store::seed_special).key;
+	auto wallet_seed = cipher.value ().decrypt (encrypted_seed, salt (transaction).owords[seed_iv_index]);
 	return nano::deterministic_key (wallet_seed, index);
 }
 
@@ -561,14 +602,7 @@ void wallet_store::deterministic_clear (nano::store::write_transaction const & t
 
 bool wallet_store::valid_password (nano::store::transaction const & transaction_a) const
 {
-	nano::raw_key zero;
-	zero.clear ();
-	nano::raw_key wallet_key_l;
-	wallet_key (wallet_key_l, transaction_a);
-	nano::uint256_union check_l;
-	check_l.encrypt (zero, wallet_key_l, salt (transaction_a).owords[check_iv_index]);
-	bool ok = check (transaction_a) == check_l;
-	return ok;
+	return unlock (transaction_a).has_value ();
 }
 
 bool wallet_store::attempt_password (nano::store::transaction const & transaction_a, std::string const & password_a)
@@ -597,28 +631,18 @@ bool wallet_store::attempt_password (nano::store::transaction const & transactio
 bool wallet_store::rekey (nano::store::write_transaction const & transaction_a, std::string const & password_a)
 {
 	nano::lock_guard<std::recursive_mutex> lock{ mutex };
-	bool result (false);
-	if (valid_password (transaction_a))
+	auto cipher = unlock (transaction_a);
+	if (!cipher)
 	{
-		nano::raw_key password_new;
-		derive_key (password_new, transaction_a, password_a);
-		nano::raw_key wallet_key_l;
-		wallet_key (wallet_key_l, transaction_a);
-		nano::raw_key password_l;
-		password.value (password_l);
-		password.value_set (password_new);
-		nano::raw_key encrypted;
-		encrypted.encrypt (wallet_key_l, password_new, salt (transaction_a).owords[0]);
-		nano::raw_key wallet_enc;
-		wallet_enc = encrypted;
-		wallet_key_mem.value_set (wallet_enc);
-		entry_put_raw (transaction_a, wallet_store::wallet_key_special, nano::wallet::wallet_value (encrypted, 0));
+		return true;
 	}
-	else
-	{
-		result = true;
-	}
-	return result;
+	nano::raw_key password_new;
+	derive_key (password_new, transaction_a, password_a);
+	auto encrypted = cipher.value ().reseal (password_new, salt (transaction_a).owords[0]);
+	password.value_set (password_new);
+	wallet_key_mem.value_set (encrypted);
+	entry_put_raw (transaction_a, wallet_store::wallet_key_special, nano::wallet::wallet_value (encrypted, 0));
+	return false;
 }
 
 void wallet_store::derive_key (nano::raw_key & prv_a, nano::store::transaction const & transaction_a, std::string const & password_a) const

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -315,8 +315,7 @@ nano::result<nano::raw_key> wallet_store::fetch (nano::store::transaction const 
 	{
 		case key_type::deterministic:
 		{
-			auto encrypted_seed = entry_get_raw (transaction, wallet_store::seed_special).key;
-			auto seed_l = cipher.value ().decrypt (encrypted_seed, salt_get (transaction).owords[seed_iv_index]);
+			auto seed_l = seed_decrypt (transaction, cipher.value ());
 			auto index = static_cast<uint32_t> (value.key.number () & static_cast<uint32_t> (-1));
 			prv = nano::deterministic_key (seed_l, index);
 			break;
@@ -510,8 +509,13 @@ nano::raw_key wallet_store::seed (nano::store::transaction const & transaction) 
 {
 	auto cipher = unlock (transaction);
 	release_assert (cipher, "wallet is locked or password is invalid");
-	nano::wallet::wallet_value value (entry_get_raw (transaction, wallet_store::seed_special));
-	return cipher.value ().decrypt (value.key, salt_get (transaction).owords[seed_iv_index]);
+	return seed_decrypt (transaction, cipher.value ());
+}
+
+nano::raw_key wallet_store::seed_decrypt (nano::store::transaction const & transaction, nano::wallet::wallet_cipher const & cipher) const
+{
+	auto encrypted_seed = entry_get_raw (transaction, wallet_store::seed_special).key;
+	return cipher.decrypt (encrypted_seed, salt_get (transaction).owords[seed_iv_index]);
 }
 
 void wallet_store::seed_set (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv_a)
@@ -558,8 +562,7 @@ nano::raw_key wallet_store::deterministic_key (nano::store::transaction const & 
 {
 	auto cipher = unlock (transaction);
 	release_assert (cipher, "wallet is locked or password is invalid");
-	auto encrypted_seed = entry_get_raw (transaction, wallet_store::seed_special).key;
-	auto wallet_seed = cipher.value ().decrypt (encrypted_seed, salt_get (transaction).owords[seed_iv_index]);
+	auto wallet_seed = seed_decrypt (transaction, cipher.value ());
 	return nano::deterministic_key (wallet_seed, index);
 }
 

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -480,7 +480,7 @@ nano::uint256_union wallet_store::salt_get (nano::store::transaction const & tra
 	return value.key;
 }
 
-nano::result<wallet_cipher> wallet_store::unlock (nano::store::transaction const & transaction_a) const
+std::optional<wallet_cipher> wallet_store::unlock (nano::store::transaction const & transaction_a) const
 {
 	auto const wallet_key_l = wallet_key_decrypt (transaction_a);
 	nano::raw_key zero{};
@@ -489,7 +489,7 @@ nano::result<wallet_cipher> wallet_store::unlock (nano::store::transaction const
 	check_l.encrypt (zero, wallet_key_l, salt_get (transaction_a).owords[check_iv_index]);
 	if (check_value_get (transaction_a) != check_l)
 	{
-		return nano::error (nano::error_common::wallet_locked);
+		return std::nullopt;
 	}
 	return wallet_cipher{ wallet_key_l };
 }

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -63,7 +63,7 @@ public:
 
 	// Returns a cipher if the password decrypts the wallet key correctly.
 	// The cipher is the only way to encrypt/decrypt account data.
-	nano::result<nano::wallet::wallet_cipher> unlock (nano::store::transaction const &) const;
+	std::optional<nano::wallet::wallet_cipher> unlock (nano::store::transaction const &) const;
 
 	std::vector<nano::account> accounts (nano::store::transaction const &) const;
 	bool rekey (nano::store::write_transaction const &, std::string const & password);

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -66,7 +66,6 @@ public:
 	nano::result<nano::wallet::wallet_cipher> unlock (nano::store::transaction const &) const;
 
 	std::vector<nano::account> accounts (nano::store::transaction const &) const;
-	nano::uint256_union check (nano::store::transaction const &) const;
 	bool rekey (nano::store::write_transaction const &, std::string const & password);
 	bool valid_password (nano::store::transaction const &) const;
 	bool valid_public_key (nano::public_key const &) const;
@@ -80,7 +79,8 @@ public:
 	uint32_t deterministic_index_get (nano::store::transaction const &) const;
 	void deterministic_index_set (nano::store::write_transaction const &, uint32_t index);
 	void deterministic_clear (nano::store::write_transaction const &);
-	nano::uint256_union salt (nano::store::transaction const &) const;
+	nano::uint256_union salt_get (nano::store::transaction const &) const;
+	nano::uint256_union check_value_get (nano::store::transaction const &) const;
 	bool is_representative (nano::store::transaction const &) const;
 	nano::account representative (nano::store::transaction const &) const;
 	void representative_set (nano::store::write_transaction const &, nano::account const & rep);

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -30,6 +30,28 @@ enum class key_type
 	deterministic
 };
 
+class wallet_store;
+
+/**
+ * Validated handle for wallet-key crypto. The only way to obtain one is via wallet_store::unlock(), which has therefore already validated the password.
+ * The cipher exposes encrypt/decrypt but never the underlying wallet key, so it is impossible to encrypt or decrypt with an unvalidated key.
+ */
+class wallet_cipher final
+{
+public:
+	nano::raw_key encrypt (nano::raw_key const & plaintext, nano::uint128_union const & iv) const;
+	nano::raw_key decrypt (nano::uint256_union const & ciphertext, nano::uint128_union const & iv) const;
+
+	// Re-encrypt the wallet key under a new password key. Used by rekey.
+	nano::raw_key reseal (nano::raw_key const & new_password_key, nano::uint128_union const & iv) const;
+
+private:
+	friend class wallet_store;
+	explicit wallet_cipher (nano::raw_key wallet_key);
+
+	nano::raw_key wallet_key;
+};
+
 class wallet_store final
 {
 public:
@@ -39,13 +61,16 @@ public:
 	wallet_store (nano::kdf &, nano::store::write_transaction &, nano::wallet::wallets_backend &, nano::account representative, unsigned fanout, std::string const & wallet_path);
 	wallet_store (nano::kdf &, nano::store::write_transaction &, nano::wallet::wallets_backend &, unsigned fanout, std::string const & wallet_path, std::string const & json);
 
+	// Returns a cipher if the password decrypts the wallet key correctly.
+	// The cipher is the only way to encrypt/decrypt account data.
+	nano::result<nano::wallet::wallet_cipher> unlock (nano::store::transaction const &) const;
+
 	std::vector<nano::account> accounts (nano::store::transaction const &) const;
 	nano::uint256_union check (nano::store::transaction const &) const;
 	bool rekey (nano::store::write_transaction const &, std::string const & password);
 	bool valid_password (nano::store::transaction const &) const;
 	bool valid_public_key (nano::public_key const &) const;
 	bool attempt_password (nano::store::transaction const &, std::string const & password);
-	void wallet_key (nano::raw_key & result, nano::store::transaction const &) const;
 	nano::raw_key seed (nano::store::transaction const &) const;
 	void seed_set (nano::store::write_transaction const &, nano::raw_key const & seed);
 	nano::wallet::key_type key_type (nano::wallet::wallet_value const &) const;
@@ -87,6 +112,12 @@ public:
 	nano::kdf & kdf;
 	nano::locked<nano::wallet::wallet_handle> handle;
 	mutable std::recursive_mutex mutex;
+
+private:
+	// Decrypts the wallet key using whatever the live password fan currently is.
+	// Used only by unlock() and during construction; callers outside wallet_store
+	// must go through unlock() so that the password is validated first.
+	void wallet_key (nano::raw_key & result, nano::store::transaction const &) const;
 
 private:
 	nano::wallet::wallets_backend & backend;

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -117,7 +117,7 @@ private:
 	// Decrypts the wallet key using whatever the live password fan currently is.
 	// Used only by unlock() and during construction; callers outside wallet_store
 	// must go through unlock() so that the password is validated first.
-	void wallet_key (nano::raw_key & result, nano::store::transaction const &) const;
+	nano::raw_key wallet_key_decrypt (nano::store::transaction const &) const;
 
 private:
 	nano::wallet::wallets_backend & backend;

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -96,7 +96,7 @@ public:
 	iterator begin (nano::store::transaction const &, nano::account const & key) const;
 	iterator begin (nano::store::transaction const &) const;
 	iterator end (nano::store::transaction const &) const;
-	void derive_key (nano::raw_key & result, nano::store::transaction const &, std::string const & password) const;
+	nano::raw_key derive_key (nano::store::transaction const &, std::string const & password) const;
 	void serialize_json (nano::store::transaction const &, std::string & json) const;
 	void write_backup (nano::store::transaction const &, std::filesystem::path const & path) const;
 	nano::result<bool> move (nano::store::write_transaction const &, wallet_store & source, std::vector<nano::public_key> const & keys);

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -119,6 +119,10 @@ private:
 	// must go through unlock() so that the password is validated first.
 	nano::raw_key wallet_key_decrypt (nano::store::transaction const &) const;
 
+	// Decrypts the wallet seed using an already-unlocked cipher.
+	// Centralises the seed_special / seed_iv_index plumbing so callers can't drift.
+	nano::raw_key seed_decrypt (nano::store::transaction const &, nano::wallet::wallet_cipher const &) const;
+
 private:
 	nano::wallet::wallets_backend & backend;
 


### PR DESCRIPTION
This changes wallet-store crypto operations to go through a `wallet_cipher` returned by `wallet_store::unlock()` instead of exposing the decrypted wallet key directly.

The wallet cipher is only constructed after the current password has been validated against the wallet check value, and it exposes only the encryption operations needed by wallet code.

#### Why

Previously, wallet code could ask `wallet_store` for the decrypted wallet key directly and then use that key for encryption or decryption. Even when existing callers checked the password first, the API made it possible for future code to accidentally use a decrypted key without tying that use to password validation.

This PR makes the validation boundary explicit: code that wants to encrypt or decrypt wallet entries must first obtain a `wallet_cipher`, and obtaining that cipher requires a successful unlock. That keeps the raw wallet key out of the public wallet-store interface and makes misuse harder by construction.

This is specifically a wallet crypto interface hardening change. It does not change the wallet storage format.
