### PR TITLE
Expose peer capabilities in peers RPC

### DIFF
--- a/nano/core_test/enums.cpp
+++ b/nano/core_test/enums.cpp
@@ -267,3 +267,40 @@ TEST (enum_flags, to_string_all)
 	flags.set (test_flags::gamma);
 	ASSERT_EQ (to_string (flags), "alpha, beta, gamma");
 }
+
+TEST (enum_flags, to_string_list_none)
+{
+	nano::enum_flags<test_flags> flags;
+	ASSERT_TRUE (to_string_list (flags).empty ());
+}
+
+TEST (enum_flags, to_string_list_single)
+{
+	nano::enum_flags<test_flags> flags{ test_flags::beta };
+	ASSERT_EQ (to_string_list (flags), (std::vector<std::string>{ "beta" }));
+}
+
+TEST (enum_flags, to_string_list_multiple)
+{
+	nano::enum_flags<test_flags> flags;
+	flags.set (test_flags::alpha);
+	flags.set (test_flags::gamma);
+	ASSERT_EQ (to_string_list (flags), (std::vector<std::string>{ "alpha", "gamma" }));
+}
+
+TEST (enum_flags, to_string_list_unknown)
+{
+	// Bits not covered by known enum values are reported as unknown(0x..)
+	nano::node_capabilities_flags flags{ nano::node_capabilities::topo_index };
+	flags.underlying () |= (1ULL << 8); // simulate an unknown capability advertised by a newer peer
+	ASSERT_EQ (to_string_list (flags), (std::vector<std::string>{ "topo_index", "unknown(0x100)" }));
+}
+
+TEST (enum_flags, to_string_unknown_narrow_underlying)
+{
+	// Unknown bits of a narrow (uint8_t) underlying type must format as a hex number, not a char
+	nano::enum_flags<test_flags> flags{ test_flags::alpha };
+	flags.underlying () |= 0x48; // unknown bits 0x08 | 0x40; 0x48 is the ASCII code for 'H'
+	ASSERT_EQ (to_string (flags), "alpha, unknown(0x48)");
+	ASSERT_EQ (to_string_list (flags), (std::vector<std::string>{ "alpha", "unknown(0x48)" }));
+}

--- a/nano/lib/enum_flags.hpp
+++ b/nano/lib/enum_flags.hpp
@@ -3,6 +3,7 @@
 #include <iosfwd>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 namespace nano
 {
@@ -14,6 +15,9 @@ std::ostream & operator<< (std::ostream &, enum_flags<E> const &);
 
 template <typename E>
 std::string to_string (enum_flags<E> const &);
+
+template <typename E>
+std::vector<std::string> to_string_list (enum_flags<E> const &);
 
 /**
  * Type-safe wrapper for flag enums (bitfields)

--- a/nano/lib/enum_flags_templ.hpp
+++ b/nano/lib/enum_flags_templ.hpp
@@ -5,6 +5,7 @@
 #include <ostream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include <magic_enum.hpp>
 
@@ -59,5 +60,36 @@ std::string to_string (enum_flags<E> const & flags)
 	std::ostringstream ss;
 	ss << flags;
 	return ss.str ();
+}
+
+template <typename E>
+std::vector<std::string> to_string_list (enum_flags<E> const & flags)
+{
+	using underlying_t = typename enum_flags<E>::underlying_t;
+	std::vector<std::string> result;
+	underlying_t known_bits = 0;
+	// Names of all known set flags
+	for (auto val : magic_enum::enum_values<E> ())
+	{
+		auto bit = static_cast<underlying_t> (val);
+		if (bit == 0)
+		{
+			continue; // Skip the zero/none value
+		}
+		known_bits |= bit;
+		if (flags.test (val))
+		{
+			result.emplace_back (magic_enum::enum_name (val));
+		}
+	}
+	// Any bits not covered by known enum values (e.g. from a newer peer)
+	auto unknown = flags.underlying () & ~known_bits;
+	if (unknown)
+	{
+		std::ostringstream ss;
+		ss << "unknown(0x" << std::hex << unknown << std::dec << ")";
+		result.push_back (ss.str ());
+	}
+	return result;
 }
 }

--- a/nano/lib/node_capabilities.cpp
+++ b/nano/lib/node_capabilities.cpp
@@ -9,3 +9,4 @@ std::string_view nano::to_string (nano::node_capabilities value)
 
 template std::ostream & nano::operator<< <nano::node_capabilities> (std::ostream &, nano::node_capabilities_flags const &);
 template std::string nano::to_string<nano::node_capabilities> (nano::node_capabilities_flags const &);
+template std::vector<std::string> nano::to_string_list<nano::node_capabilities> (nano::node_capabilities_flags const &);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -5,6 +5,7 @@
 #include <nano/lib/json_error_response.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/lib/logging.hpp>
+#include <nano/lib/node_capabilities.hpp>
 #include <nano/lib/saturate.hpp>
 #include <nano/lib/stats.hpp>
 #include <nano/lib/stats_sinks.hpp>
@@ -3057,6 +3058,16 @@ void nano::json_handler::peers ()
 
 			auto peering_endpoint = channel->get_peering_endpoint ();
 			pending_tree.put ("peering", boost::lexical_cast<std::string> (peering_endpoint));
+
+			// Capabilities (extensions) the peer advertised during the node id handshake
+			boost::property_tree::ptree capabilities_l;
+			for (auto const & capability : nano::to_string_list (channel->get_flags ()))
+			{
+				boost::property_tree::ptree entry;
+				entry.put ("", capability);
+				capabilities_l.push_back (std::make_pair ("", entry));
+			}
+			pending_tree.add_child ("capabilities", capabilities_l);
 
 			peers_l.push_back (boost::property_tree::ptree::value_type (text.str (), pending_tree));
 		}

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -6,6 +6,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/files.hpp>
 #include <nano/lib/jsonconfig.hpp>
+#include <nano/lib/node_capabilities.hpp>
 #include <nano/lib/rpcconfig.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/threading.hpp>
@@ -1841,6 +1842,35 @@ TEST (rpc, peers_peering_endpoint)
 	auto peer = peers_node.begin ();
 	ASSERT_NE (peer->first, boost::lexical_cast<std::string> (node2->network.endpoint ()));
 	ASSERT_EQ (peer->second.get<std::string> ("peering"), boost::lexical_cast<std::string> (node2->network.endpoint ()));
+}
+
+TEST (rpc, peers_capabilities)
+{
+	nano::test::system system;
+	// Peer advertises the topo_index capability during the handshake
+	nano::node_flags node_flags;
+	node_flags.capabilities_override = nano::node_capabilities_flags{ nano::node_capabilities::topo_index };
+	auto const node2 = system.add_node (node_flags);
+	auto node = add_ipc_enabled_node (system);
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "peers");
+	request.put ("peer_details", true);
+	auto response (wait_response (system, rpc_ctx, request));
+	auto & peers_node (response.get_child ("peers"));
+	ASSERT_EQ (1, peers_node.size ());
+
+	auto peer = peers_node.begin ();
+	ASSERT_EQ (peer->first, boost::lexical_cast<std::string> (node2->network.endpoint ()));
+
+	auto tree1 = peer->second;
+	std::vector<std::string> capabilities;
+	for (auto const & [key, value] : tree1.get_child ("capabilities"))
+	{
+		capabilities.push_back (value.get_value<std::string> ());
+	}
+	ASSERT_EQ (1, capabilities.size ());
+	ASSERT_EQ ("topo_index", capabilities.front ());
 }
 
 TEST (rpc, version)


### PR DESCRIPTION
Include capabilities in detailed peers responses and cover the formatter and RPC output with tests.