### PR TITLE
Pin Windows CI runners to windows-2022

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -161,7 +161,7 @@ jobs:
     name: Windows [${{ matrix.network }}]
     needs: prepare_build
     if: ${{ needs.prepare_build.outputs.tag_created == 'true' }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 90
     strategy:
       matrix:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -136,7 +136,7 @@ jobs:
         BACKEND: [lmdb, rocksdb]
         RELEASE:
           - ${{ startsWith(github.ref, 'refs/tags/') }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       NANO_BACKEND: ${{ matrix.BACKEND }}
       BUILD_TYPE: ${{ matrix.RELEASE && 'RelWithDebInfo' || 'Debug' }}


### PR DESCRIPTION
Switch build/deploy and unit test workflows from windows-latest to windows-2022 to keep the Windows CI environment stable across GitHub runner image updates.