### PR TITLE
Add per-block tags to block_processor

### DIFF
--- a/nano/core_test/block_processor.cpp
+++ b/nano/core_test/block_processor.cpp
@@ -4,6 +4,7 @@
 #include <nano/node/backlog_scan.hpp>
 #include <nano/node/block_processor.hpp>
 #include <nano/node/bounded_backlog.hpp>
+#include <nano/node/ledger_notifications.hpp>
 #include <nano/node/node.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/secure/common.hpp>
@@ -14,7 +15,12 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <any>
 #include <atomic>
+#include <mutex>
+#include <string>
+#include <vector>
 
 using namespace std::chrono_literals;
 
@@ -115,6 +121,86 @@ TEST (block_processor, add_blocking)
 	auto result2 = node.block_processor.add_blocking (send, nano::block_source::local);
 	ASSERT_TRUE (result2.has_value ());
 	ASSERT_EQ (result2.value (), nano::block_status::old);
+}
+
+TEST (block_processor, tags)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+
+	std::mutex mutex;
+	std::vector<std::pair<nano::block_hash, std::string>> observed;
+	node.ledger_notifications.blocks_processed.add ([&] (auto const & batch) {
+		std::lock_guard<std::mutex> lock{ mutex };
+		for (auto const & entry : batch)
+		{
+			auto const & context = entry.second;
+			if (context.block != nullptr)
+			{
+				if (auto tag = std::any_cast<std::string> (&context.tag))
+				{
+					observed.emplace_back (context.block->hash (), *tag);
+				}
+			}
+		}
+	});
+
+	auto latest = nano::dev::genesis->hash ();
+	auto balance = nano::dev::constants.genesis_amount;
+	auto make_send = [&] (nano::account const & destination) {
+		nano::block_builder builder;
+		balance -= nano::Knano_ratio;
+		auto send = builder
+					.state ()
+					.account (nano::dev::genesis_key.pub)
+					.previous (latest)
+					.representative (nano::dev::genesis_key.pub)
+					.balance (balance)
+					.link (destination)
+					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					.work (*system.work.generate (latest))
+					.build ();
+		latest = send->hash ();
+		return send;
+	};
+
+	nano::keypair key1;
+	auto send1 = make_send (key1.pub);
+	ASSERT_TRUE (node.block_processor.add (send1, nano::block_source::live, nullptr, nullptr, std::string{ "single" }));
+	ASSERT_TIMELY (5s, node.block_or_pruned_exists (send1->hash ()));
+
+	nano::keypair key2;
+	auto send2 = make_send (key2.pub);
+	nano::keypair key3;
+	auto send3 = make_send (key3.pub);
+	nano::keypair key4;
+	auto send4 = make_send (key4.pub);
+	std::deque<std::shared_ptr<nano::block>> batch{ send2, send3, send4 };
+	ASSERT_EQ (node.block_processor.add_many (batch, nano::block_source::live, nullptr, nullptr, std::string{ "batch" }), batch.size ());
+	for (auto const & block : batch)
+	{
+		ASSERT_TIMELY (5s, node.block_or_pruned_exists (block->hash ()));
+	}
+
+	nano::keypair key5;
+	auto send5 = make_send (key5.pub);
+	auto result = node.block_processor.add_blocking (send5, nano::block_source::local, std::string{ "blocking" });
+	ASSERT_TRUE (result.has_value ());
+	ASSERT_EQ (result.value (), nano::block_status::progress);
+
+	auto has_observed = [&] (nano::block_hash const & hash, std::string const & tag) {
+		std::lock_guard<std::mutex> lock{ mutex };
+		return std::any_of (observed.begin (), observed.end (), [&] (auto const & entry) {
+			return entry.first == hash && entry.second == tag;
+		});
+	};
+
+	ASSERT_TIMELY (5s, has_observed (send1->hash (), "single"));
+	for (auto const & block : batch)
+	{
+		ASSERT_TIMELY (5s, has_observed (block->hash (), "batch"));
+	}
+	ASSERT_TIMELY (5s, has_observed (send5->hash (), "blocking"));
 }
 
 // When queue is full, add_blocking returns nullopt because the promise is destroyed unfulfilled

--- a/nano/node/block_context.hpp
+++ b/nano/node/block_context.hpp
@@ -4,6 +4,7 @@
 #include <nano/node/block_source.hpp>
 #include <nano/secure/common.hpp>
 
+#include <any>
 #include <future>
 
 namespace nano
@@ -19,12 +20,14 @@ public: // Keep fields public for simplicity
 	nano::block_source source;
 	callback_t callback;
 	std::chrono::steady_clock::time_point arrival{ std::chrono::steady_clock::now () };
+	std::any tag; // Opaque per-block tag from the submitter
 
 public:
-	block_context (std::shared_ptr<nano::block> block, nano::block_source source, callback_t callback = nullptr) :
+	block_context (std::shared_ptr<nano::block> block, nano::block_source source, callback_t callback = nullptr, std::any tag = {}) :
 		block{ std::move (block) },
 		source{ source },
-		callback{ std::move (callback) }
+		callback{ std::move (callback) },
+		tag{ std::move (tag) }
 	{
 		debug_assert (source != nano::block_source::unknown);
 	}

--- a/nano/node/block_processor.cpp
+++ b/nano/node/block_processor.cpp
@@ -110,7 +110,7 @@ std::size_t nano::block_processor::size (nano::block_source source) const
 	return queue.size ({ source });
 }
 
-bool nano::block_processor::add (std::shared_ptr<nano::block> const & block, block_source const source, std::shared_ptr<nano::transport::channel> const & channel, std::function<void (nano::block_status)> callback)
+bool nano::block_processor::add (std::shared_ptr<nano::block> const & block, block_source const source, std::shared_ptr<nano::transport::channel> const & channel, std::function<void (nano::block_status)> callback, std::any tag)
 {
 	if (network_params.work.validate_entry (*block)) // true => error
 	{
@@ -120,7 +120,7 @@ bool nano::block_processor::add (std::shared_ptr<nano::block> const & block, blo
 
 	logger.debug (nano::log::type::block_processor, "Processing block (async): {} (source: {} {})", block->hash (), source, channel);
 
-	bool added = add_impl ({ block, source, std::move (callback) }, channel);
+	bool added = add_impl ({ block, source, std::move (callback), std::move (tag) }, channel);
 	if (added)
 	{
 		stats.inc (nano::stat::type::block_processor, nano::stat::detail::process);
@@ -128,7 +128,7 @@ bool nano::block_processor::add (std::shared_ptr<nano::block> const & block, blo
 	return added;
 }
 
-std::size_t nano::block_processor::add_many (std::deque<std::shared_ptr<nano::block>> const & blocks, block_source const source, std::shared_ptr<nano::transport::channel> const & channel, std::function<void (nano::block_status)> last_callback)
+std::size_t nano::block_processor::add_many (std::deque<std::shared_ptr<nano::block>> const & blocks, block_source const source, std::shared_ptr<nano::transport::channel> const & channel, std::function<void (nano::block_status)> last_callback, std::any tag)
 {
 	if (blocks.empty ())
 	{
@@ -147,7 +147,7 @@ std::size_t nano::block_processor::add_many (std::deque<std::shared_ptr<nano::bl
 		}
 		else
 		{
-			contexts.emplace_back (block, source);
+			contexts.emplace_back (block, source, nullptr, tag);
 		}
 	}
 
@@ -202,11 +202,11 @@ std::size_t nano::block_processor::add_many (std::deque<std::shared_ptr<nano::bl
 	return added;
 }
 
-std::optional<nano::block_status> nano::block_processor::add_blocking (std::shared_ptr<nano::block> const & block, block_source const source)
+std::optional<nano::block_status> nano::block_processor::add_blocking (std::shared_ptr<nano::block> const & block, block_source const source, std::any tag)
 {
 	logger.debug (nano::log::type::block_processor, "Processing block (blocking): {} (source: {})", block->hash (), source);
 
-	nano::block_context ctx{ block, source };
+	nano::block_context ctx{ block, source, nullptr, std::move (tag) };
 	auto future = ctx.get_future ();
 	bool added = add_impl (std::move (ctx));
 	if (added)

--- a/nano/node/block_processor.hpp
+++ b/nano/node/block_processor.hpp
@@ -9,6 +9,7 @@
 
 #include <boost/thread.hpp>
 
+#include <any>
 #include <chrono>
 #include <deque>
 #include <future>
@@ -65,17 +66,20 @@ public:
 	std::shared_ptr<nano::block> const & block,
 	nano::block_source source,
 	std::shared_ptr<nano::transport::channel> const & channel = nullptr,
-	std::function<void (nano::block_status)> callback = {});
+	std::function<void (nano::block_status)> callback = nullptr,
+	std::any tag = {});
 
 	std::size_t add_many (
 	std::deque<std::shared_ptr<nano::block>> const & blocks,
 	nano::block_source source,
 	std::shared_ptr<nano::transport::channel> const & channel = nullptr,
-	std::function<void (nano::block_status)> last_callback = {});
+	std::function<void (nano::block_status)> last_callback = nullptr,
+	std::any tag = {});
 
 	std::optional<nano::block_status> add_blocking (
 	std::shared_ptr<nano::block> const & block,
-	nano::block_source source);
+	nano::block_source source,
+	std::any tag = {});
 
 	void force (std::shared_ptr<nano::block> const & block);
 

--- a/nano/node/block_processor.hpp
+++ b/nano/node/block_processor.hpp
@@ -30,6 +30,7 @@ public:
 	nano::error serialize (nano::tomlconfig & toml) const;
 
 public:
+	// Maximum number of blocks processed in a single batch (under a single write transaction)
 	size_t batch_size{ 256 };
 
 	// Maximum number of blocks to queue from network peers
@@ -50,8 +51,10 @@ public:
 };
 
 /**
- * Processing blocks is a potentially long IO operation.
- * This class isolates block insertion from other operations like servicing network operations
+ * Processes blocks into the ledger on a dedicated thread.
+ * Blocks are queued in a fair queue that balances between sources (live, bootstrap, local, forced, ...) according to configured priorities and per-source size limits.
+ * Blocks that cannot be processed yet (gaps) are stored in the unchecked map and requeued once their dependencies are satisfied.
+ * Processing results are dispatched asynchronously via ledger_notifications.
  */
 class block_processor final
 {
@@ -62,6 +65,7 @@ public:
 	void start ();
 	void stop ();
 
+	/// Queues a block for processing, returns false if the block was dropped (insufficient work or queue overfill)
 	bool add (
 	std::shared_ptr<nano::block> const & block,
 	nano::block_source source,
@@ -69,6 +73,7 @@ public:
 	std::function<void (nano::block_status)> callback = nullptr,
 	std::any tag = {});
 
+	/// Queues multiple blocks under a single lock, attaching the callback to the last valid block; returns the number of blocks added
 	std::size_t add_many (
 	std::deque<std::shared_ptr<nano::block>> const & blocks,
 	nano::block_source source,
@@ -76,14 +81,18 @@ public:
 	std::function<void (nano::block_status)> last_callback = nullptr,
 	std::any tag = {});
 
+	/// Queues a block and waits for its processing result, returns nullopt if the block was dropped
 	std::optional<nano::block_status> add_blocking (
 	std::shared_ptr<nano::block> const & block,
 	nano::block_source source,
 	std::any tag = {});
 
+	/// Queues a block for processing that rolls back any competing fork block already in the ledger
 	void force (std::shared_ptr<nano::block> const & block);
 
+	/// Total number of queued blocks
 	std::size_t size () const;
+	/// Number of queued blocks from the given source
 	std::size_t size (nano::block_source) const;
 
 	nano::container_info container_info () const;
@@ -101,18 +110,29 @@ private: // Dependencies
 private:
 	void run ();
 
-	// Roll back block in the ledger that conflicts with 'block'
-	void rollback_competitor (secure::write_transaction &, nano::block const & block);
+	/// Processes a single block into the ledger and handles the result (e.g. stores gapped blocks as unchecked)
 	nano::block_status process_one (secure::write_transaction const &, nano::block_context const &, bool forced = false);
+	/// Processes the next batch of blocks under a single write transaction and queues result notifications
 	void process_batch (nano::unique_lock<nano::mutex> &);
+	/// Pops up to max_count blocks from the queue
 	std::deque<nano::block_context> next_batch (size_t max_count);
+	/// Pops the next block from the queue
 	nano::block_context next ();
+
+	/// Rolls back the ledger block occupying the same qualified root, together with its dependents
+	void rollback_competitor (secure::write_transaction &, nano::block const & block);
+
+	/// Pushes a block context onto the queue and notifies the processing thread, returns false on overfill
 	bool add_impl (nano::block_context, std::shared_ptr<nano::transport::channel> const & channel = nullptr);
 
+	/// Throttles processing when the ledger backlog exceeds the configured threshold
 	void wait_backlog (nano::unique_lock<nano::mutex> &);
+
+	/// Ratio of ledger backlog to the throttling threshold, 0 when below the threshold
 	double backlog_factor () const;
 
 private:
+	/// Queue of blocks to be processed, fairly balanced between sources
 	nano::fair_queue<nano::block_context, nano::block_source, std::shared_ptr<nano::transport::channel>> queue;
 
 	bool stopped{ false };

--- a/nano/node/bootstrap/bootstrap_context.cpp
+++ b/nano/node/bootstrap/bootstrap_context.cpp
@@ -64,8 +64,7 @@ nano::ledger_notifications & ledger_notifications_a, nano::block_processor & blo
 			auto transaction = ledger.tx_begin_read ();
 			for (auto const & [result, block_context] : batch)
 			{
-				debug_assert (block_context.block != nullptr);
-				inspect (transaction, result, *block_context.block, block_context.source);
+				inspect (transaction, result, block_context);
 			}
 		}
 		condition.notify_all ();
@@ -282,11 +281,14 @@ size_t bootstrap_context::count_tags (nano::block_hash const & hash, query_sourc
  * - Marks an account as blocked if the result code is gap source as there is no reason request additional blocks for this account until the dependency is resolved
  * - Marks an account as forwarded if it has been recently referenced by a block that has been inserted
  */
-void bootstrap_context::inspect (secure::transaction const & tx, nano::block_status const & result, nano::block const & block, nano::block_source source)
+void bootstrap_context::inspect (secure::transaction const & tx, nano::block_status const & result, nano::block_context const & context)
 {
 	debug_assert (!mutex.try_lock ());
+	debug_assert (context.block != nullptr);
 
-	auto const hash = block.hash ();
+	auto const & block = *context.block;
+	auto const & source = context.source;
+	auto const & hash = block.hash ();
 
 	switch (result)
 	{

--- a/nano/node/bootstrap/bootstrap_context.hpp
+++ b/nano/node/bootstrap/bootstrap_context.hpp
@@ -79,7 +79,7 @@ public:
 	size_t count_tags (nano::block_hash const & hash, query_source source) const;
 
 	// Inspects a block that has been processed by the block processor
-	void inspect (secure::transaction const &, nano::block_status const & result, nano::block const & block, nano::block_source);
+	void inspect (secure::transaction const &, nano::block_status const & result, nano::block_context const & context);
 
 	// Calculates a lookback size based on the size of the ledger
 	std::size_t compute_throttle_size () const;

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -14,6 +14,7 @@ class active_elections_config;
 class backlog_scan;
 class backlog_scan_config;
 class bandwidth_limiter;
+class block_context;
 class block_processor;
 class block_processor_config;
 class block_rebroadcaster;


### PR DESCRIPTION
Adds an opaque std::any tag field to nano::block_context and threads it through the block_processor submission APIs (add, add_many, add_blocking), allowing submitters to attach arbitrary per-block metadata that is carried alongside the block through processing and available in result notifications. bootstrap_context::inspect is updated to take the full block_context instead of unpacked block/source arguments, giving it access to the context (including the tag) in one place. Also adds test coverage for tag propagation and documentation comments to the block_processor header.