### PR TITLE
Support topology index and random block bootstrap requests

### DIFF
--- a/nano/core_test/bootstrap_server.cpp
+++ b/nano/core_test/bootstrap_server.cpp
@@ -1,7 +1,11 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/messages/asc_pull.hpp>
 #include <nano/node/bootstrap/bootstrap_server.hpp>
+#include <nano/node/node.hpp>
 #include <nano/node/transport/fake.hpp>
+#include <nano/secure/ledger.hpp>
+#include <nano/store/ledger/topology.hpp>
+#include <nano/store/ledger_store.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/random.hpp>
 #include <nano/test_common/system.hpp>
@@ -549,5 +553,256 @@ TEST (bootstrap_server, serve_frontiers_invalid_count)
 	ASSERT_TIMELY_EQ (5s, node.stats.count (nano::stat::type::bootstrap_server, nano::stat::detail::invalid), 3);
 
 	// Ensure we don't get any unexpected responses
+	ASSERT_ALWAYS (1s, responses.size () == 0);
+}
+
+TEST (bootstrap_server, serve_blocks_random)
+{
+	nano::test::system system{};
+	auto & node = *system.add_node ();
+
+	responses_helper responses;
+	responses.connect (node.bootstrap_server);
+
+	auto chains = nano::test::setup_chains (system, node, /* chain count */ 1, /* block count */ 16);
+	auto [account, blocks] = chains.front ();
+
+	// Mix of existing and non-existing hashes
+	std::deque<nano::block_hash> requested;
+	requested.push_back (blocks[0]->hash ());
+	requested.push_back (nano::test::random_hash ()); // missing
+	requested.push_back (blocks[5]->hash ());
+	requested.push_back (blocks[10]->hash ());
+	requested.push_back (nano::test::random_hash ()); // missing
+
+	nano::messages::asc_pull_req request{ node.network_params.network };
+	request.id = 7;
+	request.type = nano::messages::asc_pull_type::blocks_random;
+
+	nano::messages::asc_pull_req::blocks_random_payload payload{};
+	payload.hashes = requested;
+	request.payload = payload;
+	request.update_header ();
+
+	node.inbound (request, nano::test::fake_channel (node));
+
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
+
+	auto response = responses.get ().front ();
+	ASSERT_EQ (response.id, 7);
+	ASSERT_EQ (response.type, nano::messages::asc_pull_type::blocks_random);
+
+	auto response_payload = std::get<nano::messages::asc_pull_ack::blocks_payload> (response.payload);
+	ASSERT_EQ (response_payload.blocks.size (), 3);
+
+	std::set<nano::block_hash> returned;
+	for (auto const & b : response_payload.blocks)
+	{
+		returned.insert (b->hash ());
+	}
+	ASSERT_TRUE (returned.count (blocks[0]->hash ()));
+	ASSERT_TRUE (returned.count (blocks[5]->hash ()));
+	ASSERT_TRUE (returned.count (blocks[10]->hash ()));
+}
+
+TEST (bootstrap_server, serve_blocks_random_empty)
+{
+	nano::test::system system{};
+	auto & node = *system.add_node ();
+
+	responses_helper responses;
+	responses.connect (node.bootstrap_server);
+
+	nano::test::setup_chains (system, node, 1, 8);
+
+	std::deque<nano::block_hash> requested;
+	requested.push_back (nano::test::random_hash ());
+	requested.push_back (nano::test::random_hash ());
+
+	nano::messages::asc_pull_req request{ node.network_params.network };
+	request.id = 7;
+	request.type = nano::messages::asc_pull_type::blocks_random;
+
+	nano::messages::asc_pull_req::blocks_random_payload payload{};
+	payload.hashes = requested;
+	request.payload = payload;
+	request.update_header ();
+
+	node.inbound (request, nano::test::fake_channel (node));
+
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
+
+	auto response_payload = std::get<nano::messages::asc_pull_ack::blocks_payload> (responses.get ().front ().payload);
+	ASSERT_TRUE (response_payload.blocks.empty ());
+}
+
+TEST (bootstrap_server, serve_blocks_random_invalid)
+{
+	nano::test::system system{};
+	auto & node = *system.add_node ();
+
+	responses_helper responses;
+	responses.connect (node.bootstrap_server);
+
+	// Empty hash list - rejected by verify
+	{
+		nano::messages::asc_pull_req request{ node.network_params.network };
+		request.id = 7;
+		request.type = nano::messages::asc_pull_type::blocks_random;
+
+		nano::messages::asc_pull_req::blocks_random_payload payload{}; // empty
+		request.payload = payload;
+		request.update_header ();
+
+		node.inbound (request, nano::test::fake_channel (node));
+	}
+
+	ASSERT_TIMELY_EQ (5s, node.stats.count (nano::stat::type::bootstrap_server, nano::stat::detail::invalid), 1);
+	ASSERT_ALWAYS (1s, responses.size () == 0);
+}
+
+TEST (bootstrap_server, serve_topo_index)
+{
+	nano::test::system system{};
+	auto & node = *system.add_node ();
+
+	responses_helper responses;
+	responses.connect (node.bootstrap_server);
+
+	nano::test::setup_chains (system, node, /* chain count */ 4, /* block count */ 4);
+
+	auto entry_count = [&] () {
+		auto txn = node.ledger.tx_begin_read ();
+		return node.ledger.store.topology.count (txn);
+	};
+	ASSERT_GT (entry_count (), 0u);
+
+	// Request from beginning
+	nano::messages::asc_pull_req request{ node.network_params.network };
+	request.id = 7;
+	request.type = nano::messages::asc_pull_type::topo_index;
+
+	nano::messages::asc_pull_req::topo_index_payload payload{};
+	payload.start = nano::topo_key{};
+	payload.count = 1000;
+	request.payload = payload;
+	request.update_header ();
+
+	node.inbound (request, nano::test::fake_channel (node));
+
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
+
+	auto response = responses.get ().front ();
+	ASSERT_EQ (response.id, 7);
+	ASSERT_EQ (response.type, nano::messages::asc_pull_type::topo_index);
+
+	auto response_payload = std::get<nano::messages::asc_pull_ack::topo_index_payload> (response.payload);
+	ASSERT_FALSE (response_payload.entries.empty ());
+
+	// Verify entries are in topo-ascending order AND dense: topo heights are
+	// contiguous, so consecutive entries are at most one height apart.
+	for (std::size_t n = 1; n < response_payload.entries.size (); ++n)
+	{
+		ASSERT_LT (response_payload.entries[n - 1], response_payload.entries[n]);
+		ASSERT_LE (response_payload.entries[n].topo_height - response_payload.entries[n - 1].topo_height, 1u);
+	}
+
+	// Continuation request from last returned entry
+	auto last = response_payload.entries.back ();
+
+	nano::messages::asc_pull_req request2{ node.network_params.network };
+	request2.id = 8;
+	request2.type = nano::messages::asc_pull_type::topo_index;
+
+	nano::messages::asc_pull_req::topo_index_payload payload2{};
+	payload2.start = last;
+	payload2.count = 1000;
+	request2.payload = payload2;
+	request2.update_header ();
+
+	node.inbound (request2, nano::test::fake_channel (node));
+
+	ASSERT_TIMELY_EQ (5s, responses.size (), 2);
+
+	auto response2 = responses.get ().back ();
+	auto response2_payload = std::get<nano::messages::asc_pull_ack::topo_index_payload> (response2.payload);
+
+	// Continuation should include `last` at the start (lower_bound semantics)
+	if (!response2_payload.entries.empty ())
+	{
+		ASSERT_GE (response2_payload.entries.front (), last);
+	}
+}
+
+TEST (bootstrap_server, serve_topo_index_empty)
+{
+	nano::test::system system{};
+	auto & node = *system.add_node ();
+
+	responses_helper responses;
+	responses.connect (node.bootstrap_server);
+
+	nano::test::setup_chains (system, node, 1, 4);
+
+	// Request from a position past the end
+	nano::messages::asc_pull_req request{ node.network_params.network };
+	request.id = 7;
+	request.type = nano::messages::asc_pull_type::topo_index;
+
+	nano::messages::asc_pull_req::topo_index_payload payload{};
+	payload.start = nano::topo_key{ std::numeric_limits<uint64_t>::max () - 1, nano::block_hash{} };
+	payload.count = 100;
+	request.payload = payload;
+	request.update_header ();
+
+	node.inbound (request, nano::test::fake_channel (node));
+
+	ASSERT_TIMELY_EQ (5s, responses.size (), 1);
+
+	auto response_payload = std::get<nano::messages::asc_pull_ack::topo_index_payload> (responses.get ().front ().payload);
+	ASSERT_TRUE (response_payload.entries.empty ());
+}
+
+TEST (bootstrap_server, serve_topo_index_invalid_count)
+{
+	nano::test::system system{};
+	auto & node = *system.add_node ();
+
+	responses_helper responses;
+	responses.connect (node.bootstrap_server);
+
+	nano::test::setup_chains (system, node, 1, 4);
+
+	// Zero count
+	{
+		nano::messages::asc_pull_req request{ node.network_params.network };
+		request.id = 7;
+		request.type = nano::messages::asc_pull_type::topo_index;
+
+		nano::messages::asc_pull_req::topo_index_payload payload{};
+		payload.count = 0;
+		request.payload = payload;
+		request.update_header ();
+
+		node.inbound (request, nano::test::fake_channel (node));
+	}
+
+	ASSERT_TIMELY_EQ (5s, node.stats.count (nano::stat::type::bootstrap_server, nano::stat::detail::invalid), 1);
+
+	// Count over max
+	{
+		nano::messages::asc_pull_req request{ node.network_params.network };
+		request.id = 7;
+		request.type = nano::messages::asc_pull_type::topo_index;
+
+		nano::messages::asc_pull_req::topo_index_payload payload{};
+		payload.count = nano::bootstrap_server::max_topo_entries + 1;
+		request.payload = payload;
+		request.update_header ();
+
+		node.inbound (request, nano::test::fake_channel (node));
+	}
+
+	ASSERT_TIMELY_EQ (5s, node.stats.count (nano::stat::type::bootstrap_server, nano::stat::detail::invalid), 2);
 	ASSERT_ALWAYS (1s, responses.size () == 0);
 }

--- a/nano/core_test/message.cpp
+++ b/nano/core_test/message.cpp
@@ -732,6 +732,154 @@ TEST (message, asc_pull_ack_serialization_frontiers)
 	ASSERT_TRUE (nano::at_end (stream));
 }
 
+TEST (message, asc_pull_req_serialization_blocks_random)
+{
+	nano::messages::asc_pull_req original{ nano::dev::network_params.network };
+	original.id = 7;
+	original.type = nano::messages::asc_pull_type::blocks_random;
+
+	nano::messages::asc_pull_req::blocks_random_payload original_payload{};
+	for (std::size_t n = 0; n < nano::messages::asc_pull_req::blocks_random_payload::max_hashes; ++n)
+	{
+		original_payload.hashes.push_back (nano::test::random_hash ());
+	}
+
+	original.payload = original_payload;
+	original.update_header ();
+
+	std::vector<uint8_t> bytes;
+	{
+		nano::vectorstream stream{ bytes };
+		original.serialize (stream);
+	}
+	nano::bufferstream stream{ bytes.data (), bytes.size () };
+
+	bool error = false;
+	nano::messages::message_header header (error, stream);
+	ASSERT_FALSE (error);
+	ASSERT_EQ (nano::messages::message_type::asc_pull_req, header.type);
+
+	nano::messages::asc_pull_req message (error, stream, header);
+	ASSERT_FALSE (error);
+	ASSERT_EQ (original.id, message.id);
+	ASSERT_EQ (original.type, message.type);
+
+	nano::messages::asc_pull_req::blocks_random_payload message_payload;
+	ASSERT_NO_THROW (message_payload = std::get<nano::messages::asc_pull_req::blocks_random_payload> (message.payload));
+	ASSERT_EQ (original_payload.hashes, message_payload.hashes);
+
+	ASSERT_TRUE (nano::at_end (stream));
+}
+
+TEST (message, asc_pull_req_serialization_topo_index)
+{
+	nano::messages::asc_pull_req original{ nano::dev::network_params.network };
+	original.id = 21;
+	original.type = nano::messages::asc_pull_type::topo_index;
+
+	nano::messages::asc_pull_req::topo_index_payload original_payload{};
+	original_payload.start = nano::topo_key{ 4242, nano::test::random_hash () };
+	original_payload.count = 777;
+
+	original.payload = original_payload;
+	original.update_header ();
+
+	std::vector<uint8_t> bytes;
+	{
+		nano::vectorstream stream{ bytes };
+		original.serialize (stream);
+	}
+	nano::bufferstream stream{ bytes.data (), bytes.size () };
+
+	bool error = false;
+	nano::messages::message_header header (error, stream);
+	ASSERT_FALSE (error);
+	ASSERT_EQ (nano::messages::message_type::asc_pull_req, header.type);
+
+	nano::messages::asc_pull_req message (error, stream, header);
+	ASSERT_FALSE (error);
+	ASSERT_EQ (original.id, message.id);
+	ASSERT_EQ (original.type, message.type);
+
+	nano::messages::asc_pull_req::topo_index_payload message_payload;
+	ASSERT_NO_THROW (message_payload = std::get<nano::messages::asc_pull_req::topo_index_payload> (message.payload));
+	ASSERT_EQ (original_payload.start, message_payload.start);
+	ASSERT_EQ (original_payload.count, message_payload.count);
+
+	ASSERT_TRUE (nano::at_end (stream));
+}
+
+TEST (message, asc_pull_ack_serialization_topo_index)
+{
+	nano::messages::asc_pull_ack original{ nano::dev::network_params.network };
+	original.id = 22;
+	original.type = nano::messages::asc_pull_type::topo_index;
+
+	nano::messages::asc_pull_ack::topo_index_payload original_payload{};
+	for (std::size_t n = 0; n < nano::messages::asc_pull_ack::topo_index_payload::max_entries; ++n)
+	{
+		original_payload.entries.push_back (nano::topo_key{ n + 1, nano::test::random_hash () });
+	}
+
+	original.payload = original_payload;
+	original.update_header ();
+
+	std::vector<uint8_t> bytes;
+	{
+		nano::vectorstream stream{ bytes };
+		original.serialize (stream);
+	}
+	nano::bufferstream stream{ bytes.data (), bytes.size () };
+
+	bool error = false;
+	nano::messages::message_header header (error, stream);
+	ASSERT_FALSE (error);
+	ASSERT_EQ (nano::messages::message_type::asc_pull_ack, header.type);
+
+	nano::messages::asc_pull_ack message (error, stream, header);
+	ASSERT_FALSE (error);
+	ASSERT_EQ (original.id, message.id);
+	ASSERT_EQ (original.type, message.type);
+
+	nano::messages::asc_pull_ack::topo_index_payload message_payload;
+	ASSERT_NO_THROW (message_payload = std::get<nano::messages::asc_pull_ack::topo_index_payload> (message.payload));
+
+	ASSERT_EQ (original_payload.entries.size (), message_payload.entries.size ());
+	ASSERT_TRUE (std::equal (original_payload.entries.begin (), original_payload.entries.end (), message_payload.entries.begin ()));
+
+	ASSERT_TRUE (nano::at_end (stream));
+}
+
+TEST (message, asc_pull_ack_serialization_topo_index_empty)
+{
+	nano::messages::asc_pull_ack original{ nano::dev::network_params.network };
+	original.id = 23;
+	original.type = nano::messages::asc_pull_type::topo_index;
+
+	nano::messages::asc_pull_ack::topo_index_payload original_payload{};
+	// Empty entries
+
+	original.payload = original_payload;
+	original.update_header ();
+
+	std::vector<uint8_t> bytes;
+	{
+		nano::vectorstream stream{ bytes };
+		original.serialize (stream);
+	}
+	nano::bufferstream stream{ bytes.data (), bytes.size () };
+
+	bool error = false;
+	nano::messages::message_header header (error, stream);
+	ASSERT_FALSE (error);
+	nano::messages::asc_pull_ack message (error, stream, header);
+	ASSERT_FALSE (error);
+
+	auto message_payload = std::get<nano::messages::asc_pull_ack::topo_index_payload> (message.payload);
+	ASSERT_TRUE (message_payload.entries.empty ());
+	ASSERT_TRUE (nano::at_end (stream));
+}
+
 TEST (message, node_id_handshake_query_serialization)
 {
 	nano::messages::node_id_handshake::query_payload query{};

--- a/nano/lib/constants.hpp
+++ b/nano/lib/constants.hpp
@@ -211,11 +211,14 @@ public:
 	}
 
 	/** Current protocol version */
-	uint8_t const protocol_version = 0x15;
+	uint8_t const protocol_version = 0x16;
 	/** Minimum accepted protocol version */
 	uint8_t const protocol_version_min = 0x14;
 
 	/** Minimum accepted protocol version used when bootstrapping */
 	uint8_t const bootstrap_protocol_version_min = 0x14;
+
+	/** Minimum protocol version that understands the topology bootstrap message types (topo_index, blocks_random) */
+	uint8_t const topo_bootstrap_protocol_version_min = 0x16;
 };
 }

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -566,6 +566,7 @@ enum class detail
 	processing_frontiers,
 	frontiers_dropped,
 	sync_accounts,
+	topo_indexes,
 
 	prioritize,
 	prioritize_failed,
@@ -683,6 +684,8 @@ enum class detail
 	blocks_by_hash,
 	blocks_by_account,
 	account_info_by_hash,
+	blocks_random,
+	topo_index,
 
 	// query_source
 	database,

--- a/nano/messages/CMakeLists.txt
+++ b/nano/messages/CMakeLists.txt
@@ -33,4 +33,4 @@ add_library(
   telemetry.cpp
   uniquers.hpp)
 
-target_link_libraries(nano_messages nano_lib Boost::endian)
+target_link_libraries(nano_messages nano_lib secure Boost::endian)

--- a/nano/messages/asc_pull.cpp
+++ b/nano/messages/asc_pull.cpp
@@ -86,6 +86,20 @@ void asc_pull_req::deserialize_payload (nano::stream & stream)
 			payload = pld;
 			break;
 		}
+		case asc_pull_type::blocks_random:
+		{
+			blocks_random_payload pld{};
+			pld.deserialize (stream);
+			payload = pld;
+			break;
+		}
+		case asc_pull_type::topo_index:
+		{
+			topo_index_payload pld{};
+			pld.deserialize (stream);
+			payload = pld;
+			break;
+		}
 		default:
 			throw std::runtime_error ("Unknown asc_pull_type");
 	}
@@ -131,6 +145,14 @@ bool asc_pull_req::verify_consistency () const
 		void operator() (frontiers_payload) const
 		{
 			debug_assert (type == asc_pull_type::frontiers);
+		}
+		void operator() (blocks_random_payload) const
+		{
+			debug_assert (type == asc_pull_type::blocks_random);
+		}
+		void operator() (topo_index_payload) const
+		{
+			debug_assert (type == asc_pull_type::topo_index);
 		}
 	};
 	std::visit (consistency_visitor{ type }, payload);
@@ -217,6 +239,64 @@ void asc_pull_req::frontiers_payload::operator() (nano::object_stream & obs) con
 }
 
 /*
+ * asc_pull_req::blocks_random_payload
+ */
+
+void asc_pull_req::blocks_random_payload::serialize (nano::stream & stream) const
+{
+	debug_assert (hashes.size () <= max_hashes);
+
+	for (auto const & hash : hashes)
+	{
+		nano::write (stream, hash);
+	}
+	// Terminator: zero hash
+	nano::write (stream, nano::block_hash{ 0 });
+}
+
+void asc_pull_req::blocks_random_payload::deserialize (nano::stream & stream)
+{
+	nano::block_hash hash;
+	nano::read (stream, hash);
+	while (!hash.is_zero () && hashes.size () < max_hashes)
+	{
+		hashes.push_back (hash);
+		nano::read (stream, hash);
+	}
+}
+
+void asc_pull_req::blocks_random_payload::operator() (nano::object_stream & obs) const
+{
+	obs.write_range ("hashes", hashes);
+}
+
+/*
+ * asc_pull_req::topo_index_payload
+ */
+
+void asc_pull_req::topo_index_payload::serialize (nano::stream & stream) const
+{
+	start.serialize (stream);
+	nano::write_big_endian (stream, count);
+}
+
+void asc_pull_req::topo_index_payload::deserialize (nano::stream & stream)
+{
+	if (start.deserialize (stream))
+	{
+		throw std::runtime_error ("Failed to deserialize topo_key");
+	}
+	nano::read_big_endian (stream, count);
+}
+
+void asc_pull_req::topo_index_payload::operator() (nano::object_stream & obs) const
+{
+	obs.write ("start_height", start.topo_height);
+	obs.write ("start_hash", start.hash);
+	obs.write ("count", count);
+}
+
+/*
  * asc_pull_ack
  */
 
@@ -296,6 +376,21 @@ void asc_pull_ack::deserialize_payload (nano::stream & stream)
 			payload = pld;
 			break;
 		}
+		case asc_pull_type::blocks_random:
+		{
+			// Response reuses blocks_payload format
+			blocks_payload pld{};
+			pld.deserialize (stream);
+			payload = pld;
+			break;
+		}
+		case asc_pull_type::topo_index:
+		{
+			topo_index_payload pld{};
+			pld.deserialize (stream);
+			payload = pld;
+			break;
+		}
 		default:
 			throw std::runtime_error ("Unknown asc_pull_type");
 	}
@@ -332,7 +427,7 @@ bool asc_pull_ack::verify_consistency () const
 		}
 		void operator() (blocks_payload) const
 		{
-			debug_assert (type == asc_pull_type::blocks);
+			debug_assert (type == asc_pull_type::blocks || type == asc_pull_type::blocks_random);
 		}
 		void operator() (account_info_payload) const
 		{
@@ -341,6 +436,10 @@ bool asc_pull_ack::verify_consistency () const
 		void operator() (frontiers_payload) const
 		{
 			debug_assert (type == asc_pull_type::frontiers);
+		}
+		void operator() (topo_index_payload) const
+		{
+			debug_assert (type == asc_pull_type::topo_index);
 		}
 	};
 	std::visit (consistency_visitor{ type }, payload);
@@ -470,6 +569,47 @@ void asc_pull_ack::frontiers_payload::operator() (nano::object_stream & obs) con
 		auto & [account, hash] = entry;
 		obs.write ("account", account);
 		obs.write ("hash", hash);
+	});
+}
+
+/*
+ * asc_pull_ack::topo_index_payload
+ */
+
+void asc_pull_ack::topo_index_payload::serialize (nano::stream & stream) const
+{
+	debug_assert (entries.size () <= max_entries);
+
+	for (auto const & entry : entries)
+	{
+		entry.serialize (stream);
+	}
+	// Terminator: zero topo_key (topo_height=0, hash=0)
+	nano::topo_key{}.serialize (stream);
+}
+
+void asc_pull_ack::topo_index_payload::deserialize (nano::stream & stream)
+{
+	nano::topo_key current;
+	if (current.deserialize (stream))
+	{
+		throw std::runtime_error ("Failed to deserialize topo_key");
+	}
+	while ((current.topo_height != 0 || !current.hash.is_zero ()) && entries.size () < max_entries)
+	{
+		entries.push_back (current);
+		if (current.deserialize (stream))
+		{
+			throw std::runtime_error ("Failed to deserialize topo_key");
+		}
+	}
+}
+
+void asc_pull_ack::topo_index_payload::operator() (nano::object_stream & obs) const
+{
+	obs.write_range ("entries", entries, [] (auto const & entry, nano::object_stream & obs) {
+		obs.write ("topo_height", entry.topo_height);
+		obs.write ("hash", entry.hash);
 	});
 }
 }

--- a/nano/messages/asc_pull.hpp
+++ b/nano/messages/asc_pull.hpp
@@ -2,6 +2,7 @@
 
 #include <nano/lib/numbers.hpp>
 #include <nano/messages/message.hpp>
+#include <nano/secure/common.hpp>
 
 #include <cstdint>
 #include <deque>
@@ -20,6 +21,8 @@ enum class asc_pull_type : uint8_t
 	blocks = 0x1,
 	account_info = 0x2,
 	frontiers = 0x3,
+	blocks_random = 0x4,
+	topo_index = 0x5,
 };
 
 /**
@@ -101,12 +104,41 @@ public: // Payload definitions
 		void operator() (nano::object_stream &) const;
 	};
 
+	struct blocks_random_payload
+	{
+		constexpr static std::size_t max_hashes = 128;
+
+		void serialize (nano::stream &) const;
+		void deserialize (nano::stream &);
+
+	public: // Payload
+		std::deque<nano::block_hash> hashes;
+
+	public: // Logging
+		void operator() (nano::object_stream &) const;
+	};
+
+	struct topo_index_payload
+	{
+		void serialize (nano::stream &) const;
+		void deserialize (nano::stream &);
+
+	public: // Payload
+		nano::topo_key start{};
+		uint16_t count{ 0 };
+
+	public: // Logging
+		void operator() (nano::object_stream &) const;
+	};
+
+	using payload_variant = std::variant<empty_payload, blocks_payload, account_info_payload, frontiers_payload, blocks_random_payload, topo_index_payload>;
+
 public: // Payload
 	asc_pull_type type{ asc_pull_type::invalid };
 	id_t id{ 0 };
 
 	/** Payload depends on `asc_pull_type` */
-	std::variant<empty_payload, blocks_payload, account_info_payload, frontiers_payload> payload;
+	payload_variant payload;
 
 public:
 	/** Size of message without payload */
@@ -201,12 +233,31 @@ public: // Payload definitions
 		void operator() (nano::object_stream &) const;
 	};
 
+	struct topo_index_payload
+	{
+		/* Header allows for 16 bit extensions; 65536 bytes / 40 bytes (topo_height + hash) ~ 1638, cap at 1000 */
+		constexpr static std::size_t max_entries = 1000;
+
+		void serialize (nano::stream &) const;
+		void deserialize (nano::stream &);
+
+	public: // Payload
+		std::deque<nano::topo_key> entries;
+
+	public: // Logging
+		void operator() (nano::object_stream &) const;
+	};
+
+	// Note: blocks_random response reuses blocks_payload
+
+	using payload_variant = std::variant<empty_payload, blocks_payload, account_info_payload, frontiers_payload, topo_index_payload>;
+
 public: // Payload
 	asc_pull_type type{ asc_pull_type::invalid };
 	id_t id{ 0 };
 
 	/** Payload depends on `asc_pull_type` */
-	std::variant<empty_payload, blocks_payload, account_info_payload, frontiers_payload> payload;
+	payload_variant payload;
 
 public:
 	/** Size of message without payload */

--- a/nano/node/bootstrap/bootstrap_context.cpp
+++ b/nano/node/bootstrap/bootstrap_context.cpp
@@ -460,6 +460,10 @@ void bootstrap_context::process (nano::messages::asc_pull_ack const & message, s
 		{
 			return type == query_type::frontiers;
 		}
+		bool operator() (const nano::messages::asc_pull_ack::topo_index_payload & response) const
+		{
+			return false; // Topology strategy not implemented yet, we never request topo indexes
+		}
 		bool operator() (const nano::messages::empty_payload & response) const
 		{
 			return false; // Should not happen
@@ -616,6 +620,12 @@ bool bootstrap_context::process (nano::messages::asc_pull_ack::account_info_payl
 bool bootstrap_context::process (nano::messages::asc_pull_ack::frontiers_payload const & response, async_tag const & tag)
 {
 	return frontier_strat.process (response, tag);
+}
+
+bool bootstrap_context::process (nano::messages::asc_pull_ack::topo_index_payload const & response, async_tag const & tag)
+{
+	debug_assert (false, "topo_index payload"); // Topology strategy not implemented yet; verifier rejects these before we get here
+	return false; // Invalid
 }
 
 bool bootstrap_context::process (nano::messages::empty_payload const & response, async_tag const & tag)

--- a/nano/node/bootstrap/bootstrap_context.hpp
+++ b/nano/node/bootstrap/bootstrap_context.hpp
@@ -91,6 +91,7 @@ private:
 	bool process (nano::messages::asc_pull_ack::blocks_payload const & response, async_tag const & tag);
 	bool process (nano::messages::asc_pull_ack::account_info_payload const & response, async_tag const & tag);
 	bool process (nano::messages::asc_pull_ack::frontiers_payload const & response, async_tag const & tag);
+	bool process (nano::messages::asc_pull_ack::topo_index_payload const & response, async_tag const & tag);
 	bool process (nano::messages::empty_payload const & response, async_tag const & tag);
 
 	// Inserts the tag and transmits the message over the channel

--- a/nano/node/bootstrap/bootstrap_server.cpp
+++ b/nano/node/bootstrap/bootstrap_server.cpp
@@ -11,6 +11,7 @@
 #include <nano/store/ledger/block.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>
 #include <nano/store/ledger/successor.hpp>
+#include <nano/store/ledger/topology.hpp>
 #include <nano/store/ledger_store.hpp>
 
 nano::bootstrap_server::bootstrap_server (bootstrap_server_config const & config_a, nano::store::ledger_store & store_a, nano::ledger & ledger_a, nano::network_constants const & network_constants_a, nano::stats & stats_a) :
@@ -77,6 +78,8 @@ bool nano::bootstrap_server::verify_request_type (nano::messages::asc_pull_type 
 		case nano::messages::asc_pull_type::blocks:
 		case nano::messages::asc_pull_type::account_info:
 		case nano::messages::asc_pull_type::frontiers:
+		case nano::messages::asc_pull_type::blocks_random:
+		case nano::messages::asc_pull_type::topo_index:
 			return true;
 	}
 	return false;
@@ -106,6 +109,14 @@ bool nano::bootstrap_server::verify (const nano::messages::asc_pull_req & messag
 		bool operator() (nano::messages::asc_pull_req::frontiers_payload const & pld) const
 		{
 			return pld.count > 0 && pld.count <= max_frontiers;
+		}
+		bool operator() (nano::messages::asc_pull_req::blocks_random_payload const & pld) const
+		{
+			return !pld.hashes.empty () && pld.hashes.size () <= max_random_hashes;
+		}
+		bool operator() (nano::messages::asc_pull_req::topo_index_payload const & pld) const
+		{
+			return pld.count > 0 && pld.count <= max_topo_entries;
 		}
 	};
 
@@ -170,6 +181,10 @@ void nano::bootstrap_server::respond (nano::messages::asc_pull_ack & response, s
 		void operator() (nano::messages::asc_pull_ack::frontiers_payload const & pld)
 		{
 			stats.add (nano::stat::type::bootstrap_server, nano::stat::detail::frontiers, nano::stat::dir::out, pld.frontiers.size ());
+		}
+		void operator() (nano::messages::asc_pull_ack::topo_index_payload const & pld)
+		{
+			stats.add (nano::stat::type::bootstrap_server, nano::stat::detail::topo_indexes, nano::stat::dir::out, pld.entries.size ());
 		}
 	};
 	std::visit (stat_visitor{ stats }, response.payload);
@@ -420,6 +435,61 @@ nano::messages::asc_pull_ack nano::bootstrap_server::process (secure::transactio
 }
 
 /*
+ * Blocks random request
+ */
+
+nano::messages::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::messages::asc_pull_req::id_t id, nano::messages::asc_pull_req::blocks_random_payload const & request) const
+{
+	nano::messages::asc_pull_ack response{ network_constants };
+	response.id = id;
+	response.type = nano::messages::asc_pull_type::blocks_random;
+
+	nano::messages::asc_pull_ack::blocks_payload response_payload{};
+	for (auto const & hash : request.hashes)
+	{
+		auto block = ledger.any.block_get (transaction, hash);
+		if (block)
+		{
+			response_payload.blocks.push_back (block);
+		}
+	}
+
+	response.payload = response_payload;
+	response.update_header ();
+	return response;
+}
+
+/*
+ * Topo index request
+ */
+
+nano::messages::asc_pull_ack nano::bootstrap_server::process (secure::transaction const & transaction, nano::messages::asc_pull_req::id_t id, nano::messages::asc_pull_req::topo_index_payload const & request) const
+{
+	debug_assert (request.count <= max_topo_entries); // Should be filtered out earlier
+
+	nano::messages::asc_pull_ack response{ network_constants };
+	response.id = id;
+	response.type = nano::messages::asc_pull_type::topo_index;
+
+	nano::messages::asc_pull_ack::topo_index_payload response_payload{};
+
+	auto begin = (request.start == nano::topo_key{})
+	? store.topology.begin (transaction)
+	: store.topology.begin (transaction, request.start);
+
+	auto end = store.topology.end (transaction);
+
+	for (auto it = std::move (begin); it != end && response_payload.entries.size () < request.count; ++it)
+	{
+		response_payload.entries.push_back (it->first);
+	}
+
+	response.payload = response_payload;
+	response.update_header ();
+	return response;
+}
+
+/*
  *
  */
 
@@ -433,6 +503,10 @@ nano::stat::detail nano::to_stat_detail (nano::messages::asc_pull_type type)
 			return nano::stat::detail::account_info;
 		case messages::asc_pull_type::frontiers:
 			return nano::stat::detail::frontiers;
+		case messages::asc_pull_type::blocks_random:
+			return nano::stat::detail::blocks_random;
+		case messages::asc_pull_type::topo_index:
+			return nano::stat::detail::topo_index;
 		default:
 			return nano::stat::detail::invalid;
 	}

--- a/nano/node/bootstrap/bootstrap_server.hpp
+++ b/nano/node/bootstrap/bootstrap_server.hpp
@@ -80,6 +80,16 @@ private:
 	nano::messages::asc_pull_ack process (secure::transaction const &, nano::messages::asc_pull_req::id_t id, nano::messages::asc_pull_req::frontiers_payload const & request) const;
 
 	/*
+	 * Blocks random request
+	 */
+	nano::messages::asc_pull_ack process (secure::transaction const &, nano::messages::asc_pull_req::id_t id, nano::messages::asc_pull_req::blocks_random_payload const & request) const;
+
+	/*
+	 * Topo index request
+	 */
+	nano::messages::asc_pull_ack process (secure::transaction const &, nano::messages::asc_pull_req::id_t id, nano::messages::asc_pull_req::topo_index_payload const & request) const;
+
+	/*
 	 * Checks if the request should be dropped early on
 	 */
 	bool verify (nano::messages::asc_pull_req const & message) const;
@@ -105,6 +115,8 @@ public: // Config
 	/** Maximum number of blocks to send in a single response, cannot be higher than capacity of a single `asc_pull_ack` message */
 	constexpr static std::size_t max_blocks = nano::messages::asc_pull_ack::blocks_payload::max_blocks;
 	constexpr static std::size_t max_frontiers = nano::messages::asc_pull_ack::frontiers_payload::max_frontiers;
+	constexpr static std::size_t max_topo_entries = nano::messages::asc_pull_ack::topo_index_payload::max_entries;
+	constexpr static std::size_t max_random_hashes = nano::messages::asc_pull_req::blocks_random_payload::max_hashes;
 };
 
 nano::stat::detail to_stat_detail (nano::messages::asc_pull_type);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -889,10 +889,15 @@ nano::node_capabilities_flags nano::node::get_capabilities () const
 	{
 		return *flags.capabilities_override;
 	}
+
 	nano::node_capabilities_flags caps;
 	if (flags.peering_only)
 	{
 		caps.set (nano::node_capabilities::no_ledger);
+	}
+	if (ledger.flags.topo_index)
+	{
+		caps.set (nano::node_capabilities::topo_index);
 	}
 	return caps;
 }


### PR DESCRIPTION
Adds the protocol and server-side foundation for topology bootstrap. Client-side topology bootstrap behavior is intentionally left for a follow-up PR.

- Extends ASC pull with:
  - `blocks_random` requests for retrieving blocks by a batch of hashes
  - `topo_index` requests for retrieving topology index ranges
- Validates and serves both request types through the bootstrap server
- Bumps the protocol version to `0x16`
- Advertises topology index support only when the ledger has it enabled
