### PR TITLE
Remove unused Boost filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,7 +417,6 @@ set(BOOST_INCLUDE_LIBRARIES
     circular_buffer
     dll
     endian
-    filesystem
     format
     iostreams
     lexical_cast

--- a/nano/core_test/entry.cpp
+++ b/nano/core_test/entry.cpp
@@ -4,8 +4,6 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/filesystem/path.hpp>
-
 namespace nano
 {
 namespace test

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -37,8 +37,6 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/filesystem.hpp>
-
 #include <numeric>
 #include <sstream>
 #include <string>

--- a/nano/core_test/utility.cpp
+++ b/nano/core_test/utility.cpp
@@ -9,8 +9,6 @@
 
 #include <gtest/gtest.h>
 
-#include <boost/filesystem.hpp>
-
 #include <fstream>
 #include <future>
 

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -14,7 +14,6 @@
 #include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
 
-#include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
 #include <latch>


### PR DESCRIPTION
Boost filesystem was replaced with std filesystem a few versions ago. But Boost is still imported and compiled on every build unnecessarily.
