### PR TITLE
Add to_json() and serialize_json() to block_sideband

### DIFF
--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -491,19 +491,39 @@ TEST (block_sideband, to_json)
 	sideband1.details = nano::block_details{ nano::epoch::epoch_1, false, true, false };
 
 	auto json (sideband1.to_json ());
-	ASSERT_NE (0, json.size ());
+	ASSERT_FALSE (json.empty ());
 
 	boost::property_tree::ptree tree;
 	std::stringstream istream (json);
 	boost::property_tree::read_json (istream, tree);
 
-	ASSERT_EQ (sideband1.account.to_account (), tree.get<std::string> ("account"));
-	ASSERT_EQ (sideband1.balance.to_string_dec (), tree.get<std::string> ("balance"));
-	ASSERT_EQ (std::to_string (sideband1.height), tree.get<std::string> ("height"));
-	ASSERT_EQ (std::to_string (sideband1.timestamp), tree.get<std::string> ("timestamp"));
-	ASSERT_EQ (std::to_string (sideband1.topo_height), tree.get<std::string> ("topo_height"));
-	ASSERT_EQ (std::to_string (static_cast<uint8_t> (sideband1.source_epoch)), tree.get<std::string> ("source_epoch"));
-	ASSERT_EQ (nano::state_subtype (sideband1.details), tree.get<std::string> ("details"));
+	ASSERT_EQ ("nano_1111111111111111111111111111111111111111111111111113b8661hfk", tree.get<std::string> ("account"));
+	ASSERT_EQ ("2", tree.get<std::string> ("balance"));
+	ASSERT_EQ ("3", tree.get<std::string> ("height"));
+	ASSERT_EQ ("5", tree.get<std::string> ("timestamp"));
+	ASSERT_EQ ("42", tree.get<std::string> ("topo_height"));
+	ASSERT_EQ ("3", tree.get<std::string> ("source_epoch"));
+	ASSERT_EQ ("receive", tree.get<std::string> ("details"));
+}
+
+// Exercises the remaining state_subtype branches (send / epoch / change)
+// independently of to_json's internal conversions.
+TEST (block_sideband, to_json_details_subtype)
+{
+	nano::block_sideband sideband;
+	sideband.source_epoch = nano::epoch::epoch_1;
+
+	auto assert_subtype = [&sideband] (nano::block_details const & details, std::string const & expected) {
+		sideband.details = details;
+		boost::property_tree::ptree tree;
+		std::stringstream istream (sideband.to_json ());
+		boost::property_tree::read_json (istream, tree);
+		ASSERT_EQ (expected, tree.get<std::string> ("details"));
+	};
+
+	assert_subtype ({ nano::epoch::epoch_1, true, false, false }, "send");
+	assert_subtype ({ nano::epoch::epoch_2, false, false, true }, "epoch");
+	assert_subtype ({ nano::epoch::epoch_1, false, false, false }, "change");
 }
 
 TEST (block_uniquer, single)

--- a/nano/core_test/block.cpp
+++ b/nano/core_test/block.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/block_sideband.hpp>
 #include <nano/lib/block_uniquer.hpp>
 #include <nano/lib/blockbuilders.hpp>
 #include <nano/lib/blocks.hpp>
@@ -476,6 +477,33 @@ TEST (block_uniquer, null)
 {
 	nano::block_uniquer uniquer;
 	ASSERT_EQ (nullptr, uniquer.unique (nullptr));
+}
+
+TEST (block_sideband, to_json)
+{
+	nano::block_sideband sideband1;
+	sideband1.account = 1;
+	sideband1.balance = 2;
+	sideband1.height = 3;
+	sideband1.timestamp = 5;
+	sideband1.topo_height = 42;
+	sideband1.source_epoch = nano::epoch::epoch_1;
+	sideband1.details = nano::block_details{ nano::epoch::epoch_1, false, true, false };
+
+	auto json (sideband1.to_json ());
+	ASSERT_NE (0, json.size ());
+
+	boost::property_tree::ptree tree;
+	std::stringstream istream (json);
+	boost::property_tree::read_json (istream, tree);
+
+	ASSERT_EQ (sideband1.account.to_account (), tree.get<std::string> ("account"));
+	ASSERT_EQ (sideband1.balance.to_string_dec (), tree.get<std::string> ("balance"));
+	ASSERT_EQ (std::to_string (sideband1.height), tree.get<std::string> ("height"));
+	ASSERT_EQ (std::to_string (sideband1.timestamp), tree.get<std::string> ("timestamp"));
+	ASSERT_EQ (std::to_string (sideband1.topo_height), tree.get<std::string> ("topo_height"));
+	ASSERT_EQ (std::to_string (static_cast<uint8_t> (sideband1.source_epoch)), tree.get<std::string> ("source_epoch"));
+	ASSERT_EQ (nano::state_subtype (sideband1.details), tree.get<std::string> ("details"));
 }
 
 TEST (block_uniquer, single)

--- a/nano/lib/block_sideband.cpp
+++ b/nano/lib/block_sideband.cpp
@@ -3,7 +3,11 @@
 #include <nano/lib/object_stream.hpp>
 #include <nano/lib/stream.hpp>
 
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+
 #include <bitset>
+#include <sstream>
 
 /*
  * block_details
@@ -247,6 +251,26 @@ void nano::block_sideband::operator() (nano::object_stream & obs) const
 	obs.write ("topo_height", topo_height);
 	obs.write ("source_epoch", source_epoch);
 	obs.write ("details", details);
+}
+
+void nano::block_sideband::serialize_json (boost::property_tree::ptree & tree) const
+{
+	tree.put ("account", account.to_account ());
+	tree.put ("balance", balance.to_string_dec ());
+	tree.put ("height", std::to_string (height));
+	tree.put ("timestamp", std::to_string (timestamp));
+	tree.put ("topo_height", std::to_string (topo_height));
+	tree.put ("source_epoch", std::to_string (static_cast<uint8_t> (source_epoch)));
+	tree.put ("details", state_subtype (details));
+}
+
+std::string nano::block_sideband::to_json () const
+{
+	std::stringstream stream;
+	boost::property_tree::ptree tree;
+	serialize_json (tree);
+	boost::property_tree::write_json (stream, tree);
+	return stream.str ();
 }
 
 /*

--- a/nano/lib/block_sideband.hpp
+++ b/nano/lib/block_sideband.hpp
@@ -4,6 +4,8 @@
 #include <nano/lib/fwd.hpp>
 #include <nano/lib/numbers.hpp>
 
+#include <boost/property_tree/ptree_fwd.hpp>
+
 #include <cstdint>
 #include <memory>
 
@@ -72,6 +74,8 @@ public:
 
 public: // Logging
 	void operator() (nano::object_stream &) const;
+	void serialize_json (boost::property_tree::ptree &) const;
+	std::string to_json () const;
 };
 
 /**


### PR DESCRIPTION
## Summary

Implements the `to_json()` inspection method requested in #4390 for `nano::block_sideband`. Useful for debugging and consistent with the existing `nano::vote::to_json()` pattern.

## Changes

- `nano/lib/block_sideband.hpp` — declare `to_json()` and `serialize_json()` alongside the existing logging `operator()`.
- `nano/lib/block_sideband.cpp` — implement both, writing all 7 sideband fields: account, balance, height, timestamp, topo_height, source_epoch, details (via `state_subtype`).
- `nano/core_test/block.cpp` — add `TEST (block_sideband, to_json)` covering all fields, mirroring the existing `block_store, sideband_serialization` test style.

## Notes

- Pattern mirrors `nano::vote::to_json()` (vote.cpp:164) and `nano::vote::serialize_json()` (vote.cpp:147).
- `source_epoch` is serialized as the underlying integer value (matching how it's persisted) rather than the enum name; a future change to enum names would be a no-op for persisted data.
- Local build not verified due to slow submodule fetch in the dev environment; relying on CI for `core_test` verification.

Fixes #4390