### PR TITLE
Add --database_upgrade CLI option

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1328,7 +1328,7 @@ TEST (block_store, default_database_backend)
 
 	auto store = nano::test::make_store ();
 
-	auto vendor = store->vendor_get ();
+	auto vendor = store->get_vendor ();
 	if (backend == nano::database_backend::rocksdb)
 	{
 		ASSERT_TRUE (vendor.find ("RocksDB") != std::string::npos);

--- a/nano/nano_node/benchmarks/benchmark_block_processing.cpp
+++ b/nano/nano_node/benchmarks/benchmark_block_processing.cpp
@@ -107,7 +107,7 @@ void run_block_processing_benchmark (boost::program_options::variables_map const
 	node->start ();
 
 	std::cout << "\nSystem Info:\n";
-	fmt::print ("  Backend: {}\n", node->store.vendor_get ());
+	fmt::print ("  Backend: {}\n", node->store.get_vendor ());
 	fmt::print ("  Block processor threads: {}\n", 1); // TODO: Log number of block processor threads when upstreamed
 	fmt::print ("  Block processor batch size: {}\n", node->config.block_processor->batch_size);
 	std::cout << "\n";

--- a/nano/nano_node/benchmarks/benchmark_cementing.cpp
+++ b/nano/nano_node/benchmarks/benchmark_cementing.cpp
@@ -105,7 +105,7 @@ void run_cementing_benchmark (boost::program_options::variables_map const & vm, 
 	node->start ();
 
 	fmt::print ("\nSystem Info:\n");
-	fmt::print ("  Backend: {}\n", node->store.vendor_get ());
+	fmt::print ("  Backend: {}\n", node->store.get_vendor ());
 	fmt::print ("\n");
 
 	// Wait for node to be ready

--- a/nano/nano_node/benchmarks/benchmark_elections.cpp
+++ b/nano/nano_node/benchmarks/benchmark_elections.cpp
@@ -131,7 +131,7 @@ void run_elections_benchmark (boost::program_options::variables_map const & vm, 
 	node->start ();
 
 	fmt::print ("\nSystem Info:\n");
-	fmt::print ("  Backend: {}\n", node->store.vendor_get ());
+	fmt::print ("  Backend: {}\n", node->store.get_vendor ());
 	fmt::print ("\n");
 
 	// Insert dev genesis representative key for voting

--- a/nano/nano_node/benchmarks/benchmark_pipeline.cpp
+++ b/nano/nano_node/benchmarks/benchmark_pipeline.cpp
@@ -130,7 +130,7 @@ void run_pipeline_benchmark (boost::program_options::variables_map const & vm, s
 	node->start ();
 
 	fmt::print ("\nSystem Info:\n");
-	fmt::print ("  Backend: {}\n", node->store.vendor_get ());
+	fmt::print ("  Backend: {}\n", node->store.get_vendor ());
 	fmt::print ("  Block processor threads: {}\n", 1); // TODO: Log number of block processor threads when upstreamed
 	fmt::print ("  Vote processor threads: {}\n", node->config.vote_processor->threads);
 	fmt::print ("  Active elections limit: {}\n", node->config.active_elections->size);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -1,7 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/cli.hpp>
 #include <nano/lib/files.hpp>
-#include <nano/lib/kdf.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/tomlconfig.hpp>
@@ -9,6 +8,7 @@
 #include <nano/node/daemonconfig.hpp>
 #include <nano/node/endpoint.hpp>
 #include <nano/node/inactive_node.hpp>
+#include <nano/node/make_store.hpp>
 #include <nano/node/migrations.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node.hpp>
@@ -72,6 +72,7 @@ void nano::add_node_options (boost::program_options::options_description & descr
 	("confirmation_height_clear", "Clear confirmation height. Requires an <account> option that can be 'all' to clear all accounts")
 	("final_vote_clear", "Clear final votes")
 	("migrate_database_lmdb_to_rocksdb", "Migrates LMDB database to RocksDB")
+	("database_upgrade", "Upgrade the ledger database to the latest version without starting the node")
 	("rollback", "Rolls back the specified block hash, effectively removing this block and all blocks following it")
 	("diagnostics", "Run internal diagnostics")
 	("generate_config", boost::program_options::value<std::string> (), "Write configuration to stdout, populated with defaults suitable for this system. Pass the configuration type node, rpc or log. See also use_defaults.")
@@ -522,6 +523,41 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 		{
 			nano::default_logger ().error (nano::log::type::migration, "Migration failed: {}", e.what ());
 			std::cerr << "Migration failed: " << e.what () << std::endl;
+		}
+	}
+	else if (vm.count ("database_upgrade"))
+	{
+		nano::logger::initialize (nano::log_config::daemon_default (), data_path);
+
+		nano::network_params network_params{ nano::get_active_network () };
+		nano::daemon_config daemon_config{ data_path, network_params };
+
+		auto config_arg (vm.find ("config"));
+		std::vector<std::string> config_overrides;
+		if (config_arg != vm.end ())
+		{
+			config_overrides = nano::config_overrides (config_arg->second.as<std::vector<nano::config_key_value_pair>> ());
+		}
+
+		if (auto error = nano::read_node_config_toml (data_path, daemon_config, config_overrides))
+		{
+			std::cerr << "Error reading config: " << error.get_message () << std::endl;
+			ec = nano::error_cli::reading_config;
+		}
+		else
+		{
+			try
+			{
+				auto & logger = nano::default_logger ();
+				nano::stats stats{ logger };
+				auto store = nano::make_store (logger, stats, data_path, network_params.ledger, false, true, daemon_config.node);
+				std::cout << "Database upgrade completed successfully" << std::endl;
+			}
+			catch (std::exception const & e)
+			{
+				std::cerr << "Database upgrade failed: " << e.what () << std::endl;
+				ec = nano::error_cli::generic;
+			}
 		}
 	}
 	else if (vm.count ("rollback"))

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -552,6 +552,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 				nano::stats stats{ logger };
 				auto store = nano::make_store (logger, stats, data_path, network_params.ledger, false, true, daemon_config.node);
 				std::cout << "Database upgrade completed successfully" << std::endl;
+				std::cout << "Database version: " << store->get_version () << " (" << store->get_vendor () << ")" << std::endl;
 			}
 			catch (std::exception const & e)
 			{

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4343,7 +4343,7 @@ void nano::json_handler::version ()
 	response_l.put ("store_version", std::to_string (node.store_version ()));
 	response_l.put ("protocol_version", std::to_string (node.network_params.network.protocol_version));
 	response_l.put ("node_vendor", boost::str (boost::format ("Nano %1%") % NANO_VERSION_STRING));
-	response_l.put ("store_vendor", node.store.vendor_get ());
+	response_l.put ("store_vendor", node.store.get_vendor ());
 	response_l.put ("network", node.network_params.network.get_current_network_as_string ());
 	response_l.put ("network_identifier", node.network_params.ledger.genesis->hash ().to_string ());
 	response_l.put ("build_info", BUILD_INFO);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -335,7 +335,7 @@ nano::node::node (std::filesystem::path const & application_path_a, nano::node_c
 	logger.info (nano::log::type::node, "Version: {}", NANO_VERSION_STRING);
 	logger.info (nano::log::type::node, "Build information: {}", BUILD_INFO);
 	logger.info (nano::log::type::node, "Active network: {}", network_label);
-	logger.info (nano::log::type::node, "Database backend: {}", store.vendor_get ());
+	logger.info (nano::log::type::node, "Database backend: {}", store.get_vendor ());
 	logger.info (nano::log::type::node, "Data path: {}", application_path.string ());
 	logger.info (nano::log::type::node, "Ledger path: {}", store.get_database_path ().string ());
 	logger.info (nano::log::type::node, "Work pool threads: {} ({})", work.threads.size (), (work.opencl ? "OpenCL" : "CPU"));

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1859,7 +1859,7 @@ TEST (rpc, version)
 	}
 	ASSERT_EQ (std::to_string (node1->network_params.network.protocol_version), response1.json.get<std::string> ("protocol_version"));
 	ASSERT_EQ (boost::str (boost::format ("Nano %1%") % NANO_VERSION_STRING), response1.json.get<std::string> ("node_vendor"));
-	ASSERT_EQ (node1->store.vendor_get (), response1.json.get<std::string> ("store_vendor"));
+	ASSERT_EQ (node1->store.get_vendor (), response1.json.get<std::string> ("store_vendor"));
 	auto network_label (node1->network_params.network.get_current_network_as_string ());
 	ASSERT_EQ (network_label, response1.json.get<std::string> ("network"));
 	auto genesis_open (node1->latest (nano::dev::genesis_key.pub));

--- a/nano/store/backend.hpp
+++ b/nano/store/backend.hpp
@@ -123,7 +123,7 @@ public:
 	// Helper methods
 	void release_assert_success (int status) const;
 
-	virtual std::string vendor_get () const = 0;
+	virtual std::string get_vendor () const = 0;
 	virtual std::string get_database_path () const = 0;
 
 	std::optional<nano::store::open_mode> get_mode () const;

--- a/nano/store/ledger_store.cpp
+++ b/nano/store/ledger_store.cpp
@@ -215,9 +215,14 @@ void ledger_store::perform_upgrades (nano::store::backend_meta meta)
 	}
 }
 
-std::string ledger_store::vendor_get () const
+uint64_t ledger_store::get_version () const
 {
-	return backend.vendor_get ();
+	return version.get (backend.tx_begin_read ());
+}
+
+std::string ledger_store::get_vendor () const
+{
+	return backend.get_vendor ();
 }
 
 std::filesystem::path ledger_store::get_database_path () const

--- a/nano/store/ledger_store.hpp
+++ b/nano/store/ledger_store.hpp
@@ -32,7 +32,8 @@ public:
 
 	uint64_t count (nano::store::transaction const &, nano::store::table) const;
 
-	std::string vendor_get () const;
+	uint64_t get_version () const;
+	std::string get_vendor () const;
 	std::filesystem::path get_database_path () const;
 	nano::store::open_mode get_mode () const;
 

--- a/nano/store/lmdb/backend_lmdb.cpp
+++ b/nano/store/lmdb/backend_lmdb.cpp
@@ -247,7 +247,7 @@ void backend_lmdb::copy_with_compaction (std::filesystem::path const & destinati
 	}
 }
 
-std::string backend_lmdb::vendor_get () const
+std::string backend_lmdb::get_vendor () const
 {
 	return boost::str (boost::format ("LMDB %1%.%2%.%3%") % MDB_VERSION_MAJOR % MDB_VERSION_MINOR % MDB_VERSION_PATCH);
 }

--- a/nano/store/lmdb/backend_lmdb.hpp
+++ b/nano/store/lmdb/backend_lmdb.hpp
@@ -46,7 +46,7 @@ public:
 
 	void collect_memory_stats (boost::property_tree::ptree &) const override;
 
-	std::string vendor_get () const override;
+	std::string get_vendor () const override;
 	std::string get_database_path () const override;
 
 protected:

--- a/nano/store/rocksdb/backend_rocksdb.cpp
+++ b/nano/store/rocksdb/backend_rocksdb.cpp
@@ -609,7 +609,7 @@ void backend_rocksdb::copy_with_compaction (std::filesystem::path const & destin
 	// Opening a database causes WAL to be flushed
 }
 
-std::string backend_rocksdb::vendor_get () const
+std::string backend_rocksdb::get_vendor () const
 {
 	return boost::str (boost::format ("RocksDB %1%.%2%.%3%") % ROCKSDB_MAJOR % ROCKSDB_MINOR % ROCKSDB_PATCH);
 }

--- a/nano/store/rocksdb/backend_rocksdb.hpp
+++ b/nano/store/rocksdb/backend_rocksdb.hpp
@@ -53,7 +53,7 @@ public:
 
 	void collect_memory_stats (boost::property_tree::ptree &) const override;
 
-	std::string vendor_get () const override;
+	std::string get_vendor () const override;
 	std::string get_database_path () const override;
 
 protected:


### PR DESCRIPTION
Adds a new `--database_upgrade` CLI option that opens the ledger store, runs any pending schema migrations, and exits — without starting the node. Useful for performing the upgrade step out-of-band before launching the daemon.

## CLI changes

### New option

- `--database_upgrade` — Upgrade the ledger database to the latest version without starting the node.

### Behavior

- Reads the node config from the standard data path (respects `--config <key=value>` overrides and `--data_path`).
- Opens the store, applies migrations, then closes.
- Exits with success or a non-zero error code on failure.

### Output

On success:
```
Database upgrade completed successfully
Database version: <N> (<backend>)
```
where `<backend>` is `lmdb` or `rocksdb`.

On failure:
```
Database upgrade failed: <reason>
```
or, if the config can't be read:
```
Error reading config: <reason>
```