### PR TITLE
Extract bootstrap verify policy

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   bootstrap.cpp
   bootstrap_account_sets.cpp
   bootstrap_frontier_scan.cpp
+  bootstrap_verify.cpp
   bootstrap_server.cpp
   bounded_dfs.cpp
   bucketing.cpp

--- a/nano/core_test/bootstrap_verify.cpp
+++ b/nano/core_test/bootstrap_verify.cpp
@@ -1,0 +1,160 @@
+#include <nano/lib/blockbuilders.hpp>
+#include <nano/lib/blocks.hpp>
+#include <nano/lib/keypair.hpp>
+#include <nano/messages/asc_pull.hpp>
+#include <nano/node/bootstrap/verify.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace nano::bootstrap;
+
+namespace
+{
+std::deque<std::pair<nano::account, nano::block_hash>> make_frontiers (std::initializer_list<uint64_t> accounts)
+{
+	std::deque<std::pair<nano::account, nano::block_hash>> result;
+	for (auto account : accounts)
+	{
+		result.push_back ({ nano::account{ account }, nano::block_hash{ account } });
+	}
+	return result;
+}
+}
+
+/*
+ * Response verification: frontiers
+ */
+
+TEST (bootstrap_verify, frontiers_empty)
+{
+	frontiers_query query{ .start = nano::account{ 1 }, .count = 1000 };
+	nano::messages::asc_pull_ack::frontiers_payload response;
+	ASSERT_EQ (verify (response, query), verify_result::nothing_new);
+}
+
+TEST (bootstrap_verify, frontiers_ok)
+{
+	frontiers_query query{ .start = nano::account{ 1 }, .count = 1000 };
+	nano::messages::asc_pull_ack::frontiers_payload response;
+	response.frontiers = make_frontiers ({ 2, 3, 5 });
+	ASSERT_EQ (verify (response, query), verify_result::ok);
+}
+
+TEST (bootstrap_verify, frontiers_unordered)
+{
+	frontiers_query query{ .start = nano::account{ 1 }, .count = 1000 };
+	nano::messages::asc_pull_ack::frontiers_payload response;
+	response.frontiers = make_frontiers ({ 5, 3 });
+	ASSERT_EQ (verify (response, query), verify_result::invalid);
+}
+
+TEST (bootstrap_verify, frontiers_duplicate)
+{
+	frontiers_query query{ .start = nano::account{ 1 }, .count = 1000 };
+	nano::messages::asc_pull_ack::frontiers_payload response;
+	response.frontiers = make_frontiers ({ 3, 3 });
+	ASSERT_EQ (verify (response, query), verify_result::invalid);
+}
+
+TEST (bootstrap_verify, frontiers_below_start)
+{
+	frontiers_query query{ .start = nano::account{ 10 }, .count = 1000 };
+	nano::messages::asc_pull_ack::frontiers_payload response;
+	response.frontiers = make_frontiers ({ 5, 11 });
+	ASSERT_EQ (verify (response, query), verify_result::invalid);
+}
+
+/*
+ * Response verification: blocks
+ */
+
+namespace
+{
+// A small chain of state blocks; verification checks hashes and links, not signatures or work
+std::deque<std::shared_ptr<nano::block>> make_chain (size_t count)
+{
+	std::deque<std::shared_ptr<nano::block>> blocks;
+	nano::keypair key;
+	nano::block_builder builder;
+	nano::block_hash previous{ 0 };
+	for (size_t n = 0; n < count; ++n)
+	{
+		auto block = builder.state ()
+					 .make_block ()
+					 .account (key.pub)
+					 .previous (previous)
+					 .representative (key.pub)
+					 .balance (count - n)
+					 .link (0)
+					 .sign (key.prv, key.pub)
+					 .work (0)
+					 .build ();
+		previous = block->hash ();
+		blocks.push_back (block);
+	}
+	return blocks;
+}
+}
+
+TEST (bootstrap_verify, blocks_empty)
+{
+	blocks_query query{ .account = nano::account{ 1 }, .start = nano::account{ 1 }, .count = 128, .type = query_type::blocks_by_account };
+	nano::messages::asc_pull_ack::blocks_payload response;
+	ASSERT_EQ (verify (response, query), verify_result::nothing_new);
+}
+
+TEST (bootstrap_verify, blocks_chain_ok)
+{
+	auto chain = make_chain (3);
+	blocks_query query{ .account = chain.front ()->account_field ().value (), .start = chain.front ()->hash (), .count = 128, .type = query_type::blocks_by_hash };
+	nano::messages::asc_pull_ack::blocks_payload response;
+	response.blocks = chain;
+	ASSERT_EQ (verify (response, query), verify_result::ok);
+}
+
+TEST (bootstrap_verify, blocks_single_echo)
+{
+	auto chain = make_chain (1);
+	blocks_query query{ .account = chain.front ()->account_field ().value (), .start = chain.front ()->hash (), .count = 128, .type = query_type::blocks_by_hash };
+	nano::messages::asc_pull_ack::blocks_payload response;
+	response.blocks = chain;
+	ASSERT_EQ (verify (response, query), verify_result::nothing_new);
+}
+
+TEST (bootstrap_verify, blocks_count_overflow)
+{
+	auto chain = make_chain (5);
+	blocks_query query{ .account = chain.front ()->account_field ().value (), .start = chain.front ()->hash (), .count = 3, .type = query_type::blocks_by_hash };
+	nano::messages::asc_pull_ack::blocks_payload response;
+	response.blocks = chain;
+	ASSERT_EQ (verify (response, query), verify_result::invalid);
+}
+
+TEST (bootstrap_verify, blocks_start_mismatch)
+{
+	auto chain = make_chain (3);
+	blocks_query query{ .account = chain.front ()->account_field ().value (), .start = nano::block_hash{ 12345 }, .count = 128, .type = query_type::blocks_by_hash };
+	nano::messages::asc_pull_ack::blocks_payload response;
+	response.blocks = chain;
+	ASSERT_EQ (verify (response, query), verify_result::invalid);
+}
+
+TEST (bootstrap_verify, blocks_chain_break)
+{
+	auto chain = make_chain (3);
+	auto foreign = make_chain (1);
+	chain[1] = foreign.front (); // Break the previous () linkage
+	blocks_query query{ .account = chain.front ()->account_field ().value (), .start = chain.front ()->hash (), .count = 128, .type = query_type::blocks_by_hash };
+	nano::messages::asc_pull_ack::blocks_payload response;
+	response.blocks = chain;
+	ASSERT_EQ (verify (response, query), verify_result::invalid);
+}
+
+TEST (bootstrap_verify, blocks_by_account_mismatch)
+{
+	auto chain = make_chain (2);
+	blocks_query query{ .account = nano::account{ 999 }, .start = nano::account{ 999 }, .count = 128, .type = query_type::blocks_by_account };
+	nano::messages::asc_pull_ack::blocks_payload response;
+	response.blocks = chain;
+	ASSERT_EQ (verify (response, query), verify_result::invalid);
+}

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -61,6 +61,8 @@ add_library(
   bootstrap/database_scan_index.cpp
   bootstrap/frontier_scan_index.hpp
   bootstrap/frontier_scan_index.cpp
+  bootstrap/verify.hpp
+  bootstrap/verify.cpp
   bootstrap/peer_scoring.hpp
   bootstrap/peer_scoring.cpp
   cli.hpp

--- a/nano/node/bootstrap/bootstrap_context.cpp
+++ b/nano/node/bootstrap/bootstrap_context.cpp
@@ -12,6 +12,7 @@
 #include <nano/node/bootstrap/frontier_strategy.hpp>
 #include <nano/node/bootstrap/priority_strategy.hpp>
 #include <nano/node/bootstrap/queries.hpp>
+#include <nano/node/bootstrap/verify.hpp>
 #include <nano/node/ledger_notifications.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
@@ -472,7 +473,7 @@ bool bootstrap_context::process (nano::messages::asc_pull_ack::blocks_payload co
 
 	stats.inc (nano::stat::type::bootstrap_process, nano::stat::detail::blocks);
 
-	auto result = verify (response, tag);
+	auto result = verify (response, query);
 	switch (result)
 	{
 		case verify_result::ok:
@@ -528,67 +529,6 @@ bool bootstrap_context::process (nano::messages::asc_pull_ack::blocks_payload co
 	}
 
 	return result != verify_result::invalid;
-}
-
-verify_result bootstrap_context::verify (nano::messages::asc_pull_ack::blocks_payload const & response, async_tag const & tag) const
-{
-	release_assert (std::holds_alternative<blocks_query> (tag.query));
-	auto const & query = std::get<blocks_query> (tag.query);
-	auto const & blocks = response.blocks;
-
-	if (blocks.empty ())
-	{
-		return verify_result::nothing_new;
-	}
-	if (blocks.size () == 1 && blocks.front ()->hash () == query.start.as_block_hash ())
-	{
-		return verify_result::nothing_new;
-	}
-	if (blocks.size () > query.count)
-	{
-		return verify_result::invalid;
-	}
-
-	auto const & first = blocks.front ();
-	switch (query.type)
-	{
-		case query_type::blocks_by_hash:
-		{
-			if (first->hash () != query.start.as_block_hash ())
-			{
-				// TODO: Stat & log
-				return verify_result::invalid;
-			}
-		}
-		break;
-		case query_type::blocks_by_account:
-		{
-			// Open & state blocks always contain account field
-			if (first->account_field ().value_or (0) != query.start.as_account ())
-			{
-				// TODO: Stat & log
-				return verify_result::invalid;
-			}
-		}
-		break;
-		default:
-			return verify_result::invalid;
-	}
-
-	// Verify blocks make a valid chain
-	nano::block_hash previous_hash = blocks.front ()->hash ();
-	for (int n = 1; n < blocks.size (); ++n)
-	{
-		auto & block = blocks[n];
-		if (block->previous () != previous_hash)
-		{
-			// TODO: Stat & log
-			return verify_result::invalid; // Blocks do not make a chain
-		}
-		previous_hash = block->hash ();
-	}
-
-	return verify_result::ok;
 }
 
 bool bootstrap_context::process (nano::messages::asc_pull_ack::account_info_payload const & response, async_tag const & tag)

--- a/nano/node/bootstrap/bootstrap_context.hpp
+++ b/nano/node/bootstrap/bootstrap_context.hpp
@@ -50,13 +50,6 @@ struct async_tag
 	query_type type () const;
 };
 
-enum class verify_result
-{
-	ok,
-	nothing_new,
-	invalid,
-};
-
 class bootstrap_context
 {
 public:
@@ -98,8 +91,6 @@ private:
 	bool process (nano::messages::asc_pull_ack::account_info_payload const & response, async_tag const & tag);
 	bool process (nano::messages::asc_pull_ack::frontiers_payload const & response, async_tag const & tag);
 	bool process (nano::messages::empty_payload const & response, async_tag const & tag);
-
-	verify_result verify (nano::messages::asc_pull_ack::blocks_payload const & response, async_tag const & tag) const;
 
 	// Inserts the tag and transmits the message over the channel
 	bool transmit (std::shared_ptr<nano::transport::channel> const &, nano::messages::asc_pull_req && message, async_tag tag);

--- a/nano/node/bootstrap/common.hpp
+++ b/nano/node/bootstrap/common.hpp
@@ -32,6 +32,13 @@ enum class query_source
 	frontiers,
 };
 
+enum class verify_result
+{
+	ok,
+	nothing_new,
+	invalid,
+};
+
 nano::stat::detail to_stat_detail (nano::bootstrap::query_type);
 nano::stat::detail to_stat_detail (nano::bootstrap::query_source);
 }

--- a/nano/node/bootstrap/frontier_strategy.cpp
+++ b/nano/node/bootstrap/frontier_strategy.cpp
@@ -4,6 +4,7 @@
 #include <nano/messages/asc_pull.hpp>
 #include <nano/node/bootstrap/frontier_strategy.hpp>
 #include <nano/node/bootstrap/queries.hpp>
+#include <nano/node/bootstrap/verify.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/transport/formatting.hpp>
@@ -117,7 +118,7 @@ bool frontier_strategy::process (nano::messages::asc_pull_ack::frontiers_payload
 
 	ctx.stats.inc (nano::stat::type::bootstrap_process, nano::stat::detail::frontiers);
 
-	auto result = verify (response, tag);
+	auto result = verify (response, query);
 	switch (result)
 	{
 		case verify_result::ok:
@@ -153,37 +154,6 @@ bool frontier_strategy::process (nano::messages::asc_pull_ack::frontiers_payload
 	}
 
 	return result != verify_result::invalid;
-}
-
-verify_result frontier_strategy::verify (nano::messages::asc_pull_ack::frontiers_payload const & response, async_tag const & tag) const
-{
-	release_assert (std::holds_alternative<frontiers_query> (tag.query));
-	auto const & query = std::get<frontiers_query> (tag.query);
-	auto const & frontiers = response.frontiers;
-
-	if (frontiers.empty ())
-	{
-		return verify_result::nothing_new;
-	}
-
-	// Ensure frontiers accounts are in ascending order
-	nano::account previous{ 0 };
-	for (auto const & [account, _] : frontiers)
-	{
-		if (account.number () <= previous.number ())
-		{
-			return verify_result::invalid;
-		}
-		previous = account;
-	}
-
-	// Ensure the frontiers are larger or equal to the requested frontier
-	if (frontiers.front ().first.number () < query.start.number ())
-	{
-		return verify_result::invalid;
-	}
-
-	return verify_result::ok;
 }
 
 void frontier_strategy::process_frontiers (std::deque<std::pair<nano::account, nano::block_hash>> const & frontiers)

--- a/nano/node/bootstrap/frontier_strategy.hpp
+++ b/nano/node/bootstrap/frontier_strategy.hpp
@@ -25,7 +25,6 @@ private:
 
 	nano::account wait_frontier ();
 	bool request_frontiers (nano::account start, std::shared_ptr<nano::transport::channel> const & channel);
-	verify_result verify (nano::messages::asc_pull_ack::frontiers_payload const & response, async_tag const & tag) const;
 	void process_frontiers (std::deque<std::pair<nano::account, nano::block_hash>> const & frontiers);
 
 	bootstrap_context & ctx;

--- a/nano/node/bootstrap/verify.cpp
+++ b/nano/node/bootstrap/verify.cpp
@@ -1,0 +1,92 @@
+#include <nano/lib/blocks.hpp>
+#include <nano/node/bootstrap/verify.hpp>
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+namespace nano::bootstrap
+{
+verify_result verify (nano::messages::asc_pull_ack::blocks_payload const & response, blocks_query const & query)
+{
+	auto const & blocks = response.blocks;
+
+	if (blocks.empty ())
+	{
+		return verify_result::nothing_new;
+	}
+	if (blocks.size () == 1 && blocks.front ()->hash () == query.start.as_block_hash ())
+	{
+		return verify_result::nothing_new;
+	}
+	if (blocks.size () > query.count)
+	{
+		return verify_result::invalid;
+	}
+
+	auto const & first = blocks.front ();
+	switch (query.type)
+	{
+		case query_type::blocks_by_hash:
+		{
+			if (first->hash () != query.start.as_block_hash ())
+			{
+				return verify_result::invalid;
+			}
+		}
+		break;
+		case query_type::blocks_by_account:
+		{
+			// Open & state blocks always contain account field
+			if (first->account_field ().value_or (0) != query.start.as_account ())
+			{
+				return verify_result::invalid;
+			}
+		}
+		break;
+		default:
+			return verify_result::invalid;
+	}
+
+	// Verify blocks make a valid chain
+	nano::block_hash previous_hash = blocks.front ()->hash ();
+	for (int n = 1; n < blocks.size (); ++n)
+	{
+		auto & block = blocks[n];
+		if (block->previous () != previous_hash)
+		{
+			return verify_result::invalid; // Blocks do not make a chain
+		}
+		previous_hash = block->hash ();
+	}
+
+	return verify_result::ok;
+}
+
+verify_result verify (nano::messages::asc_pull_ack::frontiers_payload const & response, frontiers_query const & query)
+{
+	auto const & frontiers = response.frontiers;
+
+	if (frontiers.empty ())
+	{
+		return verify_result::nothing_new;
+	}
+
+	// Ensure frontiers accounts are in ascending order
+	nano::account previous{ 0 };
+	for (auto const & [account, _] : frontiers)
+	{
+		if (account.number () <= previous.number ())
+		{
+			return verify_result::invalid;
+		}
+		previous = account;
+	}
+
+	// Ensure the frontiers are larger or equal to the requested frontier
+	if (frontiers.front ().first.number () < query.start.number ())
+	{
+		return verify_result::invalid;
+	}
+
+	return verify_result::ok;
+}
+}

--- a/nano/node/bootstrap/verify.cpp
+++ b/nano/node/bootstrap/verify.cpp
@@ -48,7 +48,7 @@ verify_result verify (nano::messages::asc_pull_ack::blocks_payload const & respo
 
 	// Verify blocks make a valid chain
 	nano::block_hash previous_hash = blocks.front ()->hash ();
-	for (int n = 1; n < blocks.size (); ++n)
+	for (std::size_t n = 1; n < blocks.size (); ++n)
 	{
 		auto & block = blocks[n];
 		if (block->previous () != previous_hash)

--- a/nano/node/bootstrap/verify.hpp
+++ b/nano/node/bootstrap/verify.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <nano/messages/asc_pull.hpp>
+#include <nano/node/bootstrap/common.hpp>
+#include <nano/node/bootstrap/queries.hpp>
+
+namespace nano::bootstrap
+{
+// Validates that a blocks response forms a continuous chain matching the queried start
+verify_result verify (nano::messages::asc_pull_ack::blocks_payload const &, blocks_query const &);
+
+// Validates a frontiers response against its query: ascending account order, nothing below the start
+verify_result verify (nano::messages::asc_pull_ack::frontiers_payload const &, frontiers_query const &);
+}


### PR DESCRIPTION
verify: frontiers and blocks response validation extracted from bootstrap_context and frontier_strategy into bootstrap/verify.{hpp,cpp} as free functions over (payload, typed query). The blocks chain-continuity check and frontiers ordering/range checks now have direct unit coverage.

verify_result moves to bootstrap/common.hpp.