### PR TITLE
Replace boost::optional with std::optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,7 +423,6 @@ set(BOOST_INCLUDE_LIBRARIES
     lexical_cast
     multi_index
     multiprecision
-    optional
     outcome
     pool
     process

--- a/nano/core_test/conflicts.cpp
+++ b/nano/core_test/conflicts.cpp
@@ -13,8 +13,6 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/variant/get.hpp>
-
 using namespace std::chrono_literals;
 
 TEST (conflicts, start_stop)

--- a/nano/core_test/fakes/websocket_client.hpp
+++ b/nano/core_test/fakes/websocket_client.hpp
@@ -7,6 +7,7 @@
 #include <nano/node/websocket.hpp>
 
 #include <chrono>
+#include <optional>
 
 using namespace std::chrono_literals;
 
@@ -50,10 +51,10 @@ public:
 		socket->read (buffer);
 	}
 
-	boost::optional<std::string> get_response (std::chrono::seconds const deadline = 5s)
+	std::optional<std::string> get_response (std::chrono::seconds const deadline = 5s)
 	{
 		debug_assert (deadline > 0s);
-		boost::optional<std::string> result;
+		std::optional<std::string> result;
 		auto buffer (std::make_shared<boost::beast::flat_buffer> ());
 		socket->async_read (*buffer, [&result, &buffer, socket = this->socket] (boost::beast::error_code const & ec, std::size_t const /*n*/) {
 			if (!ec)

--- a/nano/core_test/fakes/work_peer.hpp
+++ b/nano/core_test/fakes/work_peer.hpp
@@ -143,7 +143,7 @@ private:
 		{
 			auto hash = hash_a;
 			auto request_difficulty = work_pool.network_constants.work.threshold_base (version);
-			work_pool.generate (version, hash, request_difficulty, [this_l = shared_from_this (), hash] (boost::optional<uint64_t> work_a) {
+			work_pool.generate (version, hash, request_difficulty, [this_l = shared_from_this (), hash] (std::optional<uint64_t> work_a) {
 				auto result = work_a.value_or (0);
 				auto result_difficulty (this_l->work_pool.network_constants.work.difficulty (this_l->version, hash, result));
 				ptree::ptree message_l;

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -87,7 +87,7 @@ TEST (websocket, confirmation)
 		EXPECT_TRUE (response);
 		boost::property_tree::ptree event;
 		std::stringstream stream;
-		stream << response.get ();
+		stream << response.value ();
 		boost::property_tree::read_json (stream, event);
 		EXPECT_EQ (event.get<std::string> ("topic"), "confirmation");
 		client.send_message (R"json({"action": "unsubscribe", "topic": "confirmation", "ack": true})json");
@@ -185,7 +185,7 @@ TEST (websocket, started_election)
 	ASSERT_TRUE (response);
 	boost::property_tree::ptree event;
 	std::stringstream stream;
-	stream << response.get ();
+	stream << response.value ();
 	boost::property_tree::read_json (stream, event);
 	ASSERT_EQ (event.get<std::string> ("topic"), "started_election");
 }
@@ -235,7 +235,7 @@ TEST (websocket, stopped_election)
 	ASSERT_TRUE (response);
 	boost::property_tree::ptree event;
 	std::stringstream stream;
-	stream << response.get ();
+	stream << response.value ();
 	boost::property_tree::read_json (stream, event);
 	ASSERT_EQ (event.get<std::string> ("topic"), "stopped_election");
 }
@@ -325,7 +325,7 @@ TEST (websocket, confirmation_options)
 	ASSERT_TRUE (response2);
 	boost::property_tree::ptree event;
 	std::stringstream stream;
-	stream << response2.get ();
+	stream << response2.value ();
 	boost::property_tree::read_json (stream, event);
 	ASSERT_EQ (event.get<std::string> ("topic"), "confirmation");
 	try
@@ -343,7 +343,7 @@ TEST (websocket, confirmation_options)
 		ASSERT_NE ("0", tally);
 		ASSERT_NE ("0", time);
 		auto votes_l (election_info.get_child_optional ("votes"));
-		ASSERT_FALSE (votes_l.is_initialized ());
+		ASSERT_FALSE (votes_l.has_value ());
 	}
 	catch (std::runtime_error const & ex)
 	{
@@ -434,7 +434,7 @@ TEST (websocket, confirmation_options_votes)
 	ASSERT_TRUE (response1);
 	boost::property_tree::ptree event;
 	std::stringstream stream;
-	stream << response1.get ();
+	stream << response1.value ();
 	boost::property_tree::read_json (stream, event);
 	ASSERT_EQ (event.get<std::string> ("topic"), "confirmation");
 	try
@@ -451,9 +451,9 @@ TEST (websocket, confirmation_options_votes)
 		ASSERT_NE ("0", tally);
 		ASSERT_NE ("0", time);
 		auto votes_l (election_info.get_child_optional ("votes"));
-		ASSERT_TRUE (votes_l.is_initialized ());
-		ASSERT_EQ (1, votes_l.get ().size ());
-		for (auto & vote : votes_l.get ())
+		ASSERT_TRUE (votes_l.has_value ());
+		ASSERT_EQ (1, votes_l.value ().size ());
+		for (auto & vote : votes_l.value ())
 		{
 			std::string representative (vote.second.get<std::string> ("representative"));
 			ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), representative);
@@ -521,7 +521,7 @@ TEST (websocket, confirmation_options_linked_account)
 	ASSERT_TRUE (response1);
 	boost::property_tree::ptree event;
 	std::stringstream stream;
-	stream << response1.get ();
+	stream << response1.value ();
 	boost::property_tree::read_json (stream, event);
 	ASSERT_EQ (event.get<std::string> ("topic"), "confirmation");
 	try
@@ -574,7 +574,7 @@ TEST (websocket, confirmation_options_linked_account)
 	ASSERT_TRUE (response2);
 	boost::property_tree::ptree event2;
 	std::stringstream stream2;
-	stream2 << response2.get ();
+	stream2 << response2.value ();
 	boost::property_tree::read_json (stream2, event2);
 	ASSERT_EQ (event2.get<std::string> ("topic"), "confirmation");
 	try
@@ -625,7 +625,7 @@ TEST (websocket, confirmation_options_linked_account)
 	ASSERT_TRUE (response3);
 	boost::property_tree::ptree event3;
 	std::stringstream stream3;
-	stream3 << response3.get ();
+	stream3 << response3.value ();
 	boost::property_tree::read_json (stream3, event3);
 	ASSERT_EQ (event3.get<std::string> ("topic"), "confirmation");
 	try
@@ -692,7 +692,7 @@ TEST (websocket, confirmation_options_sideband)
 	ASSERT_TRUE (response1);
 	boost::property_tree::ptree event;
 	std::stringstream stream;
-	stream << response1.get ();
+	stream << response1.value ();
 	boost::property_tree::read_json (stream, event);
 	ASSERT_EQ (event.get<std::string> ("topic"), "confirmation");
 	try
@@ -831,7 +831,7 @@ TEST (websocket, vote)
 	ASSERT_TRUE (response);
 	boost::property_tree::ptree event;
 	std::stringstream stream;
-	stream << response;
+	stream << response.value ();
 	boost::property_tree::read_json (stream, event);
 	ASSERT_EQ (event.get<std::string> ("topic"), "vote");
 	auto message_contents = event.get_child ("message");
@@ -883,7 +883,7 @@ TEST (websocket, vote_options_type)
 	ASSERT_TRUE (response);
 	boost::property_tree::ptree event;
 	std::stringstream stream;
-	stream << response;
+	stream << response.value ();
 	boost::property_tree::read_json (stream, event);
 	auto message_contents = event.get_child ("message");
 	ASSERT_EQ (1, message_contents.count ("type"));
@@ -911,7 +911,7 @@ TEST (websocket, vote_options_representatives)
 		EXPECT_TRUE (response);
 		boost::property_tree::ptree event;
 		std::stringstream stream;
-		stream << response;
+		stream << response.value ();
 		boost::property_tree::read_json (stream, event);
 		EXPECT_EQ (event.get<std::string> ("topic"), "vote");
 	});
@@ -1004,7 +1004,7 @@ TEST (websocket, work)
 	auto response = future.get ();
 	ASSERT_TRUE (response);
 	std::stringstream stream;
-	stream << response;
+	stream << response.value ();
 	boost::property_tree::ptree event;
 	boost::property_tree::read_json (stream, event);
 	ASSERT_EQ (event.get<std::string> ("topic"), "work");
@@ -1092,7 +1092,7 @@ TEST (websocket, telemetry)
 	auto response = future.get ();
 
 	std::stringstream stream;
-	stream << response;
+	stream << response.value ();
 	boost::property_tree::ptree event;
 	boost::property_tree::read_json (stream, event);
 	ASSERT_EQ (event.get<std::string> ("topic"), "telemetry");
@@ -1152,10 +1152,10 @@ TEST (websocket, new_unconfirmed_block)
 	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 
 	// Check the response
-	boost::optional<std::string> response = future.get ();
+	std::optional<std::string> response = future.get ();
 	ASSERT_TRUE (response);
 	std::stringstream stream;
-	stream << response;
+	stream << response.value ();
 	boost::property_tree::ptree event;
 	boost::property_tree::read_json (stream, event);
 	ASSERT_EQ (event.get<std::string> ("topic"), "new_unconfirmed_block");
@@ -1198,8 +1198,8 @@ TEST (websocket, confirmation_options_independent)
 	// Set up two concurrent tasks to subscribe with different options and wait for responses
 	std::atomic<bool> client1_done{ false };
 	std::atomic<bool> client2_done{ false };
-	boost::optional<std::string> client1_response;
-	boost::optional<std::string> client2_response;
+	std::optional<std::string> client1_response;
+	std::optional<std::string> client2_response;
 
 	// Client 1: Subscribe with include_block = true but no sideband
 	auto client1_task = ([&client1_done, &client1_response, &node1] () {
@@ -1241,7 +1241,7 @@ TEST (websocket, confirmation_options_independent)
 	// Parse and check client1 response (should have block but no sideband)
 	boost::property_tree::ptree event1;
 	std::stringstream stream1;
-	stream1 << client1_response.get ();
+	stream1 << client1_response.value ();
 	boost::property_tree::read_json (stream1, event1);
 	ASSERT_EQ (event1.get<std::string> ("topic"), "confirmation");
 
@@ -1252,7 +1252,7 @@ TEST (websocket, confirmation_options_independent)
 	// Parse and check client2 response (should have both block AND sideband)
 	boost::property_tree::ptree event2;
 	std::stringstream stream2;
-	stream2 << client2_response.get ();
+	stream2 << client2_response.value ();
 	boost::property_tree::read_json (stream2, event2);
 	ASSERT_EQ (event2.get<std::string> ("topic"), "confirmation");
 

--- a/nano/core_test/work_pool.cpp
+++ b/nano/core_test/work_pool.cpp
@@ -36,7 +36,7 @@ TEST (work, disabled)
 {
 	nano::work_pool pool{ nano::dev::network_params.network, 0 };
 	auto result (pool.generate (nano::block_hash ()));
-	ASSERT_FALSE (result.is_initialized ());
+	ASSERT_FALSE (result.has_value ());
 }
 
 // create a block with bad pow then fix it and check that it validates
@@ -66,7 +66,7 @@ TEST (work, cancel)
 	auto done = false;
 	while (!done)
 	{
-		pool.generate (nano::work_version::work_1, key, nano::dev::network_params.work.base, [&done] (boost::optional<uint64_t> work_a) {
+		pool.generate (nano::work_version::work_1, key, nano::dev::network_params.work.base, [&done] (std::optional<uint64_t> work_a) {
 			done = !work_a;
 		});
 		pool.cancel (key);
@@ -84,12 +84,12 @@ TEST (work, cancel_one_out_of_many)
 	nano::root key4 (1);
 	nano::root key5 (3);
 	nano::root key6 (1);
-	pool.generate (nano::work_version::work_1, key1, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key2, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key3, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key4, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key5, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
-	pool.generate (nano::work_version::work_1, key6, nano::dev::network_params.work.base, [] (boost::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key1, nano::dev::network_params.work.base, [] (std::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key2, nano::dev::network_params.work.base, [] (std::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key3, nano::dev::network_params.work.base, [] (std::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key4, nano::dev::network_params.work.base, [] (std::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key5, nano::dev::network_params.work.base, [] (std::optional<uint64_t>) {});
+	pool.generate (nano::work_version::work_1, key6, nano::dev::network_params.work.base, [] (std::optional<uint64_t>) {});
 	pool.cancel (key1);
 }
 
@@ -127,7 +127,7 @@ TEST (work, opencl)
 		nano::random_pool::generate_block (root.bytes.data (), root.bytes.size ());
 		auto nonce_opt = pool.generate (nano::work_version::work_1, root, difficulty);
 		ASSERT_TRUE (nonce_opt.has_value ());
-		auto nonce = nonce_opt.get ();
+		auto nonce = nonce_opt.value ();
 		ASSERT_GE (nano::dev::network_params.work.difficulty (nano::work_version::work_1, root, nonce), difficulty);
 		difficulty += difficulty_add;
 	}

--- a/nano/lib/jsonconfig.cpp
+++ b/nano/lib/jsonconfig.cpp
@@ -108,9 +108,9 @@ bool nano::jsonconfig::empty () const
 	return tree.empty ();
 }
 
-boost::optional<nano::jsonconfig> nano::jsonconfig::get_optional_child (std::string const & key_a)
+std::optional<nano::jsonconfig> nano::jsonconfig::get_optional_child (std::string const & key_a)
 {
-	boost::optional<jsonconfig> child_config;
+	std::optional<jsonconfig> child_config;
 	auto child = tree.get_child_optional (key_a);
 	if (child)
 	{

--- a/nano/lib/jsonconfig.hpp
+++ b/nano/lib/jsonconfig.hpp
@@ -9,6 +9,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <optional>
 
 namespace boost
 {
@@ -37,7 +38,7 @@ public:
 	void create_backup_file (std::filesystem::path const & filepath_a);
 	boost::property_tree::ptree const & get_tree ();
 	bool empty () const;
-	boost::optional<jsonconfig> get_optional_child (std::string const & key_a);
+	std::optional<jsonconfig> get_optional_child (std::string const & key_a);
 	jsonconfig get_required_child (std::string const & key_a);
 	jsonconfig & put_child (std::string const & key_a, nano::jsonconfig & conf_a);
 	jsonconfig & replace_child (std::string const & key_a, nano::jsonconfig & conf_a);
@@ -92,11 +93,11 @@ public:
 		return *this;
 	}
 
-	/** Return a boost::optional<T> for the given key */
+	/** Return a std::optional<T> for the given key */
 	template <typename T>
-	boost::optional<T> get_optional (std::string const & key)
+	std::optional<T> get_optional (std::string const & key)
 	{
-		boost::optional<T> res;
+		std::optional<T> res;
 		if (has_key (key))
 		{
 			T target{};

--- a/nano/lib/tomlconfig.cpp
+++ b/nano/lib/tomlconfig.cpp
@@ -101,9 +101,9 @@ bool nano::tomlconfig::empty () const
 	return tree->empty ();
 }
 
-boost::optional<nano::tomlconfig> nano::tomlconfig::get_optional_child (std::string const & key_a)
+std::optional<nano::tomlconfig> nano::tomlconfig::get_optional_child (std::string const & key_a)
 {
-	boost::optional<tomlconfig> child_config;
+	std::optional<tomlconfig> child_config;
 	if (tree->contains (key_a))
 	{
 		return tomlconfig (tree->get_table (key_a), error);
@@ -151,7 +151,7 @@ nano::tomlconfig & nano::tomlconfig::erase (std::string const & key_a)
 	return *this;
 }
 
-std::shared_ptr<cpptoml::array> nano::tomlconfig::create_array (std::string const & key, boost::optional<char const *> documentation_a)
+std::shared_ptr<cpptoml::array> nano::tomlconfig::create_array (std::string const & key, std::optional<char const *> documentation_a)
 {
 	if (!has_key (key))
 	{

--- a/nano/lib/tomlconfig.hpp
+++ b/nano/lib/tomlconfig.hpp
@@ -4,9 +4,9 @@
 #include <nano/lib/utility.hpp>
 
 #include <boost/lexical_cast.hpp>
-#include <boost/optional.hpp>
 
 #include <filesystem>
+#include <optional>
 
 #include <cpptoml.h>
 
@@ -42,20 +42,20 @@ public:
 	void open_or_create (std::fstream & stream_a, std::string const & path_a);
 	std::shared_ptr<cpptoml::table> get_tree ();
 	bool empty () const;
-	boost::optional<tomlconfig> get_optional_child (std::string const & key_a);
+	std::optional<tomlconfig> get_optional_child (std::string const & key_a);
 	tomlconfig get_required_child (std::string const & key_a);
 	tomlconfig & put_child (std::string const & key_a, nano::tomlconfig & conf_a);
 	tomlconfig & replace_child (std::string const & key_a, nano::tomlconfig & conf_a);
 	bool has_key (std::string const & key_a);
 	tomlconfig & erase (std::string const & key_a);
-	std::shared_ptr<cpptoml::array> create_array (std::string const & key, boost::optional<char const *> documentation_a);
+	std::shared_ptr<cpptoml::array> create_array (std::string const & key, std::optional<char const *> documentation_a);
 	void erase_default_values (tomlconfig & defaults_a);
 	std::string to_string (bool comment_values);
 	std::string merge_defaults (nano::tomlconfig & current_config, nano::tomlconfig & default_config);
 
 	/** Set value for the given key. Any existing value will be overwritten. */
 	template <typename T>
-	tomlconfig & put (std::string const & key, T const & value, boost::optional<char const *> documentation_a = boost::none)
+	tomlconfig & put (std::string const & key, T const & value, std::optional<char const *> documentation_a = std::nullopt)
 	{
 		tree->insert (key, value);
 		if (documentation_a)
@@ -123,11 +123,11 @@ public:
 		return *this;
 	}
 
-	/** Return a boost::optional<T> for the given key */
+	/** Return a std::optional<T> for the given key */
 	template <typename T>
-	boost::optional<T> get_optional (std::string const & key)
+	std::optional<T> get_optional (std::string const & key)
 	{
-		boost::optional<T> res;
+		std::optional<T> res;
 		if (has_key (key))
 		{
 			T target{};

--- a/nano/lib/work.cpp
+++ b/nano/lib/work.cpp
@@ -85,12 +85,12 @@ void nano::work_pool::loop (uint64_t thread)
 			int ticket_l (ticket);
 			lock.unlock ();
 			output = 0;
-			boost::optional<uint64_t> opt_work;
+			std::optional<uint64_t> opt_work;
 			if (thread == 0 && opencl)
 			{
 				opt_work = opencl (current_l.version, current_l.item, current_l.difficulty, ticket);
 			}
-			if (opt_work.is_initialized ())
+			if (opt_work.has_value ())
 			{
 				work = *opt_work;
 				output = network_constants.work.value (current_l.item, work);
@@ -165,7 +165,7 @@ void nano::work_pool::cancel (nano::root const & root_a)
 			{
 				if (item_a.callback)
 				{
-					item_a.callback (boost::none);
+					item_a.callback (std::nullopt);
 				}
 				result = true;
 			}
@@ -184,7 +184,7 @@ void nano::work_pool::stop ()
 	producer_condition.notify_all ();
 }
 
-void nano::work_pool::generate (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::function<void (boost::optional<uint64_t> const &)> callback_a)
+void nano::work_pool::generate (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a, std::function<void (std::optional<uint64_t> const &)> callback_a)
 {
 	debug_assert (!root_a.is_zero ());
 	if (!threads.empty ())
@@ -197,30 +197,30 @@ void nano::work_pool::generate (nano::work_version const version_a, nano::root c
 	}
 	else if (callback_a)
 	{
-		callback_a (boost::none);
+		callback_a (std::nullopt);
 	}
 }
 
-boost::optional<uint64_t> nano::work_pool::generate (nano::root const & root_a)
+std::optional<uint64_t> nano::work_pool::generate (nano::root const & root_a)
 {
 	debug_assert (network_constants.is_dev_network ());
 	return generate (nano::work_version::work_1, root_a, network_constants.work.base);
 }
 
-boost::optional<uint64_t> nano::work_pool::generate (nano::root const & root_a, uint64_t difficulty_a)
+std::optional<uint64_t> nano::work_pool::generate (nano::root const & root_a, uint64_t difficulty_a)
 {
 	debug_assert (network_constants.is_dev_network ());
 	return generate (nano::work_version::work_1, root_a, difficulty_a);
 }
 
-boost::optional<uint64_t> nano::work_pool::generate (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a)
+std::optional<uint64_t> nano::work_pool::generate (nano::work_version const version_a, nano::root const & root_a, uint64_t difficulty_a)
 {
-	boost::optional<uint64_t> result;
+	std::optional<uint64_t> result;
 	if (!threads.empty ())
 	{
-		std::promise<boost::optional<uint64_t>> work;
-		std::future<boost::optional<uint64_t>> future = work.get_future ();
-		generate (version_a, root_a, difficulty_a, [&work] (boost::optional<uint64_t> work_a) {
+		std::promise<std::optional<uint64_t>> work;
+		std::future<std::optional<uint64_t>> future = work.get_future ();
+		generate (version_a, root_a, difficulty_a, [&work] (std::optional<uint64_t> work_a) {
 			work.set_value (work_a);
 		});
 		result = future.get ().value ();

--- a/nano/lib/work.hpp
+++ b/nano/lib/work.hpp
@@ -7,11 +7,10 @@
 #include <nano/lib/utility.hpp>
 #include <nano/node/openclwork.hpp>
 
-#include <boost/optional.hpp>
-
 #include <atomic>
 #include <list>
 #include <memory>
+#include <optional>
 #include <thread>
 
 namespace nano
@@ -19,7 +18,7 @@ namespace nano
 std::string to_string (nano::work_version const version_a);
 
 // type of function that does the work generation with an optional return value
-using opencl_work_func_t = std::function<boost::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)>;
+using opencl_work_func_t = std::function<std::optional<uint64_t> (nano::work_version const, nano::root const &, uint64_t, std::atomic<int> &)>;
 
 class block;
 class block_details;
@@ -29,14 +28,14 @@ class opencl_work;
 class work_item final
 {
 public:
-	work_item (nano::work_version const version_a, nano::root const & item_a, uint64_t difficulty_a, std::function<void (boost::optional<uint64_t> const &)> const & callback_a) :
+	work_item (nano::work_version const version_a, nano::root const & item_a, uint64_t difficulty_a, std::function<void (std::optional<uint64_t> const &)> const & callback_a) :
 		version (version_a), item (item_a), difficulty (difficulty_a), callback (callback_a)
 	{
 	}
 	nano::work_version const version;
 	nano::root const item;
 	uint64_t const difficulty;
-	std::function<void (boost::optional<uint64_t> const &)> const callback;
+	std::function<void (std::optional<uint64_t> const &)> const callback;
 };
 class work_pool final
 {
@@ -46,11 +45,11 @@ public:
 	void loop (uint64_t);
 	void stop ();
 	void cancel (nano::root const &);
-	void generate (nano::work_version const, nano::root const &, uint64_t, std::function<void (boost::optional<uint64_t> const &)>);
-	boost::optional<uint64_t> generate (nano::work_version const, nano::root const &, uint64_t);
+	void generate (nano::work_version const, nano::root const &, uint64_t, std::function<void (std::optional<uint64_t> const &)>);
+	std::optional<uint64_t> generate (nano::work_version const, nano::root const &, uint64_t);
 	// For tests only
-	boost::optional<uint64_t> generate (nano::root const &);
-	boost::optional<uint64_t> generate (nano::root const &, uint64_t);
+	std::optional<uint64_t> generate (nano::root const &);
+	std::optional<uint64_t> generate (nano::root const &, uint64_t);
 	size_t size ();
 	nano::network_constants & network_constants;
 	std::atomic<int> ticket;

--- a/nano/load_test/entry.cpp
+++ b/nano/load_test/entry.cpp
@@ -23,6 +23,7 @@
 #include <future>
 #include <iomanip>
 #include <memory>
+#include <optional>
 #include <random>
 
 using socket_type = boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost::asio::io_context::executor_type>;
@@ -318,7 +319,7 @@ private:
 	http::request<http::string_body> req;
 	http::response<http::string_body> res;
 
-	std::promise<boost::optional<boost::property_tree::ptree>> promise;
+	std::promise<std::optional<boost::property_tree::ptree>> promise;
 
 public:
 	rpc_request_impl (
@@ -346,8 +347,8 @@ public:
 			throw std::runtime_error ("RPC request timed out");
 		}
 		auto response = future.get ();
-		debug_assert (response.is_initialized ());
-		return response.value_or (decltype (response)::argument_type{});
+		debug_assert (response.has_value ());
+		return response.value_or (boost::property_tree::ptree{});
 	}
 
 private:

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -25,7 +25,6 @@
 #include <nano/rpc/rpc.hpp>
 
 #include <boost/format.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/program_options.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include <boost/property_tree/ptree.hpp>

--- a/nano/nano_wallet/entry_com.cpp
+++ b/nano/nano_wallet/entry_com.cpp
@@ -5,7 +5,6 @@
 #include <nano/rpc/rpc.hpp>
 
 #include <boost/format.hpp>
-#include <boost/make_shared.hpp>
 #include <boost/program_options.hpp>
 
 int main (int argc, char * const * argv)

--- a/nano/node/distributed_work.cpp
+++ b/nano/node/distributed_work.cpp
@@ -118,8 +118,8 @@ void nano::distributed_work::start_local ()
 {
 	auto this_l (shared_from_this ());
 	local_generation_started = true;
-	node.work.generate (request.version, request.root, request.difficulty, [this_l] (boost::optional<uint64_t> const & work_a) {
-		if (work_a.is_initialized ())
+	node.work.generate (request.version, request.root, request.difficulty, [this_l] (std::optional<uint64_t> const & work_a) {
+		if (work_a.has_value ())
 		{
 			this_l->set_once (*work_a);
 		}

--- a/nano/node/ipc/action_handler.hpp
+++ b/nano/node/ipc/action_handler.hpp
@@ -4,8 +4,6 @@
 #include <nano/ipc_flatbuffers_lib/generated/flatbuffers/nanoapi_generated.h>
 #include <nano/node/ipc/ipc_access_config.hpp>
 
-#include <boost/optional.hpp>
-
 #include <functional>
 #include <memory>
 #include <unordered_map>

--- a/nano/node/ipc/flatbuffers_handler.cpp
+++ b/nano/node/ipc/flatbuffers_handler.cpp
@@ -5,9 +5,9 @@
 #include <nano/node/ipc/ipc_server.hpp>
 
 #include <boost/dll.hpp>
-#include <boost/optional.hpp>
 
 #include <iostream>
+#include <optional>
 #include <sstream>
 
 #include <flatbuffers/flatbuffers.h>
@@ -31,14 +31,14 @@ std::string make_error_response (std::string const & error_message)
 }
 
 /**
- * Returns the 'api/flatbuffers' directory, boost::none if not found.
+ * Returns the 'api/flatbuffers' directory, std::nullopt if not found.
  */
-boost::optional<std::filesystem::path> get_api_path ()
+std::optional<std::filesystem::path> get_api_path ()
 {
 	std::filesystem::path const fb_path = "api/flatbuffers";
 	if (!std::filesystem::exists (fb_path))
 	{
-		return boost::none;
+		return std::nullopt;
 	}
 	return fb_path;
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -356,10 +356,10 @@ nano::block_hash nano::json_handler::hash_impl (std::string search_text)
 nano::amount nano::json_handler::threshold_optional_impl ()
 {
 	nano::amount result (0);
-	boost::optional<std::string> threshold_text (request.get_optional<std::string> ("threshold"));
-	if (!ec && threshold_text.is_initialized ())
+	auto threshold_text (request.get_optional<std::string> ("threshold"));
+	if (!ec && threshold_text.has_value ())
 	{
-		if (result.decode_dec (threshold_text.get ()))
+		if (result.decode_dec (threshold_text.value ()))
 		{
 			ec = nano::error_common::bad_threshold;
 		}
@@ -370,10 +370,10 @@ nano::amount nano::json_handler::threshold_optional_impl ()
 uint64_t nano::json_handler::work_optional_impl ()
 {
 	uint64_t result (0);
-	boost::optional<std::string> work_text (request.get_optional<std::string> ("work"));
-	if (!ec && work_text.is_initialized ())
+	auto work_text (request.get_optional<std::string> ("work"));
+	if (!ec && work_text.has_value ())
 	{
-		if (nano::from_string_hex (work_text.get (), result))
+		if (nano::from_string_hex (work_text.value (), result))
 		{
 			ec = nano::error_common::bad_work_format;
 		}
@@ -384,10 +384,10 @@ uint64_t nano::json_handler::work_optional_impl ()
 uint64_t nano::json_handler::difficulty_optional_impl (nano::work_version const version_a)
 {
 	auto difficulty (node.default_difficulty (version_a));
-	boost::optional<std::string> difficulty_text (request.get_optional<std::string> ("difficulty"));
-	if (!ec && difficulty_text.is_initialized ())
+	auto difficulty_text (request.get_optional<std::string> ("difficulty"));
+	if (!ec && difficulty_text.has_value ())
 	{
-		if (nano::from_string_hex (difficulty_text.get (), difficulty))
+		if (nano::from_string_hex (difficulty_text.value (), difficulty))
 		{
 			ec = nano::error_rpc::bad_difficulty_format;
 		}
@@ -436,10 +436,10 @@ uint64_t nano::json_handler::difficulty_ledger (nano::block const & block_a)
 double nano::json_handler::multiplier_optional_impl (nano::work_version const version_a, uint64_t & difficulty)
 {
 	double multiplier (1.);
-	boost::optional<std::string> multiplier_text (request.get_optional<std::string> ("multiplier"));
-	if (!ec && multiplier_text.is_initialized ())
+	auto multiplier_text (request.get_optional<std::string> ("multiplier"));
+	if (!ec && multiplier_text.has_value ())
 	{
-		auto success = boost::conversion::try_lexical_convert<double> (multiplier_text.get (), multiplier);
+		auto success = boost::conversion::try_lexical_convert<double> (multiplier_text.value (), multiplier);
 		if (success && multiplier > 0.)
 		{
 			difficulty = nano::difficulty::from_multiplier (multiplier, node.default_difficulty (version_a));
@@ -455,8 +455,8 @@ double nano::json_handler::multiplier_optional_impl (nano::work_version const ve
 nano::work_version nano::json_handler::work_version_optional_impl (nano::work_version const default_a)
 {
 	nano::work_version result = default_a;
-	boost::optional<std::string> version_text (request.get_optional<std::string> ("version"));
-	if (!ec && version_text.is_initialized ())
+	auto version_text (request.get_optional<std::string> ("version"));
+	if (!ec && version_text.has_value ())
 	{
 		if (*version_text == nano::to_string (nano::work_version::work_1))
 		{
@@ -510,10 +510,10 @@ uint64_t nano::json_handler::count_impl ()
 
 uint64_t nano::json_handler::count_optional_impl (uint64_t result)
 {
-	boost::optional<std::string> count_text (request.get_optional<std::string> ("count"));
-	if (!ec && count_text.is_initialized ())
+	auto count_text (request.get_optional<std::string> ("count"));
+	if (!ec && count_text.has_value ())
 	{
-		if (decode_unsigned (count_text.get (), result))
+		if (decode_unsigned (count_text.value (), result))
 		{
 			ec = nano::error_common::invalid_count;
 		}
@@ -523,10 +523,10 @@ uint64_t nano::json_handler::count_optional_impl (uint64_t result)
 
 uint64_t nano::json_handler::offset_optional_impl (uint64_t result)
 {
-	boost::optional<std::string> offset_text (request.get_optional<std::string> ("offset"));
-	if (!ec && offset_text.is_initialized ())
+	auto offset_text (request.get_optional<std::string> ("offset"));
+	if (!ec && offset_text.has_value ())
 	{
-		if (decode_unsigned (offset_text.get (), result))
+		if (decode_unsigned (offset_text.value (), result))
 		{
 			ec = nano::error_rpc::invalid_offset;
 		}
@@ -571,10 +571,10 @@ void nano::json_handler::account_create ()
 		{
 			bool const generate_work = rpc_l->request.get<bool> ("work", true);
 			auto index_text = rpc_l->request.get_optional<std::string> ("index");
-			if (index_text.is_initialized ())
+			if (index_text.has_value ())
 			{
 				uint64_t index;
-				if (decode_unsigned (index_text.get (), index) || index > static_cast<uint64_t> (std::numeric_limits<uint32_t>::max ()))
+				if (decode_unsigned (index_text.value (), index) || index > static_cast<uint64_t> (std::numeric_limits<uint32_t>::max ()))
 				{
 					rpc_l->ec = nano::error_common::invalid_index;
 				}
@@ -1504,46 +1504,46 @@ void nano::json_handler::block_create ()
 	// Default to work_1 if not specified
 	auto work_version (work_version_optional_impl (nano::work_version::work_1));
 	auto difficulty_l (difficulty_optional_impl (work_version));
-	boost::optional<std::string> wallet_text (request.get_optional<std::string> ("wallet"));
-	if (!ec && wallet_text.is_initialized ())
+	auto wallet_text (request.get_optional<std::string> ("wallet"));
+	if (!ec && wallet_text.has_value ())
 	{
-		if (wallet.decode_hex (wallet_text.get ()))
+		if (wallet.decode_hex (wallet_text.value ()))
 		{
 			ec = nano::error_common::bad_wallet_number;
 		}
 	}
 	nano::account account{};
-	boost::optional<std::string> account_text (request.get_optional<std::string> ("account"));
-	if (!ec && account_text.is_initialized ())
+	auto account_text (request.get_optional<std::string> ("account"));
+	if (!ec && account_text.has_value ())
 	{
-		account = account_impl (account_text.get ());
+		account = account_impl (account_text.value ());
 	}
 	nano::account representative{};
-	boost::optional<std::string> representative_text (request.get_optional<std::string> ("representative"));
-	if (!ec && representative_text.is_initialized ())
+	auto representative_text (request.get_optional<std::string> ("representative"));
+	if (!ec && representative_text.has_value ())
 	{
-		representative = account_impl (representative_text.get (), nano::error_rpc::bad_representative_number);
+		representative = account_impl (representative_text.value (), nano::error_rpc::bad_representative_number);
 	}
 	nano::account destination{};
-	boost::optional<std::string> destination_text (request.get_optional<std::string> ("destination"));
-	if (!ec && destination_text.is_initialized ())
+	auto destination_text (request.get_optional<std::string> ("destination"));
+	if (!ec && destination_text.has_value ())
 	{
-		destination = account_impl (destination_text.get (), nano::error_rpc::bad_destination);
+		destination = account_impl (destination_text.value (), nano::error_rpc::bad_destination);
 	}
 	nano::block_hash source (0);
-	boost::optional<std::string> source_text (request.get_optional<std::string> ("source"));
-	if (!ec && source_text.is_initialized ())
+	auto source_text (request.get_optional<std::string> ("source"));
+	if (!ec && source_text.has_value ())
 	{
-		if (source.decode_hex (source_text.get ()))
+		if (source.decode_hex (source_text.value ()))
 		{
 			ec = nano::error_rpc::bad_source;
 		}
 	}
 	nano::amount amount (0);
-	boost::optional<std::string> amount_text (request.get_optional<std::string> ("amount"));
-	if (!ec && amount_text.is_initialized ())
+	auto amount_text (request.get_optional<std::string> ("amount"));
+	if (!ec && amount_text.has_value ())
 	{
-		if (amount.decode_dec (amount_text.get ()))
+		if (amount.decode_dec (amount_text.value ()))
 		{
 			ec = nano::error_common::invalid_amount;
 		}
@@ -1580,37 +1580,37 @@ void nano::json_handler::block_create ()
 			ec = nano::error_common::wallet_not_found;
 		}
 	}
-	boost::optional<std::string> key_text (request.get_optional<std::string> ("key"));
-	if (!ec && key_text.is_initialized ())
+	auto key_text (request.get_optional<std::string> ("key"));
+	if (!ec && key_text.has_value ())
 	{
-		if (prv.decode_hex (key_text.get ()))
+		if (prv.decode_hex (key_text.value ()))
 		{
 			ec = nano::error_common::bad_private_key;
 		}
 	}
-	boost::optional<std::string> previous_text (request.get_optional<std::string> ("previous"));
-	if (!ec && previous_text.is_initialized ())
+	auto previous_text (request.get_optional<std::string> ("previous"));
+	if (!ec && previous_text.has_value ())
 	{
-		if (previous.decode_hex (previous_text.get ()))
+		if (previous.decode_hex (previous_text.value ()))
 		{
 			ec = nano::error_rpc::bad_previous;
 		}
 	}
-	boost::optional<std::string> balance_text (request.get_optional<std::string> ("balance"));
-	if (!ec && balance_text.is_initialized ())
+	auto balance_text (request.get_optional<std::string> ("balance"));
+	if (!ec && balance_text.has_value ())
 	{
-		if (balance.decode_dec (balance_text.get ()))
+		if (balance.decode_dec (balance_text.value ()))
 		{
 			ec = nano::error_rpc::invalid_balance;
 		}
 	}
 	nano::link link (0);
-	boost::optional<std::string> link_text (request.get_optional<std::string> ("link"));
-	if (!ec && link_text.is_initialized ())
+	auto link_text (request.get_optional<std::string> ("link"));
+	if (!ec && link_text.has_value ())
 	{
-		if (link.decode_account (link_text.get ()))
+		if (link.decode_account (link_text.value ()))
 		{
-			if (link.decode_hex (link_text.get ()))
+			if (link.decode_hex (link_text.value ()))
 			{
 				ec = nano::error_rpc::bad_link;
 			}
@@ -1683,14 +1683,14 @@ void nano::json_handler::block_create ()
 		{
 			nano::account pub (nano::pub_key (prv));
 			// Fetching account balance & previous for send blocks (if aren't given directly)
-			if (!previous_text.is_initialized () && !balance_text.is_initialized ())
+			if (!previous_text.has_value () && !balance_text.has_value ())
 			{
 				auto transaction = node.ledger.tx_begin_read ();
 				previous = node.ledger.any.account_head (transaction, pub);
 				balance = node.ledger.any.account_balance (transaction, pub).value_or (0);
 			}
 			// Double check current balance if previous block is specified
-			else if (previous_text.is_initialized () && balance_text.is_initialized () && type == "send")
+			else if (previous_text.has_value () && balance_text.has_value () && type == "send")
 			{
 				auto transaction = node.ledger.tx_begin_read ();
 				if (node.ledger.any.block_exists (transaction, previous) && node.ledger.any.block_balance (transaction, previous) != balance.number ())
@@ -1699,7 +1699,7 @@ void nano::json_handler::block_create ()
 				}
 			}
 			// Check for incorrect account key
-			if (!ec && account_text.is_initialized ())
+			if (!ec && account_text.has_value ())
 			{
 				if (account != pub)
 				{
@@ -1712,7 +1712,7 @@ void nano::json_handler::block_create ()
 			std::error_code ec_build;
 			if (type == "state")
 			{
-				if (previous_text.is_initialized () && !representative.is_zero () && (!link.is_zero () || link_text.is_initialized ()))
+				if (previous_text.has_value () && !representative.is_zero () && (!link.is_zero () || link_text.has_value ()))
 				{
 					block_l = builder_l.state ()
 							  .account (pub)
@@ -1971,10 +1971,10 @@ void nano::json_handler::confirmation_active ()
 {
 	uint64_t announcements (0);
 	uint64_t confirmed (0);
-	boost::optional<std::string> announcements_text (request.get_optional<std::string> ("announcements"));
-	if (announcements_text.is_initialized ())
+	auto announcements_text (request.get_optional<std::string> ("announcements"));
+	if (announcements_text.has_value ())
 	{
-		announcements = strtoul (announcements_text.get ().c_str (), NULL, 10);
+		announcements = strtoul (announcements_text.value ().c_str (), NULL, 10);
 	}
 	boost::property_tree::ptree elections;
 	auto active_elections = node.active.list_active ();
@@ -2062,8 +2062,8 @@ void nano::json_handler::confirmation_history ()
 	boost::property_tree::ptree confirmation_stats;
 	std::chrono::milliseconds running_total (0);
 	nano::block_hash hash (0);
-	boost::optional<std::string> hash_text (request.get_optional<std::string> ("hash"));
-	if (hash_text.is_initialized ())
+	auto hash_text (request.get_optional<std::string> ("hash"));
+	if (hash_text.has_value ())
 	{
 		hash = hash_impl ();
 	}
@@ -2217,8 +2217,8 @@ void nano::json_handler::database_txn_tracker ()
 	if (node.config.txn_tracking->enable)
 	{
 		unsigned min_read_time_milliseconds = 0;
-		boost::optional<std::string> min_read_time_text (request.get_optional<std::string> ("min_read_time"));
-		if (min_read_time_text.is_initialized ())
+		auto min_read_time_text (request.get_optional<std::string> ("min_read_time"));
+		if (min_read_time_text.has_value ())
 		{
 			auto success = boost::conversion::try_lexical_convert<unsigned> (*min_read_time_text, min_read_time_milliseconds);
 			if (!success)
@@ -2230,8 +2230,8 @@ void nano::json_handler::database_txn_tracker ()
 		unsigned min_write_time_milliseconds = 0;
 		if (!ec)
 		{
-			boost::optional<std::string> min_write_time_text (request.get_optional<std::string> ("min_write_time"));
-			if (min_write_time_text.is_initialized ())
+			auto min_write_time_text (request.get_optional<std::string> ("min_write_time"));
+			if (min_write_time_text.has_value ())
 			{
 				auto success = boost::conversion::try_lexical_convert<unsigned> (*min_write_time_text, min_write_time_milliseconds);
 				if (!success)
@@ -2263,9 +2263,9 @@ void nano::json_handler::delegators ()
 	auto start_account_text (request.get_optional<std::string> ("start"));
 
 	nano::account start_account{};
-	if (!ec && start_account_text.is_initialized ())
+	if (!ec && start_account_text.has_value ())
 	{
-		start_account = account_impl (start_account_text.get ());
+		start_account = account_impl (start_account_text.value ());
 	}
 
 	if (!ec)
@@ -2360,10 +2360,10 @@ void nano::json_handler::epoch_upgrade ()
 	{
 		uint64_t count_limit (count_optional_impl ());
 		uint64_t threads (0);
-		boost::optional<std::string> threads_text (request.get_optional<std::string> ("threads"));
-		if (!ec && threads_text.is_initialized ())
+		auto threads_text (request.get_optional<std::string> ("threads"));
+		if (!ec && threads_text.has_value ())
 		{
-			if (decode_unsigned (threads_text.get (), threads))
+			if (decode_unsigned (threads_text.value (), threads))
 			{
 				ec = nano::error_rpc::invalid_threads_count;
 			}
@@ -2631,7 +2631,7 @@ void nano::json_handler::account_history ()
 {
 	std::vector<nano::public_key> accounts_to_filter;
 	auto const accounts_filter_node = request.get_child_optional ("account_filter");
-	if (accounts_filter_node.is_initialized ())
+	if (accounts_filter_node.has_value ())
 	{
 		for (auto & a : (*accounts_filter_node))
 		{
@@ -2802,16 +2802,16 @@ void nano::json_handler::ledger ()
 	if (!ec)
 	{
 		nano::account start{};
-		boost::optional<std::string> account_text (request.get_optional<std::string> ("account"));
-		if (account_text.is_initialized ())
+		auto account_text (request.get_optional<std::string> ("account"));
+		if (account_text.has_value ())
 		{
-			start = account_impl (account_text.get ());
+			start = account_impl (account_text.value ());
 		}
 		uint64_t modified_since (0);
-		boost::optional<std::string> modified_since_text (request.get_optional<std::string> ("modified_since"));
-		if (modified_since_text.is_initialized ())
+		auto modified_since_text (request.get_optional<std::string> ("modified_since"));
+		if (modified_since_text.has_value ())
 		{
-			if (decode_unsigned (modified_since_text.get (), modified_since))
+			if (decode_unsigned (modified_since_text.value (), modified_since))
 			{
 				ec = nano::error_rpc::invalid_timestamp;
 			}
@@ -3588,7 +3588,7 @@ void nano::json_handler::representatives_online ()
 	auto const accounts_node = request.get_child_optional ("accounts");
 	bool const weight = request.get<bool> ("weight", false);
 	std::vector<nano::public_key> accounts_to_filter;
-	if (accounts_node.is_initialized ())
+	if (accounts_node.has_value ())
 	{
 		for (auto & a : (*accounts_node))
 		{
@@ -3609,7 +3609,7 @@ void nano::json_handler::representatives_online ()
 		auto reps (node.online_reps.list ());
 		for (auto & i : reps)
 		{
-			if (accounts_node.is_initialized ())
+			if (accounts_node.has_value ())
 			{
 				if (accounts_to_filter.empty ())
 				{
@@ -3649,18 +3649,18 @@ void nano::json_handler::republish ()
 	auto count (count_optional_impl (1024U));
 	uint64_t sources (0);
 	uint64_t destinations (0);
-	boost::optional<std::string> sources_text (request.get_optional<std::string> ("sources"));
-	if (!ec && sources_text.is_initialized ())
+	auto sources_text (request.get_optional<std::string> ("sources"));
+	if (!ec && sources_text.has_value ())
 	{
-		if (decode_unsigned (sources_text.get (), sources))
+		if (decode_unsigned (sources_text.value (), sources))
 		{
 			ec = nano::error_rpc::invalid_sources;
 		}
 	}
-	boost::optional<std::string> destinations_text (request.get_optional<std::string> ("destinations"));
-	if (!ec && destinations_text.is_initialized ())
+	auto destinations_text (request.get_optional<std::string> ("destinations"));
+	if (!ec && destinations_text.has_value ())
 	{
-		if (decode_unsigned (destinations_text.get (), destinations))
+		if (decode_unsigned (destinations_text.value (), destinations))
 		{
 			ec = nano::error_rpc::invalid_destinations;
 		}
@@ -3827,7 +3827,8 @@ void nano::json_handler::send ()
 		if (!ec)
 		{
 			bool generate_work (work == 0); // Disable work generation if "work" option is provided
-			boost::optional<std::string> send_id (request.get_optional<std::string> ("id"));
+			auto send_id_boost (request.get_optional<std::string> ("id"));
+			std::optional<std::string> send_id = send_id_boost ? std::make_optional (*send_id_boost) : std::nullopt;
 			auto response_a (response);
 			auto response_data (std::make_shared<boost::property_tree::ptree> (response_l));
 			wallet->send_async (
@@ -3867,8 +3868,8 @@ void nano::json_handler::sign ()
 	bool const json_block_l = request.get<bool> ("json_block", false);
 	// Retrieving hash
 	nano::block_hash hash (0);
-	boost::optional<std::string> hash_text (request.get_optional<std::string> ("hash"));
-	if (hash_text.is_initialized ())
+	auto hash_text (request.get_optional<std::string> ("hash"));
+	if (hash_text.has_value ())
 	{
 		hash = hash_impl ();
 	}
@@ -3898,10 +3899,10 @@ void nano::json_handler::sign ()
 		nano::raw_key prv;
 		prv.clear ();
 		// Retrieving private key from request
-		boost::optional<std::string> key_text (request.get_optional<std::string> ("key"));
-		if (key_text.is_initialized ())
+		auto key_text (request.get_optional<std::string> ("key"));
+		if (key_text.has_value ())
 		{
-			if (prv.decode_hex (key_text.get ()))
+			if (prv.decode_hex (key_text.value ()))
 			{
 				ec = nano::error_common::bad_private_key;
 			}
@@ -3909,9 +3910,9 @@ void nano::json_handler::sign ()
 		else
 		{
 			// Retrieving private key from wallet
-			boost::optional<std::string> account_text (request.get_optional<std::string> ("account"));
-			boost::optional<std::string> wallet_text (request.get_optional<std::string> ("wallet"));
-			if (wallet_text.is_initialized () && account_text.is_initialized ())
+			auto account_text (request.get_optional<std::string> ("account"));
+			auto wallet_text (request.get_optional<std::string> ("wallet"));
+			if (wallet_text.has_value () && account_text.has_value ())
 			{
 				auto account (account_impl ());
 				auto wallet (wallet_impl ());
@@ -4030,11 +4031,11 @@ void nano::json_handler::telemetry ()
 	auto address_text (request.get_optional<std::string> ("address"));
 	auto port_text (request.get_optional<std::string> ("port"));
 
-	if (address_text.is_initialized () || port_text.is_initialized ())
+	if (address_text.has_value () || port_text.has_value ())
 	{
 		// Check both are specified
 		nano::endpoint endpoint{};
-		if (address_text.is_initialized () && port_text.is_initialized ())
+		if (address_text.has_value () && port_text.has_value ())
 		{
 			uint16_t port;
 			if (!nano::parse_port (*port_text, port))
@@ -4238,10 +4239,10 @@ void nano::json_handler::unchecked_keys ()
 	bool const json_block_l = request.get<bool> ("json_block", false);
 	auto count (count_optional_impl ());
 	nano::block_hash key (0);
-	boost::optional<std::string> hash_text (request.get_optional<std::string> ("key"));
-	if (!ec && hash_text.is_initialized ())
+	auto hash_text (request.get_optional<std::string> ("key"));
+	if (!ec && hash_text.has_value ())
 	{
-		if (key.decode_hex (hash_text.get ()))
+		if (key.decode_hex (hash_text.value ()))
 		{
 			ec = nano::error_rpc::bad_key;
 		}
@@ -4279,10 +4280,10 @@ void nano::json_handler::unopened ()
 	auto count{ count_optional_impl () };
 	auto threshold{ threshold_optional_impl () };
 	nano::account start{ 1 }; // exclude burn account by default
-	boost::optional<std::string> account_text (request.get_optional<std::string> ("account"));
-	if (account_text.is_initialized ())
+	auto account_text (request.get_optional<std::string> ("account"));
+	if (account_text.has_value ())
 	{
-		start = account_impl (account_text.get ());
+		start = account_impl (account_text.value ());
 	}
 	if (!ec)
 	{
@@ -4559,7 +4560,7 @@ void nano::json_handler::wallet_create ()
 	node.workers.post (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
 		nano::raw_key seed;
 		auto seed_text (rpc_l->request.get_optional<std::string> ("seed"));
-		if (seed_text.is_initialized () && seed.decode_hex (seed_text.get ()))
+		if (seed_text.has_value () && seed.decode_hex (seed_text.value ()))
 		{
 			rpc_l->ec = nano::error_common::bad_seed;
 		}
@@ -4576,7 +4577,7 @@ void nano::json_handler::wallet_create ()
 			{
 				rpc_l->ec = nano::error_common::wallet_lmdb_max_dbs;
 			}
-			if (!rpc_l->ec && seed_text.is_initialized ())
+			if (!rpc_l->ec && seed_text.has_value ())
 			{
 				nano::public_key account (wallet->change_seed (seed));
 				rpc_l->response_l.put ("last_restored_account", account.to_account ());
@@ -4651,10 +4652,10 @@ void nano::json_handler::wallet_frontiers ()
 void nano::json_handler::wallet_history ()
 {
 	uint64_t modified_since (0);
-	boost::optional<std::string> modified_since_text (request.get_optional<std::string> ("modified_since"));
-	if (modified_since_text.is_initialized ())
+	auto modified_since_text (request.get_optional<std::string> ("modified_since"));
+	if (modified_since_text.has_value ())
 	{
-		if (decode_unsigned (modified_since_text.get (), modified_since))
+		if (decode_unsigned (modified_since_text.value (), modified_since))
 		{
 			ec = nano::error_rpc::invalid_timestamp;
 		}
@@ -4725,10 +4726,10 @@ void nano::json_handler::wallet_ledger ()
 	bool const pending = request.get<bool> ("pending", false);
 	bool const receivable = request.get<bool> ("receivable", pending);
 	uint64_t modified_since (0);
-	boost::optional<std::string> modified_since_text (request.get_optional<std::string> ("modified_since"));
-	if (modified_since_text.is_initialized ())
+	auto modified_since_text (request.get_optional<std::string> ("modified_since"));
+	if (modified_since_text.has_value ())
 	{
-		modified_since = strtoul (modified_since_text.get ().c_str (), NULL, 10);
+		modified_since = strtoul (modified_since_text.value ().c_str (), NULL, 10);
 	}
 	auto wallet (wallet_impl ());
 	if (!ec)
@@ -4998,9 +4999,9 @@ void nano::json_handler::work_generate ()
 	auto account_opt (request.get_optional<std::string> ("account"));
 	// Default to work_1 if not specified
 	auto work_version (work_version_optional_impl (nano::work_version::work_1));
-	if (!ec && account_opt.is_initialized ())
+	if (!ec && account_opt.has_value ())
 	{
-		account = account_impl (account_opt.get ());
+		account = account_impl (account_opt.value ());
 	}
 	if (!ec)
 	{
@@ -5086,7 +5087,7 @@ void nano::json_handler::work_generate ()
 			}
 			else
 			{
-				if (!account_opt.is_initialized ())
+				if (!account_opt.has_value ())
 				{
 					// Fetch account from block if not given
 					auto transaction_l = node.ledger.tx_begin_read ();

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -8,6 +8,7 @@
 #include <boost/property_tree/ptree.hpp>
 
 #include <functional>
+#include <optional>
 #include <string>
 
 namespace nano::secure
@@ -200,19 +201,19 @@ public:
 	{
 		if (rpc)
 		{
-			rpc->stop ();
+			rpc->get ().stop ();
 		}
 	}
 
 	void rpc_instance (nano::rpc & rpc_a) override
 	{
-		rpc = &rpc_a;
+		rpc = rpc_a;
 	}
 
 private:
 	nano::node & node;
 	nano::ipc::ipc_server & ipc_server;
-	nano::rpc * rpc{ nullptr };
+	std::optional<std::reference_wrapper<nano::rpc>> rpc;
 	std::function<void ()> stop_callback;
 	nano::node_rpc_config const & node_rpc_config;
 };

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -206,13 +206,13 @@ public:
 
 	void rpc_instance (nano::rpc & rpc_a) override
 	{
-		rpc = rpc_a;
+		rpc = &rpc_a;
 	}
 
 private:
 	nano::node & node;
 	nano::ipc::ipc_server & ipc_server;
-	boost::optional<nano::rpc &> rpc;
+	nano::rpc * rpc{ nullptr };
 	std::function<void ()> stop_callback;
 	nano::node_rpc_config const & node_rpc_config;
 };

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -31,7 +31,7 @@ public:
 	syn_cookies (std::size_t max_peers_per_ip, nano::logger &);
 
 	void purge (std::chrono::steady_clock::time_point const &);
-	// Returns boost::none if the IP is rate capped on syn cookie requests,
+	// Returns std::nullopt if the IP is rate capped on syn cookie requests,
 	// or if the endpoint already has a syn cookie query
 	std::optional<nano::uint256_union> assign (nano::endpoint const &);
 	// Returns false if valid, true if invalid (true on error convention)

--- a/nano/node/openclwork.cpp
+++ b/nano/node/openclwork.cpp
@@ -442,13 +442,13 @@ nano::opencl_work::~opencl_work ()
 	}
 }
 
-boost::optional<uint64_t> nano::opencl_work::generate_work (nano::work_version const version_a, nano::root const & root_a, uint64_t const difficulty_a)
+std::optional<uint64_t> nano::opencl_work::generate_work (nano::work_version const version_a, nano::root const & root_a, uint64_t const difficulty_a)
 {
 	std::atomic<int> ticket_l{ 0 };
 	return generate_work (version_a, root_a, difficulty_a, ticket_l);
 }
 
-boost::optional<uint64_t> nano::opencl_work::generate_work (nano::work_version const version_a, nano::root const & root_a, uint64_t const difficulty_a, std::atomic<int> & ticket_a)
+std::optional<uint64_t> nano::opencl_work::generate_work (nano::work_version const version_a, nano::root const & root_a, uint64_t const difficulty_a, std::atomic<int> & ticket_a)
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	bool error (false);
@@ -514,7 +514,7 @@ boost::optional<uint64_t> nano::opencl_work::generate_work (nano::work_version c
 			logger.error (nano::log::type::opencl_work, "Error writing attempt: {}", write_error1);
 		}
 	}
-	boost::optional<uint64_t> value;
+	std::optional<uint64_t> value;
 	if (!error)
 	{
 		value = result;

--- a/nano/node/openclwork.hpp
+++ b/nano/node/openclwork.hpp
@@ -6,10 +6,9 @@
 #include <nano/node/openclconfig.hpp>
 #include <nano/node/xorshift.hpp>
 
-#include <boost/optional.hpp>
-
 #include <atomic>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 #ifdef __APPLE__
@@ -48,8 +47,8 @@ class opencl_work
 public:
 	opencl_work (bool &, nano::opencl_config const &, nano::opencl_environment &, nano::logger &, nano::work_thresholds & work);
 	~opencl_work ();
-	boost::optional<uint64_t> generate_work (nano::work_version const, nano::root const &, uint64_t const);
-	boost::optional<uint64_t> generate_work (nano::work_version const, nano::root const &, uint64_t const, std::atomic<int> &);
+	std::optional<uint64_t> generate_work (nano::work_version const, nano::root const &, uint64_t const);
+	std::optional<uint64_t> generate_work (nano::work_version const, nano::root const &, uint64_t const, std::atomic<int> &);
 	static std::unique_ptr<opencl_work> create (bool, nano::opencl_config const &, nano::logger &, nano::work_thresholds & work);
 	nano::opencl_config const & config;
 	nano::mutex mutex;

--- a/nano/node/repcrawler.hpp
+++ b/nano/node/repcrawler.hpp
@@ -16,7 +16,6 @@
 #include <boost/multi_index/random_access_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index_container.hpp>
-#include <boost/optional.hpp>
 
 #include <chrono>
 #include <memory>

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1028,7 +1028,7 @@ std::shared_ptr<nano::block> wallet::change_action (nano::account const & source
 	return block;
 }
 
-std::shared_ptr<nano::block> wallet::send_action (nano::account const & source_a, nano::account const & account_a, nano::uint128_t const & amount_a, uint64_t work_a, bool generate_work_a, boost::optional<std::string> id_a)
+std::shared_ptr<nano::block> wallet::send_action (nano::account const & source_a, nano::account const & account_a, nano::uint128_t const & amount_a, uint64_t work_a, bool generate_work_a, std::optional<std::string> id_a)
 {
 	auto prepare_send = [this, &wallets = this->wallets, &store = this->store, &source_a, &amount_a, &work_a, &account_a, &id_a] (auto const & transaction) {
 		auto ledger_txn = wallets.ledger.tx_begin_read ();
@@ -1241,7 +1241,7 @@ nano::block_hash wallet::send_sync (nano::account const & source_a, nano::accoun
 	return future.get ();
 }
 
-void wallet::send_async (nano::account const & source_a, nano::account const & account_a, nano::uint128_t const & amount_a, std::function<void (std::shared_ptr<nano::block> const &)> const & action_a, uint64_t work_a, bool generate_work_a, boost::optional<std::string> id_a)
+void wallet::send_async (nano::account const & source_a, nano::account const & account_a, nano::uint128_t const & amount_a, std::function<void (std::shared_ptr<nano::block> const &)> const & action_a, uint64_t work_a, bool generate_work_a, std::optional<std::string> id_a)
 {
 	auto this_l (shared_from_this ());
 	wallets.queue_wallet_action (wallets::high_priority, this_l, [this_l, source_a, account_a, amount_a, action_a, work_a, generate_work_a, id_a] (wallet & wallet_a) {

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -192,7 +192,7 @@ public:
 	// Block actions
 	std::shared_ptr<nano::block> change_action (nano::account const & source, nano::account const & representative, uint64_t work = 0, bool generate_work = true);
 	std::shared_ptr<nano::block> receive_action (nano::block_hash const & send_hash, nano::account const & representative, nano::uint128_union const & amount, nano::account const & account, uint64_t work = 0, bool generate_work = true);
-	std::shared_ptr<nano::block> send_action (nano::account const & source, nano::account const & destination, nano::uint128_t const & amount, uint64_t work = 0, bool generate_work = true, boost::optional<std::string> id = {});
+	std::shared_ptr<nano::block> send_action (nano::account const & source, nano::account const & destination, nano::uint128_t const & amount, uint64_t work = 0, bool generate_work = true, std::optional<std::string> id = {});
 	bool action_complete (std::shared_ptr<nano::block> const & block, nano::account const & account, bool generate_work, nano::block_details const & details);
 
 	// Sync/async block operations
@@ -201,7 +201,7 @@ public:
 	bool receive_sync (std::shared_ptr<nano::block> const & block, nano::account const & representative, nano::uint128_t const & amount);
 	void receive_async (nano::block_hash const & hash, nano::account const & representative, nano::uint128_t const & amount, nano::account const & account, std::function<void (std::shared_ptr<nano::block> const &)> const & action, uint64_t work = 0, bool generate_work = true);
 	nano::block_hash send_sync (nano::account const & source, nano::account const & destination, nano::uint128_t const & amount);
-	void send_async (nano::account const & source, nano::account const & destination, nano::uint128_t const & amount, std::function<void (std::shared_ptr<nano::block> const &)> const & action, uint64_t work = 0, bool generate_work = true, boost::optional<std::string> id = {});
+	void send_async (nano::account const & source, nano::account const & destination, nano::uint128_t const & amount, std::function<void (std::shared_ptr<nano::block> const &)> const & action, uint64_t work = 0, bool generate_work = true, std::optional<std::string> id = {});
 
 	// Work cache
 	void work_cache_blocking (nano::account const & account, nano::root const & root);

--- a/nano/node/websocket.cpp
+++ b/nano/node/websocket.cpp
@@ -66,9 +66,9 @@ nano::websocket::confirmation_options::confirmation_options (boost::property_tre
 
 	// Account filtering options
 	auto all_local_accounts_l (options_a.get_optional<bool> ("all_local_accounts"));
-	if (all_local_accounts_l.is_initialized ())
+	if (all_local_accounts_l.has_value ())
 	{
-		all_local_accounts = all_local_accounts_l.get ();
+		all_local_accounts = all_local_accounts_l.value ();
 		has_account_filtering_options = true;
 
 		if (!include_block)
@@ -511,11 +511,11 @@ void nano::websocket::session::handle_message (boost::property_tree::ptree const
 		std::unique_ptr<nano::websocket::options> options_l{ nullptr };
 		if (options_text_l && topic_l == nano::websocket::topic::confirmation)
 		{
-			options_l = std::make_unique<nano::websocket::confirmation_options> (options_text_l.get (), ws_listener.get_wallets (), logger);
+			options_l = std::make_unique<nano::websocket::confirmation_options> (options_text_l.value (), ws_listener.get_wallets (), logger);
 		}
 		else if (options_text_l && topic_l == nano::websocket::topic::vote)
 		{
-			options_l = std::make_unique<nano::websocket::vote_options> (options_text_l.get (), logger);
+			options_l = std::make_unique<nano::websocket::vote_options> (options_text_l.value (), logger);
 		}
 		else
 		{
@@ -544,7 +544,7 @@ void nano::websocket::session::handle_message (boost::property_tree::ptree const
 		if (existing != subscriptions.end ())
 		{
 			auto options_text_l (message_a.get_child_optional ("options"));
-			if (options_text_l.is_initialized () && !existing->second->update (*options_text_l))
+			if (options_text_l.has_value () && !existing->second->update (*options_text_l))
 			{
 				action_succeeded = true;
 			}

--- a/nano/rpc/rpc_handler.cpp
+++ b/nano/rpc/rpc_handler.cpp
@@ -195,26 +195,26 @@ std::unordered_set<std::string> create_rpc_control_impls ()
 std::string filter_request (boost::property_tree::ptree tree_a)
 {
 	// Replace password
-	boost::optional<std::string> password_text (tree_a.get_optional<std::string> ("password"));
-	if (password_text.is_initialized ())
+	auto password_text (tree_a.get_optional<std::string> ("password"));
+	if (password_text.has_value ())
 	{
 		tree_a.put ("password", "password");
 	}
 	// Save first 2 symbols of wallet, key, seed
-	boost::optional<std::string> wallet_text (tree_a.get_optional<std::string> ("wallet"));
-	if (wallet_text.is_initialized () && wallet_text.get ().length () > 2)
+	auto wallet_text (tree_a.get_optional<std::string> ("wallet"));
+	if (wallet_text.has_value () && wallet_text.value ().length () > 2)
 	{
-		tree_a.put ("wallet", wallet_text.get ().replace (wallet_text.get ().begin () + 2, wallet_text.get ().end (), wallet_text.get ().length () - 2, 'X'));
+		tree_a.put ("wallet", wallet_text.value ().replace (wallet_text.value ().begin () + 2, wallet_text.value ().end (), wallet_text.value ().length () - 2, 'X'));
 	}
-	boost::optional<std::string> key_text (tree_a.get_optional<std::string> ("key"));
-	if (key_text.is_initialized () && key_text.get ().length () > 2)
+	auto key_text (tree_a.get_optional<std::string> ("key"));
+	if (key_text.has_value () && key_text.value ().length () > 2)
 	{
-		tree_a.put ("key", key_text.get ().replace (key_text.get ().begin () + 2, key_text.get ().end (), key_text.get ().length () - 2, 'X'));
+		tree_a.put ("key", key_text.value ().replace (key_text.value ().begin () + 2, key_text.value ().end (), key_text.value ().length () - 2, 'X'));
 	}
-	boost::optional<std::string> seed_text (tree_a.get_optional<std::string> ("seed"));
-	if (seed_text.is_initialized () && seed_text.get ().length () > 2)
+	auto seed_text (tree_a.get_optional<std::string> ("seed"));
+	if (seed_text.has_value () && seed_text.value ().length () > 2)
 	{
-		tree_a.put ("seed", seed_text.get ().replace (seed_text.get ().begin () + 2, seed_text.get ().end (), seed_text.get ().length () - 2, 'X'));
+		tree_a.put ("seed", seed_text.value ().replace (seed_text.value ().begin () + 2, seed_text.value ().end (), seed_text.value ().length () - 2, 'X'));
 	}
 	std::string result;
 	std::stringstream stream;

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -82,9 +82,9 @@ TEST (rpc, receivable_threshold_sufficient)
 		amount.decode_dec (i->second.get<std::string> (""));
 		blocks[hash] = amount;
 		auto source = i->second.get_optional<std::string> ("source");
-		ASSERT_FALSE (source.is_initialized ());
+		ASSERT_FALSE (source.has_value ());
 		auto min_version = i->second.get_optional<uint8_t> ("min_version");
-		ASSERT_FALSE (min_version.is_initialized ());
+		ASSERT_FALSE (min_version.has_value ());
 	}
 	ASSERT_EQ (blocks[block1->hash ()], 1);
 }
@@ -489,8 +489,8 @@ TEST (rpc, accounts_receivable_threshold)
 			nano::uint128_union amount;
 			amount.decode_dec (i->second.get<std::string> (""));
 			blocks[hash] = amount;
-			boost::optional<std::string> source{ i->second.get_optional<std::string> ("source") };
-			ASSERT_FALSE (source.is_initialized ());
+			auto source = i->second.get_optional<std::string> ("source");
+			ASSERT_FALSE (source.has_value ());
 		}
 	}
 	ASSERT_EQ (blocks[block1->hash ()], 1);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -3834,7 +3834,7 @@ TEST (rpc, account_info)
 
 		auto error (response.get_optional<std::string> ("error"));
 		ASSERT_TRUE (error.has_value ());
-		ASSERT_EQ (error.get (), std::error_code (nano::error_common::account_not_found).message ());
+		ASSERT_EQ (error.value (), std::error_code (nano::error_common::account_not_found).message ());
 	}
 
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2007,7 +2007,7 @@ TEST (rpc, work_generate_multiplier)
 		request.put ("multiplier", multiplier);
 		auto response (wait_response (system, rpc_ctx, request, 10s));
 		auto work_text (response.get_optional<std::string> ("work"));
-		ASSERT_TRUE (work_text.is_initialized ());
+		ASSERT_TRUE (work_text.has_value ());
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (*work_text, work));
 		auto result_difficulty (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, work));
@@ -2098,7 +2098,7 @@ TEST (rpc, work_generate_block_low)
 	{
 		auto response (wait_response (system, rpc_ctx, request, 10s));
 		auto work_text (response.get_optional<std::string> ("work"));
-		ASSERT_TRUE (work_text.is_initialized ());
+		ASSERT_TRUE (work_text.has_value ());
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (*work_text, work));
 		ASSERT_NE (block->block_work (), work);
@@ -2183,7 +2183,7 @@ TEST (rpc, work_generate_block_ledger_epoch_2)
 	{
 		auto response (wait_response (system, rpc_ctx, request, 10s));
 		auto work_text (response.get_optional<std::string> ("work"));
-		ASSERT_TRUE (work_text.is_initialized ());
+		ASSERT_TRUE (work_text.has_value ());
 		uint64_t work;
 		ASSERT_FALSE (nano::from_string_hex (*work_text, work));
 		auto result_difficulty (nano::dev::network_params.work.difficulty (nano::work_version::work_1, hash, work));
@@ -2210,7 +2210,7 @@ TEST (rpc, work_cancel)
 	system.deadline_set (10s);
 	while (!done)
 	{
-		system.work.generate (nano::work_version::work_1, hash1, node1->network_params.work.base, [&done] (boost::optional<uint64_t> work_a) {
+		system.work.generate (nano::work_version::work_1, hash1, node1->network_params.work.base, [&done] (std::optional<uint64_t> work_a) {
 			done = !work_a;
 		});
 		auto response1 (wait_response (system, rpc_ctx, request1));
@@ -3425,10 +3425,10 @@ TEST (rpc, wallet_receivable)
 			nano::uint128_union amount;
 			amount.decode_dec (i->second.get<std::string> (""));
 			blocks[hash] = amount;
-			boost::optional<std::string> source (i->second.get_optional<std::string> ("source"));
-			ASSERT_FALSE (source.is_initialized ());
-			boost::optional<uint8_t> min_version (i->second.get_optional<uint8_t> ("min_version"));
-			ASSERT_FALSE (min_version.is_initialized ());
+			auto source (i->second.get_optional<std::string> ("source"));
+			ASSERT_FALSE (source.has_value ());
+			auto min_version (i->second.get_optional<uint8_t> ("min_version"));
+			ASSERT_FALSE (min_version.has_value ());
 		}
 	}
 	ASSERT_EQ (blocks[block1->hash ()], 100);
@@ -3765,8 +3765,8 @@ TEST (rpc, delegators_parameters)
 		delegators4.put ((i->first), (i->second.get<std::string> ("")));
 	}
 	ASSERT_EQ (1, delegators4.size ());
-	boost::optional<std::string> balance (delegators4.get_optional<std::string> (last_account.to_account ()));
-	ASSERT_TRUE (balance.is_initialized ());
+	auto balance (delegators4.get_optional<std::string> (last_account.to_account ()));
+	ASSERT_TRUE (balance.has_value ());
 
 	// Test with "start" equal to last account
 	request.put ("start", last_account.to_account ());
@@ -3833,7 +3833,7 @@ TEST (rpc, account_info)
 		auto response (wait_response (system, rpc_ctx, request));
 
 		auto error (response.get_optional<std::string> ("error"));
-		ASSERT_TRUE (error.is_initialized ());
+		ASSERT_TRUE (error.has_value ());
 		ASSERT_EQ (error.get (), std::error_code (nano::error_common::account_not_found).message ());
 	}
 
@@ -3872,12 +3872,12 @@ TEST (rpc, account_info)
 		std::string confirmation_height_frontier (response.get<std::string> ("confirmation_height_frontier"));
 		ASSERT_EQ (nano::dev::genesis->hash ().to_string (), confirmation_height_frontier);
 		ASSERT_EQ (0, response.get<uint8_t> ("account_version"));
-		boost::optional<std::string> weight (response.get_optional<std::string> ("weight"));
-		ASSERT_FALSE (weight.is_initialized ());
-		boost::optional<std::string> receivable (response.get_optional<std::string> ("receivable"));
-		ASSERT_FALSE (receivable.is_initialized ());
-		boost::optional<std::string> representative (response.get_optional<std::string> ("representative"));
-		ASSERT_FALSE (representative.is_initialized ());
+		auto weight (response.get_optional<std::string> ("weight"));
+		ASSERT_FALSE (weight.has_value ());
+		auto receivable (response.get_optional<std::string> ("receivable"));
+		ASSERT_FALSE (receivable.has_value ());
+		auto representative (response.get_optional<std::string> ("representative"));
+		ASSERT_FALSE (representative.has_value ());
 	}
 
 	// Test for optional values
@@ -3981,19 +3981,19 @@ TEST (rpc, account_info)
 
 		// These fields shouldn't exist
 		auto confirmed_balance (response.get_optional<std::string> ("confirmed_balance"));
-		ASSERT_FALSE (confirmed_balance.is_initialized ());
+		ASSERT_FALSE (confirmed_balance.has_value ());
 
 		auto confirmed_receivable (response.get_optional<std::string> ("confirmed_receivable"));
-		ASSERT_FALSE (confirmed_receivable.is_initialized ());
+		ASSERT_FALSE (confirmed_receivable.has_value ());
 
 		auto confirmed_representative (response.get_optional<std::string> ("confirmed_representative"));
-		ASSERT_FALSE (confirmed_representative.is_initialized ());
+		ASSERT_FALSE (confirmed_representative.has_value ());
 
 		auto confirmed_frontier (response.get_optional<std::string> ("confirmed_frontier"));
-		ASSERT_FALSE (confirmed_frontier.is_initialized ());
+		ASSERT_FALSE (confirmed_frontier.has_value ());
 
 		auto confirmed_height (response.get_optional<uint64_t> ("confirmed_height"));
-		ASSERT_FALSE (confirmed_height.is_initialized ());
+		ASSERT_FALSE (confirmed_height.has_value ());
 	}
 }
 
@@ -4078,18 +4078,18 @@ TEST (rpc, blocks_info)
 			ASSERT_EQ (node->latest (nano::dev::genesis_key.pub).to_string (), hash_text);
 			std::string account_text (blocks.second.get<std::string> ("block_account"));
 			ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), account_text);
-			boost::optional<std::string> linked_account (blocks.second.get_optional<std::string> ("linked_account"));
-			ASSERT_FALSE (linked_account.is_initialized ());
+			auto linked_account (blocks.second.get_optional<std::string> ("linked_account"));
+			ASSERT_FALSE (linked_account.has_value ());
 			std::string amount_text (blocks.second.get<std::string> ("amount"));
 			ASSERT_EQ (nano::dev::constants.genesis_amount.convert_to<std::string> (), amount_text);
 			std::string blocks_text (blocks.second.get<std::string> ("contents"));
 			ASSERT_FALSE (blocks_text.empty ());
-			boost::optional<std::string> receivable (blocks.second.get_optional<std::string> ("receivable"));
-			ASSERT_FALSE (receivable.is_initialized ());
-			boost::optional<std::string> receive_hash (blocks.second.get_optional<std::string> ("receive_hash"));
-			ASSERT_FALSE (receive_hash.is_initialized ());
-			boost::optional<std::string> source (blocks.second.get_optional<std::string> ("source_account"));
-			ASSERT_FALSE (source.is_initialized ());
+			auto receivable (blocks.second.get_optional<std::string> ("receivable"));
+			ASSERT_FALSE (receivable.has_value ());
+			auto receive_hash (blocks.second.get_optional<std::string> ("receive_hash"));
+			ASSERT_FALSE (receive_hash.has_value ());
+			auto source (blocks.second.get_optional<std::string> ("source_account"));
+			ASSERT_FALSE (source.has_value ());
 			std::string balance_text (blocks.second.get<std::string> ("balance"));
 			ASSERT_EQ (nano::dev::constants.genesis_amount.convert_to<std::string> (), balance_text);
 			ASSERT_TRUE (blocks.second.get<bool> ("confirmed")); // Genesis block is confirmed by default
@@ -4389,8 +4389,8 @@ TEST (rpc, block_info_pruning)
 	auto response2 (wait_response (system, rpc_ctx, request2));
 	std::string account_text (response2.get<std::string> ("block_account"));
 	ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), account_text);
-	boost::optional<std::string> amount (response2.get_optional<std::string> ("amount"));
-	ASSERT_FALSE (amount.is_initialized ()); // Cannot calculate amount
+	auto amount (response2.get_optional<std::string> ("amount"));
+	ASSERT_FALSE (amount.has_value ()); // Cannot calculate amount
 	bool json_error{ false };
 	nano::receive_block receive_from_json (json_error, response2.get_child ("contents"));
 	ASSERT_FALSE (json_error);
@@ -4576,12 +4576,12 @@ TEST (rpc, ledger)
 			ASSERT_LT (std::abs ((long)time - stol (modified_timestamp)), 5);
 			std::string block_count (account.second.get<std::string> ("block_count"));
 			ASSERT_EQ ("1", block_count);
-			boost::optional<std::string> weight (account.second.get_optional<std::string> ("weight"));
-			ASSERT_FALSE (weight.is_initialized ());
-			boost::optional<std::string> pending (account.second.get_optional<std::string> ("pending"));
-			ASSERT_FALSE (pending.is_initialized ());
-			boost::optional<std::string> representative (account.second.get_optional<std::string> ("representative"));
-			ASSERT_FALSE (representative.is_initialized ());
+			auto weight (account.second.get_optional<std::string> ("weight"));
+			ASSERT_FALSE (weight.has_value ());
+			auto pending (account.second.get_optional<std::string> ("pending"));
+			ASSERT_FALSE (pending.has_value ());
+			auto representative (account.second.get_optional<std::string> ("representative"));
+			ASSERT_FALSE (representative.has_value ());
 		}
 	}
 	// Test for optional values
@@ -4592,15 +4592,15 @@ TEST (rpc, ledger)
 		auto response (wait_response (system, rpc_ctx, request));
 		for (auto & account : response.get_child ("accounts"))
 		{
-			boost::optional<std::string> weight (account.second.get_optional<std::string> ("weight"));
-			ASSERT_TRUE (weight.is_initialized ());
-			ASSERT_EQ ("0", weight.get ());
-			boost::optional<std::string> pending (account.second.get_optional<std::string> ("pending"));
-			ASSERT_TRUE (pending.is_initialized ());
-			ASSERT_EQ ("0", pending.get ());
-			boost::optional<std::string> representative (account.second.get_optional<std::string> ("representative"));
-			ASSERT_TRUE (representative.is_initialized ());
-			ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), representative.get ());
+			auto weight (account.second.get_optional<std::string> ("weight"));
+			ASSERT_TRUE (weight.has_value ());
+			ASSERT_EQ ("0", weight.value ());
+			auto pending (account.second.get_optional<std::string> ("pending"));
+			ASSERT_TRUE (pending.has_value ());
+			ASSERT_EQ ("0", pending.value ());
+			auto representative (account.second.get_optional<std::string> ("representative"));
+			ASSERT_TRUE (representative.has_value ());
+			ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), representative.value ());
 		}
 	}
 	// Test threshold
@@ -5179,12 +5179,12 @@ TEST (rpc, wallet_ledger)
 		ASSERT_LT (std::abs ((long)time - stol (modified_timestamp)), 5);
 		std::string block_count (accounts.second.get<std::string> ("block_count"));
 		ASSERT_EQ ("1", block_count);
-		boost::optional<std::string> weight (accounts.second.get_optional<std::string> ("weight"));
-		ASSERT_FALSE (weight.is_initialized ());
-		boost::optional<std::string> pending (accounts.second.get_optional<std::string> ("pending"));
-		ASSERT_FALSE (pending.is_initialized ());
-		boost::optional<std::string> representative (accounts.second.get_optional<std::string> ("representative"));
-		ASSERT_FALSE (representative.is_initialized ());
+		auto weight (accounts.second.get_optional<std::string> ("weight"));
+		ASSERT_FALSE (weight.has_value ());
+		auto pending (accounts.second.get_optional<std::string> ("pending"));
+		ASSERT_FALSE (pending.has_value ());
+		auto representative (accounts.second.get_optional<std::string> ("representative"));
+		ASSERT_FALSE (representative.has_value ());
 	}
 	// Test for optional values
 	request.put ("weight", "true");
@@ -5193,14 +5193,14 @@ TEST (rpc, wallet_ledger)
 	auto response2 (wait_response (system, rpc_ctx, request));
 	for (auto & accounts : response2.get_child ("accounts"))
 	{
-		boost::optional<std::string> weight (accounts.second.get_optional<std::string> ("weight"));
-		ASSERT_TRUE (weight.is_initialized ());
-		ASSERT_EQ ("0", weight.get ());
-		boost::optional<std::string> pending (accounts.second.get_optional<std::string> ("pending"));
-		ASSERT_TRUE (pending.is_initialized ());
-		ASSERT_EQ ("0", pending.get ());
-		boost::optional<std::string> representative (accounts.second.get_optional<std::string> ("representative"));
-		ASSERT_FALSE (representative.is_initialized ());
+		auto weight (accounts.second.get_optional<std::string> ("weight"));
+		ASSERT_TRUE (weight.has_value ());
+		ASSERT_EQ ("0", weight.value ());
+		auto pending (accounts.second.get_optional<std::string> ("pending"));
+		ASSERT_TRUE (pending.has_value ());
+		ASSERT_EQ ("0", pending.value ());
+		auto representative (accounts.second.get_optional<std::string> ("representative"));
+		ASSERT_FALSE (representative.has_value ());
 	}
 }
 
@@ -5255,8 +5255,8 @@ TEST (rpc, online_reps)
 	auto item (representatives.begin ());
 	ASSERT_NE (representatives.end (), item);
 	ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), item->second.get<std::string> (""));
-	boost::optional<std::string> weight (item->second.get_optional<std::string> ("weight"));
-	ASSERT_FALSE (weight.is_initialized ());
+	auto weight (item->second.get_optional<std::string> ("weight"));
+	ASSERT_FALSE (weight.has_value ());
 	ASSERT_TIMELY (5s, node2->block (send_block->hash ()));
 	// Test weight option
 	request.put ("weight", "true");
@@ -6147,8 +6147,8 @@ TEST (rpc, active_difficulty)
 	{
 		auto response (wait_response (system, rpc_ctx, request));
 		auto trend_opt (response.get_child_optional ("difficulty_trend"));
-		ASSERT_TRUE (trend_opt.is_initialized ());
-		auto & trend (trend_opt.get ());
+		ASSERT_TRUE (trend_opt.has_value ());
+		auto & trend (trend_opt.value ());
 		ASSERT_EQ (1, trend.size ());
 	}
 }
@@ -6233,16 +6233,16 @@ TEST (rpc, deprecated_account_format)
 	request.put ("action", "account_info");
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
 	auto response (wait_response (system, rpc_ctx, request));
-	boost::optional<std::string> deprecated_account_format (response.get_optional<std::string> ("deprecated_account_format"));
-	ASSERT_FALSE (deprecated_account_format.is_initialized ());
+	auto deprecated_account_format (response.get_optional<std::string> ("deprecated_account_format"));
+	ASSERT_FALSE (deprecated_account_format.has_value ());
 	std::string account_text (nano::dev::genesis_key.pub.to_account ());
 	account_text[4] = '-';
 	request.put ("account", account_text);
 	auto response2 (wait_response (system, rpc_ctx, request));
 	std::string frontier (response2.get<std::string> ("frontier"));
 	ASSERT_EQ (nano::dev::genesis->hash ().to_string (), frontier);
-	boost::optional<std::string> deprecated_account_format2 (response2.get_optional<std::string> ("deprecated_account_format"));
-	ASSERT_TRUE (deprecated_account_format2.is_initialized ());
+	auto deprecated_account_format2 (response2.get_optional<std::string> ("deprecated_account_format"));
+	ASSERT_TRUE (deprecated_account_format2.has_value ());
 }
 
 TEST (rpc, epoch_upgrade)
@@ -7068,7 +7068,7 @@ TEST (rpc, confirmation_info)
 		ASSERT_EQ ("1500000000000000000000000000000000000", representatives_final.get<std::string> (rep5.pub.to_account ()));
 
 		// Verify the contents field exists
-		ASSERT_TRUE (block_info->second.get_child_optional ("contents").is_initialized ());
+		ASSERT_TRUE (block_info->second.get_child_optional ("contents").has_value ());
 	}
 }
 

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -12,7 +12,6 @@
 #include <boost/endian/conversion.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/property_tree/json_parser.hpp>
-#include <boost/variant/get.hpp>
 
 #include <limits>
 #include <queue>


### PR DESCRIPTION
This PR replaces the use of Boost optional with the std equivalent built into c++ 17