### PR TITLE
Disable RPC logging by default

### DIFF
--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -943,7 +943,7 @@ TEST (toml_config, rpc_config_deserialize_no_defaults)
 	ipc_port = 999
 	num_ipc_connections = 999
 	[logging]
-	log_rpc = false
+	log_rpc = true
 	)toml";
 
 	nano::tomlconfig toml;

--- a/nano/lib/rpcconfig.hpp
+++ b/nano/lib/rpcconfig.hpp
@@ -30,7 +30,7 @@ public:
 class rpc_logging_config final
 {
 public:
-	bool log_rpc{ true };
+	bool log_rpc{ false };
 };
 
 class rpc_config final


### PR DESCRIPTION
Set the default RPC logging configuration to false so RPC activity is not logged unless explicitly enabled.