### PR TITLE
Remove pending check for epoch open blocks

### DIFF
--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -4206,6 +4206,7 @@ TEST (ledger, epoch_open_pending)
 	auto & node1 = *system.nodes[0];
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1{};
+	// Epoch open should succeed even without pending entries
 	auto epoch_open = builder.state ()
 					  .account (key1.pub)
 					  .previous (0)
@@ -4215,28 +4216,17 @@ TEST (ledger, epoch_open_pending)
 					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 					  .work (*pool.generate (key1.pub))
 					  .build ();
-	auto process_result = node1.ledger.process (node1.ledger.tx_begin_write (), epoch_open);
-	ASSERT_EQ (nano::block_status::gap_epoch_open_pending, process_result);
-	node1.block_processor.add (epoch_open, nano::block_source::test);
-	// Waits for the block to get saved in the database
-	ASSERT_TIMELY_EQ (10s, 1, node1.unchecked.count ());
-	ASSERT_FALSE (node1.block_or_pruned_exists (epoch_open->hash ()));
-	// Open block should be inserted into unchecked
-	auto blocks = node1.unchecked.get (nano::hash_or_account (epoch_open->account_field ().value ()).hash);
-	ASSERT_EQ (blocks.size (), 1);
-	ASSERT_EQ (blocks[0].block->full_hash (), epoch_open->full_hash ());
-	// New block to process epoch open
-	auto send1 = builder.state ()
-				 .account (nano::dev::genesis_key.pub)
-				 .previous (nano::dev::genesis->hash ())
-				 .representative (nano::dev::genesis_key.pub)
-				 .balance (nano::dev::constants.genesis_amount - 100)
-				 .link (key1.pub)
-				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				 .work (*pool.generate (nano::dev::genesis->hash ()))
-				 .build ();
-	node1.block_processor.add (send1, nano::block_source::test);
-	ASSERT_TIMELY (10s, node1.block_or_pruned_exists (epoch_open->hash ()));
+	auto transaction = node1.ledger.tx_begin_write ();
+	ASSERT_FALSE (node1.ledger.any.receivable_exists (transaction, key1.pub));
+	ASSERT_EQ (nano::block_status::progress, node1.ledger.process (transaction, epoch_open));
+	// Block should be stored and the account opened at epoch 1 with zero balance
+	ASSERT_TRUE (node1.ledger.any.block_exists (transaction, epoch_open->hash ()));
+	ASSERT_EQ (nano::epoch::epoch_1, epoch_open->sideband ().details.epoch);
+	auto info = node1.ledger.any.account_get (transaction, key1.pub);
+	ASSERT_TRUE (info);
+	ASSERT_EQ (nano::epoch::epoch_1, info->epoch ());
+	ASSERT_EQ (0, info->balance.number ());
+	ASSERT_EQ (epoch_open->hash (), info->head);
 }
 
 TEST (ledger, block_hash_account_conflict)

--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -250,8 +250,6 @@ std::string nano::error_process_messages::message (int ev) const
 			return "Gap previous block";
 		case nano::error_process::gap_source:
 			return "Gap source block";
-		case nano::error_process::gap_epoch_open_pending:
-			return "Gap pending for open epoch block";
 		case nano::error_process::opened_burn_account:
 			return "Block attempts to open the burn account";
 		case nano::error_process::balance_mismatch:

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -170,7 +170,6 @@ enum class error_process
 	unreceivable, // Source block doesn't exist or has already been received
 	gap_previous, // Block marked as previous is unknown
 	gap_source, // Block marked as source is unknown
-	gap_epoch_open_pending, // Block marked as pending blocks required for epoch open block are unknown
 	opened_burn_account, // Block attempts to open the burn account
 	balance_mismatch, // Balance and amount delta don't match
 	block_position, // This block cannot follow the previous block

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -234,7 +234,6 @@ enum class detail
 	bad_signature,
 	negative_spend,
 	unreceivable,
-	gap_epoch_open_pending,
 	opened_burn_account,
 	balance_mismatch,
 	representative_mismatch,

--- a/nano/node/block_processor.cpp
+++ b/nano/node/block_processor.cpp
@@ -523,12 +523,6 @@ nano::block_status nano::block_processor::process_one (secure::write_transaction
 			stats.inc (nano::stat::type::ledger, nano::stat::detail::gap_source);
 			break;
 		}
-		case nano::block_status::gap_epoch_open_pending:
-		{
-			unchecked.put (block->account_field ().value_or (0), block); // Specific unchecked key starting with epoch open block account public key
-			stats.inc (nano::stat::type::ledger, nano::stat::detail::gap_source);
-			break;
-		}
 		case nano::block_status::old:
 		{
 			stats.inc (nano::stat::type::ledger, nano::stat::detail::old);

--- a/nano/node/bootstrap/bootstrap_context.cpp
+++ b/nano/node/bootstrap/bootstrap_context.cpp
@@ -338,14 +338,6 @@ void bootstrap_context::inspect (secure::transaction const & tx, nano::block_sta
 			}
 		}
 		break;
-		case nano::block_status::gap_epoch_open_pending:
-		{
-			// Epoch open blocks for accounts that don't have any pending blocks yet
-			debug_assert (block.type () == block_type::state); // Only state blocks can have epoch open pending status
-			const auto account = block.account_field ().value_or (0);
-			accounts.priority_erase (account);
-		}
-		break;
 		default: // No need to handle other cases
 			// TODO: If we receive blocks that are invalid (bad signature, fork, etc.), we should penalize the peer that sent them
 			break;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3363,11 +3363,6 @@ void nano::json_handler::process ()
 								rpc_l->ec = nano::error_process::block_position;
 								break;
 							}
-							case nano::block_status::gap_epoch_open_pending:
-							{
-								rpc_l->ec = nano::error_process::gap_epoch_open_pending;
-								break;
-							}
 							case nano::block_status::fork:
 							{
 								bool const force = rpc_l->request.get<bool> ("force", false);

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -109,7 +109,6 @@ enum class block_status
 	unreceivable, // Source block doesn't exist, has already been received, or requires an account upgrade (epoch blocks)
 	gap_previous, // Block marked as previous is unknown
 	gap_source, // Block marked as source is unknown
-	gap_epoch_open_pending, // Block marked as pending blocks required for epoch open block are unknown
 	opened_burn_account, // Block attempts to open the burn account
 	balance_mismatch, // Balance and amount delta don't match
 	representative_mismatch, // Representative is changed when it is not allowed

--- a/nano/secure/ledger_processor.cpp
+++ b/nano/secure/ledger_processor.cpp
@@ -488,12 +488,6 @@ void nano::ledger_processor::epoch_block_impl (nano::state_block & block_a)
 				else
 				{
 					result = block_a.hashables.representative.is_zero () ? nano::block_status::progress : nano::block_status::representative_mismatch;
-					// Non-exisitng account should have pending entries
-					if (result == nano::block_status::progress)
-					{
-						bool pending_exists = ledger.any.receivable_exists (transaction, block_a.hashables.account);
-						result = pending_exists ? nano::block_status::progress : nano::block_status::gap_epoch_open_pending;
-					}
 				}
 				if (result == nano::block_status::progress)
 				{
@@ -514,10 +508,11 @@ void nano::ledger_processor::epoch_block_impl (nano::state_block & block_a)
 
 								// Epoch open on an unopened account is the only block type with no
 								// usable block-graph dep (no `previous`, and `link` is the epoch
-								// payload rather than a block hash). It's still anchored to the graph
-								// implicitly via the pending entry it requires, so we treat it as a
-								// known rootless start and index it at 1. For an epoch *upgrade* on
-								// an existing chain we go through the standard path keyed off `previous`.
+								// payload rather than a block hash). Topology ordering must therefore
+								// treat it as a rootless start and index it at 1, alongside genesis.
+								// Later receives still carry explicit dependencies on this open block
+								// and their source send. For an epoch *upgrade* on an existing chain we
+								// go through the standard path keyed off `previous`.
 								uint64_t topo = 0;
 								if (ledger.flags.topo_index)
 								{

--- a/nano/slow_test/bootstrap.cpp
+++ b/nano/slow_test/bootstrap.cpp
@@ -130,7 +130,6 @@ TEST (bootstrap, profile)
 	rate.observe (*client, nano::stat::type::bootstrap, nano::stat::detail::blocks, nano::stat::dir::in);
 	rate.observe (*server, nano::stat::type::bootstrap_server, nano::stat::detail::blocks, nano::stat::dir::out);
 	rate.observe (*client, nano::stat::type::ledger, nano::stat::detail::old, nano::stat::dir::in);
-	rate.observe (*client, nano::stat::type::ledger, nano::stat::detail::gap_epoch_open_pending, nano::stat::dir::in);
 	rate.observe (*client, nano::stat::type::ledger, nano::stat::detail::gap_source, nano::stat::dir::in);
 	rate.observe (*client, nano::stat::type::ledger, nano::stat::detail::gap_previous, nano::stat::dir::in);
 	rate.background_print (3s);


### PR DESCRIPTION
We need to remove the pending check because it creates an implicit dependency that the topology index cannot represent.

For an epoch open:

- `previous == 0`
- `link` is the epoch link, not a source block hash
- sideband marks it as an epoch block, not a receive
- `block.dependencies()` therefore returns no dependency edges
- `topo_height` is assigned `1`, same as genesis

That is correct from the visible block graph. The block is a root-like account opener. Any later receive from that account has explicit dependencies: `previous = epoch_open` and `link = send_hash`, so that later receive gets ordered after both the epoch open and the send.

The old pending check broke this model. It said: “do not process this epoch open unless there is already some receivable for this account.” But that receivable comes from a send block, and that send block is not referenced anywhere in the epoch open payload. In topo order, that send will usually have `topo_height >= 2`, while the epoch open is at `topo_height = 1`. So topo bootstrap would deliver/process the epoch open before the pending entry exists, and the ledger would reject it with `gap_epoch_open_pending`.

That means the old rule made epoch opens depend on a later topo block. Worse, the dependency is not discoverable from the epoch-open block itself, so bootstrap cannot request or order the missing source deterministically. It turns a supposed one-pass topological stream into “process this root block only after some unknown future send creates pending.”

Removing the pending check makes the rules consistent:

- epoch opens are accepted as rootless topo-height-1 blocks;
- they do not create funds or consume pending;
- actual receives still require the explicit pending source and are ordered after both dependencies;
- topo bootstrap can process blocks in topo order without hidden edges.