### PR TITLE
Fixed race condition in fork_publish test

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -562,10 +562,12 @@ TEST (node, fork_publish)
 	node1.work_generate_blocking (*send2);
 	node1.process_active (send1);
 	node1.process_active (send2);
-	// Ensure both forks have joined the same election before the genesis rep starts voting
-	ASSERT_TIMELY (5s, node1.active.active (*send1) && node1.active.active (*send2));
+	// Wait for the election to start before fetching it
+	ASSERT_TIMELY (5s, node1.active.active (*send1));
 	auto election (node1.active.election (send1->qualified_root ()));
 	ASSERT_NE (nullptr, election);
+	// Ensure both forks have actually joined the same election before the genesis rep starts voting
+	ASSERT_TIMELY_EQ (5s, election->blocks ().size (), 2);
 	// Insert the genesis key so voting only begins once both forks are in the election
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	// Wait until the genesis rep activated & makes vote

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -525,14 +525,14 @@ TEST (node, coherent_observer)
 	system.wallet (0)->send_action (nano::dev::genesis_key.pub, key.pub, 1);
 }
 
-// FIXME: This test is racy, there is no guarantee that the election won't be confirmed until all forks are fully processed
 /**
  * Test that two forking blocks processed in quick succession result in a
  * single election containing both blocks.
  *
  * Setup:
- * - Single node with genesis key in wallet (has voting weight)
- * - send1 and send2 (forks) are both processed via process_active
+ * - Single node, send1 and send2 (forks) are both processed via process_active
+ * - The genesis key is inserted into the wallet (giving voting weight) only
+ *   after both forks have joined the election
  *
  * Both blocks enter the same election. Genesis votes for send1 (the block
  * it saw first) and send1 wins the election.
@@ -541,7 +541,6 @@ TEST (node, fork_publish)
 {
 	nano::test::system system (1);
 	auto & node1 (*system.nodes[0]);
-	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key1;
 	nano::send_block_builder builder;
 	auto send1 = builder.make_block ()
@@ -563,9 +562,12 @@ TEST (node, fork_publish)
 	node1.work_generate_blocking (*send2);
 	node1.process_active (send1);
 	node1.process_active (send2);
+	// Ensure both forks have joined the same election before the genesis rep starts voting
 	ASSERT_TIMELY (5s, node1.active.active (*send1) && node1.active.active (*send2));
 	auto election (node1.active.election (send1->qualified_root ()));
 	ASSERT_NE (nullptr, election);
+	// Insert the genesis key so voting only begins once both forks are in the election
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	// Wait until the genesis rep activated & makes vote
 	ASSERT_TIMELY_EQ (1s, election->votes ().size (), 2);
 	auto votes1 (election->votes ());


### PR DESCRIPTION
Removes race in fork_publish unit test.
Previously the genesis key was inserted into the wallet before the forks were processed, so the genesis rep could start voting and confirm the election on send1 alone before send2 had a chance to join the same election.
The fix reorders the setup so voting weight is only granted after both forks are confirmed active in the election