### PR TITLE
Fix race condition in fork_publish unit test

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -563,8 +563,7 @@ TEST (node, fork_publish)
 	node1.work_generate_blocking (*send2);
 	node1.process_active (send1);
 	node1.process_active (send2);
-	ASSERT_TIMELY_EQ (5s, 1, node1.active.size ());
-	ASSERT_TIMELY (5s, node1.active.active (*send2));
+	ASSERT_TIMELY (5s, node1.active.active (*send1) && node1.active.active (*send2));
 	auto election (node1.active.election (send1->qualified_root ()));
 	ASSERT_NE (nullptr, election);
 	// Wait until the genesis rep activated & makes vote


### PR DESCRIPTION
Intermittent race condition in fork_publish :

[ RUN      ] node.fork_publish
D:\a\nano-node\nano-node\nano\core_test\node.cpp(566): error: Expected equality of these values:
  1
  node1.active.size ()
    Which is: 0

This PR replaces the two sequential timely-assertions with one combined that waits until both send1 and send2 are active