### PR TITLE
Add peering (networking-only) node mode

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1146,3 +1146,35 @@ TEST (network, disable_reachout)
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::network, nano::stat::detail::reachout_cached));
 	ASSERT_EQ (0, node.stats.count (nano::stat::type::network, nano::stat::detail::reachout_preconfigured));
 }
+
+/*
+ * Two nodes that know nothing of each other discover one another purely by connecting to a
+ * peering-only node. Keeping no ledger does not stop it gossiping peers, which is what a
+ * DNS-attached peering-only node exists to do.
+ */
+TEST (network, peer_discovery_via_peering_only_node)
+{
+	nano::test::system system;
+
+	nano::node_flags peering_flags;
+	peering_flags.peering_only = true;
+	auto node_c = system.make_disconnected_node (system.default_config (), peering_flags);
+
+	auto node_a = system.make_disconnected_node ();
+	auto node_b = system.make_disconnected_node ();
+
+	node_a->network.merge_peer (node_c->network.endpoint ());
+	node_b->network.merge_peer (node_c->network.endpoint ());
+
+	ASSERT_TIMELY (10s, node_a->network.find_node_id (node_c->get_node_id ()));
+	ASSERT_TIMELY (10s, node_b->network.find_node_id (node_c->get_node_id ()));
+
+	ASSERT_EQ (nullptr, node_a->network.find_node_id (node_b->get_node_id ()));
+	ASSERT_EQ (nullptr, node_b->network.find_node_id (node_a->get_node_id ()));
+
+	ASSERT_TIMELY (30s, node_a->network.find_node_id (node_b->get_node_id ()));
+	ASSERT_TIMELY (30s, node_b->network.find_node_id (node_a->get_node_id ()));
+
+	// C brokered the introduction without ever holding a ledger
+	ASSERT_EQ (1, node_c->ledger.block_count ());
+}

--- a/nano/core_test/tcp_server.cpp
+++ b/nano/core_test/tcp_server.cpp
@@ -410,3 +410,34 @@ TEST (tcp_server, handshake_flags_exchanged)
 	ASSERT_EQ (node1->stats.count (nano::stat::type::tcp_server, nano::stat::detail::handshake_abort), 0);
 	ASSERT_EQ (node2->stats.count (nano::stat::type::tcp_server, nano::stat::detail::handshake_abort), 0);
 }
+
+/*
+ * A peering-only node advertises the no_ledger capability; a full peer sees it as not serving a ledger
+ */
+TEST (tcp_server, handshake_peering_only_flag)
+{
+	nano::test::system system;
+
+	auto node1 = system.add_node ();
+
+	nano::node_flags peering_flags;
+	peering_flags.peering_only = true;
+	auto node2 = system.add_node (peering_flags);
+
+	node1->network.merge_peer (node2->network.endpoint ());
+
+	ASSERT_TIMELY (10s, node1->network.find_node_id (node2->get_node_id ()));
+	ASSERT_TIMELY (10s, node2->network.find_node_id (node1->get_node_id ()));
+
+	// node1's channel to the peering-only node2 reports it as not serving a ledger
+	auto chan1 = node1->network.find_node_id (node2->get_node_id ());
+	ASSERT_TRUE (chan1);
+	ASSERT_TRUE (chan1->get_flags ().test (nano::node_capabilities::no_ledger));
+	ASSERT_FALSE (chan1->serves_ledger ());
+
+	// node2's channel to the full node1 reports it as serving a ledger
+	auto chan2 = node2->network.find_node_id (node1->get_node_id ());
+	ASSERT_TRUE (chan2);
+	ASSERT_FALSE (chan2->get_flags ().test (nano::node_capabilities::no_ledger));
+	ASSERT_TRUE (chan2->serves_ledger ());
+}

--- a/nano/core_test/telemetry.cpp
+++ b/nano/core_test/telemetry.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/node_capabilities.hpp>
 #include <nano/lib/stream.hpp>
 #include <nano/messages/telemetry.hpp>
 #include <nano/node/network.hpp>
@@ -391,6 +392,18 @@ TEST (telemetry, maker_pruning)
 
 	// Ensure telemetry response indicates pruned node
 	ASSERT_EQ (nano::messages::telemetry_maker::nf_pruned_node, telemetry_data->maker);
+}
+
+TEST (telemetry, maker_peering)
+{
+	nano::test::system system;
+	nano::node_flags node_flags;
+	node_flags.peering_only = true;
+	auto & node = *system.add_node (node_flags);
+
+	// A peering-only node advertises the peering maker and the no_ledger capability
+	ASSERT_EQ (nano::messages::telemetry_maker::nf_peering_node, node.local_telemetry ().maker);
+	ASSERT_TRUE (node.get_capabilities ().test (nano::node_capabilities::no_ledger));
 }
 
 TEST (telemetry, invalid_signature)

--- a/nano/lib/node_capabilities.hpp
+++ b/nano/lib/node_capabilities.hpp
@@ -12,6 +12,7 @@ enum class node_capabilities : uint64_t
 	none = 0,
 	topo_index = 1ULL << 0,
 	vote_storage = 1ULL << 1,
+	no_ledger = 1ULL << 2, // Set when this node does not maintain a ledger
 };
 
 std::string_view to_string (node_capabilities);

--- a/nano/messages/telemetry.cpp
+++ b/nano/messages/telemetry.cpp
@@ -423,8 +423,8 @@ std::string to_string (telemetry_maker maker)
 			return "nf_node";
 		case telemetry_maker::nf_pruned_node:
 			return "nf_pruned_node";
-		case telemetry_maker::nano_node_light:
-			return "nano_node_light";
+		case telemetry_maker::nf_peering_node:
+			return "nf_peering_node";
 		case telemetry_maker::rs_nano:
 			return "rs_nano";
 	}
@@ -465,8 +465,8 @@ telemetry_maker telemetry_maker_from_string (std::string const & str)
 		return telemetry_maker::nf_node;
 	if (str == "nf_pruned_node")
 		return telemetry_maker::nf_pruned_node;
-	if (str == "nano_node_light")
-		return telemetry_maker::nano_node_light;
+	if (str == "nf_peering_node")
+		return telemetry_maker::nf_peering_node;
 	if (str == "rs_nano")
 		return telemetry_maker::rs_nano;
 	return telemetry_maker::nf_node;

--- a/nano/messages/telemetry.hpp
+++ b/nano/messages/telemetry.hpp
@@ -18,7 +18,7 @@ enum class telemetry_maker : uint8_t
 {
 	nf_node = 0,
 	nf_pruned_node = 1,
-	nano_node_light = 2,
+	nf_peering_node = 2,
 	rs_nano = 3
 };
 

--- a/nano/node/bootstrap/bootstrap_context.cpp
+++ b/nano/node/bootstrap/bootstrap_context.cpp
@@ -16,6 +16,7 @@
 #include <nano/node/ledger_notifications.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/nodeconfig.hpp>
+#include <nano/node/transport/channel.hpp>
 #include <nano/node/transport/formatting.hpp>
 #include <nano/node/transport/transport.hpp>
 #include <nano/secure/common.hpp>
@@ -353,7 +354,11 @@ void bootstrap_context::maintenance (nano::unique_lock<nano::mutex> & lock)
 
 	// Snapshot peers without the bootstrap mutex held, to avoid nesting the network mutex under it
 	lock.unlock ();
-	auto channels = network.list (/* all */ 0, network_constants.bootstrap_protocol_version_min);
+	// Only request ledger data from peers that both meet the bootstrap protocol version and serve a ledger
+	auto const min_version = network_constants.bootstrap_protocol_version_min;
+	auto channels = network.list (/* all */ 0, [min_version] (auto const & channel) {
+		return channel->get_network_version () >= min_version && channel->serves_ledger ();
+	});
 	lock.lock ();
 
 	scoring.sync (channels);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -55,6 +55,8 @@ std::string nano::error_cli_messages::message (int ev) const
 			return "Config file read error";
 		case nano::error_cli::ambiguous_pruning_voting_options:
 			return "Flag --enable_pruning and --enable_voting in node config cannot be used together";
+		case nano::error_cli::ambiguous_peering_only_options:
+			return "Flag --peering_only cannot be used together with --enable_voting or --enable_pruning";
 	}
 
 	return "Invalid error code";
@@ -143,6 +145,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_search_pending", "Disables the periodic search for pending transactions")
 		("disable_topo_index", "Initialize a fresh ledger without the topology index. Required for pruning. Has no effect on an existing ledger; use --drop_topo_index to disable on an existing ledger.")
 		("enable_pruning", "Enable experimental ledger pruning")
+		("peering_only", "Run as a peering-only node: keep a genesis-only ledger, run no ledger subsystems, and participate only in the peer-to-peer network (peer discovery/bootstrap)")
 		("enable_rpc", "Enable RPC")
 		("enable_voting", "Enable voting")
 		("super_rebroadcaster", "Broadcast all blocks and votes to all peers (high bandwidth usage)")
@@ -187,6 +190,7 @@ void nano::update_flags (nano::node_flags & flags_a, boost::program_options::var
 	flags_a.disable_block_processor_unchecked_deletion = (vm.count ("disable_block_processor_unchecked_deletion") > 0);
 	flags_a.disable_topo_index = (vm.count ("disable_topo_index") > 0);
 	flags_a.enable_pruning = (vm.count ("enable_pruning") > 0);
+	flags_a.peering_only = (vm.count ("peering_only") > 0);
 	flags_a.enable_rpc = (vm.count ("enable_rpc") > 0);
 	flags_a.enable_voting = (vm.count ("enable_voting") > 0);
 	flags_a.super_rebroadcaster = (vm.count ("super_rebroadcaster") > 0);
@@ -252,6 +256,10 @@ std::error_code nano::flags_config_conflicts (nano::node_flags const & flags_a, 
 	if (flags_a.enable_pruning && (config_a.enable_voting || flags_a.enable_voting))
 	{
 		ec = nano::error_cli::ambiguous_pruning_voting_options;
+	}
+	if (flags_a.peering_only && (config_a.enable_voting || flags_a.enable_voting || flags_a.enable_pruning))
+	{
+		ec = nano::error_cli::ambiguous_peering_only_options;
 	}
 	return ec;
 }

--- a/nano/node/cli.hpp
+++ b/nano/node/cli.hpp
@@ -16,7 +16,8 @@ enum class error_cli
 	unknown_command = 4,
 	database_write_error = 5,
 	reading_config = 6,
-	ambiguous_pruning_voting_options = 7
+	ambiguous_pruning_voting_options = 7,
+	ambiguous_peering_only_options = 8
 };
 
 void add_node_options (boost::program_options::options_description &);

--- a/nano/node/message_processor.cpp
+++ b/nano/node/message_processor.cpp
@@ -200,6 +200,12 @@ public:
 
 	void publish (nano::messages::publish const & message) override
 	{
+		// A peering-only node keeps no ledger and does no block processing
+		if (node.flags.peering_only)
+		{
+			node.stats.inc (nano::stat::type::message_drop, nano::stat::detail::publish, nano::stat::dir::in);
+			return;
+		}
 		// Put blocks that are being initially broadcasted in a separate queue, so that they won't have to compete with rebroadcasted blocks
 		// Both queues have the same priority and size, so the potential for exploiting this is limited
 		debug_assert (message.digest != 0 || channel->get_type () != nano::transport::transport_type::tcp); // Messages received from the network should have their digest set
@@ -226,6 +232,12 @@ public:
 
 	void confirm_ack (nano::messages::confirm_ack const & message) override
 	{
+		// A peering-only node keeps no ledger and does no vote processing
+		if (node.flags.peering_only)
+		{
+			node.stats.inc (nano::stat::type::message_drop, nano::stat::detail::confirm_ack, nano::stat::dir::in);
+			return;
+		}
 		// Ignore zero account votes
 		if (message.vote->account.is_zero ())
 		{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -878,8 +878,11 @@ nano::node_capabilities_flags nano::node::get_capabilities () const
 	{
 		return *flags.capabilities_override;
 	}
-	// TODO: Set capabilities flags based on node configuration and state
 	nano::node_capabilities_flags caps;
+	if (flags.peering_only)
+	{
+		caps.set (nano::node_capabilities::no_ledger);
+	}
 	return caps;
 }
 
@@ -935,7 +938,9 @@ nano::messages::telemetry_data nano::node::local_telemetry () const
 	telemetry_data.minor_version = nano::get_minor_node_version ();
 	telemetry_data.patch_version = nano::get_patch_node_version ();
 	telemetry_data.pre_release_version = nano::get_pre_release_node_version ();
-	telemetry_data.maker = ledger.pruning ? nano::messages::telemetry_maker::nf_pruned_node : nano::messages::telemetry_maker::nf_node;
+	telemetry_data.maker = flags.peering_only
+	? nano::messages::telemetry_maker::nf_peering_node
+	: (ledger.pruning ? nano::messages::telemetry_maker::nf_pruned_node : nano::messages::telemetry_maker::nf_node);
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
 	telemetry_data.active_difficulty = default_difficulty (nano::work_version::work_1);
 	telemetry_data.database_backend = nano::messages::to_telemetry_database_backend (config.database_backend);

--- a/nano/node/nodeconfig.cpp
+++ b/nano/node/nodeconfig.cpp
@@ -66,6 +66,24 @@ nano::node_config nano::apply_flag_overrides (nano::node_config config, nano::no
 	{
 		config.bounded_backlog->enable = false;
 	}
+	// A peering-only node participates only in the peer-to-peer network; it keeps a genesis-only ledger and runs no ledger subsystems
+	if (flags.peering_only)
+	{
+		config.enable_voting = false;
+		config.priority_scheduler->enable = false;
+		config.hinted_scheduler->enable = false;
+		config.optimistic_scheduler->enable = false;
+		config.active_elections->enable = false;
+		config.bounded_backlog->enable = false;
+		config.backlog_scan->enable = false;
+		config.cementing_set->enable = false;
+		config.vote_processor->enable = false;
+		config.vote_rebroadcaster->enable = false;
+		config.block_rebroadcaster->enable = false;
+		config.local_block_broadcaster->enable = false;
+		config.bootstrap->enable = false;
+		config.bootstrap_server->enable = false;
+	}
 	return config;
 }
 

--- a/nano/node/nodeconfig.hpp
+++ b/nano/node/nodeconfig.hpp
@@ -160,6 +160,7 @@ public:
 	bool disable_search_pending{ false };
 	bool disable_bounded_backlog{ false };
 	bool enable_pruning{ false };
+	bool peering_only{ false };
 	bool disable_topo_index{ false };
 	bool enable_rpc{ false };
 	bool enable_voting{ false };

--- a/nano/node/repcrawler.cpp
+++ b/nano/node/repcrawler.cpp
@@ -279,6 +279,11 @@ std::deque<std::shared_ptr<nano::transport::channel>> nano::rep_crawler::prepare
 	auto random_peers = node.network.random_set (required_peer_count);
 
 	auto should_query = [&, this] (std::shared_ptr<nano::transport::channel> const & channel) {
+		// Only crawl peers that serve a ledger; others cannot represent
+		if (!channel->serves_ledger ())
+		{
+			return false;
+		}
 		if (auto rep = reps.get<tag_channel> ().find (channel); rep != reps.get<tag_channel> ().end ())
 		{
 			// Throttle queries to active reps

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -121,6 +121,11 @@ public:
 		flags = value;
 	}
 
+	bool serves_ledger () const
+	{
+		return !get_flags ().test (nano::node_capabilities::no_ledger);
+	}
+
 	nano::endpoint get_peering_endpoint () const;
 	void set_peering_endpoint (nano::endpoint endpoint);
 


### PR DESCRIPTION
Introduce a --peering_only mode for nodes that only participate in the peer-to-peer network and do not maintain a ledger. These are intended for the DNS bootstrap entries, where a node must be reachable and gossip peers but has no need to spend IO/CPU keeping the ledger current.

A peering node keeps a genesis-only store and disables the ledger-consuming subsystems (schedulers, active elections, bootstrap sync and server, vote/cementing/backlog processing, rebroadcasters, voting), and drops incoming publish/confirm_ack at the message boundary so no blocks or votes are processed.

To keep peering nodes from degrading peers that do serve a ledger, a node advertises a no_ledger capability in the v3 handshake (and the nano_node_peering telemetry maker). Peers that understand the capability exclude peering nodes from bootstrap candidate selection and rep-crawler targets, while still gossiping them normally so they remain useful for peer discovery.

The capability describes the property (no ledger); the mode name describes the role (peering). "light" was avoided as it collides with both pruned nodes and light wallets.