### PR TITLE
Don't abort the reps scan on a watch-only representative

### DIFF
--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -991,3 +991,30 @@ TEST (wallets, rep_keys_cache_weight_lost)
 	ASSERT_TRUE (accounts.count (nano::dev::genesis_key.pub));
 	ASSERT_FALSE (accounts.count (rep2.pub));
 }
+
+/*
+ * A watch-only account (public key only, no private key) can hold representative weight, e.g. via the
+ * wallet_add_watch RPC. The reps scan must not abort on such an account: it cannot vote, so it is simply
+ * excluded from the keys cache. Regression test for a release_assert in refresh_rep_keys_cache that
+ * aborted the node whenever a representative had no fetchable private key.
+ */
+TEST (wallets, rep_keys_cache_watch_only_representative)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+
+	// Genesis holds the entire supply, so it qualifies as a representative by weight. Add it as a
+	// watch-only account (no private key), exactly as wallet_add_watch does.
+	ASSERT_FALSE (system.wallet (0)->insert_watch (nano::dev::genesis_key.pub));
+
+	// Must not abort even though a representative-weight account has no fetchable private key.
+	node.wallets.refresh_reps ();
+
+	// The watch-only representative contributes no votable key to the cache.
+	auto sign = node.wallets.signer ();
+	std::set<nano::account> accounts;
+	sign ([&] (nano::public_key const & pub, nano::raw_key const &) {
+		accounts.insert (pub);
+	});
+	ASSERT_TRUE (accounts.empty ());
+}

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -2037,11 +2037,14 @@ void wallets::refresh_rep_keys_cache ()
 			{
 				if (wallet->store.valid_password (wallet_txn))
 				{
+					// A watch-only account can hold representative weight, so a representative here may have no
+					// private key to fetch. Such an account cannot vote and is simply left out of the keys cache.
 					auto prv_result = wallet->store.fetch (wallet_txn, account);
-					release_assert (prv_result, "failed to fetch private key for representative account", account.to_account ());
-
-					// Store private key spread across multiple heap allocations via fan to avoid plaintext keys in memory at rest
-					new_cache.emplace_back (account, std::make_unique<nano::fan> (prv_result.value (), config.password_fanout));
+					if (prv_result)
+					{
+						// Store private key spread across multiple heap allocations via fan to avoid plaintext keys in memory at rest
+						new_cache.emplace_back (account, std::make_unique<nano::fan> (prv_result.value (), config.password_fanout));
+					}
 				}
 				else
 				{


### PR DESCRIPTION
refresh_rep_keys_cache asserted that every representative in a wallet has a fetchable private key. Representative status is decided purely by ledger weight (check_rep_impl), so a watch-only account (public key only, no private key) that holds weight - e.g. genesis added via the wallet_add_watch RPC - qualifies as a representative. fetch() then returns no key and the release_assert aborted the node on the next periodic reps scan.

The abort is reachable on any voting node holding a watch-only account for a weighty representative; run_reps_scan samples the condition periodically, which is why it surfaced as a flaky CI crash (rpc.wallet_add_watch) rather than a deterministic one. It is a regression from promoting the prior debug_assert (a no-op in release builds) to a release_assert.

Treat a missing private key as the expected watch-only case: skip the account so it contributes no votable key, leaving the locked-wallet warning intact. Add a deterministic regression test that makes genesis a watch-only representative and checks the scan neither aborts nor caches a key for it.