### PR TITLE
Fix tracking of TCP peer protocol versions

### DIFF
--- a/nano/core_test/bootstrap_peer_pool.cpp
+++ b/nano/core_test/bootstrap_peer_pool.cpp
@@ -1,8 +1,7 @@
 #include <nano/node/bootstrap/bootstrap_config.hpp>
 #include <nano/node/bootstrap/peer_pool.hpp>
-#include <nano/node/transport/channel.hpp>
+#include <nano/node/transport/fake.hpp>
 #include <nano/test_common/system.hpp>
-#include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
 
@@ -15,9 +14,13 @@ class bootstrap_peer_pool : public ::testing::Test
 protected:
 	std::shared_ptr<nano::transport::channel> make_channel (nano::account node_id, nano::node_capabilities_flags capabilities = {})
 	{
-		auto channel = nano::test::fake_channel (system.node (0), node_id);
-		channel->set_flags (capabilities);
-		return channel;
+		auto & node = system.node (0);
+		nano::transport::peer_info const peer{
+			.node_id = node_id,
+			.protocol_version = node.network_params.network.protocol_version,
+			.capabilities = capabilities,
+		};
+		return std::make_shared<nano::transport::fake::channel> (node, peer);
 	}
 
 	nano::test::system system{ 1 };
@@ -113,20 +116,4 @@ TEST_F (bootstrap_peer_pool, probe_release_and_decay)
 	ASSERT_EQ (nano::bootstrap::peer_acquire_status::acquired, pool.acquire ().status);
 	pool.decay ();
 	ASSERT_EQ (nano::bootstrap::peer_probe_status::available, pool.probe ());
-}
-
-TEST_F (bootstrap_peer_pool, update_refreshes_cached_metadata)
-{
-	auto channel = make_channel ({ 1 }, nano::node_capabilities::topo_index);
-	pool.update ({ channel });
-	ASSERT_TRUE (pool.has_candidate (nano::node_capabilities::topo_index));
-
-	channel->set_node_id ({ 2 });
-	channel->set_flags (nano::node_capabilities::vote_storage);
-	pool.update ({ channel });
-
-	ASSERT_FALSE (pool.has_candidate (nano::node_capabilities::topo_index));
-	ASSERT_TRUE (pool.has_candidate (nano::node_capabilities::vote_storage));
-	auto result = pool.acquire (nano::node_capabilities::vote_storage);
-	ASSERT_EQ (nano::account{ 2 }, result.node_id);
 }

--- a/nano/core_test/tcp_listener.cpp
+++ b/nano/core_test/tcp_listener.cpp
@@ -234,7 +234,8 @@ TEST (tcp_listener, timeout_node_id_handshake)
 	ASSERT_TRUE (cookie);
 	nano::messages::node_id_handshake::query_payload query{ *cookie };
 	nano::messages::node_id_handshake node_id_handshake{ nano::dev::network_params.network, query };
-	auto channel = std::make_shared<nano::transport::tcp_channel> (*node0, socket);
+	nano::transport::peer_info const peer{ .protocol_version = node0->network_params.network.protocol_version };
+	auto channel = std::make_shared<nano::transport::tcp_channel> (*node0, socket, peer);
 	socket->async_connect (node0->tcp_listener.endpoint (), [&node_id_handshake, channel] (boost::system::error_code const & ec) {
 		ASSERT_FALSE (ec);
 		channel->send (node_id_handshake, nano::transport::traffic_type::test, [] (boost::system::error_code const & ec, size_t size_a) {

--- a/nano/core_test/tcp_server.cpp
+++ b/nano/core_test/tcp_server.cpp
@@ -39,6 +39,84 @@ TEST (tcp_server, handshake_success)
 }
 
 /*
+ * A TCP channel records the remote protocol version from the handshake
+ */
+TEST (tcp_server, handshake_records_remote_protocol_version)
+{
+	nano::test::system system;
+	auto node = system.add_node ();
+	auto client_socket = std::make_shared<nano::transport::tcp_socket> (*node);
+
+	auto ec = client_socket->blocking_connect (node->network.endpoint ());
+	ASSERT_FALSE (ec);
+	ASSERT_TIMELY_EQ (5s, node->tcp_listener.all_sockets ().size (), 1);
+
+	auto const remote_protocol_version = node->network_params.network.protocol_version_min;
+	ASSERT_LT (remote_protocol_version, node->network_params.network.protocol_version);
+
+	// Begin a normal two-step handshake while advertising an older, still-supported protocol version.
+	nano::messages::node_id_handshake::query_payload initial_query{ nano::random_pool::generate<nano::uint256_union> () };
+	nano::messages::node_id_handshake initial_handshake{ node->network_params.network, initial_query };
+	initial_handshake.header.version_max = remote_protocol_version;
+	initial_handshake.header.version_using = remote_protocol_version;
+	initial_handshake.header.version_min = remote_protocol_version;
+
+	auto initial_buffer = initial_handshake.to_shared_const_buffer ();
+	auto [initial_write_ec, initial_bytes_written] = client_socket->blocking_write (initial_buffer, initial_buffer.size ());
+	ASSERT_FALSE (initial_write_ec);
+	ASSERT_EQ (initial_bytes_written, initial_buffer.size ());
+
+	// Read the node's response and extract its query, which the simulated remote peer must sign.
+	auto response_header_buffer = std::make_shared<std::vector<uint8_t>> (nano::messages::message_header::size);
+	auto [header_read_ec, header_bytes_read] = client_socket->blocking_read (response_header_buffer, response_header_buffer->size ());
+	ASSERT_FALSE (header_read_ec);
+	ASSERT_EQ (header_bytes_read, response_header_buffer->size ());
+
+	bool header_error = false;
+	nano::bufferstream response_header_stream{ response_header_buffer->data (), response_header_buffer->size () };
+	nano::messages::message_header response_header{ header_error, response_header_stream };
+	ASSERT_FALSE (header_error);
+	ASSERT_EQ (response_header.type, nano::messages::message_type::node_id_handshake);
+
+	auto response_payload_buffer = std::make_shared<std::vector<uint8_t>> (response_header.payload_length_bytes ());
+	auto [payload_read_ec, payload_bytes_read] = client_socket->blocking_read (response_payload_buffer, response_payload_buffer->size ());
+	ASSERT_FALSE (payload_read_ec);
+	ASSERT_EQ (payload_bytes_read, response_payload_buffer->size ());
+
+	bool response_error = false;
+	nano::bufferstream response_payload_stream{ response_payload_buffer->data (), response_payload_buffer->size () };
+	nano::messages::node_id_handshake node_handshake{ response_error, response_payload_stream, response_header };
+	ASSERT_FALSE (response_error);
+	ASSERT_TRUE (node_handshake.query);
+
+	nano::keypair remote_node_id;
+	nano::messages::node_id_handshake::response_payload response;
+	response.node_id = remote_node_id.pub;
+	nano::messages::node_id_handshake::response_payload::v3_payload response_v3;
+	response_v3.salt = nano::random_pool::generate<nano::uint256_union> ();
+	response_v3.genesis = node->network_params.ledger.genesis->hash ();
+	response.ext = response_v3;
+	response.sign (node_handshake.query->cookie, remote_node_id);
+
+	nano::messages::node_id_handshake final_handshake{ node->network_params.network, std::nullopt, response };
+	final_handshake.header.version_max = remote_protocol_version;
+	final_handshake.header.version_using = remote_protocol_version;
+	final_handshake.header.version_min = remote_protocol_version;
+
+	auto final_buffer = final_handshake.to_shared_const_buffer ();
+	auto [final_write_ec, final_bytes_written] = client_socket->blocking_write (final_buffer, final_buffer.size ());
+	ASSERT_FALSE (final_write_ec);
+	ASSERT_EQ (final_bytes_written, final_buffer.size ());
+
+	ASSERT_TIMELY (5s, node->network.find_node_id (remote_node_id.pub));
+	auto channel = node->network.find_node_id (remote_node_id.pub);
+	ASSERT_TRUE (channel);
+	ASSERT_EQ (channel->get_network_version (), remote_protocol_version);
+	ASSERT_EQ (node->network.tcp_channels.list (remote_protocol_version).size (), 1);
+	ASSERT_TRUE (node->network.tcp_channels.list (remote_protocol_version + 1).empty ());
+}
+
+/*
  * This test verifies that when a tcp_server receives a malformed handshake message
  * that fails deserialization, it properly aborts the connection instead of continuing
  * processing with an invalid message.

--- a/nano/node/bootstrap/peer_pool.cpp
+++ b/nano/node/bootstrap/peer_pool.cpp
@@ -138,21 +138,12 @@ void peer_pool::update (std::deque<std::shared_ptr<nano::transport::channel>> co
 {
 	auto & by_channel = entries.get<tag_channel> ();
 
-	// Track new channels and refresh the cached identity of known ones
+	// Track new channels
 	for (auto const & channel : channels)
 	{
-		if (auto it = by_channel.find (channel); it != by_channel.end ())
+		if (by_channel.find (channel) == by_channel.end ())
 		{
-			[[maybe_unused]] auto success = by_channel.modify (it, [&channel] (auto & entry) {
-				entry.channel = channel;
-				entry.node_id = channel->get_node_id ();
-				entry.capabilities = channel->get_flags ();
-			});
-			debug_assert (success);
-		}
-		else
-		{
-			by_channel.emplace (channel, channel->get_node_id (), channel->get_flags ());
+			by_channel.emplace (channel, channel->get_peer_info ());
 		}
 	}
 
@@ -229,10 +220,10 @@ nano::stat::detail to_stat_detail (peer_probe_status status)
  * peer_pool::entry
  */
 
-peer_pool::entry::entry (std::shared_ptr<nano::transport::channel> channel_a, nano::account node_id_a, nano::node_capabilities_flags capabilities_a) :
+peer_pool::entry::entry (std::shared_ptr<nano::transport::channel> channel_a, nano::transport::peer_info const & peer) :
 	channel{ std::move (channel_a) },
-	node_id{ node_id_a },
-	capabilities{ capabilities_a }
+	node_id{ peer.node_id },
+	capabilities{ peer.capabilities }
 {
 }
 }

--- a/nano/node/bootstrap/peer_pool.hpp
+++ b/nano/node/bootstrap/peer_pool.hpp
@@ -44,7 +44,8 @@ nano::stat::detail to_stat_detail (peer_probe_status);
  * request concludes. The periodic update () tracks newly connected channels and drops closed ones; the
  * periodic decay () shrinks loads that drift upwards when responses are lost.
  *
- * Peer identity (node id) and capabilities are cached per entry so selection scans avoid locking each channel.
+ * Peer identity (node id) and capabilities are cached from the channel's immutable peer information for
+ * efficient selection scans.
  * Channels are held by shared_ptr and liveness is checked only in update (), so a closed channel may be
  * offered for up to one update interval;
  *
@@ -97,11 +98,11 @@ private: // Dependencies
 private:
 	struct entry
 	{
-		entry (std::shared_ptr<nano::transport::channel>, nano::account, nano::node_capabilities_flags);
+		entry (std::shared_ptr<nano::transport::channel>, nano::transport::peer_info const &);
 
 		std::shared_ptr<nano::transport::channel> channel;
 
-		// Cached so selection scans do not need to lock the channel
+		// Cached from the channel's immutable peer information for selection scans
 		nano::account node_id;
 		nano::node_capabilities_flags capabilities;
 

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3039,15 +3039,15 @@ void nano::json_handler::peers ()
 	{
 		std::stringstream text;
 		auto channel (*i);
+		auto const & peer = channel->get_peer_info ();
 		text << channel->to_string ();
 		if (peer_details)
 		{
 			boost::property_tree::ptree pending_tree;
-			pending_tree.put ("protocol_version", std::to_string (channel->get_network_version ()));
-			auto node_id_l (channel->get_node_id_optional ());
-			if (node_id_l.has_value ())
+			pending_tree.put ("protocol_version", std::to_string (peer.protocol_version));
+			if (!peer.node_id.is_zero ())
 			{
-				pending_tree.put ("node_id", node_id_l.value ().to_node_id ());
+				pending_tree.put ("node_id", peer.node_id.to_node_id ());
 			}
 			else
 			{
@@ -3061,7 +3061,7 @@ void nano::json_handler::peers ()
 
 			// Capabilities (extensions) the peer advertised during the node id handshake
 			boost::property_tree::ptree capabilities_l;
-			for (auto const & capability : nano::to_string_list (channel->get_flags ()))
+			for (auto const & capability : nano::to_string_list (peer.capabilities))
 			{
 				boost::property_tree::ptree entry;
 				entry.put ("", capability);
@@ -3073,7 +3073,7 @@ void nano::json_handler::peers ()
 		}
 		else
 		{
-			peers_l.push_back (boost::property_tree::ptree::value_type (text.str (), boost::property_tree::ptree (std::to_string (channel->get_network_version ()))));
+			peers_l.push_back (boost::property_tree::ptree::value_type (text.str (), boost::property_tree::ptree (std::to_string (peer.protocol_version))));
 		}
 	}
 	response_l.add_child ("peers", peers_l);

--- a/nano/node/transport/channel.cpp
+++ b/nano/node/transport/channel.cpp
@@ -7,16 +7,15 @@
 #include <nano/secure/network_params.hpp>
 
 nano::transport::channel::channel (nano::node & node_a) :
-	node{ node_a },
-	network_version{ node_a.network_params.network.protocol_version }
+	channel{ node_a, nano::transport::peer_info{
+					 .protocol_version = node_a.network_params.network.protocol_version,
+					 } }
 {
 }
 
-nano::transport::channel::channel (nano::node & node_a, nano::transport::peer_info const & peer) :
+nano::transport::channel::channel (nano::node & node_a, nano::transport::peer_info const & peer_a) :
 	node{ node_a },
-	node_id{ peer.node_id },
-	network_version{ peer.protocol_version },
-	flags{ peer.capabilities }
+	peer{ peer_a }
 {
 }
 

--- a/nano/node/transport/channel.cpp
+++ b/nano/node/transport/channel.cpp
@@ -7,9 +7,17 @@
 #include <nano/secure/network_params.hpp>
 
 nano::transport::channel::channel (nano::node & node_a) :
-	node{ node_a }
+	node{ node_a },
+	network_version{ node_a.network_params.network.protocol_version }
 {
-	set_network_version (node_a.network_params.network.protocol_version);
+}
+
+nano::transport::channel::channel (nano::node & node_a, nano::transport::peer_info const & peer) :
+	node{ node_a },
+	node_id{ peer.node_id },
+	network_version{ peer.protocol_version },
+	flags{ peer.capabilities }
+{
 }
 
 bool nano::transport::channel::send (nano::messages::message const & message, nano::transport::traffic_type traffic_type, callback_t callback)

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -22,6 +22,13 @@ enum class transport_type : uint8_t
 	fake = 3
 };
 
+struct peer_info final
+{
+	nano::account node_id;
+	uint8_t protocol_version{ 0 };
+	nano::node_capabilities_flags capabilities;
+};
+
 class channel
 {
 public:

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -24,9 +24,9 @@ enum class transport_type : uint8_t
 
 struct peer_info final
 {
-	nano::account node_id;
+	nano::account node_id{};
 	uint8_t protocol_version{ 0 };
-	nano::node_capabilities_flags capabilities;
+	nano::node_capabilities_flags capabilities{};
 };
 
 class channel
@@ -95,38 +95,30 @@ public:
 
 	std::optional<nano::account> get_node_id_optional () const
 	{
-		nano::lock_guard<nano::mutex> lock{ mutex };
-		return node_id;
+		if (peer.node_id.is_zero ())
+		{
+			return std::nullopt;
+		}
+		return peer.node_id;
 	}
 	nano::account get_node_id () const
 	{
-		nano::lock_guard<nano::mutex> lock{ mutex };
-		return node_id.value_or (0);
-	}
-	void set_node_id (nano::account node_id_a)
-	{
-		nano::lock_guard<nano::mutex> lock{ mutex };
-		node_id = node_id_a;
+		return peer.node_id;
 	}
 
 	uint8_t get_network_version () const
 	{
-		return network_version;
-	}
-	void set_network_version (uint8_t network_version_a)
-	{
-		network_version = network_version_a;
+		return peer.protocol_version;
 	}
 
 	nano::node_capabilities_flags get_flags () const
 	{
-		nano::lock_guard<nano::mutex> lock{ mutex };
-		return flags;
+		return peer.capabilities;
 	}
-	void set_flags (nano::node_capabilities_flags value)
+
+	nano::transport::peer_info const & get_peer_info () const noexcept
 	{
-		nano::lock_guard<nano::mutex> lock{ mutex };
-		flags = value;
+		return peer;
 	}
 
 	bool serves_ledger () const
@@ -153,9 +145,7 @@ private:
 	std::chrono::steady_clock::time_point last_bootstrap_attempt{ std::chrono::steady_clock::time_point () };
 	std::chrono::steady_clock::time_point last_packet_received{ std::chrono::steady_clock::now () };
 	std::chrono::steady_clock::time_point last_packet_sent{ std::chrono::steady_clock::now () };
-	std::optional<nano::account> node_id{};
-	std::atomic<uint8_t> network_version{ 0 };
-	nano::node_capabilities_flags flags;
+	nano::transport::peer_info const peer;
 	std::optional<nano::endpoint> peering_endpoint{};
 	std::optional<nano::messages::keepalive> last_keepalive{};
 

--- a/nano/node/transport/channel.hpp
+++ b/nano/node/transport/channel.hpp
@@ -36,6 +36,7 @@ public:
 
 public:
 	explicit channel (nano::node &);
+	channel (nano::node &, nano::transport::peer_info const &);
 	virtual ~channel () = default;
 
 	/// @returns true if the message was sent (or queued to be sent), false if it was immediately dropped

--- a/nano/node/transport/fake.cpp
+++ b/nano/node/transport/fake.cpp
@@ -7,11 +7,17 @@
 #include <boost/format.hpp>
 
 nano::transport::fake::channel::channel (nano::node & node) :
-	transport::channel{ node },
+	channel{ node, nano::transport::peer_info{
+				   .node_id = node.get_node_id (),
+				   .protocol_version = node.network_params.network.protocol_version,
+				   } }
+{
+}
+
+nano::transport::fake::channel::channel (nano::node & node, nano::transport::peer_info const & peer) :
+	transport::channel{ node, peer },
 	endpoint{ node.network.endpoint () }
 {
-	set_node_id (node.get_node_id ());
-	set_network_version (node.network_params.network.protocol_version);
 }
 
 /**

--- a/nano/node/transport/fake.hpp
+++ b/nano/node/transport/fake.hpp
@@ -8,7 +8,7 @@ namespace nano
 namespace transport
 {
 	/**
-	 * Fake channel that connects to nothing and allows its attributes to be manipulated. Mostly useful for unit tests.
+	 * Fake channel that connects to nothing. Mostly useful for unit tests.
 	 **/
 	namespace fake
 	{
@@ -16,6 +16,7 @@ namespace transport
 		{
 		public:
 			explicit channel (nano::node &);
+			channel (nano::node &, nano::transport::peer_info const &);
 
 			std::string to_string () const override;
 

--- a/nano/node/transport/fwd.hpp
+++ b/nano/node/transport/fwd.hpp
@@ -5,6 +5,7 @@ namespace nano::transport
 class channel;
 class loopback_channel;
 class message_deserializer;
+struct peer_info;
 
 class tcp_config;
 class tcp_channel;

--- a/nano/node/transport/inproc.cpp
+++ b/nano/node/transport/inproc.cpp
@@ -8,12 +8,12 @@
 #include <boost/format.hpp>
 
 nano::transport::inproc::channel::channel (nano::node & node, nano::node & destination) :
-	transport::channel{ node },
-	destination{ destination },
-	endpoint{ node.network.endpoint () }
+	transport::channel{ node, nano::transport::peer_info{
+							  .node_id = node.get_node_id (),
+							  .protocol_version = node.network_params.network.protocol_version,
+							  } },
+	destination{ destination }, endpoint{ node.network.endpoint () }
 {
-	set_node_id (node.get_node_id ());
-	set_network_version (node.network_params.network.protocol_version);
 }
 
 /**

--- a/nano/node/transport/loopback.cpp
+++ b/nano/node/transport/loopback.cpp
@@ -8,11 +8,12 @@
 #include <boost/format.hpp>
 
 nano::transport::loopback_channel::loopback_channel (nano::node & node) :
-	transport::channel{ node },
+	transport::channel{ node, nano::transport::peer_info{
+							  .node_id = node.get_node_id (),
+							  .protocol_version = node.network_params.network.protocol_version,
+							  } },
 	endpoint{ node.network.endpoint () }
 {
-	set_node_id (node.get_node_id ());
-	set_network_version (node.network_params.network.protocol_version);
 }
 
 bool nano::transport::loopback_channel::send_impl (nano::messages::message const & message, nano::transport::traffic_type traffic_type, nano::transport::channel::callback_t callback)

--- a/nano/node/transport/tcp_channel.cpp
+++ b/nano/node/transport/tcp_channel.cpp
@@ -12,8 +12,8 @@
  * tcp_channel
  */
 
-nano::transport::tcp_channel::tcp_channel (nano::node & node_a, std::shared_ptr<nano::transport::tcp_socket> socket_a) :
-	channel (node_a),
+nano::transport::tcp_channel::tcp_channel (nano::node & node_a, std::shared_ptr<nano::transport::tcp_socket> socket_a, nano::transport::peer_info const & peer) :
+	channel{ node_a, peer },
 	socket{ socket_a },
 	strand{ node_a.io_ctx.get_executor () },
 	sending_task{ strand }

--- a/nano/node/transport/tcp_channel.hpp
+++ b/nano/node/transport/tcp_channel.hpp
@@ -45,7 +45,7 @@ private:
 class tcp_channel final : public nano::transport::channel, public std::enable_shared_from_this<tcp_channel>
 {
 public:
-	tcp_channel (nano::node &, std::shared_ptr<nano::transport::tcp_socket>);
+	tcp_channel (nano::node &, std::shared_ptr<nano::transport::tcp_socket>, nano::transport::peer_info const &);
 	~tcp_channel () override;
 
 	void close () override;

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -128,10 +128,7 @@ auto nano::transport::tcp_channels::create (const std::shared_ptr<nano::transpor
 	nano::log::as_node_id (peer.node_id));
 
 	// This should be the only place in node where channels are created
-	auto channel = std::make_shared<nano::transport::tcp_channel> (node, socket);
-	channel->set_node_id (peer.node_id);
-	channel->set_network_version (peer.protocol_version);
-	channel->set_flags (peer.capabilities);
+	auto channel = std::make_shared<nano::transport::tcp_channel> (node, socket, peer);
 
 	attempts.get<endpoint_tag> ().erase (endpoint);
 

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -99,7 +99,7 @@ auto nano::transport::tcp_channels::check (const nano::tcp_endpoint & endpoint, 
 	return channel_result::accepted;
 }
 
-auto nano::transport::tcp_channels::create (const std::shared_ptr<nano::transport::tcp_socket> & socket, const std::shared_ptr<nano::transport::tcp_server> & server, const nano::account & node_id, nano::node_capabilities_flags flags) -> create_result
+auto nano::transport::tcp_channels::create (const std::shared_ptr<nano::transport::tcp_socket> & socket, const std::shared_ptr<nano::transport::tcp_server> & server, const nano::transport::peer_info & peer) -> create_result
 {
 	auto const endpoint = socket->get_remote_endpoint ();
 	debug_assert (endpoint.address ().is_v6 ());
@@ -111,11 +111,11 @@ auto nano::transport::tcp_channels::create (const std::shared_ptr<nano::transpor
 		return { channel_result::rejected, nullptr };
 	}
 
-	auto const check_result = check (endpoint, node_id);
+	auto const check_result = check (endpoint, peer.node_id);
 	if (check_result != channel_result::accepted)
 	{
 		node.stats.inc (nano::stat::type::tcp_channels, nano::stat::detail::channel_rejected);
-		node.logger.debug (nano::log::type::tcp_channels, "Rejected channel: {} ({})", endpoint, nano::log::as_node_id (node_id));
+		node.logger.debug (nano::log::type::tcp_channels, "Rejected channel: {} ({})", endpoint, nano::log::as_node_id (peer.node_id));
 		// Rejection reason should be logged earlier
 
 		return { check_result, nullptr };
@@ -125,12 +125,13 @@ auto nano::transport::tcp_channels::create (const std::shared_ptr<nano::transpor
 	node.logger.debug (nano::log::type::tcp_channels, "Accepted channel: {} ({}) ({})",
 	socket->get_remote_endpoint (),
 	socket->get_endpoint_type (),
-	nano::log::as_node_id (node_id));
+	nano::log::as_node_id (peer.node_id));
 
 	// This should be the only place in node where channels are created
 	auto channel = std::make_shared<nano::transport::tcp_channel> (node, socket);
-	channel->set_node_id (node_id);
-	channel->set_flags (flags);
+	channel->set_node_id (peer.node_id);
+	channel->set_network_version (peer.protocol_version);
+	channel->set_flags (peer.capabilities);
 
 	attempts.get<endpoint_tag> ().erase (endpoint);
 

--- a/nano/node/transport/tcp_channels.hpp
+++ b/nano/node/transport/tcp_channels.hpp
@@ -53,7 +53,7 @@ public:
 		std::shared_ptr<nano::transport::tcp_channel> channel;
 	};
 
-	create_result create (std::shared_ptr<nano::transport::tcp_socket> const &, std::shared_ptr<nano::transport::tcp_server> const &, nano::account const & node_id, nano::node_capabilities_flags = {});
+	create_result create (std::shared_ptr<nano::transport::tcp_socket> const &, std::shared_ptr<nano::transport::tcp_server> const &, nano::transport::peer_info const &);
 
 	void erase (nano::tcp_endpoint const &);
 	std::size_t size () const;

--- a/nano/node/transport/tcp_server.cpp
+++ b/nano/node/transport/tcp_server.cpp
@@ -357,7 +357,12 @@ auto nano::transport::tcp_server::process_handshake (nano::messages::node_id_han
 	{
 		if (node.network.verify_handshake_response (*message.response, get_remote_endpoint ()))
 		{
-			bool success = to_realtime_connection (message.response->node_id, message.response->flags ());
+			nano::transport::peer_info const peer{
+				.node_id = message.response->node_id,
+				.protocol_version = message.header.version_using,
+				.capabilities = message.response->flags (),
+			};
+			bool success = to_realtime_connection (peer);
 			if (success)
 			{
 				co_return handshake_status::realtime; // Switched to realtime
@@ -508,7 +513,7 @@ bool nano::transport::tcp_server::to_bootstrap_connection ()
 	return true;
 }
 
-bool nano::transport::tcp_server::to_realtime_connection (nano::account const & node_id, nano::node_capabilities_flags flags)
+bool nano::transport::tcp_server::to_realtime_connection (nano::transport::peer_info const & peer)
 {
 	if (node.flags.disable_tcp_realtime)
 	{
@@ -519,7 +524,7 @@ bool nano::transport::tcp_server::to_realtime_connection (nano::account const & 
 		return false;
 	}
 
-	auto create_result = node.network.tcp_channels.create (socket, shared_from_this (), node_id, flags);
+	auto create_result = node.network.tcp_channels.create (socket, shared_from_this (), peer);
 	if (!create_result.channel)
 	{
 		return false;

--- a/nano/node/transport/tcp_server.hpp
+++ b/nano/node/transport/tcp_server.hpp
@@ -77,7 +77,7 @@ private:
 
 private:
 	bool to_bootstrap_connection ();
-	bool to_realtime_connection (nano::account const & node_id, nano::node_capabilities_flags flags);
+	bool to_realtime_connection (nano::transport::peer_info const &);
 
 private: // Visitors
 	class realtime_message_visitor : public nano::messages::message_visitor

--- a/nano/test_common/testutil.cpp
+++ b/nano/test_common/testutil.cpp
@@ -236,22 +236,20 @@ std::vector<std::shared_ptr<nano::block>> nano::test::clone (std::vector<std::sh
 
 std::shared_ptr<nano::transport::channel> nano::test::fake_channel (nano::node & node, nano::account node_id)
 {
-	auto channel = std::make_shared<nano::transport::fake::channel> (node);
-	if (!node_id.is_zero ())
-	{
-		channel->set_node_id (node_id);
-	}
-	return channel;
+	nano::transport::peer_info const peer{
+		.node_id = node_id.is_zero () ? node.get_node_id () : node_id,
+		.protocol_version = node.network_params.network.protocol_version,
+	};
+	return std::make_shared<nano::transport::fake::channel> (node, peer);
 }
 
 std::shared_ptr<nano::transport::test_channel> nano::test::test_channel (nano::node & node, nano::account node_id)
 {
-	auto channel = std::make_shared<nano::transport::test_channel> (node);
-	if (!node_id.is_zero ())
-	{
-		channel->set_node_id (node_id);
-	}
-	return channel;
+	nano::transport::peer_info const peer{
+		.node_id = node_id,
+		.protocol_version = node.network_params.network.protocol_version,
+	};
+	return std::make_shared<nano::transport::test_channel> (node, peer);
 }
 
 std::shared_ptr<nano::election> nano::test::start_election (nano::test::system & system, nano::node & node, const nano::block_hash & hash)


### PR DESCRIPTION
Peer protocol versions were incorrectly initialized using the local node’s protocol version. This caused peers to appear as if they supported the latest protocol even when their handshake advertised an older version.

This change:

- captures the remote protocol version from the verified node ID handshake
- groups the remote node ID, protocol version, and capabilities in `peer_info`
- passes `peer_info` into the TCP channel constructor
- initializes channel metadata atomically during construction
- adds regression coverage using peers with different protocol versions