### PR TITLE
Rework token bucket rate limiting

### DIFF
--- a/nano/core_test/rate_limiting.cpp
+++ b/nano/core_test/rate_limiting.cpp
@@ -80,6 +80,29 @@ TEST (rate, reset)
 	ASSERT_TRUE (bucket.try_consume (1000000));
 }
 
+TEST (rate, can_consume)
+{
+	nano::rate::token_bucket bucket (2, 1);
+
+	ASSERT_TRUE (bucket.can_consume (2));
+	ASSERT_TRUE (bucket.can_consume (2));
+	ASSERT_EQ (bucket.largest_burst (), 0);
+
+	bucket.consume_checked (2);
+	ASSERT_EQ (bucket.largest_burst (), 2);
+	ASSERT_FALSE (bucket.can_consume (1));
+}
+
+TEST (rate_limiter, can_consume)
+{
+	nano::rate_limiter limiter (2);
+
+	ASSERT_TRUE (limiter.can_consume (2));
+	ASSERT_TRUE (limiter.can_consume (2));
+	limiter.consume_checked (2);
+	ASSERT_FALSE (limiter.can_consume (1));
+}
+
 TEST (rate, unlimited)
 {
 	nano::rate::token_bucket bucket (0, 0);

--- a/nano/core_test/rate_limiting.cpp
+++ b/nano/core_test/rate_limiting.cpp
@@ -1,136 +1,434 @@
 #include <nano/lib/rate_limiting.hpp>
-#include <nano/lib/utility.hpp>
 
 #include <gtest/gtest.h>
 
-#include <fstream>
-#include <future>
+#include <atomic>
+#include <chrono>
+#include <limits>
+#include <thread>
+#include <type_traits>
+#include <vector>
 
 using namespace std::chrono_literals;
 
-TEST (rate, basic)
+using test_clock = nano::rate::token_bucket::clock;
+
+/*
+ * token_bucket
+ */
+
+TEST (token_bucket, construction_starts_full)
 {
-	nano::rate::token_bucket bucket (10, 10);
-
-	// Initial burst
-	ASSERT_TRUE (bucket.try_consume (10));
-	ASSERT_FALSE (bucket.try_consume (10));
-
-	// With a fill rate of 10 tokens/sec, await 1/3 sec and get 3 tokens
-	std::this_thread::sleep_for (300ms);
-	ASSERT_TRUE (bucket.try_consume (3));
-	ASSERT_FALSE (bucket.try_consume (10));
-
-	// Allow time for the bucket to completely refill and do a full burst
-	std::this_thread::sleep_for (1s);
-	ASSERT_TRUE (bucket.try_consume (10));
-	ASSERT_EQ (bucket.largest_burst (), 10);
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 1000, 1.0, now };
+	ASSERT_EQ (bucket.capacity (), 1000);
+	ASSERT_EQ (bucket.available (now), 1000);
+	ASSERT_TRUE (bucket.can_consume (1000, now));
 }
 
-TEST (rate, network)
+TEST (token_bucket, basic_consume)
 {
-	// For the purpose of the test, one token represents 1MB instead of one byte.
-	// Allow for 10 mb/s bursts (max bucket size), 5 mb/s long term rate
-	nano::rate::token_bucket bucket (10, 5);
-
-	// Initial burst of 10 mb/s over two calls
-	ASSERT_TRUE (bucket.try_consume (5));
-	ASSERT_EQ (bucket.largest_burst (), 5);
-	ASSERT_TRUE (bucket.try_consume (5));
-	ASSERT_EQ (bucket.largest_burst (), 10);
-	ASSERT_FALSE (bucket.try_consume (5));
-
-	// After 200 ms, the 5 mb/s fillrate means we have 1 mb available
-	std::this_thread::sleep_for (200ms);
-	ASSERT_TRUE (bucket.try_consume (1));
-	ASSERT_FALSE (bucket.try_consume (1));
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 1000, 1.0, now };
+	ASSERT_TRUE (bucket.consume (400, now));
+	ASSERT_TRUE (bucket.consume (400, now));
+	// Only 200 tokens left, a large request must fail
+	ASSERT_FALSE (bucket.consume (400, now));
+	ASSERT_EQ (bucket.available (now), 200);
 }
 
-TEST (rate, reset)
+TEST (token_bucket, drained_rejects)
 {
-	nano::rate::token_bucket bucket (0, 0);
-
-	// consume lots of tokens, buckets should be unlimited
-	ASSERT_TRUE (bucket.try_consume (1000000));
-	ASSERT_TRUE (bucket.try_consume (1000000));
-
-	// set bucket to be limited
-	bucket.reset (1000, 1000);
-	ASSERT_FALSE (bucket.try_consume (1001));
-	ASSERT_TRUE (bucket.try_consume (1000));
-	ASSERT_FALSE (bucket.try_consume (1000));
-	std::this_thread::sleep_for (2ms);
-	ASSERT_TRUE (bucket.try_consume (2));
-
-	// reduce the limit
-	bucket.reset (100, 100 * 1000);
-	ASSERT_FALSE (bucket.try_consume (101));
-	ASSERT_TRUE (bucket.try_consume (100));
-	std::this_thread::sleep_for (1ms);
-	ASSERT_TRUE (bucket.try_consume (100));
-
-	// increase the limit
-	bucket.reset (2000, 1);
-	ASSERT_FALSE (bucket.try_consume (2001));
-	ASSERT_TRUE (bucket.try_consume (2000));
-
-	// back to unlimited
-	bucket.reset (0, 0);
-	ASSERT_TRUE (bucket.try_consume (1000000));
-	ASSERT_TRUE (bucket.try_consume (1000000));
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 1000000, 1.0, now };
+	ASSERT_TRUE (bucket.consume (1000000, now));
+	ASSERT_FALSE (bucket.consume (500000, now));
+	ASSERT_FALSE (bucket.can_consume (500000, now));
 }
 
-TEST (rate, can_consume)
+TEST (token_bucket, consume_zero_always_granted)
 {
-	nano::rate::token_bucket bucket (2, 1);
-
-	ASSERT_TRUE (bucket.can_consume (2));
-	ASSERT_TRUE (bucket.can_consume (2));
-	ASSERT_EQ (bucket.largest_burst (), 0);
-
-	bucket.consume_checked (2);
-	ASSERT_EQ (bucket.largest_burst (), 2);
-	ASSERT_FALSE (bucket.can_consume (1));
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 10, 1.0, now };
+	ASSERT_TRUE (bucket.consume (10, now));
+	// Even with a drained balance, zero tokens must be granted immediately
+	ASSERT_TRUE (bucket.consume (0, now));
+	ASSERT_TRUE (bucket.can_consume (0, now));
+	ASSERT_EQ (bucket.time_to_consume (0, now), 0ms);
 }
 
-TEST (rate_limiter, can_consume)
+TEST (token_bucket, unlimited)
 {
-	nano::rate_limiter limiter (2);
-
-	ASSERT_TRUE (limiter.can_consume (2));
-	ASSERT_TRUE (limiter.can_consume (2));
-	limiter.consume_checked (2);
-	ASSERT_FALSE (limiter.can_consume (1));
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 0, 1.0, now };
+	ASSERT_TRUE (bucket.consume (std::numeric_limits<std::size_t>::max (), now));
+	ASSERT_TRUE (bucket.consume (std::numeric_limits<std::size_t>::max (), now));
+	ASSERT_TRUE (bucket.can_consume (std::numeric_limits<std::size_t>::max (), now));
+	ASSERT_EQ (bucket.time_to_consume (std::numeric_limits<std::size_t>::max (), now), 0ms);
+	ASSERT_EQ (bucket.limit ().rate, 0);
+	ASSERT_EQ (bucket.capacity (), 0);
+	ASSERT_EQ (bucket.available (now), 0);
 }
 
-TEST (rate, unlimited)
+TEST (token_bucket, burst_capacity)
 {
-	nano::rate::token_bucket bucket (0, 0);
-	ASSERT_TRUE (bucket.try_consume (5));
-	ASSERT_EQ (bucket.largest_burst (), 5);
-	ASSERT_TRUE (bucket.try_consume (static_cast<size_t> (1e9)));
-	ASSERT_EQ (bucket.largest_burst (), static_cast<size_t> (1e9));
-
-	// With unlimited tokens, consuming always succeed
-	ASSERT_TRUE (bucket.try_consume (static_cast<size_t> (1e9)));
-	ASSERT_EQ (bucket.largest_burst (), static_cast<size_t> (1e9));
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 10, 3.0, now };
+	ASSERT_EQ (bucket.capacity (), 30);
+	ASSERT_TRUE (bucket.consume (30, now));
+	ASSERT_FALSE (bucket.consume (1, now));
 }
 
-TEST (rate, busy_spin)
+TEST (token_bucket, minimum_capacity)
 {
-	// Bucket should refill at a rate of 1 token per second
-	nano::rate::token_bucket bucket (1, 1);
+	// Tiny burst ratios must still leave a usable bucket of at least one token
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 10, 0.001, now };
+	ASSERT_EQ (bucket.capacity (), 1);
+	ASSERT_TRUE (bucket.consume (1, now));
+	ASSERT_FALSE (bucket.consume (1, now));
+}
 
-	// Run a very tight loop for 5 seconds + a bit of wiggle room
-	int counter = 0;
-	for (auto start = std::chrono::steady_clock::now (), now = start; now < start + 5500ms; now = std::chrono::steady_clock::now ())
+TEST (token_bucket, refill)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 10000, 1.0, now };
+	ASSERT_TRUE (bucket.consume (10000, now));
+	ASSERT_FALSE (bucket.consume (1, now));
+	// At 10k tokens/s, 100ms refills exactly 1000 tokens
+	ASSERT_EQ (bucket.available (now + 100ms), 1000);
+	ASSERT_TRUE (bucket.consume (1000, now + 100ms));
+	ASSERT_FALSE (bucket.consume (1, now + 100ms));
+}
+
+TEST (token_bucket, busy_spin)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 1000, 1.0, now };
+	ASSERT_TRUE (bucket.consume (1000, now));
+	// Hammer a drained bucket with rejected requests every microsecond; each call accrues only 0.001 tokens
+	for (int i = 1; i <= 100000; ++i)
 	{
-		if (bucket.try_consume ())
-		{
-			++counter;
-		}
+		ASSERT_FALSE (bucket.consume (1000, now + i * 1us));
+	}
+	// The fractional refill must have accumulated to ~100 tokens instead of being truncated away
+	ASSERT_TRUE (bucket.consume (100, now + 100ms));
+}
+
+TEST (token_bucket, refill_clamped_to_capacity)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 1000, 0.01, now }; // Capacity 10
+	ASSERT_TRUE (bucket.consume (10, now));
+	// 100ms at 1000 tokens/s would be 100 tokens, but the bucket must clamp at its capacity
+	ASSERT_EQ (bucket.available (now + 100ms), 10);
+	ASSERT_TRUE (bucket.consume (10, now + 100ms));
+	ASSERT_FALSE (bucket.consume (1, now + 100ms));
+}
+
+TEST (token_bucket, time_to_consume)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 1000, 1.0, now };
+	ASSERT_EQ (bucket.time_to_consume (1000, now), 0ms);
+	ASSERT_TRUE (bucket.consume (1000, now));
+	// Deficit of 100 tokens at 1000 tokens/s is exactly 100ms
+	ASSERT_EQ (bucket.time_to_consume (100, now), 100ms);
+	ASSERT_EQ (bucket.time_to_consume (1000, now), 1000ms);
+	// Partially refilled deficits shrink accordingly
+	ASSERT_EQ (bucket.time_to_consume (100, now + 50ms), 50ms);
+}
+
+TEST (token_bucket, time_to_consume_is_sufficient)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 1000, 1.0, now };
+	ASSERT_TRUE (bucket.consume (1000, now));
+	auto const wait = bucket.time_to_consume (100, now);
+	// Waiting the returned duration must be enough for the request to succeed
+	ASSERT_TRUE (bucket.consume (100, now + wait));
+}
+
+TEST (token_bucket, oversized_request_granted_when_full)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 10, 1.0, now }; // Capacity 10
+	ASSERT_TRUE (bucket.can_consume (100, now));
+	ASSERT_EQ (bucket.time_to_consume (100, now), 0ms);
+	ASSERT_TRUE (bucket.consume (100, now));
+}
+
+TEST (token_bucket, oversized_request_overdraws)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 10, 1.0, now }; // Capacity 10
+	ASSERT_TRUE (bucket.consume (100, now));
+	// Balance is now -90, nothing is consumable until the debt refills
+	ASSERT_EQ (bucket.available (now), 0);
+	ASSERT_FALSE (bucket.consume (1, now));
+	ASSERT_FALSE (bucket.can_consume (100, now));
+	// Deficit of 91 tokens at 10 tokens/s is exactly 9.1s
+	ASSERT_EQ (bucket.time_to_consume (1, now), 9100ms);
+	ASSERT_TRUE (bucket.consume (1, now + 9100ms));
+}
+
+TEST (token_bucket, oversized_request_rejected_when_not_full)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 10, 1.0, now };
+	ASSERT_TRUE (bucket.consume (1, now));
+	// Bucket is no longer full, so a request above capacity must wait
+	ASSERT_FALSE (bucket.consume (100, now));
+	ASSERT_FALSE (bucket.can_consume (100, now));
+	// Oversized requests only need a full bucket, deficit of 1 token at 10 tokens/s
+	ASSERT_EQ (bucket.time_to_consume (100, now), 100ms);
+	ASSERT_TRUE (bucket.consume (100, now + 100ms));
+}
+
+TEST (token_bucket, can_consume_does_not_consume)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 1000, 1.0, now };
+	for (int i = 0; i < 100; ++i)
+	{
+		ASSERT_TRUE (bucket.can_consume (1000, now));
+	}
+	ASSERT_TRUE (bucket.consume (1000, now));
+}
+
+TEST (token_bucket, getters)
+{
+	nano::rate::token_bucket bucket{ 100, 2.5 };
+	ASSERT_EQ (bucket.capacity (), 250);
+	auto limit = bucket.limit ();
+	ASSERT_EQ (limit.rate, 100);
+	ASSERT_EQ (limit.burst_ratio, 2.5);
+}
+
+TEST (token_bucket, rate_limit_construction)
+{
+	nano::rate::token_bucket bucket{ nano::rate_limit{ 100, 2.5 } };
+	ASSERT_EQ (bucket.limit ().rate, 100);
+	ASSERT_EQ (bucket.limit ().burst_ratio, 2.5);
+	nano::rate::token_bucket unlimited{ nano::rate_limit::unlimited () };
+	ASSERT_TRUE (unlimited.consume (std::numeric_limits<std::size_t>::max ()));
+}
+
+TEST (token_bucket, reset_replaces_limits)
+{
+	nano::rate::token_bucket bucket{ 100, 2.5 };
+	bucket.reset (200, 1.5);
+	ASSERT_EQ (bucket.limit ().rate, 200);
+	ASSERT_EQ (bucket.limit ().burst_ratio, 1.5);
+	ASSERT_EQ (bucket.capacity (), 300);
+}
+
+TEST (token_bucket, reset_carries_balance)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 1000, 1.0, now };
+	ASSERT_TRUE (bucket.consume (1000, now));
+	// A drained bucket must not become full again just because the limits changed
+	bucket.reset (1000000, 1.0, now);
+	ASSERT_EQ (bucket.available (now), 0);
+	ASSERT_FALSE (bucket.consume (1, now));
+}
+
+TEST (token_bucket, reset_clamps_to_new_capacity)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 1000000, 1.0, now };
+	bucket.reset (10, 1.0, now);
+	ASSERT_EQ (bucket.available (now), 10);
+	ASSERT_TRUE (bucket.consume (10, now));
+	ASSERT_FALSE (bucket.consume (1, now));
+}
+
+TEST (token_bucket, reset_from_unlimited_starts_full)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 0, 1.0, now };
+	bucket.reset (1000, 1.0, now);
+	ASSERT_EQ (bucket.available (now), 1000);
+	ASSERT_TRUE (bucket.consume (1000, now));
+	ASSERT_FALSE (bucket.consume (1000, now));
+}
+
+TEST (token_bucket, reset_to_unlimited)
+{
+	auto const now = test_clock::now ();
+	nano::rate::token_bucket bucket{ 10, 1.0, now };
+	ASSERT_TRUE (bucket.consume (10, now));
+	bucket.reset (0, 1.0, now);
+	ASSERT_TRUE (bucket.consume (std::numeric_limits<std::size_t>::max (), now));
+}
+
+TEST (token_bucket, reset_with_rate_limit)
+{
+	nano::rate::token_bucket bucket{ 100 };
+	bucket.reset (nano::rate_limit{ 200, 1.5 });
+	ASSERT_EQ (bucket.limit ().rate, 200);
+	ASSERT_EQ (bucket.limit ().burst_ratio, 1.5);
+}
+
+/*
+ * rate_limiter, both threading variants
+ */
+
+template <typename Limiter>
+class rate_limiter_test : public ::testing::Test
+{
+};
+
+using rate_limiter_types = ::testing::Types<nano::rate_limiter, nano::rate_limiter_st>;
+TYPED_TEST_SUITE (rate_limiter_test, rate_limiter_types);
+
+// Both threading variants must share a single result type
+static_assert (std::is_same_v<nano::rate_limiter::result, nano::rate_limiter_st::result>);
+static_assert (std::is_same_v<nano::rate_limiter::result, nano::limiter_result>);
+
+TYPED_TEST (rate_limiter_test, consume_granted)
+{
+	auto const now = test_clock::now ();
+	TypeParam limiter{ 1000, 1.0, now };
+	auto result = limiter.consume (100, now);
+	ASSERT_TRUE (result);
+	ASSERT_TRUE (result.granted);
+	ASSERT_EQ (result.retry_after, 0ms);
+}
+
+TYPED_TEST (rate_limiter_test, consume_rejected_with_retry_hint)
+{
+	auto const now = test_clock::now ();
+	TypeParam limiter{ 1000, 1.0, now };
+	ASSERT_TRUE (limiter.consume (1000, now));
+	auto result = limiter.consume (100, now);
+	ASSERT_FALSE (result);
+	ASSERT_FALSE (result.granted);
+	// Deficit of 100 tokens at 1000 tokens/s is exactly 100ms
+	ASSERT_EQ (result.retry_after, 100ms);
+}
+
+TYPED_TEST (rate_limiter_test, retry_hint_is_sufficient)
+{
+	auto const now = test_clock::now ();
+	TypeParam limiter{ 1000, 1.0, now };
+	ASSERT_TRUE (limiter.consume (1000, now));
+	auto result = limiter.consume (100, now);
+	ASSERT_FALSE (result);
+	// Waiting the returned duration must be enough for the request to succeed
+	ASSERT_TRUE (limiter.try_consume (100, now + result.retry_after));
+}
+
+TYPED_TEST (rate_limiter_test, try_consume)
+{
+	auto const now = test_clock::now ();
+	TypeParam limiter{ 1000, 1.0, now };
+	ASSERT_TRUE (limiter.try_consume (1000, now));
+	ASSERT_FALSE (limiter.try_consume (1000, now));
+}
+
+TYPED_TEST (rate_limiter_test, can_consume)
+{
+	auto const now = test_clock::now ();
+	TypeParam limiter{ 1000, 1.0, now };
+	ASSERT_TRUE (limiter.can_consume (1000, now));
+	ASSERT_TRUE (limiter.try_consume (1000, now));
+	ASSERT_FALSE (limiter.can_consume (1000, now));
+}
+
+TYPED_TEST (rate_limiter_test, unlimited)
+{
+	TypeParam limiter{ 0 };
+	ASSERT_TRUE (limiter.consume (std::numeric_limits<std::size_t>::max ()));
+	ASSERT_EQ (limiter.consume (std::numeric_limits<std::size_t>::max ()).retry_after, 0ms);
+}
+
+TYPED_TEST (rate_limiter_test, reset_and_getters)
+{
+	auto const now = test_clock::now ();
+	TypeParam limiter{ 100, 2.0, now };
+	ASSERT_EQ (limiter.limit ().rate, 100);
+	ASSERT_EQ (limiter.limit ().burst_ratio, 2.0);
+	ASSERT_EQ (limiter.capacity (), 200);
+	ASSERT_EQ (limiter.available (now), 200);
+	limiter.reset (50, 1.0, now);
+	ASSERT_EQ (limiter.limit ().rate, 50);
+	ASSERT_EQ (limiter.capacity (), 50);
+	ASSERT_EQ (limiter.available (now), 50);
+}
+
+TYPED_TEST (rate_limiter_test, default_token_count)
+{
+	auto const now = test_clock::now ();
+	TypeParam limiter{ 3, 1.0, now };
+	ASSERT_TRUE (limiter.try_consume (1, now));
+	ASSERT_TRUE (limiter.try_consume (1, now));
+	ASSERT_TRUE (limiter.try_consume (1, now));
+	ASSERT_FALSE (limiter.try_consume (1, now));
+}
+
+/*
+ * rate_limiter, thread safety
+ */
+
+TEST (rate_limiter, concurrent_consume_respects_limit)
+{
+	std::size_t const capacity = 1000;
+	nano::rate_limiter limiter{ capacity, 1.0 };
+
+	std::atomic<std::size_t> granted{ 0 };
+	auto const started = std::chrono::steady_clock::now ();
+
+	std::vector<std::thread> threads;
+	for (int t = 0; t < 4; ++t)
+	{
+		threads.emplace_back ([&] () {
+			for (int i = 0; i < 10000; ++i)
+			{
+				if (limiter.try_consume (1))
+				{
+					++granted;
+				}
+			}
+		});
+	}
+	for (auto & thread : threads)
+	{
+		thread.join ();
 	}
 
-	// Bucket starts fully refilled, therefore we see 1 additional request
-	ASSERT_EQ (counter, 6);
+	auto const elapsed = std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - started);
+
+	// All initial capacity must be grantable
+	ASSERT_GE (granted, capacity);
+	// Grants can never exceed initial capacity plus refill over the elapsed time (1 token/ms), plus rounding slack
+	ASSERT_LE (granted, capacity + elapsed.count () + 10);
+}
+
+TEST (rate_limiter, concurrent_mixed_operations)
+{
+	nano::rate_limiter limiter{ 10000, 3.0 };
+
+	// Exercise all operations concurrently; correctness here is the absence of crashes and data races
+	std::vector<std::thread> threads;
+	for (int t = 0; t < 4; ++t)
+	{
+		threads.emplace_back ([&, t] () {
+			for (int i = 0; i < 1000; ++i)
+			{
+				limiter.consume (10);
+				limiter.can_consume (10);
+				limiter.available ();
+				if (t == 0 && i % 100 == 0)
+				{
+					limiter.reset (10000, 3.0);
+				}
+			}
+		});
+	}
+	for (auto & thread : threads)
+	{
+		thread.join ();
+	}
 }

--- a/nano/core_test/utility.cpp
+++ b/nano/core_test/utility.cpp
@@ -1,7 +1,6 @@
 #include <nano/lib/files.hpp>
 #include <nano/lib/interval.hpp>
 #include <nano/lib/optional_ptr.hpp>
-#include <nano/lib/rate_limiting.hpp>
 #include <nano/lib/relaxed_atomic.hpp>
 #include <nano/lib/timer.hpp>
 #include <nano/lib/utility.hpp>

--- a/nano/lib/fwd.hpp
+++ b/nano/lib/fwd.hpp
@@ -40,6 +40,8 @@ class lmdb_config;
 class keypair;
 class logger;
 class mutable_block_visitor;
+class mutex;
+class null_mutex;
 class network_constants;
 class network_filter;
 class object_stream;
@@ -53,12 +55,19 @@ class vote;
 class work_pool;
 
 struct bootstrap_weights;
+struct limiter_result;
+struct rate_limit;
 
 template <typename Key, typename Value>
 class uniquer;
 
 template <typename E>
 class enum_flags;
+
+template <typename Mutex>
+class rate_limiter_impl;
+using rate_limiter = nano::rate_limiter_impl<nano::mutex>;
+using rate_limiter_st = nano::rate_limiter_impl<nano::null_mutex>;
 
 enum class node_capabilities : uint64_t;
 using node_capabilities_flags = nano::enum_flags<nano::node_capabilities>;
@@ -67,6 +76,11 @@ using stream = std::basic_streambuf<uint8_t, uint8_char_traits>;
 
 using seconds_t = uint64_t;
 using millis_t = uint64_t;
+}
+
+namespace nano::rate
+{
+class token_bucket;
 }
 
 namespace nano::stat

--- a/nano/lib/locks.hpp
+++ b/nano/lib/locks.hpp
@@ -101,6 +101,22 @@ private:
 	std::mutex mutex_m;
 };
 
+/** No-op mutex for single-threaded contexts, satisfies the Lockable requirements */
+class null_mutex
+{
+public:
+	void lock ()
+	{
+	}
+	void unlock ()
+	{
+	}
+	bool try_lock ()
+	{
+		return true;
+	}
+};
+
 #if USING_NANO_TIMED_LOCKS
 template <typename Mutex>
 void output (char const * str, std::chrono::milliseconds time, Mutex & mutex);

--- a/nano/lib/rate_limiting.cpp
+++ b/nano/lib/rate_limiting.cpp
@@ -13,6 +13,13 @@ nano::rate::token_bucket::token_bucket (std::size_t max_token_count_a, std::size
 	reset (max_token_count_a, refill_rate_a);
 }
 
+bool nano::rate::token_bucket::can_consume (unsigned tokens_required_a)
+{
+	debug_assert (tokens_required_a <= 1e9);
+	refill ();
+	return current_size >= tokens_required_a || refill_rate == unlimited_rate_sentinel;
+}
+
 bool nano::rate::token_bucket::try_consume (unsigned tokens_required_a)
 {
 	debug_assert (tokens_required_a <= 1e9);
@@ -31,6 +38,12 @@ bool nano::rate::token_bucket::try_consume (unsigned tokens_required_a)
 	smallest_size = std::min (smallest_size, current_size);
 
 	return possible || refill_rate == unlimited_rate_sentinel;
+}
+
+void nano::rate::token_bucket::consume_checked (unsigned tokens_required_a)
+{
+	auto const consumed = try_consume (tokens_required_a);
+	release_assert (consumed);
 }
 
 void nano::rate::token_bucket::refill ()
@@ -79,10 +92,22 @@ nano::rate_limiter::rate_limiter (std::size_t limit_a, double burst_ratio_a) :
 {
 }
 
-bool nano::rate_limiter::should_pass (std::size_t message_size_a)
+bool nano::rate_limiter::can_consume (std::size_t token_count_a)
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
-	return bucket.try_consume (nano::narrow_cast<unsigned int> (message_size_a));
+	return bucket.can_consume (nano::narrow_cast<unsigned int> (token_count_a));
+}
+
+bool nano::rate_limiter::try_consume (std::size_t token_count_a)
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return bucket.try_consume (nano::narrow_cast<unsigned int> (token_count_a));
+}
+
+void nano::rate_limiter::consume_checked (std::size_t token_count_a)
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	bucket.consume_checked (nano::narrow_cast<unsigned int> (token_count_a));
 }
 
 void nano::rate_limiter::reset (std::size_t limit_a, double burst_ratio_a)

--- a/nano/lib/rate_limiting.cpp
+++ b/nano/lib/rate_limiting.cpp
@@ -1,131 +1,131 @@
-#include <nano/lib/locks.hpp>
+#include <nano/lib/assert.hpp>
 #include <nano/lib/rate_limiting.hpp>
-#include <nano/lib/utility.hpp>
 
+#include <algorithm>
 #include <limits>
 
 /*
  * token_bucket
  */
 
-nano::rate::token_bucket::token_bucket (std::size_t max_token_count_a, std::size_t refill_rate_a)
+namespace
 {
-	reset (max_token_count_a, refill_rate_a);
+// Tolerance for floating point comparisons, far below one token but above accumulated rounding error
+constexpr double epsilon = 1e-6;
+
+double compute_capacity (nano::rate_limit limit)
+{
+	// Even with tiny burst ratios the bucket must hold at least one token to remain usable
+	return std::max (1.0, static_cast<double> (limit.rate) * limit.burst_ratio);
+}
 }
 
-bool nano::rate::token_bucket::can_consume (unsigned tokens_required_a)
+nano::rate::token_bucket::token_bucket (std::size_t rate_a, double burst_ratio_a, clock::time_point now) :
+	token_bucket{ nano::rate_limit{ rate_a, burst_ratio_a }, now }
 {
-	debug_assert (tokens_required_a <= 1e9);
-	refill ();
-	return current_size >= tokens_required_a || refill_rate == unlimited_rate_sentinel;
 }
 
-bool nano::rate::token_bucket::try_consume (unsigned tokens_required_a)
+nano::rate::token_bucket::token_bucket (nano::rate_limit limit, clock::time_point now) :
+	limit_m{ limit },
+	capacity_m{ compute_capacity (limit) },
+	balance{ capacity_m }, // Start with a full bucket so startup is not throttled
+	last_refill{ now }
 {
-	debug_assert (tokens_required_a <= 1e9);
-	refill ();
-	bool possible = current_size >= tokens_required_a;
-	if (possible)
+	debug_assert (limit.burst_ratio > 0.0);
+}
+
+bool nano::rate::token_bucket::consume (std::size_t tokens, clock::time_point now)
+{
+	// Rate 0 means limiting is disabled; consuming nothing always succeeds
+	if (limit_m.rate == 0 || tokens == 0)
 	{
-		current_size -= tokens_required_a;
+		return true;
 	}
-	else if (tokens_required_a == 1e9)
+	balance = projected (now);
+	// Never rewind; `now` may be stale when default arguments are evaluated before the caller's lock
+	last_refill = std::max (last_refill, now);
+	bool const granted = balance >= required (tokens) - epsilon;
+	if (granted)
 	{
-		current_size = 0;
+		balance -= static_cast<double> (tokens); // May overdraw below zero for requests larger than the capacity
 	}
-
-	// Keep track of smallest observed bucket size so burst size can be computed (for tests and stats)
-	smallest_size = std::min (smallest_size, current_size);
-
-	return possible || refill_rate == unlimited_rate_sentinel;
+	return granted;
 }
 
-void nano::rate::token_bucket::consume_checked (unsigned tokens_required_a)
+bool nano::rate::token_bucket::can_consume (std::size_t tokens, clock::time_point now) const
 {
-	auto const consumed = try_consume (tokens_required_a);
-	release_assert (consumed);
-}
-
-void nano::rate::token_bucket::refill ()
-{
-	auto now (std::chrono::steady_clock::now ());
-	std::size_t tokens_to_add = static_cast<std::size_t> (std::chrono::duration_cast<std::chrono::nanoseconds> (now - last_refill).count () / 1e9 * refill_rate);
-	// Only update if there are any tokens to add
-	if (tokens_to_add > 0)
+	// Rate 0 means limiting is disabled; consuming nothing always succeeds
+	if (limit_m.rate == 0 || tokens == 0)
 	{
-		current_size = std::min (current_size + tokens_to_add, max_token_count);
-		last_refill = std::chrono::steady_clock::now ();
+		return true;
 	}
+	return projected (now) >= required (tokens) - epsilon;
 }
 
-void nano::rate::token_bucket::reset (std::size_t max_token_count_a, std::size_t refill_rate_a)
+std::chrono::milliseconds nano::rate::token_bucket::time_to_consume (std::size_t tokens, clock::time_point now) const
 {
-	// A token count of 0 indicates unlimited capacity. We use 1e9 as
-	// a sentinel, allowing largest burst to still be computed.
-	if (max_token_count_a == 0 || refill_rate_a == 0)
+	// Rate 0 means limiting is disabled; consuming nothing always succeeds
+	if (limit_m.rate == 0 || tokens == 0)
 	{
-		refill_rate_a = max_token_count_a = unlimited_rate_sentinel;
+		return {};
 	}
-	max_token_count = smallest_size = current_size = max_token_count_a;
-	refill_rate = refill_rate_a;
-	last_refill = std::chrono::steady_clock::now ();
+	// Already consumable, no wait needed
+	auto const deficit = required (tokens) - projected (now);
+	if (deficit <= epsilon)
+	{
+		return {};
+	}
+	// Round up so that waiting the returned duration is sufficient
+	return std::chrono::ceil<std::chrono::milliseconds> (std::chrono::duration<double> (deficit / static_cast<double> (limit_m.rate)));
 }
 
-std::size_t nano::rate::token_bucket::largest_burst () const
+void nano::rate::token_bucket::reset (std::size_t rate_a, double burst_ratio_a, clock::time_point now)
 {
-	return max_token_count - smallest_size;
+	reset (nano::rate_limit{ rate_a, burst_ratio_a }, now);
 }
 
-std::size_t nano::rate::token_bucket::size () const
+void nano::rate::token_bucket::reset (nano::rate_limit limit, clock::time_point now)
 {
-	return current_size;
+	debug_assert (limit.burst_ratio > 0.0);
+	// Start full when transitioning from unlimited, otherwise carry the balance over
+	auto const carried = limit_m.rate == 0 ? std::numeric_limits<double>::max () : projected (now);
+	limit_m = limit;
+	capacity_m = compute_capacity (limit);
+	balance = std::min (carried, capacity_m);
+	last_refill = std::max (last_refill, now);
 }
 
-/*
- * rate_limiter
- */
-
-nano::rate_limiter::rate_limiter (std::size_t limit_a, double burst_ratio_a) :
-	bucket (static_cast<std::size_t> (limit_a * burst_ratio_a), limit_a),
-	limit{ limit_a },
-	burst_ratio{ burst_ratio_a }
+nano::rate_limit nano::rate::token_bucket::limit () const
 {
+	return limit_m;
 }
 
-bool nano::rate_limiter::can_consume (std::size_t token_count_a)
+std::size_t nano::rate::token_bucket::capacity () const
 {
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	return bucket.can_consume (nano::narrow_cast<unsigned int> (token_count_a));
+	// When limiting is disabled there is no meaningful capacity, report 0 rather than the internal placeholder
+	return limit_m.rate == 0 ? 0 : static_cast<std::size_t> (capacity_m);
 }
 
-bool nano::rate_limiter::try_consume (std::size_t token_count_a)
+std::size_t nano::rate::token_bucket::available (clock::time_point now) const
 {
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	return bucket.try_consume (nano::narrow_cast<unsigned int> (token_count_a));
+	// When limiting is disabled the balance is never updated, so it carries no meaningful information
+	if (limit_m.rate == 0)
+	{
+		return 0;
+	}
+	// An overdrawn (negative) balance is reported as 0 available tokens
+	return static_cast<std::size_t> (std::max (0.0, projected (now)));
 }
 
-void nano::rate_limiter::consume_checked (std::size_t token_count_a)
+double nano::rate::token_bucket::projected (clock::time_point now) const
 {
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	bucket.consume_checked (nano::narrow_cast<unsigned int> (token_count_a));
+	// Clamp to protect against timestamps older than the last refill
+	auto const elapsed = std::max (0.0, std::chrono::duration_cast<std::chrono::duration<double>> (now - last_refill).count ());
+	return std::min (balance + elapsed * static_cast<double> (limit_m.rate), capacity_m);
 }
 
-void nano::rate_limiter::reset (std::size_t limit_a, double burst_ratio_a)
+double nano::rate::token_bucket::required (std::size_t tokens) const
 {
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	bucket.reset (static_cast<std::size_t> (limit_a * burst_ratio_a), limit_a);
-	limit = limit_a;
-	burst_ratio = burst_ratio_a;
-}
-
-std::size_t nano::rate_limiter::size () const
-{
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	return bucket.size ();
-}
-
-std::pair<std::size_t, double> nano::rate_limiter::get_limit () const
-{
-	nano::lock_guard<nano::mutex> guard{ mutex };
-	return { limit, burst_ratio };
+	// Requests larger than the capacity can never accumulate fully; they are granted when the bucket is full
+	return std::min (static_cast<double> (tokens), capacity_m);
 }

--- a/nano/lib/rate_limiting.hpp
+++ b/nano/lib/rate_limiting.hpp
@@ -30,13 +30,15 @@ public:
 	 */
 	token_bucket (std::size_t max_token_count, std::size_t refill_rate);
 
+	/** Returns true when the requested cost is currently available without deducting it. */
+	bool can_consume (unsigned tokens_required = 1);
 	/**
-	 * Determine if an operation of cost \p tokens_required is possible, and deduct from the
-	 * bucket if that's the case.
-	 * The default cost is 1 token, but resource intensive operations may request
-	 * more tokens to be available.
+	 * Deducts the requested cost if currently available.
+	 * The default cost is 1 token, but resource intensive operations may request more tokens.
 	 */
 	bool try_consume (unsigned tokens_required = 1);
+	/** Deducts the requested cost and asserts if the caller has not already ensured availability. */
+	void consume_checked (unsigned tokens_required = 1);
 
 	/** Update the max_token_count and/or refill_rate_a parameters */
 	void reset (std::size_t max_token_count, std::size_t refill_rate);
@@ -69,7 +71,12 @@ public:
 	// initialize with limit 0 = unbounded
 	rate_limiter (std::size_t limit, double burst_ratio = 1.0);
 
-	bool should_pass (std::size_t buffer_size);
+	// Returns true when the requested cost is currently available without deducting it
+	bool can_consume (std::size_t token_count);
+	// Deducts the requested cost if currently available
+	bool try_consume (std::size_t token_count);
+	// Deducts the requested cost and asserts if it is not available
+	void consume_checked (std::size_t token_count);
 	void reset (std::size_t limit, double burst_ratio = 1.0);
 
 	std::size_t size () const;

--- a/nano/lib/rate_limiting.hpp
+++ b/nano/lib/rate_limiting.hpp
@@ -2,90 +2,176 @@
 
 #include <nano/lib/locks.hpp>
 
-#include <algorithm>
 #include <chrono>
-#include <mutex>
+#include <cstddef>
 
-/* Namespace for shaping (egress) and policing (ingress) rate limiting algorithms */
+namespace nano
+{
+/** Rate and burst parameters of a limiter; a rate of 0 disables limiting */
+struct rate_limit
+{
+	std::size_t rate{ 0 };
+	double burst_ratio{ 1.0 };
+
+	static constexpr rate_limit unlimited ()
+	{
+		return {};
+	}
+};
+
+// Result of a consume attempt, contextually convertible to bool (true = granted)
+struct limiter_result
+{
+	bool granted{ false };
+	// Time until retry is worthwhile; zero when granted; a hint, not a reservation
+	std::chrono::milliseconds retry_after{ 0 };
+
+	explicit operator bool () const
+	{
+		return granted;
+	}
+};
+}
+
 namespace nano::rate
 {
 /**
- * Token bucket based rate limiting. This is suitable for rate limiting ipc/api calls
- * and network traffic, while allowing short bursts.
- *
- * Tokens are refilled at N tokens per second and there's a bucket capacity to limit
- * bursts.
- *
- * A bucket has low overhead and can be instantiated for various purposes, such as one
- * bucket per session, or one for bandwidth limiting. A token can represent bytes,
- * messages, or the cost of API invocations.
+ * Token bucket rate limiting algorithm. Refills lazily from a steady clock, no timer thread.
+ * Not thread-safe; use nano::rate_limiter for concurrent use.
+ * A rate of 0 disables limiting: every request is granted.
+ * Requests larger than the bucket capacity are granted when the bucket is full, overdrawing the balance; this preserves the average rate without deadlocking the caller.
  */
-class token_bucket
+class token_bucket final
 {
 public:
-	/**
-	 * Set up a token bucket.
-	 * @param max_token_count Maximum number of tokens in this bucket, which limits bursts.
-	 * @param refill_rate Token refill rate, which limits the long term rate (tokens per seconds)
-	 */
-	token_bucket (std::size_t max_token_count, std::size_t refill_rate);
+	using clock = std::chrono::steady_clock;
 
-	/** Returns true when the requested cost is currently available without deducting it. */
-	bool can_consume (unsigned tokens_required = 1);
-	/**
-	 * Deducts the requested cost if currently available.
-	 * The default cost is 1 token, but resource intensive operations may request more tokens.
-	 */
-	bool try_consume (unsigned tokens_required = 1);
-	/** Deducts the requested cost and asserts if the caller has not already ensured availability. */
-	void consume_checked (unsigned tokens_required = 1);
+	// The `now` parameters default to the current time; tests may inject timestamps for deterministic behavior
 
-	/** Update the max_token_count and/or refill_rate_a parameters */
-	void reset (std::size_t max_token_count, std::size_t refill_rate);
+	// Refills `rate` tokens per second; bucket capacity is rate * burst_ratio
+	explicit token_bucket (std::size_t rate, double burst_ratio = 1.0, clock::time_point now = clock::now ());
+	explicit token_bucket (nano::rate_limit limit, clock::time_point now = clock::now ());
 
-	/** Returns the largest burst observed */
-	std::size_t largest_burst () const;
-	std::size_t size () const;
+	// Attempts to consume tokens; returns true when granted
+	bool consume (std::size_t tokens = 1, clock::time_point now = clock::now ());
+	// Checks whether tokens could be consumed right now, without consuming
+	bool can_consume (std::size_t tokens = 1, clock::time_point now = clock::now ()) const;
+	// Time until `tokens` become consumable; zero if consumable now
+	std::chrono::milliseconds time_to_consume (std::size_t tokens = 1, clock::time_point now = clock::now ()) const;
+
+	// Replaces rate and burst ratio; balance is clamped to the new capacity
+	void reset (std::size_t rate, double burst_ratio = 1.0, clock::time_point now = clock::now ());
+	void reset (nano::rate_limit limit, clock::time_point now = clock::now ());
+
+	// Current rate and burst ratio
+	nano::rate_limit limit () const;
+	// Maximum token balance; zero indicates no limiting
+	std::size_t capacity () const;
+	// Current token balance, including pending refill
+	std::size_t available (clock::time_point now = clock::now ()) const;
 
 private:
-	void refill ();
+	// Balance projected to `now`, including pending refill, clamped to capacity
+	double projected (clock::time_point now) const;
+	// Balance needed to grant the request; oversized requests only need a full bucket
+	double required (std::size_t tokens) const;
 
-private:
-	std::size_t max_token_count;
-	std::size_t refill_rate;
-
-	std::size_t current_size{ 0 };
-	/** The minimum observed bucket size, from which the largest burst can be derived */
-	std::size_t smallest_size{ 0 };
-	std::chrono::steady_clock::time_point last_refill;
-
-	static std::size_t constexpr unlimited_rate_sentinel{ static_cast<std::size_t> (1e9) };
+	nano::rate_limit limit_m;
+	double capacity_m; // Derived from limit_m on reset, at least one token so that small rates remain usable
+	double balance; // Fractional to stay accurate at low rates, may be negative after an oversized request
+	clock::time_point last_refill;
 };
 }
 
 namespace nano
 {
-class rate_limiter final
+/**
+ * Rate limiter over nano::rate::token_bucket, thread safety determined by the mutex type.
+ * Use the nano::rate_limiter alias by default; nano::rate_limiter_st avoids locking overhead in single-threaded contexts.
+ */
+template <typename Mutex>
+class rate_limiter_impl final
 {
 public:
-	// initialize with limit 0 = unbounded
-	rate_limiter (std::size_t limit, double burst_ratio = 1.0);
+	using clock = nano::rate::token_bucket::clock;
 
-	// Returns true when the requested cost is currently available without deducting it
-	bool can_consume (std::size_t token_count);
-	// Deducts the requested cost if currently available
-	bool try_consume (std::size_t token_count);
-	// Deducts the requested cost and asserts if it is not available
-	void consume_checked (std::size_t token_count);
-	void reset (std::size_t limit, double burst_ratio = 1.0);
+	// Refills `rate` tokens per second; bucket capacity is rate * burst_ratio
+	explicit rate_limiter_impl (std::size_t rate, double burst_ratio = 1.0, clock::time_point now = clock::now ()) :
+		bucket{ rate, burst_ratio, now }
+	{
+	}
 
-	std::size_t size () const;
-	std::pair<std::size_t, double> get_limit () const;
+	explicit rate_limiter_impl (nano::rate_limit limit, clock::time_point now = clock::now ()) :
+		bucket{ limit, now }
+	{
+	}
+
+	// Shared across all specializations
+	using result = nano::limiter_result;
+
+	// Attempts to consume tokens; on failure includes how long until retry is worthwhile
+	result consume (std::size_t tokens = 1, clock::time_point now = clock::now ())
+	{
+		nano::lock_guard<Mutex> guard{ mutex };
+		if (bucket.consume (tokens, now))
+		{
+			return { true };
+		}
+		return { false, bucket.time_to_consume (tokens, now) };
+	}
+
+	// Convenience wrapper when the retry hint is not needed
+	bool try_consume (std::size_t tokens = 1, clock::time_point now = clock::now ())
+	{
+		return consume (tokens, now).granted;
+	}
+
+	// Checks whether tokens could be consumed right now, without consuming; advisory under concurrency
+	bool can_consume (std::size_t tokens = 1, clock::time_point now = clock::now ()) const
+	{
+		nano::lock_guard<Mutex> guard{ mutex };
+		return bucket.can_consume (tokens, now);
+	}
+
+	// Replaces rate and burst ratio; balance is clamped to the new capacity
+	void reset (std::size_t rate, double burst_ratio = 1.0, clock::time_point now = clock::now ())
+	{
+		nano::lock_guard<Mutex> guard{ mutex };
+		bucket.reset (rate, burst_ratio, now);
+	}
+
+	void reset (nano::rate_limit limit, clock::time_point now = clock::now ())
+	{
+		nano::lock_guard<Mutex> guard{ mutex };
+		bucket.reset (limit, now);
+	}
+
+	// Current rate and burst ratio
+	nano::rate_limit limit () const
+	{
+		nano::lock_guard<Mutex> guard{ mutex };
+		return bucket.limit ();
+	}
+
+	std::size_t capacity () const
+	{
+		nano::lock_guard<Mutex> guard{ mutex };
+		return bucket.capacity ();
+	}
+
+	std::size_t available (clock::time_point now = clock::now ()) const
+	{
+		nano::lock_guard<Mutex> guard{ mutex };
+		return bucket.available (now);
+	}
 
 private:
+	mutable Mutex mutex;
 	nano::rate::token_bucket bucket;
-	std::size_t limit;
-	double burst_ratio;
-	mutable nano::mutex mutex;
 };
+
+// Thread-safe rate limiter (default)
+using rate_limiter = rate_limiter_impl<nano::mutex>;
+// Single-threaded rate limiter, no locking overhead
+using rate_limiter_st = rate_limiter_impl<nano::null_mutex>;
 }

--- a/nano/node/backlog_scan.cpp
+++ b/nano/node/backlog_scan.cpp
@@ -92,7 +92,7 @@ void nano::backlog_scan::populate_backlog (nano::unique_lock<nano::mutex> & lock
 	while (!stopped && !done)
 	{
 		// Wait for the rate limiter
-		while (!limiter.should_pass (config.batch_size))
+		while (!limiter.try_consume (config.batch_size))
 		{
 			std::chrono::milliseconds const wait_time{ 1000 / std::max ((config.rate_limit / config.batch_size), size_t{ 1 }) / 2 };
 			condition.wait_for (lock, std::max (wait_time, 10ms));

--- a/nano/node/backlog_scan.cpp
+++ b/nano/node/backlog_scan.cpp
@@ -92,10 +92,9 @@ void nano::backlog_scan::populate_backlog (nano::unique_lock<nano::mutex> & lock
 	while (!stopped && !done)
 	{
 		// Wait for the rate limiter
-		while (!limiter.try_consume (config.batch_size))
+		for (auto result = limiter.consume (config.batch_size); !result; result = limiter.consume (config.batch_size))
 		{
-			std::chrono::milliseconds const wait_time{ 1000 / std::max ((config.rate_limit / config.batch_size), size_t{ 1 }) / 2 };
-			condition.wait_for (lock, std::max (wait_time, 10ms));
+			condition.wait_for (lock, result.retry_after);
 			if (stopped)
 			{
 				return;
@@ -156,7 +155,7 @@ nano::container_info nano::backlog_scan::container_info () const
 {
 	nano::lock_guard<nano::mutex> guard{ mutex };
 	nano::container_info info;
-	info.put ("limiter", limiter.size ());
+	info.put ("limiter", limiter.available ());
 	return info;
 }
 

--- a/nano/node/bandwidth_limiter.cpp
+++ b/nano/node/bandwidth_limiter.cpp
@@ -36,10 +36,10 @@ nano::rate_limiter const & nano::bandwidth_limiter::select_limiter (nano::transp
 	}
 }
 
-bool nano::bandwidth_limiter::should_pass (std::size_t buffer_size, nano::transport::traffic_type type)
+bool nano::bandwidth_limiter::try_consume (std::size_t buffer_size, nano::transport::traffic_type type)
 {
 	auto & limiter = select_limiter (type);
-	return limiter.should_pass (buffer_size);
+	return limiter.try_consume (buffer_size);
 }
 
 void nano::bandwidth_limiter::reset (std::size_t limit, double burst_ratio, nano::transport::traffic_type type)

--- a/nano/node/bandwidth_limiter.cpp
+++ b/nano/node/bandwidth_limiter.cpp
@@ -8,9 +8,8 @@
 
 nano::bandwidth_limiter::bandwidth_limiter (nano::node_config const & node_config, nano::node_flags const & flags) :
 	config{ node_config },
-	// In super_rebroadcaster mode, use unlimited bandwidth (0 = no limit)
-	limiter_generic{ flags.super_rebroadcaster ? 0 : config.generic_limit, config.generic_burst_ratio },
-	limiter_bootstrap{ config.bootstrap_limit, config.bootstrap_burst_ratio }
+	limiter_generic{ flags.super_rebroadcaster ? nano::rate_limit::unlimited () : config.generic },
+	limiter_bootstrap{ config.bootstrap }
 {
 }
 
@@ -36,29 +35,35 @@ nano::rate_limiter const & nano::bandwidth_limiter::select_limiter (nano::transp
 	}
 }
 
+nano::limiter_result nano::bandwidth_limiter::consume (std::size_t buffer_size, nano::transport::traffic_type type)
+{
+	auto & limiter = select_limiter (type);
+	return limiter.consume (buffer_size);
+}
+
 bool nano::bandwidth_limiter::try_consume (std::size_t buffer_size, nano::transport::traffic_type type)
 {
 	auto & limiter = select_limiter (type);
 	return limiter.try_consume (buffer_size);
 }
 
-void nano::bandwidth_limiter::reset (std::size_t limit, double burst_ratio, nano::transport::traffic_type type)
+void nano::bandwidth_limiter::reset (nano::rate_limit limit, nano::transport::traffic_type type)
 {
 	auto & limiter = select_limiter (type);
-	limiter.reset (limit, burst_ratio);
+	limiter.reset (limit);
 }
 
 nano::container_info nano::bandwidth_limiter::container_info () const
 {
 	nano::container_info info;
-	info.put ("generic", limiter_generic.size ());
-	info.put ("bootstrap", limiter_bootstrap.size ());
+	info.put ("generic", limiter_generic.available ());
+	info.put ("bootstrap", limiter_bootstrap.available ());
 	return info;
 }
 
-std::pair<std::size_t, double> nano::bandwidth_limiter::get_limit (nano::transport::traffic_type type) const
+nano::rate_limit nano::bandwidth_limiter::get_limit (nano::transport::traffic_type type) const
 {
-	return select_limiter (type).get_limit ();
+	return select_limiter (type).limit ();
 }
 
 /*
@@ -66,9 +71,7 @@ std::pair<std::size_t, double> nano::bandwidth_limiter::get_limit (nano::transpo
  */
 
 nano::bandwidth_limiter_config::bandwidth_limiter_config (nano::node_config const & node_config) :
-	generic_limit{ node_config.bandwidth_limit },
-	generic_burst_ratio{ node_config.bandwidth_limit_burst_ratio },
-	bootstrap_limit{ node_config.bootstrap_bandwidth_limit },
-	bootstrap_burst_ratio{ node_config.bootstrap_bandwidth_burst_ratio }
+	generic{ node_config.bandwidth_limit, node_config.bandwidth_limit_burst_ratio },
+	bootstrap{ node_config.bootstrap_bandwidth_limit, node_config.bootstrap_bandwidth_burst_ratio }
 {
 }

--- a/nano/node/bandwidth_limiter.hpp
+++ b/nano/node/bandwidth_limiter.hpp
@@ -28,10 +28,10 @@ public:
 	bandwidth_limiter (nano::node_config const &, nano::node_flags const &);
 
 	/**
-	 * Check whether packet falls withing bandwidth limits and should be allowed
+	 * Consumes bandwidth tokens when packet falls within bandwidth limits
 	 * @return true if OK, false if needs to be dropped
 	 */
-	bool should_pass (std::size_t buffer_size, nano::transport::traffic_type type);
+	bool try_consume (std::size_t buffer_size, nano::transport::traffic_type type);
 	/**
 	 * Reset limits of selected limiter type to values passed in arguments
 	 */

--- a/nano/node/bandwidth_limiter.hpp
+++ b/nano/node/bandwidth_limiter.hpp
@@ -12,11 +12,8 @@ public:
 	explicit bandwidth_limiter_config (nano::node_config const &);
 
 public:
-	std::size_t generic_limit;
-	double generic_burst_ratio;
-
-	std::size_t bootstrap_limit;
-	double bootstrap_burst_ratio;
+	nano::rate_limit generic;
+	nano::rate_limit bootstrap;
 };
 
 /**
@@ -27,19 +24,17 @@ class bandwidth_limiter final
 public:
 	bandwidth_limiter (nano::node_config const &, nano::node_flags const &);
 
-	/**
-	 * Consumes bandwidth tokens when packet falls within bandwidth limits
-	 * @return true if OK, false if needs to be dropped
-	 */
+	// Attempts to consume bandwidth tokens; on failure includes how long until retry is worthwhile
+	nano::limiter_result consume (std::size_t buffer_size, nano::transport::traffic_type type);
+	// Convenience wrapper when the retry hint is not needed
 	bool try_consume (std::size_t buffer_size, nano::transport::traffic_type type);
-	/**
-	 * Reset limits of selected limiter type to values passed in arguments
-	 */
-	void reset (std::size_t limit, double burst_ratio, nano::transport::traffic_type type = nano::transport::traffic_type::generic);
+	// Resets limits of selected limiter type to values passed in arguments
+	void reset (nano::rate_limit limit, nano::transport::traffic_type type = nano::transport::traffic_type::generic);
 
 	nano::container_info container_info () const;
 
-	std::pair<std::size_t, double> get_limit (nano::transport::traffic_type type = nano::transport::traffic_type::generic) const;
+	// Returns rate and burst ratio of the selected limiter type
+	nano::rate_limit get_limit (nano::transport::traffic_type type = nano::transport::traffic_type::generic) const;
 
 private:
 	/**

--- a/nano/node/bootstrap/bootstrap_context.cpp
+++ b/nano/node/bootstrap/bootstrap_context.cpp
@@ -622,9 +622,9 @@ nano::container_info bootstrap_context::container_info () const
 
 	auto collect_limiters = [this] () {
 		nano::container_info info;
-		info.put ("total", limiter.size ());
-		info.put ("database", database_limiter.size ());
-		info.put ("frontiers", frontiers_limiter.size ());
+		info.put ("total", limiter.available ());
+		info.put ("database", database_limiter.available ());
+		info.put ("frontiers", frontiers_limiter.available ());
 		return info;
 	};
 

--- a/nano/node/bootstrap/bootstrap_context.cpp
+++ b/nano/node/bootstrap/bootstrap_context.cpp
@@ -250,7 +250,7 @@ std::shared_ptr<nano::transport::channel> bootstrap_context::wait_channel ()
 
 	// Wait until more requests can be sent
 	wait ([this] () {
-		return limiter.should_pass (1);
+		return limiter.try_consume (1);
 	});
 
 	// Wait until a channel is available

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -192,7 +192,7 @@ void nano::bootstrap_server::run ()
 		});
 
 		// Rate limit the processing
-		while (!stopped && !limiter.should_pass (config.batch_size))
+		while (!stopped && !limiter.try_consume (config.batch_size))
 		{
 			stats.inc (nano::stat::type::bootstrap_server, nano::stat::detail::cooldown);
 			condition.wait_for (lock, 100ms);

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -19,7 +19,7 @@ nano::bootstrap_server::bootstrap_server (bootstrap_server_config const & config
 	ledger{ ledger_a },
 	network_constants{ network_constants_a },
 	stats{ stats_a },
-	limiter{ config.limiter, /* allow bursts */ 3.0 } // TODO: Limiter bucket capacity should be at least equal to the batch size, currently it's not configurable
+	limiter{ config.limiter, /* allow bursts */ 3.0 } // Batches larger than the bucket capacity are granted when the bucket is full
 {
 	queue.max_size_query = [this] (auto const & origin) {
 		return config.channel_limit;
@@ -192,10 +192,10 @@ void nano::bootstrap_server::run ()
 		});
 
 		// Rate limit the processing
-		while (!stopped && !limiter.try_consume (config.batch_size))
+		for (auto result = limiter.consume (config.batch_size); !stopped && !result; result = limiter.consume (config.batch_size))
 		{
 			stats.inc (nano::stat::type::bootstrap_server, nano::stat::detail::cooldown);
-			condition.wait_for (lock, 100ms);
+			condition.wait_for (lock, result.retry_after);
 		}
 
 		if (stopped)

--- a/nano/node/bootstrap/database_strategy.cpp
+++ b/nano/node/bootstrap/database_strategy.cpp
@@ -66,7 +66,7 @@ std::optional<blocks_query> database_strategy::next_database (bool should_thrott
 	debug_assert (ctx.config.database_warmup_ratio > 0);
 
 	// Throttling increases the weight of database requests
-	if (!ctx.database_limiter.should_pass (should_throttle ? ctx.config.database_warmup_ratio : 1))
+	if (!ctx.database_limiter.try_consume (should_throttle ? ctx.config.database_warmup_ratio : 1))
 	{
 		return std::nullopt;
 	}

--- a/nano/node/bootstrap/frontier_strategy.cpp
+++ b/nano/node/bootstrap/frontier_strategy.cpp
@@ -55,7 +55,7 @@ void frontier_strategy::run_one ()
 		return !ctx.accounts.priority_half_full ();
 	});
 	ctx.wait ([this] () {
-		return ctx.frontiers_limiter.should_pass (1);
+		return ctx.frontiers_limiter.try_consume (1);
 	});
 	ctx.wait ([this] () {
 		return ctx.workers.queued_tasks () < ctx.config.frontier_scan.max_pending;

--- a/nano/node/bounded_backlog.cpp
+++ b/nano/node/bounded_backlog.cpp
@@ -400,7 +400,7 @@ void nano::bounded_backlog::run_scan ()
 	while (!stopped)
 	{
 		auto wait = [&] (auto count) {
-			while (!scan_limiter.should_pass (count))
+			while (!scan_limiter.try_consume (count))
 			{
 				condition.wait_for (lock, 100ms);
 				if (stopped)

--- a/nano/node/bounded_backlog.cpp
+++ b/nano/node/bounded_backlog.cpp
@@ -400,9 +400,9 @@ void nano::bounded_backlog::run_scan ()
 	while (!stopped)
 	{
 		auto wait = [&] (auto count) {
-			while (!scan_limiter.try_consume (count))
+			for (auto result = scan_limiter.consume (count); !result; result = scan_limiter.consume (count))
 			{
-				condition.wait_for (lock, 100ms);
+				condition.wait_for (lock, result.retry_after);
 				if (stopped)
 				{
 					return;

--- a/nano/node/local_block_broadcaster.cpp
+++ b/nano/node/local_block_broadcaster.cpp
@@ -187,7 +187,7 @@ void nano::local_block_broadcaster::run_broadcasts (nano::unique_lock<nano::mute
 
 	for (auto const & entry : to_broadcast)
 	{
-		while (!limiter.should_pass (1))
+		while (!limiter.try_consume (1))
 		{
 			std::this_thread::sleep_for (std::chrono::milliseconds{ 100 });
 			if (stopped)

--- a/nano/node/local_block_broadcaster.cpp
+++ b/nano/node/local_block_broadcaster.cpp
@@ -187,9 +187,10 @@ void nano::local_block_broadcaster::run_broadcasts (nano::unique_lock<nano::mute
 
 	for (auto const & entry : to_broadcast)
 	{
-		while (!limiter.try_consume (1))
+		for (auto result = limiter.consume (); !result; result = limiter.consume ())
 		{
-			std::this_thread::sleep_for (std::chrono::milliseconds{ 100 });
+			// Cap the wait so stopping is not delayed by long refill times
+			std::this_thread::sleep_for (std::min (result.retry_after, std::chrono::milliseconds{ 100 }));
 			if (stopped)
 			{
 				return;

--- a/nano/node/transport/tcp_channel.cpp
+++ b/nano/node/transport/tcp_channel.cpp
@@ -159,7 +159,7 @@ asio::awaitable<boost::system::error_code> nano::transport::tcp_channel::send_on
 	while (allocated_bandwidth < size)
 	{
 		// TODO: Consider implementing a subsribe/notification mechanism for bandwidth allocation
-		if (node.outbound_limiter.should_pass (bandwidth_chunk, type)) // Allocate bandwidth in larger chunks
+		if (node.outbound_limiter.try_consume (bandwidth_chunk, type)) // Allocate bandwidth in larger chunks
 		{
 			allocated_bandwidth += bandwidth_chunk;
 		}

--- a/nano/node/transport/tcp_channel.cpp
+++ b/nano/node/transport/tcp_channel.cpp
@@ -152,21 +152,19 @@ asio::awaitable<boost::system::error_code> nano::transport::tcp_channel::send_on
 	auto const & [buffer, callback] = item;
 	auto const size = buffer.size ();
 
-	// Wait for bandwidth
-	// This is somewhat inefficient
-	// The performance impact *should* be mitigated by the fact that we allocate it in larger chunks, so this happens relatively infrequently
+	// Wait for bandwidth, allocated in larger chunks to reduce the number of limiter calls
 	const size_t bandwidth_chunk = 128 * 1024; // TODO: Make this configurable
 	while (allocated_bandwidth < size)
 	{
-		// TODO: Consider implementing a subsribe/notification mechanism for bandwidth allocation
-		if (node.outbound_limiter.try_consume (bandwidth_chunk, type)) // Allocate bandwidth in larger chunks
+		if (auto result = node.outbound_limiter.consume (bandwidth_chunk, type))
 		{
 			allocated_bandwidth += bandwidth_chunk;
 		}
 		else
 		{
 			node.stats.inc (nano::stat::type::tcp_channel_wait, nano::stat::detail::wait_bandwidth, nano::stat::dir::out);
-			co_await nano::async::sleep_for (100ms); // TODO: Exponential backoff
+			// Cap the wait so channel teardown is not delayed by long refill times
+			co_await nano::async::sleep_for (std::min (result.retry_after, std::chrono::milliseconds{ 100 }));
 		}
 	}
 	allocated_bandwidth -= size;


### PR DESCRIPTION
Replaces the old rate limiter with a redesigned, layered implementation in `nano/lib/rate_limiting.{hpp,cpp}`:

- **`nano::rate::token_bucket`** — the pure algorithm: lazily refilled from a steady clock, fractional balance for accuracy at low rates. All time-dependent methods take a defaulted `now` parameter so tests can inject timestamps and assert exact values instead of sleeping.
- **`nano::rate_limiter_impl<Mutex>`** — a thin locking wrapper with two aliases: `nano::rate_limiter` (thread-safe, default) and `nano::rate_limiter_st` (single-threaded, backed by the new `nano::null_mutex`).
- **Vocabulary types** at `nano::` scope: `rate_limit` (rate + burst ratio, with `rate_limit::unlimited ()`) and `limiter_result` (granted + `retry_after`).

Key semantics:

- A rate of 0 disables limiting entirely.
- Requests larger than the bucket capacity are granted when the bucket is full and overdraw the balance, preserving the average rate without deadlocking callers (resolves the old bootstrap_server TODO about batch size vs. capacity).
- On rejection, `consume` returns an exact `retry_after` hint, so wait loops sleep precisely as long as needed instead of polling on fixed 100ms intervals or hand-computed heuristics. All call sites (tcp_channel, local_block_broadcaster, backlog_scan, bounded_backlog, bootstrap_server) are ported to it.
- Comparisons use an epsilon tolerance so the retry hint is guaranteed sufficient at floating-point boundaries, and `last_refill` never moves backwards when concurrent callers pass slightly out-of-order timestamps.

`bandwidth_limiter` keeps its traffic-type routing role but its config collapses to two `rate_limit` members.

Includes a deterministic test suite (42 cases, both limiter variants): refill math, burst capacity, overdraw, retry-hint sufficiency, reset transitions, a busy-spin regression hammering the bucket with rejected microsecond-spaced requests, and multi-threaded consistency checks.