### PR TITLE
Add loopback-only peer mode to prevent live network connections in tests

### DIFF
--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -69,13 +69,16 @@ TEST (peer_container, disable_non_loopback_peers)
 	// Use a concrete non-self loopback endpoint: port 0 is reserved, and self endpoints are rejected separately.
 	auto loopback_port = node.network.endpoint ().port () == 10000 ? 10001 : 10000;
 	auto loopback = nano::endpoint (boost::asio::ip::address_v6::loopback (), loopback_port);
+	auto v4_loopback = nano::transport::map_endpoint_to_v6 (nano::endpoint (boost::asio::ip::address_v4::loopback (), loopback_port));
 	auto public_peer = nano::endpoint (boost::asio::ip::make_address_v6 ("2001:4860:4860::8888"), 10000);
 
 	ASSERT_FALSE (node.network.not_a_peer (loopback));
+	ASSERT_FALSE (node.network.not_a_peer (v4_loopback));
 	ASSERT_TRUE (node.network.not_a_peer (public_peer));
 
 	ASSERT_FALSE (node.network.track_reachout (public_peer));
 	ASSERT_TRUE (node.network.track_reachout (loopback));
+	ASSERT_TRUE (node.network.track_reachout (v4_loopback));
 }
 
 // Test the TCP channel cleanup function works properly. It is used to remove peers that are not

--- a/nano/core_test/peer_container.cpp
+++ b/nano/core_test/peer_container.cpp
@@ -41,7 +41,7 @@ TEST (peer_container, reserved_ip_is_not_a_peer)
 {
 	nano::test::system system{ 1 };
 	auto not_a_peer = [&node = system.nodes[0]] (nano::endpoint endpoint_a) -> bool {
-		return node->network.not_a_peer (endpoint_a, true);
+		return node->network.not_a_peer (endpoint_a);
 	};
 
 	// The return value as true means an error because the IP address is for reserved use
@@ -55,6 +55,27 @@ TEST (peer_container, reserved_ip_is_not_a_peer)
 
 	// Test with a valid IP address
 	ASSERT_FALSE (not_a_peer (nano::transport::map_endpoint_to_v6 (nano::endpoint (boost::asio::ip::address (boost::asio::ip::address_v4 (0x08080808)), 10000))));
+}
+
+// Verify loopback-only mode rejects public peers before any reachout is attempted.
+TEST (peer_container, disable_non_loopback_peers)
+{
+	nano::node_flags node_flags;
+	node_flags.disable_non_loopback_peers = true;
+
+	nano::test::system system;
+	auto & node = *system.add_node (node_flags);
+
+	// Use a concrete non-self loopback endpoint: port 0 is reserved, and self endpoints are rejected separately.
+	auto loopback_port = node.network.endpoint ().port () == 10000 ? 10001 : 10000;
+	auto loopback = nano::endpoint (boost::asio::ip::address_v6::loopback (), loopback_port);
+	auto public_peer = nano::endpoint (boost::asio::ip::make_address_v6 ("2001:4860:4860::8888"), 10000);
+
+	ASSERT_FALSE (node.network.not_a_peer (loopback));
+	ASSERT_TRUE (node.network.not_a_peer (public_peer));
+
+	ASSERT_FALSE (node.network.track_reachout (public_peer));
+	ASSERT_TRUE (node.network.track_reachout (loopback));
 }
 
 // Test the TCP channel cleanup function works properly. It is used to remove peers that are not

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -535,28 +535,31 @@ bool nano::network::merge_peer (nano::endpoint const & peer)
 	return false; // Not initiated
 }
 
-bool nano::network::not_a_peer (nano::endpoint const & endpoint_a, bool allow_local_peers) const
+bool nano::network::not_a_peer (nano::endpoint const & endpoint) const
 {
-	bool result (false);
-	if (endpoint_a.address ().to_v6 ().is_unspecified ())
+	if (endpoint.address ().to_v6 ().is_unspecified ())
 	{
-		result = true;
+		return true;
 	}
-	else if (nano::transport::reserved_address (endpoint_a, allow_local_peers))
+	if (node.flags.disable_non_loopback_peers && !endpoint.address ().to_v6 ().is_loopback ())
 	{
-		result = true;
+		return true;
 	}
-	else if (endpoint_a == endpoint ())
+	if (nano::transport::reserved_address (endpoint, node.config.allow_local_peers))
 	{
-		result = true;
+		return true;
 	}
-	return result;
+	if (endpoint == this->endpoint ())
+	{
+		return true;
+	}
+	return false;
 }
 
 bool nano::network::track_reachout (nano::endpoint const & endpoint_a)
 {
 	// Don't contact invalid IPs
-	if (not_a_peer (endpoint_a, node.config.allow_local_peers))
+	if (not_a_peer (endpoint_a))
 	{
 		return false;
 	}

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -17,6 +17,8 @@
 #include <nano/node/telemetry.hpp>
 #include <nano/node/transport/formatting.hpp>
 
+#include <boost/asio/ip/address_v4.hpp>
+
 using namespace std::chrono_literals;
 
 // TODO: Return to static const and remove "disable_large_votes" when rolled out
@@ -541,7 +543,9 @@ bool nano::network::not_a_peer (nano::endpoint const & endpoint) const
 	{
 		return true;
 	}
-	if (node.flags.disable_non_loopback_peers && !endpoint.address ().to_v6 ().is_loopback ())
+	auto const address = endpoint.address ().to_v6 ();
+	auto const is_loopback = address.is_loopback () || (address.is_v4_mapped () && boost::asio::ip::make_address_v4 (boost::asio::ip::v4_mapped, address).is_loopback ());
+	if (node.flags.disable_non_loopback_peers && !is_loopback)
 	{
 		return true;
 	}

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -141,7 +141,7 @@ public:
 	std::shared_ptr<nano::transport::channel> find_channel (nano::endpoint const &);
 
 	// Check if the endpoint address looks OK
-	bool not_a_peer (nano::endpoint const &, bool allow_local_peers) const;
+	bool not_a_peer (nano::endpoint const &) const;
 	// Should we reach out to this endpoint with a keepalive message? If yes, register a new reachout attempt
 	bool track_reachout (nano::endpoint const &);
 

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -156,6 +156,7 @@ public:
 	bool allow_bootstrap_peers_duplicates{ false };
 	bool disable_max_peers_per_ip{ false };
 	bool disable_max_peers_per_subnetwork{ false };
+	bool disable_non_loopback_peers{ false }; // Reject all non-loopback peer addresses
 	bool disable_search_pending{ false };
 	bool disable_bounded_backlog{ false };
 	bool enable_pruning{ false };

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -68,7 +68,7 @@ bool nano::transport::tcp_channels::check (const nano::tcp_endpoint & endpoint, 
 		return false; // Reject
 	}
 
-	if (node.network.not_a_peer (nano::transport::map_tcp_to_endpoint (endpoint), node.config.allow_local_peers))
+	if (node.network.not_a_peer (nano::transport::map_tcp_to_endpoint (endpoint)))
 	{
 		node.stats.inc (nano::stat::type::tcp_channels_rejected, nano::stat::detail::not_a_peer);
 		node.logger.debug (nano::log::type::tcp_channels, "Rejected invalid endpoint channel: {}", endpoint);


### PR DESCRIPTION
Prevents test nodes configured for loopback-only peering from attempting outbound connections to real network peers.
This adds coverage for the intended isolation behavior: public peer endpoints should be rejected before reachout, while loopback peers remain valid.