### PR TITLE
Scan backlog confirmation heights in lockstep using crawlers

### DIFF
--- a/nano/node/backlog_scan.cpp
+++ b/nano/node/backlog_scan.cpp
@@ -109,16 +109,23 @@ void nano::backlog_scan::populate_backlog (nano::unique_lock<nano::mutex> & lock
 		{
 			auto transaction = ledger.tx_begin_read ();
 
-			auto it = ledger.store.account.begin (transaction, next);
-			auto const end = ledger.store.account.end (transaction);
+			// Both tables are keyed by account, crawl them in lockstep to avoid a random confirmation height lookup per account
+			auto account_crawler = ledger.store.account.crawl (transaction, next);
+			auto conf_crawler = ledger.store.confirmation_height.crawl (transaction, next);
 
-			for (size_t count = 0; it != end && count < config.batch_size; ++it, ++count, ++total)
+			for (size_t count = 0; account_crawler && count < config.batch_size; ++account_crawler, ++count, ++total)
 			{
 				stats.inc (nano::stat::type::backlog_scan, nano::stat::detail::total);
 
-				auto const [account, account_info] = *it;
-				auto const maybe_conf_info = ledger.store.confirmation_height.get (transaction, account);
-				auto const conf_info = maybe_conf_info.value_or (nano::confirmation_height_info{});
+				auto const & [account, account_info] = *account_crawler;
+
+				conf_crawler.skip_to (account);
+
+				nano::confirmation_height_info conf_info{};
+				if (conf_crawler && conf_crawler->first == account)
+				{
+					conf_info = conf_crawler->second;
+				}
 
 				activated_info info{ account, account_info, conf_info };
 
@@ -131,7 +138,7 @@ void nano::backlog_scan::populate_backlog (nano::unique_lock<nano::mutex> & lock
 				next = inc_sat (account.number ());
 			}
 
-			done = (it == end);
+			done = !account_crawler;
 		}
 
 		stats.add (nano::stat::type::backlog_scan, nano::stat::detail::scanned, scanned.size ());

--- a/nano/store/ledger/confirmation_height.hpp
+++ b/nano/store/ledger/confirmation_height.hpp
@@ -3,6 +3,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/store/backend.hpp>
+#include <nano/store/crawler.hpp>
 #include <nano/store/typed_iterator.hpp>
 #include <nano/store/typed_iterator_templ.hpp>
 
@@ -30,6 +31,12 @@ public:
 	iterator begin (nano::store::transaction const &) const;
 	iterator end (nano::store::transaction const &) const;
 	void for_each_par (std::function<void (nano::store::read_transaction const &, iterator, iterator)> const & action) const;
+
+	template <typename Transaction>
+	auto crawl (Transaction & txn, nano::account const & start = { 0 }) const -> nano::store::crawler<confirmation_height_view, Transaction>
+	{
+		return nano::store::crawler<confirmation_height_view, Transaction>{ *this, txn, start };
+	}
 
 private:
 	nano::store::backend & backend;


### PR DESCRIPTION
Add a confirmation height crawler and use it alongside the account crawler during backlog population. This avoids issuing a separate confirmation height lookup for every account while preserving batch progression.