### PR TITLE
Fix crash in --validate_blocks for open state blocks

### DIFF
--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1558,10 +1558,28 @@ int main (int argc, char * const * argv)
 					}
 					else
 					{
-						auto prev_balance = node->ledger.any.block_balance (transaction, block->previous ());
-						if (!node->ledger.pruning || prev_balance)
+						// An open block's previous is the zero hash by definition, so its
+						// previous balance is implicitly zero -- mirrors the same pattern
+						// already used for the epoch-link signature check above, rather than
+						// assuming the lookup below always succeeds (it never can for an
+						// open block, since there is no block at hash zero to look up).
+						nano::amount prev_balance{ 0 };
+						bool prev_balance_known = true;
+						if (!block->previous ().is_zero ())
 						{
-							if (block->balance () < prev_balance.value ())
+							auto prev_balance_opt = node->ledger.any.block_balance (transaction, block->previous ());
+							if (prev_balance_opt)
+							{
+								prev_balance = prev_balance_opt.value ();
+							}
+							else
+							{
+								prev_balance_known = false;
+							}
+						}
+						if (prev_balance_known)
+						{
+							if (block->balance () < prev_balance)
 							{
 								// State send
 								block_details_error = !sideband.details.is_send || sideband.details.is_receive || sideband.details.is_epoch;
@@ -1573,7 +1591,7 @@ int main (int argc, char * const * argv)
 									// State change
 									block_details_error = sideband.details.is_send || sideband.details.is_receive || sideband.details.is_epoch;
 								}
-								else if (block->balance () == prev_balance.value () && node->ledger.is_epoch_link (block->link_field ().value ()))
+								else if (block->balance () == prev_balance && node->ledger.is_epoch_link (block->link_field ().value ()))
 								{
 									// State epoch
 									block_details_error = !sideband.details.is_epoch || sideband.details.is_send || sideband.details.is_receive;
@@ -1586,9 +1604,16 @@ int main (int argc, char * const * argv)
 								}
 							}
 						}
-						else if (!node->store.pruned.exists (transaction, block->previous ()))
+						else if (node->ledger.pruning)
 						{
-							print_error_message (boost::str (boost::format ("Previous pruned block does not exist %1%\n") % block->previous ().to_string ()));
+							if (!node->store.pruned.exists (transaction, block->previous ()))
+							{
+								print_error_message (boost::str (boost::format ("Previous pruned block does not exist %1%\n") % block->previous ().to_string ()));
+							}
+						}
+						else
+						{
+							print_error_message (boost::str (boost::format ("Missing previous block balance for %1%\n") % hash.to_string ()));
 						}
 					}
 					if (block_details_error)


### PR DESCRIPTION
## Summary

`nano_node --validate_blocks` crashes with `terminate called after throwing an instance of 'std::bad_optional_access'` (SIGABRT) the first time it encounters a state-type open block, on any ledger, whenever pruning is disabled (the common case — pruning is opt-in).

## Root cause

In `check_account()`'s "Validate block details set in the sideband" branch:

```cpp
auto prev_balance = node->ledger.any.block_balance (transaction, block->previous ());
if (!node->ledger.pruning || prev_balance)
{
	if (block->balance () < prev_balance.value ())
	...
```

`prev_balance` is a `std::optional<nano::amount>`. The guard `!node->ledger.pruning || prev_balance` is only a real check when pruning is *enabled* — when it's disabled, `!node->ledger.pruning` is `true`, so the guard passes regardless of whether `prev_balance` actually has a value, and the `.value()` calls below run unconditionally.

For any account's *open* block, `previous` is the zero hash by definition. `block_balance(transaction, zero_hash)` correctly returns an empty optional — there is no block at hash zero to look up. So this crashes deterministically on the first state-type open block processed, on essentially every real-world ledger (pruning is opt-in and uncommon).

Confirmed via `gdb` + a `RelWithDebInfo` build with a temporary diagnostic print at the crash site, against a real synced ledger:

```
account=nano_1111111111111111111111111111111111111111111111111117353trpda
previous=0000000000000000000000000000000000000000000000000000000000000000
height=0
type=6 (state)
```

(Not a special/reserved account — its public key is just numerically close to zero, hence the address encodes as mostly `1`s.)

## Fix

Default `prev_balance` to zero when `block->previous()` is the zero hash (an open block), mirroring the pattern already used a few lines above for the epoch-link signature check in the same function, which already handles this correctly via `nano::amount prev_balance (0)` + `value_or (0)`. Only fall back to the pruned-block-exists check when pruning is actually enabled; report a clear error via the existing `print_error_message` mechanism instead of crashing for the (otherwise unreachable, and likely indicative of a real problem) case of a missing previous balance with pruning disabled.

## Testing

- Reproduced the crash reliably against a real, live-synced ledger (not synthetic data).
- Confirmed deterministic, not a threading race (`--threads=1` reproduces identically).
- Confirmed unchanged/still-present on `V27.0`, `V28.2` (current stable), and `develop` prior to this fix.
- Applied the fix, rebuilt, and re-ran `--validate_blocks` against the exact same ledger data that previously crashed: completes successfully now (45,684 accounts / 74,818 pending blocks validated, exits cleanly instead of SIGABRT).

## Note

That test run reported some unrelated pre-existing validation findings (`Incorrect source epoch for block ...`) on this still-syncing ledger. Those are a separate concern, unaffected by and unrelated to this fix — this PR is scoped only to eliminating the crash so `--validate_blocks` can actually run to completion and report whatever it finds, rather than aborting immediately.