### PR TITLE
Move signature verification out of the write transaction and parallelize it

### DIFF
--- a/nano/core_test/block_processor.cpp
+++ b/nano/core_test/block_processor.cpp
@@ -397,6 +397,141 @@ TEST (block_processor, add_many_empty)
 	ASSERT_EQ (node.ledger.block_count (), 1);
 }
 
+// Parallel signature pre-validation processes a valid block and increments the blocks_verified stat
+TEST (block_processor, verification)
+{
+	nano::test::system system;
+
+	nano::node_config node_config;
+	node_config.block_processor->verification_threads = 2;
+	auto & node = *system.add_node (node_config);
+
+	nano::keypair key;
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Knano_ratio)
+				.link (key.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
+
+	auto result = node.block_processor.add_blocking (send, nano::block_source::local);
+	ASSERT_TRUE (result.has_value ());
+	ASSERT_EQ (result.value (), nano::block_status::progress);
+	ASSERT_TRUE (node.block_or_pruned_exists (send->hash ()));
+	ASSERT_EQ (node.stats.count (nano::stat::type::block_processor, nano::stat::detail::blocks_verified), 1);
+}
+
+// Epoch blocks signed by the epoch signer rather than the account owner are pre-validated as valid_epoch and still process correctly
+TEST (block_processor, verification_epoch)
+{
+	nano::test::system system;
+
+	nano::node_config node_config;
+	node_config.block_processor->verification_threads = 2;
+	auto & node = *system.add_node (node_config);
+
+	nano::keypair key;
+	nano::block_builder builder;
+
+	// Fund the account so it can be opened by an epoch block
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Knano_ratio)
+				.link (key.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
+
+	auto send_result = node.block_processor.add_blocking (send, nano::block_source::local);
+	ASSERT_TRUE (send_result.has_value ());
+	ASSERT_EQ (send_result.value (), nano::block_status::progress);
+
+	// Signed by the epoch signer (dev genesis), not the account owner, so pre-validation returns valid_epoch
+	auto epoch = builder
+				 .state ()
+				 .account (key.pub)
+				 .previous (0)
+				 .representative (0)
+				 .balance (0)
+				 .link (node.ledger.epoch_link (nano::epoch::epoch_1))
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*system.work.generate (key.pub))
+				 .build ();
+
+	auto epoch_result = node.block_processor.add_blocking (epoch, nano::block_source::local);
+	ASSERT_TRUE (epoch_result.has_value ());
+	ASSERT_EQ (epoch_result.value (), nano::block_status::progress);
+	ASSERT_TRUE (node.block_or_pruned_exists (epoch->hash ()));
+	ASSERT_EQ (node.stats.count (nano::stat::type::block_processor, nano::stat::detail::blocks_verified), 2);
+}
+
+// Blocks pre-validated as invalid are rejected with bad_signature
+TEST (block_processor, verification_bad_signature)
+{
+	nano::test::system system;
+
+	nano::node_config node_config;
+	node_config.block_processor->verification_threads = 2;
+	auto & node = *system.add_node (node_config);
+
+	nano::keypair key;
+	nano::keypair wrong_key;
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Knano_ratio)
+				.link (key.pub)
+				.sign (wrong_key.prv, wrong_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
+
+	auto result = node.block_processor.add_blocking (send, nano::block_source::local);
+	ASSERT_TRUE (result.has_value ());
+	ASSERT_EQ (result.value (), nano::block_status::bad_signature);
+	ASSERT_FALSE (node.block_or_pruned_exists (send->hash ()));
+	ASSERT_EQ (node.stats.count (nano::stat::type::block_processor, nano::stat::detail::blocks_verified), 1);
+}
+
+// verification_threads = 0 disables the pre-validation pool, blocks are verified inline as before
+TEST (block_processor, verification_disabled)
+{
+	nano::test::system system;
+
+	nano::node_config node_config;
+	node_config.block_processor->verification_threads = 0;
+	auto & node = *system.add_node (node_config);
+
+	nano::keypair key;
+	nano::block_builder builder;
+	auto send = builder
+				.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - nano::Knano_ratio)
+				.link (key.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
+
+	auto result = node.block_processor.add_blocking (send, nano::block_source::local);
+	ASSERT_TRUE (result.has_value ());
+	ASSERT_EQ (result.value (), nano::block_status::progress);
+	ASSERT_TRUE (node.block_or_pruned_exists (send->hash ()));
+	ASSERT_EQ (node.stats.count (nano::stat::type::block_processor, nano::stat::detail::blocks_verified), 0);
+}
+
 TEST (block_processor, backlog_throttling)
 {
 	nano::test::system system;

--- a/nano/core_test/toml.cpp
+++ b/nano/core_test/toml.cpp
@@ -407,6 +407,7 @@ TEST (toml_config, daemon_config_deserialize_defaults)
 	ASSERT_EQ (conf.node.vote_cache->max_size, defaults.node.vote_cache->max_size);
 	ASSERT_EQ (conf.node.vote_cache->max_voters, defaults.node.vote_cache->max_voters);
 
+	ASSERT_EQ (conf.node.block_processor->verification_threads, defaults.node.block_processor->verification_threads);
 	ASSERT_EQ (conf.node.block_processor->max_peer_queue, defaults.node.block_processor->max_peer_queue);
 	ASSERT_EQ (conf.node.block_processor->max_system_queue, defaults.node.block_processor->max_system_queue);
 	ASSERT_EQ (conf.node.block_processor->priority_live, defaults.node.block_processor->priority_live);
@@ -521,6 +522,7 @@ TEST (toml_config, daemon_config_deserialize_no_defaults)
 	scan_rate = 999
 
 	[node.block_processor]
+	verification_threads = 999
 	max_peer_queue = 999
 	max_system_queue = 999
 	priority_live = 999
@@ -840,6 +842,7 @@ TEST (toml_config, daemon_config_deserialize_no_defaults)
 	ASSERT_NE (conf.node.vote_cache->max_size, defaults.node.vote_cache->max_size);
 	ASSERT_NE (conf.node.vote_cache->max_voters, defaults.node.vote_cache->max_voters);
 
+	ASSERT_NE (conf.node.block_processor->verification_threads, defaults.node.block_processor->verification_threads);
 	ASSERT_NE (conf.node.block_processor->max_peer_queue, defaults.node.block_processor->max_peer_queue);
 	ASSERT_NE (conf.node.block_processor->max_system_queue, defaults.node.block_processor->max_system_queue);
 	ASSERT_NE (conf.node.block_processor->priority_live, defaults.node.block_processor->priority_live);

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -245,6 +245,7 @@ enum class detail
 	force,
 	force_overfill,
 	cooldown_backlog,
+	blocks_verified,
 
 	// block source
 	live,

--- a/nano/node/block_context.hpp
+++ b/nano/node/block_context.hpp
@@ -21,6 +21,8 @@ public: // Keep fields public for simplicity
 	callback_t callback;
 	std::chrono::steady_clock::time_point arrival{ std::chrono::steady_clock::now () };
 	std::any tag; // Opaque per-block tag from the submitter
+	// Result of parallel signature pre-validation, consumed by ledger processing
+	nano::signature_verification verified{ nano::signature_verification::unknown };
 
 public:
 	block_context (std::shared_ptr<nano::block> block, nano::block_source source, callback_t callback = nullptr, std::any tag = {}) :

--- a/nano/node/block_processor.cpp
+++ b/nano/node/block_processor.cpp
@@ -3,6 +3,7 @@
 #include <nano/lib/config.hpp>
 #include <nano/lib/enum_util.hpp>
 #include <nano/lib/logging.hpp>
+#include <nano/lib/thread_pool.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/node/active_elections.hpp>
@@ -16,6 +17,7 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 
+#include <latch>
 #include <utility>
 
 /*
@@ -63,6 +65,11 @@ nano::block_processor::block_processor (nano::node_config const & node_config_a,
 	unchecked.satisfied.add ([this] (nano::unchecked_info const & info) {
 		add (info.block, nano::block_source::unchecked);
 	});
+
+	if (config.verification_threads > 0)
+	{
+		verification_pool = std::make_unique<nano::thread_pool> (config.verification_threads, nano::thread_role::name::signature_checking);
+	}
 }
 
 nano::block_processor::~block_processor ()
@@ -74,6 +81,11 @@ nano::block_processor::~block_processor ()
 void nano::block_processor::start ()
 {
 	debug_assert (!thread.joinable ());
+
+	if (verification_pool)
+	{
+		verification_pool->start ();
+	}
 
 	boost::thread::attributes attrs;
 	attrs.set_stack_size (nano::ledger_thread_stack_size ());
@@ -94,6 +106,11 @@ void nano::block_processor::stop ()
 	if (thread.joinable ())
 	{
 		thread.join ();
+	}
+	// The pool must be stopped after joining the processing thread, verify_batch () relies on posted tasks always completing
+	if (verification_pool)
+	{
+		verification_pool->stop ();
 	}
 }
 
@@ -420,6 +437,64 @@ auto nano::block_processor::next_batch (size_t max_count) -> std::deque<nano::bl
 	return results;
 }
 
+nano::signature_verification nano::block_processor::verify (nano::block const & block) const
+{
+	switch (block.type ())
+	{
+		case nano::block_type::state:
+		{
+			auto const & hash = block.hash ();
+			auto const account = block.account_field ().value ();
+			// Check the signers in the same order as ledger processing (account owner first, epoch signer second)
+			if (!nano::validate_message (account, hash, block.block_signature ()))
+			{
+				return nano::signature_verification::valid;
+			}
+			auto const link = block.link_field ().value ();
+			if (ledger.is_epoch_link (link) && !nano::validate_message (ledger.epoch_signer (link), hash, block.block_signature ()))
+			{
+				return nano::signature_verification::valid_epoch;
+			}
+			return nano::signature_verification::invalid;
+		}
+		case nano::block_type::open:
+		{
+			return nano::validate_message (block.account_field ().value (), block.hash (), block.block_signature ()) ? nano::signature_verification::invalid : nano::signature_verification::valid;
+		}
+		default:
+		{
+			// Legacy send/receive/change blocks require a ledger lookup to determine the signer
+			return nano::signature_verification::unknown;
+		}
+	}
+}
+
+void nano::block_processor::verify_batch (std::deque<nano::block_context> & batch)
+{
+	debug_assert (verification_pool);
+	debug_assert (!batch.empty ());
+
+	// Waiting on the latch is only safe because the pool outlives the processing thread, see stop ()
+	size_t const num_chunks = std::min (static_cast<size_t> (config.verification_threads), batch.size ());
+	std::latch latch (num_chunks);
+
+	for (size_t chunk = 0; chunk < num_chunks; ++chunk)
+	{
+		auto const begin = batch.begin () + chunk * batch.size () / num_chunks;
+		auto const end = batch.begin () + (chunk + 1) * batch.size () / num_chunks;
+		verification_pool->post ([this, begin, end, &latch] {
+			for (auto it = begin; it != end; ++it)
+			{
+				it->verified = verify (*it->block);
+			}
+			latch.count_down ();
+		});
+	}
+	latch.wait ();
+
+	stats.add (nano::stat::type::block_processor, nano::stat::detail::blocks_verified, batch.size ());
+}
+
 void nano::block_processor::process_batch (nano::unique_lock<nano::mutex> & lock)
 {
 	debug_assert (lock.owns_lock ());
@@ -429,6 +504,12 @@ void nano::block_processor::process_batch (nano::unique_lock<nano::mutex> & lock
 	auto batch = next_batch (config.batch_size);
 
 	lock.unlock ();
+
+	// Pre-validate signatures in parallel before opening the write transaction
+	if (verification_pool)
+	{
+		verify_batch (batch);
+	}
 
 	auto transaction = ledger.tx_begin_write (nano::store::writer::block_processor);
 
@@ -481,7 +562,7 @@ nano::block_status nano::block_processor::process_one (secure::write_transaction
 {
 	auto block = context.block;
 	auto const hash = block->hash ();
-	nano::block_status result = ledger.process (transaction_a, block);
+	nano::block_status result = ledger.process (transaction_a, block, context.verified);
 
 	stats.inc (nano::stat::type::block_processor_result, to_stat_detail (result));
 	stats.inc (nano::stat::type::block_processor_source, to_stat_detail (context.source));
@@ -599,12 +680,14 @@ nano::container_info nano::block_processor::container_info () const
  * block_processor_config
  */
 
-nano::block_processor_config::block_processor_config (const nano::network_constants & network_constants)
+nano::block_processor_config::block_processor_config (const nano::network_constants & network_constants) :
+	verification_threads{ std::min (nano::hardware_concurrency (), 4u) }
 {
 }
 
 nano::error nano::block_processor_config::serialize (nano::tomlconfig & toml) const
 {
+	toml.put ("verification_threads", verification_threads, "Number of threads used to pre-validate block signatures in parallel before ledger processing, 0 to disable pre-validation. \ntype:uint32");
 	toml.put ("max_peer_queue", max_peer_queue, "Maximum number of blocks to queue from network peers. \ntype:uint64");
 	toml.put ("max_system_queue", max_system_queue, "Maximum number of blocks to queue from system components (local RPC, bootstrap). \ntype:uint64");
 	toml.put ("priority_live", priority_live, "Priority for live network blocks. Higher priority gets processed more frequently. \ntype:uint64");
@@ -620,6 +703,7 @@ nano::error nano::block_processor_config::serialize (nano::tomlconfig & toml) co
 
 nano::error nano::block_processor_config::deserialize (nano::tomlconfig & toml)
 {
+	toml.get ("verification_threads", verification_threads);
 	toml.get ("max_peer_queue", max_peer_queue);
 	toml.get ("max_system_queue", max_system_queue);
 	toml.get ("priority_live", priority_live);

--- a/nano/node/block_processor.hpp
+++ b/nano/node/block_processor.hpp
@@ -33,6 +33,9 @@ public:
 	// Maximum number of blocks processed in a single batch (under a single write transaction)
 	size_t batch_size{ 256 };
 
+	// Number of threads used to pre-validate block signatures in parallel before ledger processing, 0 to disable pre-validation
+	unsigned verification_threads;
+
 	// Maximum number of blocks to queue from network peers
 	size_t max_peer_queue{ 128 };
 	// Maximum number of blocks to queue from system components (local RPC, bootstrap)
@@ -114,6 +117,9 @@ private:
 	nano::block_status process_one (secure::write_transaction const &, nano::block_context const &, bool forced = false);
 	/// Processes the next batch of blocks under a single write transaction and queues result notifications
 	void process_batch (nano::unique_lock<nano::mutex> &);
+	/// Pre-validate signatures for the batch in parallel on the verification pool
+	void verify_batch (std::deque<nano::block_context> & batch);
+	nano::signature_verification verify (nano::block const &) const;
 	/// Pops up to max_count blocks from the queue
 	std::deque<nano::block_context> next_batch (size_t max_count);
 	/// Pops the next block from the queue
@@ -139,6 +145,7 @@ private:
 	nano::condition_variable condition;
 	mutable nano::mutex mutex{ mutex_identifier (mutexes::block_processor) };
 	boost::thread thread;
+	std::unique_ptr<nano::thread_pool> verification_pool; // Only allocated when verification_threads > 0
 
 	nano::interval log_processing_interval;
 	nano::interval log_backlog_interval;

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -119,6 +119,15 @@ enum class block_status
 std::string_view to_string (block_status);
 nano::stat::detail to_stat_detail (block_status);
 
+/** Result of pre-validating a block signature outside of ledger processing */
+enum class signature_verification
+{
+	unknown, // Not pre-validated, ledger processing must verify the signature (default value)
+	valid, // Signed correctly by the account owner
+	valid_epoch, // Signed correctly by the epoch signer instead of the account owner
+	invalid // Signed neither by the account owner nor, for epoch links, the epoch signer
+};
+
 enum class tally_result
 {
 	vote,

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -420,11 +420,11 @@ void nano::ledger::cement_one (secure::write_transaction & transaction, nano::bl
 	stats.inc (nano::stat::type::confirmation_height, nano::stat::detail::blocks_cemented);
 }
 
-nano::block_status nano::ledger::process (secure::write_transaction const & transaction, std::shared_ptr<nano::block> block)
+nano::block_status nano::ledger::process (secure::write_transaction const & transaction, std::shared_ptr<nano::block> block, nano::signature_verification verification)
 {
 	debug_assert (!work.validate_entry (*block) || constants.genesis == nano::dev::genesis);
 
-	ledger_processor processor (transaction, *this);
+	ledger_processor processor (transaction, *this, verification);
 	block->visit (processor);
 	if (processor.result == nano::block_status::progress)
 	{

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -81,7 +81,7 @@ public:
 	std::deque<std::shared_ptr<nano::block>> random_blocks (secure::transaction const &, size_t count) const;
 	std::optional<nano::pending_info> pending_info (secure::transaction const &, nano::pending_key const & key) const;
 	std::deque<std::shared_ptr<nano::block>> cement (secure::write_transaction &, nano::block_hash const & hash, size_t max_blocks = 1024 * 128);
-	nano::block_status process (secure::write_transaction const &, std::shared_ptr<nano::block> block);
+	nano::block_status process (secure::write_transaction const &, std::shared_ptr<nano::block> block, nano::signature_verification verification = nano::signature_verification::unknown);
 	bool rollback (secure::write_transaction const &, nano::block_hash const &, std::deque<std::shared_ptr<nano::block>> & rollback_list, size_t depth = 0, size_t max_depth = nano::ledger_max_rollback_depth ());
 	bool rollback (secure::write_transaction const &, nano::block_hash const &);
 	void update_account (secure::write_transaction const &, nano::account const &, nano::account_info const &, nano::account_info const &);

--- a/nano/secure/ledger_processor.cpp
+++ b/nano/secure/ledger_processor.cpp
@@ -18,10 +18,39 @@
 
 #include <boost/multiprecision/cpp_int.hpp>
 
-nano::ledger_processor::ledger_processor (nano::secure::write_transaction const & transaction_a, nano::ledger & ledger_a) :
+nano::ledger_processor::ledger_processor (nano::secure::write_transaction const & transaction_a, nano::ledger & ledger_a, nano::signature_verification verification_a) :
 	transaction (transaction_a),
-	ledger (ledger_a)
+	ledger (ledger_a),
+	verification (verification_a)
 {
+}
+
+bool nano::ledger_processor::validate_signature (nano::account const & signer, nano::block_hash const & hash, nano::signature const & signature, bool epoch_signer) const
+{
+	switch (verification)
+	{
+		case nano::signature_verification::valid:
+			if (!epoch_signer)
+			{
+				debug_assert (!validate_message (signer, hash, signature));
+				return false;
+			}
+			break; // Pre-verified against the account owner, inconclusive for the epoch signer
+		case nano::signature_verification::valid_epoch:
+			if (epoch_signer)
+			{
+				debug_assert (!validate_message (signer, hash, signature));
+				return false;
+			}
+			break; // Pre-verified against the epoch signer, inconclusive for the account owner
+		case nano::signature_verification::invalid:
+			// Pre-verification checks the account owner and, for epoch links, the epoch signer, so a failure of both is conclusive here
+			debug_assert (validate_message (signer, hash, signature));
+			return true;
+		case nano::signature_verification::unknown:
+			break;
+	}
+	return validate_message (signer, hash, signature);
 }
 
 void nano::ledger_processor::send_block (nano::send_block & block_a)
@@ -172,7 +201,7 @@ void nano::ledger_processor::open_block (nano::open_block & block_a)
 	result = existing ? nano::block_status::old : nano::block_status::progress; // Have we seen this block already? (Harmless)
 	if (result == nano::block_status::progress)
 	{
-		result = validate_message (block_a.hashables.account, hash, block_a.signature) ? nano::block_status::bad_signature : nano::block_status::progress; // Is the signature valid (Malformed)
+		result = validate_signature (block_a.hashables.account, hash, block_a.signature) ? nano::block_status::bad_signature : nano::block_status::progress; // Is the signature valid (Malformed)
 		if (result == nano::block_status::progress)
 		{
 			debug_assert (!validate_message (block_a.hashables.account, hash, block_a.signature));
@@ -319,7 +348,7 @@ void nano::ledger_processor::state_block_impl (nano::state_block & block_a)
 	result = existing ? nano::block_status::old : nano::block_status::progress; // Have we seen this block before? (Unambiguous)
 	if (result == nano::block_status::progress)
 	{
-		result = validate_message (block_a.hashables.account, hash, block_a.signature) ? nano::block_status::bad_signature : nano::block_status::progress; // Is this block signed correctly (Unambiguous)
+		result = validate_signature (block_a.hashables.account, hash, block_a.signature) ? nano::block_status::bad_signature : nano::block_status::progress; // Is this block signed correctly (Unambiguous)
 		if (result == nano::block_status::progress)
 		{
 			debug_assert (!validate_message (block_a.hashables.account, hash, block_a.signature));
@@ -463,7 +492,7 @@ void nano::ledger_processor::epoch_block_impl (nano::state_block & block_a)
 	result = existing ? nano::block_status::old : nano::block_status::progress; // Have we seen this block before? (Unambiguous)
 	if (result == nano::block_status::progress)
 	{
-		result = validate_message (ledger.epoch_signer (block_a.hashables.link), hash, block_a.signature) ? nano::block_status::bad_signature : nano::block_status::progress; // Is this block signed correctly (Unambiguous)
+		result = validate_signature (ledger.epoch_signer (block_a.hashables.link), hash, block_a.signature, /* epoch_signer */ true) ? nano::block_status::bad_signature : nano::block_status::progress; // Is this block signed correctly (Unambiguous)
 		if (result == nano::block_status::progress)
 		{
 			debug_assert (!validate_message (ledger.epoch_signer (block_a.hashables.link), hash, block_a.signature));
@@ -566,10 +595,10 @@ bool nano::ledger_processor::validate_epoch_block (nano::state_block const & blo
 		else
 		{
 			// Check for possible regular state blocks with epoch link (send subtype)
-			if (validate_message (block_a.hashables.account, block_a.hash (), block_a.signature))
+			if (validate_signature (block_a.hashables.account, block_a.hash (), block_a.signature))
 			{
 				// Is epoch block signed correctly
-				if (validate_message (ledger.epoch_signer (block_a.link_field ().value ()), block_a.hash (), block_a.signature))
+				if (validate_signature (ledger.epoch_signer (block_a.link_field ().value ()), block_a.hash (), block_a.signature, /* epoch_signer */ true))
 				{
 					result = nano::block_status::bad_signature;
 				}

--- a/nano/secure/ledger_processor.cpp
+++ b/nano/secure/ledger_processor.cpp
@@ -42,7 +42,9 @@ bool nano::ledger_processor::validate_signature (nano::account const & signer, n
 				debug_assert (!validate_message (signer, hash, signature));
 				return false;
 			}
-			break; // Pre-verified against the epoch signer, inconclusive for the account owner
+			// Pre-verification only yields valid_epoch after the account owner check has failed, so a failure is conclusive here
+			debug_assert (validate_message (signer, hash, signature));
+			return true;
 		case nano::signature_verification::invalid:
 			// Pre-verification checks the account owner and, for epoch links, the epoch signer, so a failure of both is conclusive here
 			debug_assert (validate_message (signer, hash, signature));

--- a/nano/secure/ledger_processor.hpp
+++ b/nano/secure/ledger_processor.hpp
@@ -10,7 +10,7 @@ namespace nano
 class ledger_processor final : public nano::mutable_block_visitor
 {
 public:
-	ledger_processor (nano::secure::write_transaction const &, nano::ledger &);
+	ledger_processor (nano::secure::write_transaction const &, nano::ledger &, nano::signature_verification = nano::signature_verification::unknown);
 
 	void send_block (nano::send_block &) override;
 	void receive_block (nano::receive_block &) override;
@@ -23,10 +23,15 @@ public:
 
 	nano::secure::write_transaction const & transaction;
 	nano::ledger & ledger;
+	nano::signature_verification const verification;
 	nano::block_status result{ nano::block_status::invalid };
 
 private:
 	bool validate_epoch_block (nano::state_block const & block);
+
+	// Signature check that consumes the pre-computed verification result when available, falling back to validate_message () otherwise.
+	// Returns true if the signature is invalid, matching validate_message () semantics.
+	bool validate_signature (nano::account const & signer, nano::block_hash const & hash, nano::signature const & signature, bool epoch_signer = false) const;
 
 	// Returns 1 + max(deps' topo_height) or 0 (unindexed sentinel) when the index is disabled or any dependency is itself unindexed
 	uint64_t topology_height (std::shared_ptr<nano::block> const & dep1, std::shared_ptr<nano::block> const & dep2 = nullptr) const;


### PR DESCRIPTION
Block signature verification currently runs serially inside the ledger write transaction: the block processor opens a write tx per batch and each ledger.process() call does its ed25519 checks while holding it. This PR moves that CPU work out of the transaction and onto a small worker pool, so batches are pre-validated in parallel before the write tx is opened.

Benefits

- Higher block throughput. Serial signature work now spread across up to 4 threads
- Shorter write transaction hold times. The write tx now spends its time on actual store reads/writes instead of signature validation
- Zero behavioral change. Results are bit-identical to today: same checks, same order of ledger application, same result codes, same notification order. A duplicate block with a bad signature still returns old, forks and rollbacks are untouched.

How it works

- block_context gains a nano::signature_verification result (unknown / valid / valid_epoch / invalid), defaulting to unknown.
- process_batch() fans the batch out across a dedicated nano::thread_pool between next_batch() and tx_begin_write(). Workers verify state blocks (against the account owner first, then the epoch signer for epoch links — the same order the ledger processor uses) and open blocks. Legacy send/receive/change blocks need a frontier lookup to determine the signer, so they stay unknown and are verified inline as today; they are effectively extinct on the live network.
- ledger.process() accepts the verification result (defaulting to unknown, so all existing callers keep today's behavior). Inside ledger_processor, a new validate_signature() helper consumes the pre-computed result where it is conclusive and falls back to validate_message() where it isn't. Debug builds re-verify every skipped check via debug_assert.
- Pre-verified invalid blocks are still rejected at the existing check site inside the transaction (not short-circuited earlier), preserving today's result-code precedence.

Co-authored with Claude Fable