### PR TITLE
ci: retire the public test network from the release pipeline

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        network: ["TEST", "BETA", "LIVE"]
+        network: ["BETA", "LIVE"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -82,7 +82,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        network: ["TEST", "BETA", "LIVE"]
+        network: ["BETA", "LIVE"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -119,7 +119,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        network: ["TEST", "BETA", "LIVE"]
+        network: ["BETA", "LIVE"]
     env:
       CI_TAG: ${{ needs.prepare_build.outputs.ci_tag }}
       DOCKER_REGISTRY: ${{ vars.DOCKER_REGISTRY }}
@@ -165,7 +165,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        network: ["TEST", "BETA", "LIVE"]
+        network: ["BETA", "LIVE"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/ci/actions/deploy.sh
+++ b/ci/actions/deploy.sh
@@ -11,9 +11,6 @@ case "${NETWORK}" in
   "BETA")
       BUILD="beta"
       ;;
-  "TEST")
-      BUILD="test"
-      ;;
   *)
       BUILD="live"
       ;;

--- a/ci/actions/linux/docker-impl/docker-common.sh
+++ b/ci/actions/linux/docker-impl/docker-common.sh
@@ -28,10 +28,6 @@ elif [[ "$NETWORK" = "BETA" ]]; then
     echo "Beta"
     network_tag_suffix="-beta"
     network="beta"
-elif [[ "$NETWORK" = "TEST" ]]; then
-    echo "Test"
-    network_tag_suffix="-test"
-    network="test"
 fi
 
 docker_image_name="${DOCKER_REGISTRY}/nano${network_tag_suffix}"

--- a/ci/actions/windows/build.ps1
+++ b/ci/actions/windows/build.ps1
@@ -6,9 +6,6 @@ if (${env:artifact} -eq 1) {
         $env:NETWORK_CFG = "beta"
         $env:BUILD_TYPE = "RelWithDebInfo"
     }
-    elseif (${env:NETWORK} -eq "TEST") {
-        $env:NETWORK_CFG = "test"
-    }
     else {
         $env:NETWORK_CFG = "live"
     }

--- a/ci/actions/windows/deploy.ps1
+++ b/ci/actions/windows/deploy.ps1
@@ -4,9 +4,6 @@ $env:S3_BUCKET_NAME = $env:S3_BUCKET_NAME ?? "repo.nano.org"
 if ( "${env:NETWORK}" -eq "BETA" ) {
     $network_cfg = "beta"
 }
-elseif ( "${env:NETWORK}" -eq "TEST" ) {
-    $network_cfg = "test"
-}
 else {
     $network_cfg = "live"
 }

--- a/ci/build-deploy.sh
+++ b/ci/build-deploy.sh
@@ -20,9 +20,6 @@ case "${NETWORK}" in
       NETWORK_CFG="beta"
       CONFIGURATION="RelWithDebInfo"
       ;;
-  "TEST")
-      NETWORK_CFG="test"
-      ;;
   *)
       NETWORK_CFG="live"
       ;;


### PR DESCRIPTION
The Nano Foundation public test network is being decommissioned (test.nano.org, peering-test.nano.org, and the test-net docs have already been retired). This stops the release CI from building and publishing test-network artifacts.

## Changes
- **`build_deploy.yml`** — drop `"TEST"` from the macOS/Linux/Docker/Windows `network` matrices. This is the load-bearing change: no test builds are produced or published anymore.
- **`ci/actions/deploy.sh`, `ci/actions/windows/deploy.ps1`** — remove the now-dead `NETWORK=TEST` branch that uploaded to `s3://repo.nano.org/test/binaries/`.
- **`ci/build-deploy.sh`, `ci/actions/windows/build.ps1`** — remove the dead `NETWORK=TEST` branch that configured `-DACTIVE_NETWORK=nano_test_network`.
- **`ci/actions/linux/docker-impl/docker-common.sh`** — remove the `NETWORK=TEST` branch that built and pushed the `nanocurrency/nano-test` image (`-test` tag suffix).

## Notes
- The `nano_test_network` build type is **still available** for local builds (`-DACTIVE_NETWORK=nano_test_network`); only the CI-published public test-net artifacts are retired.
- No `case`/matrix mismatch: `NETWORK=TEST` can no longer reach the scripts, so there's no risk of a test build falling through to the `live` publish path.
- The one remaining `"test"` string in `build.ps1` (`$env:RUN = "test"`) is the unit-test *run mode*, unrelated to the network.
- Legacy `.gitlab-ci.yml` / `ci/build-gitlab.sh` left untouched — that pipeline never sets `NETWORK`, so its `TEST)` case was already unreachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)