### PR TITLE
Fix race condition in rpc.online_reps unit test

### DIFF
--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5272,9 +5272,7 @@ TEST (rpc, online_reps)
 	auto send (system.wallet (0)->send_action (nano::dev::genesis_key.pub, new_rep, node1->config.receive_minimum.number ()));
 	ASSERT_NE (nullptr, send);
 	ASSERT_TIMELY (10s, node2->block (send->hash ()));
-	auto receive (system.wallet (1)->receive_action (send->hash (), new_rep, node1->config.receive_minimum.number (), send->destination ()));
-	ASSERT_NE (nullptr, receive);
-	ASSERT_TIMELY (5s, node2->block (receive->hash ()));
+	ASSERT_TIMELY (5s, !node2->ledger.any.account_head (node2->ledger.tx_begin_read (), new_rep).is_zero ());
 	auto change (system.wallet (0)->change_action (nano::dev::genesis_key.pub, new_rep));
 	ASSERT_NE (nullptr, change);
 	ASSERT_TIMELY (5s, node2->block (change->hash ()));


### PR DESCRIPTION
Explicit receive_action() asserted the result was non-null, but wallet auto-receive could land first which caused the explicit receive to result in nullptr result

Replaced explicit receive + block-wait with a single ASSERT_TIMELY that waits for new_rep's account head to appear on node2