### PR TITLE
Add flag to disable elections

### DIFF
--- a/nano/core_test/bootstrap.cpp
+++ b/nano/core_test/bootstrap.cpp
@@ -131,15 +131,13 @@ TEST (bootstrap, frontier_scan)
 
 	nano::node_flags flags;
 	flags.disable_legacy_bootstrap = true;
+	flags.disable_elections = true; // Disable election schedulers
 	nano::node_config config;
 	// Disable other bootstrap strategies
 	config.bootstrap->enable_priorities = false;
 	config.bootstrap->enable_dependency_walker = false;
 	// Disable election activation
 	config.backlog_scan->enable = false;
-	config.priority_scheduler->enable = false;
-	config.optimistic_scheduler->enable = false;
-	config.hinted_scheduler->enable = false;
 
 	// Prepare blocks for frontier scan (genesis 10 sends -> 10 opens -> 10 updates)
 	std::vector<std::shared_ptr<nano::block>> sends;
@@ -227,15 +225,13 @@ TEST (bootstrap, frontier_scan_pending)
 
 	nano::node_flags flags;
 	flags.disable_legacy_bootstrap = true;
+	flags.disable_elections = true; // Disable election schedulers
 	nano::node_config config;
 	// Disable other bootstrap strategies
 	config.bootstrap->enable_priorities = false;
 	config.bootstrap->enable_dependency_walker = false;
 	// Disable election activation
 	config.backlog_scan->enable = false;
-	config.priority_scheduler->enable = false;
-	config.optimistic_scheduler->enable = false;
-	config.hinted_scheduler->enable = false;
 
 	// Prepare blocks for frontier scan (genesis 10 sends -> 10 opens)
 	std::vector<std::shared_ptr<nano::block>> sends;
@@ -309,15 +305,13 @@ TEST (bootstrap, frontier_scan_cannot_prioritize)
 
 	nano::node_flags flags;
 	flags.disable_legacy_bootstrap = true;
+	flags.disable_elections = true; // Disable election schedulers
 	nano::node_config config;
 	// Disable other bootstrap strategies
 	config.bootstrap->enable_priorities = false;
 	config.bootstrap->enable_dependency_walker = false;
 	// Disable election activation
 	config.backlog_scan->enable = false;
-	config.priority_scheduler->enable = false;
-	config.optimistic_scheduler->enable = false;
-	config.hinted_scheduler->enable = false;
 
 	// Prepare blocks for frontier scan (genesis 10 sends -> 10 opens -> 10 sends -> 10 opens)
 	std::vector<std::shared_ptr<nano::block>> sends;
@@ -422,17 +416,16 @@ TEST (bootstrap, reset)
 	int const chain_count = 10;
 	int const blocks_per_chain = 5;
 
+	nano::node_flags flags;
+	flags.disable_elections = true; // Disable election schedulers
 	nano::node_config config;
 	// Disable election activation
 	config.backlog_scan->enable = false;
-	config.priority_scheduler->enable = false;
-	config.optimistic_scheduler->enable = false;
-	config.hinted_scheduler->enable = false;
 	// Add request limits to slow down bootstrap
 	config.bootstrap->rate_limit = 30;
 
 	// Start server node
-	auto & node_server = *system.add_node (config);
+	auto & node_server = *system.add_node (config, flags);
 
 	// Create multiple chains of blocks
 	auto chains = nano::test::setup_chains (system, node_server, chain_count, blocks_per_chain);
@@ -441,7 +434,7 @@ TEST (bootstrap, reset)
 	int const halfway_blocks = total_blocks / 2;
 
 	// Start client node and begin bootstrap
-	auto & node_client = *system.add_node (config);
+	auto & node_client = *system.add_node (config, flags);
 	ASSERT_LE (node_client.block_count (), halfway_blocks); // Should not be synced yet
 
 	// Wait until bootstrap has started and processed some blocks but not all
@@ -463,15 +456,14 @@ TEST (bootstrap, reset)
  */
 TEST (bootstrap, database_scan_safe_queries)
 {
+	nano::node_flags flags;
+	flags.disable_elections = true; // Disable election schedulers
 	nano::node_config config;
 	// Keep confirmation under manual control so the head can differ from the confirmed frontier
 	config.backlog_scan->enable = false;
-	config.priority_scheduler->enable = false;
-	config.optimistic_scheduler->enable = false;
-	config.hinted_scheduler->enable = false;
 
 	nano::test::system system;
-	auto & node = *system.add_node (config);
+	auto & node = *system.add_node (config, flags);
 
 	nano::keypair key;
 	nano::state_block_builder builder;

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -4063,3 +4063,43 @@ TEST (node, port_already_in_use)
 	// Exit gracefully
 	node2->stop ();
 }
+
+/*
+ * The --disable_elections node flag should prevent any elections from starting
+ */
+TEST (node, disable_elections)
+{
+	nano::test::system system;
+	nano::node_flags flags;
+	flags.disable_elections = true;
+	auto & node = *system.add_node (flags);
+
+	// Genesis representative present: with elections enabled blocks would normally start an election and confirm
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+
+	auto send1 = nano::state_block_builder{}
+				 .account (nano::dev::genesis_key.pub)
+				 .representative (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .link (nano::public_key ())
+				 .balance (nano::dev::constants.genesis_amount - 100)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (nano::dev::genesis->hash ()))
+				 .build ();
+
+	// Block flows through the block processor and lands in the ledger
+	node.process_active (send1);
+	ASSERT_TIMELY (5s, nano::test::exists (node, { send1 }));
+
+	// No election ever starts and the block is never confirmed
+	ASSERT_NEVER (1s, !node.active.empty ());
+	ASSERT_FALSE (nano::test::confirmed (node, { send1 }));
+
+	// Inserting an election directly is a no-op as well (master switch in active_elections::insert)
+	auto stored = node.block (send1->hash ());
+	ASSERT_NE (nullptr, stored);
+	auto result = node.active.insert (stored);
+	ASSERT_FALSE (result.inserted);
+	ASSERT_EQ (nullptr, result.election);
+	ASSERT_TRUE (node.active.empty ());
+}

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -3756,12 +3756,11 @@ TEST (node, local_block_broadcast)
 	nano::test::system system;
 
 	// Disable active elections to prevent the block from being broadcasted by the election
+	nano::node_flags node_flags;
+	node_flags.disable_elections = true;
 	auto node_config = system.default_config ();
-	node_config.priority_scheduler->enable = false;
-	node_config.hinted_scheduler->enable = false;
-	node_config.optimistic_scheduler->enable = false;
 	node_config.local_block_broadcaster->rebroadcast_interval = 1s;
-	auto & node1 = *system.add_node (node_config);
+	auto & node1 = *system.add_node (node_config, node_flags);
 	auto & node2 = *system.make_disconnected_node ();
 
 	nano::keypair key1;

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -151,7 +151,8 @@ auto nano::active_elections::insert (std::shared_ptr<nano::block> const & block,
 
 	insert_result result{ nullptr, false };
 
-	if (stopped)
+	// Short circuit if elections are disabled
+	if (stopped || !config.enable)
 	{
 		return result;
 	}
@@ -843,6 +844,7 @@ nano::active_elections_config::active_elections_config (const nano::network_cons
 
 nano::error nano::active_elections_config::serialize (nano::tomlconfig & toml) const
 {
+	toml.put ("enable", enable, "Enable or disable starting elections.\ntype:bool");
 	toml.put ("size", size, "Number of active elections. Elections beyond this limit have limited survival time.\nWarning: modifying this value may result in a lower confirmation rate. \ntype:uint64,[250..]");
 	toml.put ("hinted_limit_percentage", hinted_limit_percentage, "Limit of hinted elections as percentage of `active_elections_size` \ntype:uint64");
 	toml.put ("optimistic_limit_percentage", optimistic_limit_percentage, "Limit of optimistic elections as percentage of `active_elections_size`. \ntype:uint64");
@@ -854,6 +856,7 @@ nano::error nano::active_elections_config::serialize (nano::tomlconfig & toml) c
 
 nano::error nano::active_elections_config::deserialize (nano::tomlconfig & toml)
 {
+	toml.get ("enable", enable);
 	toml.get ("size", size);
 	toml.get ("hinted_limit_percentage", hinted_limit_percentage);
 	toml.get ("optimistic_limit_percentage", optimistic_limit_percentage);

--- a/nano/node/active_elections.hpp
+++ b/nano/node/active_elections.hpp
@@ -34,6 +34,8 @@ public:
 	nano::error serialize (nano::tomlconfig & toml) const;
 
 public:
+	// Enable or disable starting elections
+	bool enable{ true };
 	// Maximum number of simultaneous active elections (AEC size)
 	std::size_t size{ 5000 };
 	// Limit of hinted elections as percentage of `active_elections_size`

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -113,6 +113,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_max_peers_per_ip", "Disables the limit on the number of peer connections allowed per IP address")
 		("disable_max_peers_per_subnetwork", "Disables the limit on the number of peer connections allowed per subnetwork")
 		("disable_activate_successors", "Disables activate_successors in active_elections")
+		("disable_elections", "Disables starting elections and block confirmation; the node only processes and pulls blocks without confirming them")
 		("disable_backup", "Disable wallet automatic backups")
 		("disable_lazy_bootstrap", "Disables lazy bootstrap")
 		("disable_legacy_bootstrap", "Disables legacy bootstrap")
@@ -154,6 +155,7 @@ void nano::update_flags (nano::node_flags & flags_a, boost::program_options::var
 	flags_a.disable_max_peers_per_ip = (vm.count ("disable_max_peers_per_ip") > 0);
 	flags_a.disable_max_peers_per_subnetwork = (vm.count ("disable_max_peers_per_subnetwork") > 0);
 	flags_a.disable_activate_successors = (vm.count ("disable_activate_successors") > 0);
+	flags_a.disable_elections = (vm.count ("disable_elections") > 0);
 	flags_a.disable_backup = (vm.count ("disable_backup") > 0);
 	flags_a.disable_lazy_bootstrap = (vm.count ("disable_lazy_bootstrap") > 0);
 	flags_a.disable_legacy_bootstrap = (vm.count ("disable_legacy_bootstrap") > 0);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -103,7 +103,7 @@ nano::node::node (uint16_t peering_port_a, std::filesystem::path const & applica
 nano::node::node (std::filesystem::path const & application_path_a, nano::node_config const & config_a, nano::work_pool & work_a, nano::node_flags flags_a, unsigned seq) :
 	application_path{ application_path_a },
 	node_id{ load_or_create_node_id (application_path_a) },
-	config_impl{ std::make_unique<nano::node_config> (config_a) },
+	config_impl{ std::make_unique<nano::node_config> (apply_flag_overrides (config_a, flags_a)) },
 	config{ *config_impl },
 	flags_impl{ std::make_unique<nano::node_flags> (flags_a) },
 	flags{ *flags_impl },
@@ -114,9 +114,9 @@ nano::node::node (std::filesystem::path const & application_path_a, nano::node_c
 	logger{ *logger_impl },
 	stats_impl{ std::make_unique<nano::stats> (logger, config.stats_config) },
 	stats{ *stats_impl },
-	store_impl{ nano::make_store (logger, stats, application_path_a, network_params.ledger, flags.read_only, true, config_a) },
+	store_impl{ nano::make_store (logger, stats, application_path_a, network_params.ledger, flags.read_only, true, config) },
 	store{ *store_impl },
-	wallets_backend_impl{ std::make_unique<nano::wallet::lmdb::wallets_backend_lmdb> (application_path_a / "wallets.ldb", config_a.lmdb_config) },
+	wallets_backend_impl{ std::make_unique<nano::wallet::lmdb::wallets_backend_lmdb> (application_path_a / "wallets.ldb", config.lmdb_config) },
 	wallets_backend{ *wallets_backend_impl },
 	ledger_impl{ std::make_unique<nano::ledger> (store, network_params, stats, logger,
 	nano::ledger_options{
@@ -407,7 +407,12 @@ nano::node::node (std::filesystem::path const & application_path_a, nano::node_c
 
 	if (flags.super_rebroadcaster)
 	{
-		logger.warn (nano::log::type::node, "Super rebroadcaster mode enabled - broadcasting to all peers (expect high bandwidth usage)");
+		logger.warn (nano::log::type::node, "Super rebroadcaster mode enabled: broadcasting to all peers, expect high bandwidth usage");
+	}
+
+	if (flags.disable_elections)
+	{
+		logger.warn (nano::log::type::node, "Elections disabled: node will pull and process blocks, but will not actively confirm them");
 	}
 
 	if ((network_params.network.is_live_network () || network_params.network.is_beta_network ()) && !flags.inactive_node)

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -52,6 +52,19 @@ std::string const default_beta_peer_network = nano::env::get ("NANO_DEFAULT_PEER
 std::string const default_test_peer_network = nano::env::get ("NANO_DEFAULT_PEER").value_or ("peering-test.nano.org");
 }
 
+nano::node_config nano::apply_flag_overrides (nano::node_config config, nano::node_flags const & flags)
+{
+	// Disabling elections turns off the automatic election schedulers (priority/hinted/optimistic) and the active elections container itself
+	if (flags.disable_elections)
+	{
+		config.priority_scheduler->enable = false;
+		config.hinted_scheduler->enable = false;
+		config.optimistic_scheduler->enable = false;
+		config.active_elections->enable = false;
+	}
+	return config;
+}
+
 nano::node_config::node_config (nano::network_params const & network_params) :
 	network_params{ network_params },
 	external_address{ boost::asio::ip::address_v6{}.to_string () },

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -137,6 +137,7 @@ public:
 	std::vector<std::string> rpc_config_overrides;
 	bool disable_add_initial_peers{ false };
 	bool disable_activate_successors{ false };
+	bool disable_elections{ false };
 	bool disable_backup{ false };
 	bool disable_lazy_bootstrap{ false };
 	bool disable_legacy_bootstrap{ false };
@@ -174,4 +175,7 @@ public:
 	std::size_t bootstrap_interval{ 0 };
 	std::optional<nano::node_capabilities_flags> capabilities_override;
 };
+
+// Returns a copy of `config` with flag overrides applied
+nano::node_config apply_flag_overrides (nano::node_config config, nano::node_flags const & flags);
 }

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -771,15 +771,14 @@ TEST (wallet, republish)
 	nano_qt::eventloop_processor processor;
 
 	// Configure nodes to disable bootstrap, election schedulers, and other background processes for test isolation
+	nano::node_flags node_flags;
+	node_flags.disable_elections = true;
 	nano::node_config node_config;
 	node_config.bootstrap->enable = false;
-	node_config.priority_scheduler->enable = false;
-	node_config.optimistic_scheduler->enable = false;
-	node_config.hinted_scheduler->enable = false;
 
 	nano::test::system system;
-	auto & node1 = *system.add_node (node_config);
-	auto & node2 = *system.add_node (node_config);
+	auto & node1 = *system.add_node (node_config, node_flags);
+	auto & node2 = *system.add_node (node_config, node_flags);
 
 	ASSERT_TRUE (system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv));
 	nano::keypair key;


### PR DESCRIPTION
Add --disable_elections as a node flag that disables election schedulers while still allowing block processing and pulling.