### PR TITLE
Refine crawler navigation API

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1440,9 +1440,9 @@ TEST (block_store, topology_view_iteration_ordered_by_topo_height)
 	ASSERT_EQ (nano::block_hash{ 30 }, seek_height->first.hash);
 }
 
-// The topology crawler resolves skip_to by full (topo_height, hash) order, landing on the first key >= target,
-// so precheck can test exact membership via full_key (). Queries must be issued in ascending order (forward-only).
-TEST (block_store, topology_view_crawl_skip_to)
+// The topology crawler resolves find () by full (topo_height, hash) order, matching only an exact key
+// and parking on the first key >= target, so precheck can test exact membership. Queries must be issued in ascending order (forward-only).
+TEST (block_store, topology_view_crawl_find)
 {
 	auto store = nano::test::make_store ();
 	{
@@ -1456,20 +1456,23 @@ TEST (block_store, topology_view_crawl_skip_to)
 	auto txn = store->tx_begin_read ();
 	auto crawler = store->topology.crawl (txn);
 
-	// Exact match lands on the requested key
-	ASSERT_TRUE (crawler.skip_to ({ 1, nano::block_hash{ 100 } }));
-	ASSERT_EQ (nano::topo_key (1, nano::block_hash{ 100 }), crawler.full_key ());
+	// Exact match returns the requested key
+	auto const * found = crawler.find ({ 1, nano::block_hash{ 100 } });
+	ASSERT_NE (found, nullptr);
+	ASSERT_EQ (nano::topo_key (1, nano::block_hash{ 100 }), found->first);
 
 	// Same height, larger hash resolves by full-key order (not by topo_height alone)
-	ASSERT_TRUE (crawler.skip_to ({ 1, nano::block_hash{ 200 } }));
-	ASSERT_EQ (nano::topo_key (1, nano::block_hash{ 200 }), crawler.full_key ());
+	found = crawler.find ({ 1, nano::block_hash{ 200 } });
+	ASSERT_NE (found, nullptr);
+	ASSERT_EQ (nano::topo_key (1, nano::block_hash{ 200 }), found->first);
 
-	// A missing key lands on the next present key >= target
-	ASSERT_TRUE (crawler.skip_to ({ 1, nano::block_hash{ 250 } }));
-	ASSERT_EQ (nano::topo_key (2, nano::block_hash{ 50 }), crawler.full_key ());
+	// A missing key is not found, and parks the crawler on the next present key >= target
+	ASSERT_EQ (crawler.find ({ 1, nano::block_hash{ 250 } }), nullptr);
+	ASSERT_EQ (nano::topo_key (2, nano::block_hash{ 50 }), crawler.key ());
 
-	// Skipping past the last key reports exhaustion
-	ASSERT_FALSE (crawler.skip_to ({ 9, nano::block_hash{ 0 } }));
+	// A key past the last present one is not found and exhausts the crawler
+	ASSERT_EQ (crawler.find ({ 9, nano::block_hash{ 0 } }), nullptr);
+	ASSERT_FALSE (crawler);
 }
 
 // Mirrors precheck: a single forward crawl tests a sorted query list for membership, including a band
@@ -1505,7 +1508,7 @@ TEST (block_store, topology_view_crawl_membership_scan)
 	auto crawler = store->topology.crawl (txn, queries.front ().first);
 	for (auto const & [key, present] : queries)
 	{
-		bool const found = crawler.skip_to (key) && crawler.full_key () == key;
+		bool const found = crawler.find (key) != nullptr;
 		ASSERT_EQ (present, found) << "topo_height=" << key.topo_height << " hash=" << key.hash.to_string ();
 	}
 }

--- a/nano/core_test/crawler.cpp
+++ b/nano/core_test/crawler.cpp
@@ -12,13 +12,14 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
 #include <limits>
 #include <unordered_set>
 #include <vector>
 
 namespace
 {
-// Get sequential_attempts threshold from crawler traits
+// Get sequential_attempts threshold from crawler
 constexpr size_t sequential_threshold = nano::store::crawler<nano::store::ledger::account_view, nano::store::read_transaction>::sequential_attempts;
 
 // Helper to populate accounts with given keys
@@ -45,6 +46,10 @@ void populate_pending (nano::store::ledger_store & store, std::vector<std::pair<
 }
 }
 
+/*
+ * Construction & validity
+ */
+
 TEST (crawler, construct_with_data)
 {
 	auto store = nano::test::make_store ();
@@ -69,7 +74,6 @@ TEST (crawler, construct_at_exact_key)
 
 	ASSERT_TRUE (crawler);
 	ASSERT_EQ (crawler.key (), nano::account{ 20 });
-	ASSERT_EQ (crawler->first, nano::account{ 20 });
 }
 
 TEST (crawler, construct_between_keys)
@@ -86,6 +90,18 @@ TEST (crawler, construct_between_keys)
 	ASSERT_EQ (crawler.key (), nano::account{ 30 });
 }
 
+TEST (crawler, construct_beyond_range)
+{
+	auto store = nano::test::make_store ();
+
+	populate_accounts (*store, { 10, 20 });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn, nano::account{ std::numeric_limits<nano::uint256_t>::max () });
+
+	ASSERT_FALSE (crawler);
+}
+
 TEST (crawler, empty_db)
 {
 	auto store = nano::test::make_store ();
@@ -97,14 +113,16 @@ TEST (crawler, empty_db)
 	ASSERT_FALSE (crawler);
 
 	// Operations on invalid crawler should be safe
-	ASSERT_FALSE (crawler.next ());
-	ASSERT_FALSE (crawler.skip_to (nano::account{ 100 }));
-	ASSERT_FALSE (crawler);
-
-	// Seek should keep it invalid (no data to find)
-	crawler.seek (nano::account{ 50 });
+	ASSERT_FALSE (crawler.next_entry ());
+	ASSERT_FALSE (crawler.next_group ());
+	ASSERT_EQ (crawler.find (nano::account{ 100 }), nullptr);
+	ASSERT_EQ (crawler.find_group (nano::account{ 100 }), nullptr);
 	ASSERT_FALSE (crawler);
 }
+
+/*
+ * Access
+ */
 
 TEST (crawler, dereference_operators)
 {
@@ -137,69 +155,38 @@ TEST (crawler, dereference_operators)
 	ASSERT_EQ (crawler->second.balance, nano::amount{ 1000 });
 }
 
+TEST (crawler, key_simple)
+{
+	auto store = nano::test::make_store ();
+
+	populate_accounts (*store, { 42 });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn);
+
+	// For simple keys the full key and the group key coincide
+	ASSERT_EQ (crawler.key (), nano::account{ 42 });
+	ASSERT_EQ (crawler.group_key (), nano::account{ 42 });
+}
+
+TEST (crawler, key_compound)
+{
+	auto store = nano::test::make_store ();
+
+	populate_pending (*store, { { 5, { 7 } } });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->pending.crawl (txn);
+
+	// key() returns the full compound key, group_key() only the account prefix
+	ASSERT_EQ (crawler.key ().account, nano::account{ 5 });
+	ASSERT_EQ (crawler.key ().hash, nano::block_hash{ 7 });
+	ASSERT_EQ (crawler.group_key (), nano::account{ 5 });
+}
+
 /*
- * Navigation Operations - seek, next, skip_to, reset
+ * Entry advancement
  */
-
-TEST (crawler, seek_forward)
-{
-	auto store = nano::test::make_store ();
-
-	populate_accounts (*store, { 10, 20, 30, 40, 50 });
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn, nano::account{ 10 });
-
-	ASSERT_EQ (crawler.key (), nano::account{ 10 });
-
-	crawler.seek (nano::account{ 30 });
-	ASSERT_TRUE (crawler);
-	ASSERT_EQ (crawler.key (), nano::account{ 30 });
-
-	// Seek to non-existing key should find next
-	crawler.seek (nano::account{ 35 });
-	ASSERT_TRUE (crawler);
-	ASSERT_EQ (crawler.key (), nano::account{ 40 });
-}
-
-TEST (crawler, seek_backward)
-{
-	auto store = nano::test::make_store ();
-
-	populate_accounts (*store, { 10, 20, 30 });
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn, nano::account{ 30 });
-
-	ASSERT_EQ (crawler.key (), nano::account{ 30 });
-
-	crawler.seek (nano::account{ 10 });
-	ASSERT_TRUE (crawler);
-	ASSERT_EQ (crawler.key (), nano::account{ 10 });
-}
-
-TEST (crawler, beyond_range)
-{
-	auto store = nano::test::make_store ();
-
-	populate_accounts (*store, { 10, 20 });
-
-	auto txn = store->tx_begin_read ();
-
-	// Construct beyond all keys
-	auto crawler1 = store->account.crawl (txn, nano::account{ std::numeric_limits<nano::uint256_t>::max () });
-	ASSERT_FALSE (crawler1);
-
-	// Seek beyond range
-	auto crawler2 = store->account.crawl (txn);
-	crawler2.seek (nano::account{ 100 });
-	ASSERT_FALSE (crawler2);
-
-	// skip_to beyond range
-	auto crawler3 = store->account.crawl (txn);
-	ASSERT_FALSE (crawler3.skip_to (nano::account{ 100 }));
-	ASSERT_FALSE (crawler3);
-}
 
 TEST (crawler, operator_increment)
 {
@@ -218,35 +205,257 @@ TEST (crawler, operator_increment)
 
 	++crawler;
 	ASSERT_EQ (crawler.key (), nano::account{ 30 });
+
+	++crawler;
+	ASSERT_FALSE (crawler);
 }
 
-TEST (crawler, skip_to_exact_match)
+TEST (crawler, next_entry_returns_validity)
+{
+	auto store = nano::test::make_store ();
+
+	populate_accounts (*store, { 10, 20 });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn);
+
+	ASSERT_TRUE (crawler.next_entry ());
+	ASSERT_EQ (crawler.key (), nano::account{ 20 });
+
+	ASSERT_FALSE (crawler.next_entry ());
+	ASSERT_FALSE (crawler);
+}
+
+TEST (crawler, entry_iteration_within_group)
+{
+	auto store = nano::test::make_store ();
+
+	populate_pending (*store, {
+							  { 1, { 10, 20 } },
+							  { 2, { 30 } },
+							  });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->pending.crawl (txn);
+
+	// operator++ advances one raw entry, visiting every entry of a group
+	ASSERT_EQ (crawler.key ().account, nano::account{ 1 });
+	ASSERT_EQ (crawler.key ().hash, nano::block_hash{ 10 });
+
+	++crawler;
+	ASSERT_EQ (crawler.key ().account, nano::account{ 1 });
+	ASSERT_EQ (crawler.key ().hash, nano::block_hash{ 20 });
+
+	++crawler;
+	ASSERT_EQ (crawler.key ().account, nano::account{ 2 });
+	ASSERT_EQ (crawler.key ().hash, nano::block_hash{ 30 });
+
+	++crawler;
+	ASSERT_FALSE (crawler);
+}
+
+TEST (crawler, iteration_order_ascending)
+{
+	auto store = nano::test::make_store ();
+
+	// Insert in non-sorted order
+	populate_accounts (*store, { 50, 10, 30, 20, 40 });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn);
+
+	std::vector<nano::uint256_t> order;
+	for (; crawler; ++crawler)
+	{
+		order.push_back (crawler.key ().number ());
+	}
+
+	ASSERT_EQ (order, (std::vector<nano::uint256_t>{ 10, 20, 30, 40, 50 }));
+}
+
+/*
+ * Group advancement
+ */
+
+TEST (crawler, next_group_simple)
 {
 	auto store = nano::test::make_store ();
 
 	populate_accounts (*store, { 10, 20, 30 });
 
 	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn, nano::account{ 10 });
+	auto crawler = store->account.crawl (txn);
 
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 20 }));
+	// For simple keys every entry is its own group
+	ASSERT_TRUE (crawler.next_group ());
 	ASSERT_EQ (crawler.key (), nano::account{ 20 });
+
+	ASSERT_TRUE (crawler.next_group ());
+	ASSERT_EQ (crawler.key (), nano::account{ 30 });
+
+	ASSERT_FALSE (crawler.next_group ());
+	ASSERT_FALSE (crawler);
 }
 
-TEST (crawler, skip_to_next_available)
+TEST (crawler, next_group_compound)
 {
 	auto store = nano::test::make_store ();
 
-	populate_accounts (*store, { 10, 30 });
+	// Account 1: 3 pending entries
+	// Account 2: 2 pending entries
+	// Account 3: 1 pending entry
+	populate_pending (*store, {
+							  { 1, { 10, 20, 30 } },
+							  { 2, { 10, 20 } },
+							  { 3, { 10 } },
+							  });
 
 	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn, nano::account{ 10 });
+	auto crawler = store->pending.crawl (txn);
 
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 15 }));
-	ASSERT_EQ (crawler.key (), nano::account{ 30 });
+	ASSERT_EQ (crawler.group_key (), nano::account{ 1 });
+
+	// next_group() should skip to account 2, not to the next entry of account 1
+	ASSERT_TRUE (crawler.next_group ());
+	ASSERT_EQ (crawler.group_key (), nano::account{ 2 });
+
+	ASSERT_TRUE (crawler.next_group ());
+	ASSERT_EQ (crawler.group_key (), nano::account{ 3 });
+
+	ASSERT_FALSE (crawler.next_group ());
+	ASSERT_FALSE (crawler);
 }
 
-TEST (crawler, rewind_to_beginning)
+TEST (crawler, next_group_seek_fallback)
+{
+	auto store = nano::test::make_store ();
+
+	// Account 1 with more entries than sequential_threshold to trigger seek fallback
+	std::vector<nano::uint256_t> hashes;
+	for (size_t i = 1; i <= sequential_threshold + 1; ++i)
+	{
+		hashes.push_back (i);
+	}
+	populate_pending (*store, {
+							  { 1, hashes },
+							  { 2, { 1 } },
+							  });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->pending.crawl (txn);
+
+	ASSERT_EQ (crawler.group_key (), nano::account{ 1 });
+
+	// next_group() exhausts the sequential window and falls back to seek
+	ASSERT_TRUE (crawler.next_group ());
+	ASSERT_EQ (crawler.group_key (), nano::account{ 2 });
+
+	ASSERT_FALSE (crawler.next_group ());
+}
+
+TEST (crawler, next_group_saturation)
+{
+	auto store = nano::test::make_store ();
+
+	auto max_val = std::numeric_limits<nano::uint256_t>::max ();
+
+	// More entries than sequential_threshold at the max account
+	// This forces next_group() to exhaust sequential iteration and hit the saturation check
+	{
+		auto txn = store->tx_begin_write ();
+		for (size_t i = 1; i <= sequential_threshold + 1; ++i)
+		{
+			store->pending.put (txn,
+			nano::pending_key{ nano::account{ max_val }, nano::block_hash{ i } },
+			nano::pending_info{});
+		}
+	}
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->pending.crawl (txn, nano::account{ max_val });
+
+	ASSERT_TRUE (crawler);
+	ASSERT_EQ (crawler.group_key ().number (), max_val);
+
+	// No group past the max account is possible, saturation must move to end
+	ASSERT_FALSE (crawler.next_group ());
+	ASSERT_FALSE (crawler);
+}
+
+/*
+ * find & find_group - forward-only probing
+ */
+
+TEST (crawler, find_exact)
+{
+	auto store = nano::test::make_store ();
+
+	populate_accounts (*store, { 10, 20, 30 });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn);
+
+	auto const * found = crawler.find (nano::account{ 20 });
+	ASSERT_NE (found, nullptr);
+	ASSERT_EQ (found->first, nano::account{ 20 });
+	ASSERT_EQ (crawler.key (), nano::account{ 20 }); // Crawler parked on the match
+}
+
+TEST (crawler, find_current)
+{
+	auto store = nano::test::make_store ();
+
+	populate_accounts (*store, { 10, 20 });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn);
+
+	// Probing the current entry matches without moving
+	auto const * found = crawler.find (nano::account{ 10 });
+	ASSERT_NE (found, nullptr);
+	ASSERT_EQ (found->first, nano::account{ 10 });
+}
+
+TEST (crawler, find_miss_parks_ahead)
+{
+	auto store = nano::test::make_store ();
+
+	// Large gaps between keys
+	populate_accounts (*store, { 1, 1000, 1000000 });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn);
+
+	// A miss leaves the crawler at the first entry past the target
+	ASSERT_EQ (crawler.find (nano::account{ 500 }), nullptr);
+	ASSERT_TRUE (crawler);
+	ASSERT_EQ (crawler.key (), nano::account{ 1000 });
+
+	// The parked entry is still findable
+	ASSERT_NE (crawler.find (nano::account{ 1000 }), nullptr);
+
+	ASSERT_EQ (crawler.find (nano::account{ 500000 }), nullptr);
+	ASSERT_EQ (crawler.key (), nano::account{ 1000000 });
+}
+
+TEST (crawler, find_miss_past_end)
+{
+	auto store = nano::test::make_store ();
+
+	populate_accounts (*store, { 10, 20 });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn);
+
+	ASSERT_EQ (crawler.find (nano::account{ 100 }), nullptr);
+	ASSERT_FALSE (crawler);
+
+	// Probing an exhausted crawler stays safe
+	ASSERT_EQ (crawler.find (nano::account{ 200 }), nullptr);
+	ASSERT_FALSE (crawler);
+}
+
+TEST (crawler, find_backward_target)
 {
 	auto store = nano::test::make_store ();
 
@@ -255,43 +464,174 @@ TEST (crawler, rewind_to_beginning)
 	auto txn = store->tx_begin_read ();
 	auto crawler = store->account.crawl (txn, nano::account{ 30 });
 
-	ASSERT_EQ (crawler.key (), nano::account{ 30 });
+	// Probes are forward-only: entries behind the crawler are never found
+	ASSERT_EQ (crawler.find (nano::account{ 10 }), nullptr);
+	ASSERT_EQ (crawler.key (), nano::account{ 30 }); // Crawler did not move
 
-	crawler.rewind ();
-	ASSERT_TRUE (crawler);
-	ASSERT_EQ (crawler.key (), nano::account{ 10 });
+	ASSERT_NE (crawler.find (nano::account{ 30 }), nullptr);
 }
 
-/*
- * Edge Cases
- */
-
-TEST (crawler, single_element)
+TEST (crawler, find_compound)
 {
 	auto store = nano::test::make_store ();
 
-	populate_accounts (*store, { 42 });
+	populate_pending (*store, {
+							  { 10, { 1, 2, 3 } },
+							  { 20, { 1 } },
+							  });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->pending.crawl (txn);
+
+	// Full-key probe can target an entry in the middle of a group
+	auto const * found = crawler.find (nano::pending_key{ nano::account{ 10 }, nano::block_hash{ 2 } });
+	ASSERT_NE (found, nullptr);
+	ASSERT_EQ (found->first.account, nano::account{ 10 });
+	ASSERT_EQ (found->first.hash, nano::block_hash{ 2 });
+
+	// A miss parks at the first entry past the target, here the next group
+	ASSERT_EQ (crawler.find (nano::pending_key{ nano::account{ 10 }, nano::block_hash{ 4 } }), nullptr);
+	ASSERT_EQ (crawler.key ().account, nano::account{ 20 });
+	ASSERT_EQ (crawler.key ().hash, nano::block_hash{ 1 });
+}
+
+TEST (crawler, find_group_compound)
+{
+	auto store = nano::test::make_store ();
+
+	populate_pending (*store, {
+							  { 10, { 1, 2, 3 } },
+							  { 20, { 1 } },
+							  { 30, { 1 } },
+							  });
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->pending.crawl (txn);
+
+	// A group hit returns the first entry of the group
+	auto const * found = crawler.find_group (nano::account{ 20 });
+	ASSERT_NE (found, nullptr);
+	ASSERT_EQ (found->first.account, nano::account{ 20 });
+	ASSERT_EQ (found->first.hash, nano::block_hash{ 1 });
+
+	// A miss parks at the next group
+	ASSERT_EQ (crawler.find_group (nano::account{ 25 }), nullptr);
+	ASSERT_EQ (crawler.group_key (), nano::account{ 30 });
+}
+
+TEST (crawler, find_group_simple)
+{
+	auto store = nano::test::make_store ();
+
+	populate_accounts (*store, { 10, 20 });
 
 	auto txn = store->tx_begin_read ();
 	auto crawler = store->account.crawl (txn);
 
-	ASSERT_TRUE (crawler);
-	ASSERT_EQ (crawler.key (), nano::account{ 42 });
-
-	// skip_to same key should stay
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 42 }));
-	ASSERT_EQ (crawler.key (), nano::account{ 42 });
-
-	// next() at end should fail and invalidate crawler
-	ASSERT_FALSE (crawler.next ());
-	ASSERT_FALSE (crawler);
-
-	// Rewind and test skip_to past end
-	crawler.rewind ();
-	ASSERT_TRUE (crawler);
-	ASSERT_FALSE (crawler.skip_to (nano::account{ 43 }));
-	ASSERT_FALSE (crawler);
+	// For simple keys a group probe is equivalent to an entry probe
+	auto const * found = crawler.find_group (nano::account{ 20 });
+	ASSERT_NE (found, nullptr);
+	ASSERT_EQ (found->first, nano::account{ 20 });
 }
+
+TEST (crawler, find_within_sequential_window)
+{
+	auto store = nano::test::make_store ();
+
+	// Entries equal to sequential_threshold
+	std::vector<nano::uint256_t> keys;
+	for (size_t i = 1; i <= sequential_threshold; ++i)
+	{
+		keys.push_back (i);
+	}
+	populate_accounts (*store, keys);
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn, nano::account{ 1 });
+
+	// find() should reach the target via sequential iteration (within threshold)
+	auto const * found = crawler.find (nano::account{ sequential_threshold / 2 });
+	ASSERT_NE (found, nullptr);
+	ASSERT_EQ (found->first, nano::account{ sequential_threshold / 2 });
+}
+
+TEST (crawler, find_seek_fallback)
+{
+	auto store = nano::test::make_store ();
+
+	// More elements than threshold between start and target forces seek fallback
+	std::vector<nano::uint256_t> keys;
+	for (size_t i = 1; i <= sequential_threshold + 2; ++i)
+	{
+		keys.push_back (i);
+	}
+	keys.push_back (100); // Target far from sequential range
+	populate_accounts (*store, keys);
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn, nano::account{ 1 });
+
+	// find(100) needs to traverse more than threshold elements, triggering seek fallback
+	auto const * found = crawler.find (nano::account{ 100 });
+	ASSERT_NE (found, nullptr);
+	ASSERT_EQ (found->first, nano::account{ 100 });
+}
+
+TEST (crawler, find_target_at_window_edge)
+{
+	auto store = nano::test::make_store ();
+
+	// Dense consecutive keys so the target sits exactly one entry past the sequential window
+	std::vector<nano::uint256_t> keys;
+	for (size_t i = 1; i <= sequential_threshold + 2; ++i)
+	{
+		keys.push_back (i);
+	}
+	populate_accounts (*store, keys);
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn, nano::account{ 1 });
+
+	// The window checks entries 1..threshold, the target is found by the fallback seek
+	auto const * found = crawler.find (nano::account{ 1 + sequential_threshold });
+	ASSERT_NE (found, nullptr);
+	ASSERT_EQ (found->first, nano::account{ 1 + sequential_threshold });
+}
+
+TEST (crawler, find_large_scale)
+{
+	auto store = nano::test::make_store ();
+
+	std::vector<nano::account> sorted_accounts;
+	{
+		auto txn = store->tx_begin_write ();
+		for (int i = 0; i < 1000; ++i)
+		{
+			nano::account account;
+			nano::random_pool::generate_block (account.bytes.data (), account.bytes.size ());
+			sorted_accounts.push_back (account);
+			store->account.put (txn, account, nano::account_info{});
+		}
+	}
+	std::sort (sorted_accounts.begin (), sorted_accounts.end (), [] (auto const & a, auto const & b) {
+		return a.number () < b.number ();
+	});
+
+	auto txn = store->tx_begin_read ();
+	auto crawler = store->account.crawl (txn);
+
+	// Probe ascending positions, mixing short hops and long jumps
+	for (size_t i : { 100, 250, 500, 750, 999 })
+	{
+		auto const * found = crawler.find (sorted_accounts[i]);
+		ASSERT_NE (found, nullptr);
+		ASSERT_EQ (found->first, sorted_accounts[i]);
+	}
+}
+
+/*
+ * Saturation & boundaries
+ */
 
 TEST (crawler, key_saturation_max_value)
 {
@@ -310,203 +650,33 @@ TEST (crawler, key_saturation_max_value)
 	ASSERT_EQ (crawler.key ().number (), max_minus_one);
 
 	// Should be able to advance to max
-	ASSERT_TRUE (crawler.next ());
+	ASSERT_TRUE (crawler.next_entry ());
 	ASSERT_EQ (crawler.key ().number (), max_val);
 
-	// Attempting to go past max should fail due to saturation
-	ASSERT_FALSE (crawler.next ());
+	// Attempting to go past max ends iteration
+	ASSERT_FALSE (crawler.next_entry ());
 	ASSERT_FALSE (crawler);
 }
 
-/*
- * Simple Keys
- */
-
-TEST (crawler, simple_key_basic_iteration)
+TEST (crawler, boundary_first_key)
 {
 	auto store = nano::test::make_store ();
 
-	populate_accounts (*store, { 1, 2, 3, 4, 5 });
+	populate_accounts (*store, { 10, 20, 30 });
 
 	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn);
 
-	std::vector<nano::uint256_t> visited;
-	ASSERT_TRUE (crawler);
-	while (crawler)
-	{
-		visited.push_back (crawler.key ().number ());
-		ASSERT_EQ (crawler.key (), crawler.full_key ()); // key() == full_key() for simple keys
-		ASSERT_EQ (crawler.key (), nano::account{ visited.back () }); // key() returns correct value
-		bool has_more = crawler.next ();
-		ASSERT_EQ (has_more, static_cast<bool> (crawler));
-	}
+	// Construct with start=0 should position at first key
+	auto crawler1 = store->account.crawl (txn, nano::account{ 0 });
+	ASSERT_EQ (crawler1.key (), nano::account{ 10 });
 
-	ASSERT_EQ (visited, (std::vector<nano::uint256_t>{ 1, 2, 3, 4, 5 }));
+	// Construct with start=first key should position at first key
+	auto crawler2 = store->account.crawl (txn, nano::account{ 10 });
+	ASSERT_EQ (crawler2.key (), nano::account{ 10 });
 }
 
 /*
- * Compound Keys with Grouping
- */
-
-TEST (crawler, compound_key_group_iteration)
-{
-	auto store = nano::test::make_store ();
-
-	// Account 1: 3 pending entries
-	// Account 2: 2 pending entries
-	// Account 3: 1 pending entry
-	populate_pending (*store, {
-							  { 1, { 10, 20, 30 } },
-							  { 2, { 10, 20 } },
-							  { 3, { 10 } },
-							  });
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->pending.crawl (txn);
-
-	// First group: account 1
-	ASSERT_TRUE (crawler);
-	ASSERT_EQ (crawler.key (), nano::account{ 1 });
-	ASSERT_EQ (crawler.full_key ().account, nano::account{ 1 });
-	ASSERT_EQ (crawler.full_key ().hash, nano::block_hash{ 10 }); // First entry in group
-
-	// next() should skip to account 2, not to next entry in account 1
-	ASSERT_TRUE (crawler.next ());
-	ASSERT_EQ (crawler.key (), nano::account{ 2 });
-
-	// next() should skip to account 3
-	ASSERT_TRUE (crawler.next ());
-	ASSERT_EQ (crawler.key (), nano::account{ 3 });
-
-	// next() should end iteration
-	ASSERT_FALSE (crawler.next ());
-	ASSERT_FALSE (crawler);
-}
-
-TEST (crawler, compound_key_skip_to)
-{
-	auto store = nano::test::make_store ();
-
-	populate_pending (*store, {
-							  { 10, { 1, 2, 3 } },
-							  { 20, { 1 } },
-							  { 30, { 1 } },
-							  });
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->pending.crawl (txn);
-
-	ASSERT_EQ (crawler.key (), nano::account{ 10 });
-
-	// skip_to same account should stay at current group
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 10 }));
-	ASSERT_EQ (crawler.key (), nano::account{ 10 });
-
-	// skip_to mid-value should land on next group
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 25 }));
-	ASSERT_EQ (crawler.key (), nano::account{ 30 });
-}
-
-TEST (crawler, compound_key_many_entries_per_group)
-{
-	auto store = nano::test::make_store ();
-
-	// Account 1 with more entries than sequential_threshold to trigger seek fallback
-	std::vector<nano::uint256_t> hashes;
-	for (size_t i = 1; i <= sequential_threshold + 1; ++i)
-	{
-		hashes.push_back (i);
-	}
-	populate_pending (*store, {
-							  { 1, hashes },
-							  { 2, { 1 } },
-							  });
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->pending.crawl (txn);
-
-	ASSERT_EQ (crawler.key (), nano::account{ 1 });
-
-	// next() should skip past all entries to account 2
-	// This triggers the seek fallback after sequential attempts exhausted
-	ASSERT_TRUE (crawler.next ());
-	ASSERT_EQ (crawler.key (), nano::account{ 2 });
-
-	ASSERT_FALSE (crawler.next ());
-}
-
-/*
- * Sequential Optimization - Hybrid Seek Strategy
- */
-
-TEST (crawler, sequential_optimization_within_threshold)
-{
-	auto store = nano::test::make_store ();
-
-	// Entries equal to sequential_threshold
-	std::vector<nano::uint256_t> keys;
-	for (size_t i = 1; i <= sequential_threshold; ++i)
-	{
-		keys.push_back (i);
-	}
-	populate_accounts (*store, keys);
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn, nano::account{ 1 });
-
-	// skip_to should find target via sequential iteration (within threshold)
-	ASSERT_TRUE (crawler.skip_to (nano::account{ sequential_threshold / 2 }));
-	ASSERT_EQ (crawler.key (), nano::account{ sequential_threshold / 2 });
-}
-
-TEST (crawler, sequential_optimization_exceeds_threshold)
-{
-	auto store = nano::test::make_store ();
-
-	// More elements than threshold between start and target forces seek fallback
-	std::vector<nano::uint256_t> keys;
-	for (size_t i = 1; i <= sequential_threshold + 2; ++i)
-	{
-		keys.push_back (i);
-	}
-	keys.push_back (100); // Target far from sequential range
-	populate_accounts (*store, keys);
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn, nano::account{ 1 });
-
-	// skip_to(100) needs to traverse more than threshold elements, triggering seek fallback
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 100 }));
-	ASSERT_EQ (crawler.key (), nano::account{ 100 });
-}
-
-/*
- * Ordering Verification
- */
-
-TEST (crawler, iteration_order_ascending)
-{
-	auto store = nano::test::make_store ();
-
-	// Insert in non-sorted order
-	populate_accounts (*store, { 50, 10, 30, 20, 40 });
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn);
-
-	std::vector<nano::uint256_t> order;
-	while (crawler)
-	{
-		order.push_back (crawler.key ().number ());
-		++crawler;
-	}
-
-	ASSERT_EQ (order, (std::vector<nano::uint256_t>{ 10, 20, 30, 40, 50 }));
-}
-
-/*
- * Large Scale Iteration
+ * Large scale iteration
  */
 
 TEST (crawler, large_scale_iteration)
@@ -530,50 +700,19 @@ TEST (crawler, large_scale_iteration)
 
 	std::unordered_set<nano::account> visited;
 	nano::account previous{};
-	while (crawler)
+	for (; crawler; ++crawler)
 	{
 		auto current = crawler.key ();
 		ASSERT_GT (current.number (), previous.number ());
 		visited.insert (current);
 		previous = current;
-		++crawler;
 	}
 
 	ASSERT_EQ (visited.size (), accounts.size ());
 	ASSERT_EQ (visited, accounts);
 }
 
-TEST (crawler, large_scale_skip_to)
-{
-	auto store = nano::test::make_store ();
-
-	std::vector<nano::account> sorted_accounts;
-	{
-		auto txn = store->tx_begin_write ();
-		for (int i = 0; i < 1000; ++i)
-		{
-			nano::account account;
-			nano::random_pool::generate_block (account.bytes.data (), account.bytes.size ());
-			sorted_accounts.push_back (account);
-			store->account.put (txn, account, nano::account_info{});
-		}
-	}
-	std::sort (sorted_accounts.begin (), sorted_accounts.end (), [] (auto const & a, auto const & b) {
-		return a.number () < b.number ();
-	});
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn);
-
-	// Skip to various positions
-	for (size_t i : { 100, 250, 500, 750, 999 })
-	{
-		ASSERT_TRUE (crawler.skip_to (sorted_accounts[i]));
-		ASSERT_EQ (crawler.key (), sorted_accounts[i]);
-	}
-}
-
-TEST (crawler, large_scale_compound_key_groups)
+TEST (crawler, large_scale_groups)
 {
 	auto store = nano::test::make_store ();
 
@@ -595,13 +734,12 @@ TEST (crawler, large_scale_compound_key_groups)
 
 	size_t group_count = 0;
 	nano::uint256_t previous = 0;
-	while (crawler)
+	for (; crawler; crawler.next_group ())
 	{
-		auto current = crawler.key ().number ();
+		auto current = crawler.group_key ().number ();
 		ASSERT_GT (current, previous);
 		previous = current;
 		++group_count;
-		++crawler;
 	}
 
 	// Should have visited exactly 100 groups
@@ -609,137 +747,30 @@ TEST (crawler, large_scale_compound_key_groups)
 }
 
 /*
- * Skip_to Patterns - Sparse and Dense Data
+ * Refresh - transaction refresh with iterator re-establishment
  */
 
-TEST (crawler, skip_to_sparse_data)
+TEST (crawler, refresh_keeps_position)
 {
 	auto store = nano::test::make_store ();
 
-	// Large gaps between keys
-	populate_accounts (*store, { 1, 1000, 1000000 });
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn, nano::account{ 1 });
-
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 500 }));
-	ASSERT_EQ (crawler.key (), nano::account{ 1000 });
-
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 500000 }));
-	ASSERT_EQ (crawler.key (), nano::account{ 1000000 });
-
-	ASSERT_FALSE (crawler.skip_to (nano::account{ 2000000 }));
-	ASSERT_FALSE (crawler);
-}
-
-TEST (crawler, skip_to_dense_data)
-{
-	auto store = nano::test::make_store ();
-
-	// Consecutive keys
-	populate_accounts (*store, { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 });
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn, nano::account{ 1 });
-
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 5 }));
-	ASSERT_EQ (crawler.key (), nano::account{ 5 });
-}
-
-TEST (crawler, skip_to_backward_target)
-{
-	auto store = nano::test::make_store ();
-
-	populate_accounts (*store, { 10, 20, 30, 40, 50 });
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn, nano::account{ 30 });
-
-	ASSERT_EQ (crawler.key (), nano::account{ 30 });
-
-	// skip_to with target less than current position returns true and stays at current
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 10 }));
-	ASSERT_EQ (crawler.key (), nano::account{ 30 });
-
-	// Can still skip forward normally
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 50 }));
-	ASSERT_EQ (crawler.key (), nano::account{ 50 });
-}
-
-/*
- * Boundary Conditions
- */
-
-TEST (crawler, boundary_first_key)
-{
-	auto store = nano::test::make_store ();
-
-	populate_accounts (*store, { 10, 20, 30 });
-
-	auto txn = store->tx_begin_read ();
-
-	// Construct with start=0 should position at first key
-	auto crawler1 = store->account.crawl (txn, nano::account{ 0 });
-	ASSERT_EQ (crawler1.key (), nano::account{ 10 });
-
-	// Construct with start=first key should position at first key
-	auto crawler2 = store->account.crawl (txn, nano::account{ 10 });
-	ASSERT_EQ (crawler2.key (), nano::account{ 10 });
-}
-
-TEST (crawler, boundary_last_key_skip_to_same)
-{
-	auto store = nano::test::make_store ();
-
-	populate_accounts (*store, { 10, 20, 30 });
-
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->account.crawl (txn, nano::account{ 30 });
-
-	// skip_to same key should succeed and stay at same position
-	ASSERT_TRUE (crawler.skip_to (nano::account{ 30 }));
-	ASSERT_EQ (crawler.key (), nano::account{ 30 });
-
-	// skip_to beyond should fail
-	ASSERT_FALSE (crawler.skip_to (nano::account{ 31 }));
-	ASSERT_FALSE (crawler);
-}
-
-TEST (crawler, boundary_max_is_end)
-{
-	auto store = nano::test::make_store ();
-
-	auto max_val = std::numeric_limits<nano::uint256_t>::max ();
-
-	// Add more than sequential_threshold entries at max account
-	// This forces next() to exhaust sequential iteration and hit the saturation check
+	auto txn = store->tx_begin_write ();
+	for (nano::uint256_t i = 1; i <= 5; ++i)
 	{
-		auto txn = store->tx_begin_write ();
-		for (size_t i = 1; i <= sequential_threshold + 1; ++i)
-		{
-			store->pending.put (txn,
-			nano::pending_key{ nano::account{ max_val }, nano::block_hash{ i } },
-			nano::pending_info{});
-		}
+		store->account.put (txn, nano::account{ i }, nano::account_info{});
 	}
 
-	auto txn = store->tx_begin_read ();
-	auto crawler = store->pending.crawl (txn, nano::account{ max_val });
+	auto crawler = store->account.crawl (txn);
+	++crawler;
+	++crawler;
+	ASSERT_EQ (crawler.key (), nano::account{ 3 });
 
+	crawler.refresh ();
 	ASSERT_TRUE (crawler);
-	ASSERT_EQ (crawler.key ().number (), max_val);
-
-	// next() exhausts sequential attempts, then tries next_group(max) which saturates to max
-	// The saturation check should detect this and move to end
-	ASSERT_FALSE (crawler.next ());
-	ASSERT_FALSE (crawler);
+	ASSERT_EQ (crawler.key (), nano::account{ 3 });
 }
 
-/*
- * Refresh - Transaction refresh with iterator re-establishment
- */
-
-TEST (crawler, refresh)
+TEST (crawler, refresh_during_iteration)
 {
 	auto store = nano::test::make_store ();
 
@@ -750,12 +781,6 @@ TEST (crawler, refresh)
 	}
 
 	auto crawler = store->account.crawl (txn);
-	ASSERT_EQ (crawler.key (), nano::account{ 1 });
-
-	// Refresh maintains position
-	crawler.refresh ();
-	ASSERT_TRUE (crawler);
-	ASSERT_EQ (crawler.key (), nano::account{ 1 });
 
 	// Iterate with periodic refresh (simulates batch processing)
 	std::vector<nano::uint256_t> visited;
@@ -771,29 +796,86 @@ TEST (crawler, refresh)
 		}
 	}
 	ASSERT_EQ (visited, (std::vector<nano::uint256_t>{ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }));
+}
 
-	// Refresh at end stays at end
+TEST (crawler, refresh_at_end)
+{
+	auto store = nano::test::make_store ();
+
+	auto txn = store->tx_begin_write ();
+	store->account.put (txn, nano::account{ 1 }, nano::account_info{});
+
+	auto crawler = store->account.crawl (txn);
+	++crawler;
 	ASSERT_FALSE (crawler);
+
 	crawler.refresh ();
 	ASSERT_FALSE (crawler);
+}
+
+TEST (crawler, refresh_after_delete)
+{
+	auto store = nano::test::make_store ();
+
+	auto txn = store->tx_begin_write ();
+	for (nano::uint256_t i = 1; i <= 5; ++i)
+	{
+		store->account.put (txn, nano::account{ i }, nano::account_info{});
+	}
+
+	auto crawler = store->account.crawl (txn, nano::account{ 3 });
+	ASSERT_EQ (crawler.key (), nano::account{ 3 });
 
 	// Refresh when current entry was deleted lands on next valid entry
-	crawler.rewind ();
-	++crawler; // at 2
-	++crawler; // at 3
-	ASSERT_EQ (crawler.key (), nano::account{ 3 });
 	store->account.del (txn, nano::account{ 3 });
 	crawler.refresh ();
 	ASSERT_TRUE (crawler);
 	ASSERT_EQ (crawler.key (), nano::account{ 4 });
+}
+
+TEST (crawler, refresh_after_delete_last)
+{
+	auto store = nano::test::make_store ();
+
+	auto txn = store->tx_begin_write ();
+	for (nano::uint256_t i = 1; i <= 3; ++i)
+	{
+		store->account.put (txn, nano::account{ i }, nano::account_info{});
+	}
+
+	auto crawler = store->account.crawl (txn, nano::account{ 3 });
+	ASSERT_EQ (crawler.key (), nano::account{ 3 });
 
 	// Refresh when current entry was the last one and deleted → end
-	crawler.seek (nano::account{ 10 });
-	ASSERT_EQ (crawler.key (), nano::account{ 10 });
-	store->account.del (txn, nano::account{ 10 });
+	store->account.del (txn, nano::account{ 3 });
 	crawler.refresh ();
 	ASSERT_FALSE (crawler);
 }
+
+TEST (crawler, refresh_if_needed)
+{
+	auto store = nano::test::make_store ();
+
+	auto txn = store->tx_begin_write ();
+	for (nano::uint256_t i = 1; i <= 3; ++i)
+	{
+		store->account.put (txn, nano::account{ i }, nano::account_info{});
+	}
+
+	auto crawler = store->account.crawl (txn);
+
+	// Zero max age forces a refresh, position is preserved
+	ASSERT_TRUE (crawler.refresh_if_needed (std::chrono::milliseconds{ 0 }));
+	ASSERT_EQ (crawler.key (), nano::account{ 1 });
+
+	// Freshly refreshed transaction should not refresh again
+	ASSERT_FALSE (crawler.refresh_if_needed ());
+	ASSERT_EQ (crawler.key (), nano::account{ 1 });
+}
+
+/*
+ * Misc
+ */
 
 TEST (crawler, const_transaction)
 {
@@ -815,10 +897,9 @@ TEST (crawler, const_transaction)
 	ASSERT_EQ (crawler.key (), nano::account{ 1 });
 
 	std::vector<nano::uint256_t> visited;
-	while (crawler)
+	for (; crawler; ++crawler)
 	{
 		visited.push_back (crawler.key ().number ());
-		++crawler;
 	}
 	ASSERT_EQ (visited, (std::vector<nano::uint256_t>{ 1, 2, 3, 4, 5 }));
 }

--- a/nano/lib/formatting.cpp
+++ b/nano/lib/formatting.cpp
@@ -1,8 +1,6 @@
 #include <nano/lib/formatting.hpp>
 #include <nano/lib/ratios.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 namespace nano::log
 {
 std::ostream & operator<< (std::ostream & os, as_nano_formatter const & wrapper)

--- a/nano/lib/network_filter.hpp
+++ b/nano/lib/network_filter.hpp
@@ -4,8 +4,6 @@
 #include <nano/lib/locks.hpp>
 #include <nano/lib/numbers.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <cryptopp/seckey.h>
 #include <cryptopp/siphash.h>
 

--- a/nano/lib/numbers.cpp
+++ b/nano/lib/numbers.cpp
@@ -9,7 +9,6 @@
 #include <nano/secure/network_params.hpp>
 
 #include <boost/io/ios_state.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 
 #include <algorithm>
 #include <ostream>

--- a/nano/lib/numbers.hpp
+++ b/nano/lib/numbers.hpp
@@ -1,12 +1,7 @@
 #pragma once
 
-// clang-format off
-// <memory> must precede fwd.hpp: boost bug — fwd.hpp uses std::allocator without including <memory>
-#include <memory>
-#include <boost/multiprecision/fwd.hpp>
-// clang-format on
-
 #include <boost/functional/hash_fwd.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
 
 #include <array>
 #include <compare>

--- a/nano/nano_node/benchmarks/benchmarks.hpp
+++ b/nano/nano_node/benchmarks/benchmarks.hpp
@@ -4,7 +4,6 @@
 #include <nano/node/node.hpp>
 #include <nano/secure/common.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
 #include <boost/program_options.hpp>
 
 #include <atomic>

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -45,7 +45,6 @@
 #include <boost/dll/runtime_symbol_info.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 #include <boost/program_options.hpp>
 #include <boost/range/adaptor/reversed.hpp>
 #include <boost/unordered_map.hpp>

--- a/nano/node/backlog_scan.cpp
+++ b/nano/node/backlog_scan.cpp
@@ -118,12 +118,10 @@ void nano::backlog_scan::populate_backlog (nano::unique_lock<nano::mutex> & lock
 
 				auto const & [account, account_info] = *account_crawler;
 
-				conf_crawler.skip_to (account);
-
 				nano::confirmation_height_info conf_info{};
-				if (conf_crawler && conf_crawler->first == account)
+				if (auto const * found = conf_crawler.find (account))
 				{
-					conf_info = conf_crawler->second;
+					conf_info = found->second;
 				}
 
 				activated_info info{ account, account_info, conf_info };

--- a/nano/node/bootstrap/database_scan_index.cpp
+++ b/nano/node/bootstrap/database_scan_index.cpp
@@ -127,7 +127,7 @@ std::deque<nano::account> account_database_scanner::next_batch (nano::store::tra
 	}
 	else
 	{
-		next = crawler.key ();
+		next = crawler.group_key ();
 	}
 
 	return result;
@@ -143,7 +143,8 @@ std::deque<nano::account> pending_database_scanner::next_batch (nano::store::tra
 
 	auto crawler = ledger.store.pending.crawl (transaction, next);
 
-	for (; crawler && result.size () < batch_size; ++crawler)
+	// Advance group-wise to visit each account once, regardless of its number of pending entries
+	for (; crawler && result.size () < batch_size; crawler.next_group ())
 	{
 		auto const & [key, info] = *crawler;
 		result.push_back (key.account);
@@ -158,7 +159,7 @@ std::deque<nano::account> pending_database_scanner::next_batch (nano::store::tra
 	}
 	else
 	{
-		next = crawler.key ();
+		next = crawler.group_key ();
 	}
 
 	return result;

--- a/nano/node/bootstrap/frontier_scan_index.cpp
+++ b/nano/node/bootstrap/frontier_scan_index.cpp
@@ -1,7 +1,6 @@
 #include <nano/node/bootstrap/frontier_scan_index.hpp>
 
 #include <boost/multiprecision/cpp_dec_float.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 
 namespace nano::bootstrap
 {

--- a/nano/node/bootstrap/frontier_strategy.cpp
+++ b/nano/node/bootstrap/frontier_strategy.cpp
@@ -244,12 +244,9 @@ frontier_classification classify_frontiers (nano::secure::transaction const & tr
 	};
 
 	auto should_prioritize = [&] (nano::account const & account, nano::block_hash const & frontier) {
-		account_crawler.skip_to (account);
-		pending_crawler.skip_to (account);
-
-		if (account_crawler && account_crawler->first == account)
+		if (auto const * existing = account_crawler.find (account))
 		{
-			if (account_crawler->second.head != frontier && !block_exists (frontier))
+			if (existing->second.head != frontier && !block_exists (frontier))
 			{
 				++result.outdated;
 				return true;
@@ -257,7 +254,7 @@ frontier_classification classify_frontiers (nano::secure::transaction const & tr
 			return false;
 		}
 
-		if (pending_crawler && pending_crawler->first.account == account)
+		if (pending_crawler.find_group (account))
 		{
 			++result.pending;
 			return true;

--- a/nano/node/bootstrap/topo_strategy.cpp
+++ b/nano/node/bootstrap/topo_strategy.cpp
@@ -415,7 +415,7 @@ void topo_strategy::precheck (head_index head, std::deque<nano::topo_key> entrie
 			auto crawler = ctx.ledger.store.topology.crawl (transaction, entries.front ());
 			for (auto const & key : entries)
 			{
-				if (!crawler.skip_to (key) || crawler.full_key () != key)
+				if (!crawler.find (key))
 				{
 					missing.push_back (key);
 				}

--- a/nano/node/bootstrap/verify.cpp
+++ b/nano/node/bootstrap/verify.cpp
@@ -1,8 +1,6 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/node/bootstrap/verify.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <set>
 
 namespace nano::bootstrap

--- a/nano/node/bucketing.hpp
+++ b/nano/node/bucketing.hpp
@@ -3,8 +3,6 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/node/fwd.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <vector>
 
 namespace nano

--- a/nano/node/ipc/action_handler.cpp
+++ b/nano/node/ipc/action_handler.cpp
@@ -5,8 +5,6 @@
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/node.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 namespace
 {
 nano::account parse_account (std::string const & account, bool & out_is_deprecated_format)

--- a/nano/node/online_reps.hpp
+++ b/nano/node/online_reps.hpp
@@ -12,7 +12,6 @@
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index_container.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 
 #include <memory>
 #include <thread>

--- a/nano/node/vote_with_weight_info.hpp
+++ b/nano/node/vote_with_weight_info.hpp
@@ -2,8 +2,6 @@
 
 #include <nano/lib/numbers.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <chrono>
 
 namespace nano

--- a/nano/secure/account_iterator.cpp
+++ b/nano/secure/account_iterator.cpp
@@ -1,6 +1,4 @@
 #include <nano/secure/account_iterator_impl.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 template class nano::account_iterator<nano::ledger_set_any>;

--- a/nano/secure/account_iterator_impl.hpp
+++ b/nano/secure/account_iterator_impl.hpp
@@ -2,8 +2,6 @@
 #include <nano/secure/account_info.hpp>
 #include <nano/secure/account_iterator.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 template <typename Set>
 nano::account_iterator<Set>::account_iterator ()
 {

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -182,6 +182,19 @@ bool nano::topo_key::deserialize (nano::stream & stream_a)
 	return error;
 }
 
+std::optional<nano::topo_key> nano::next_key (nano::topo_key const & current)
+{
+	if (current.hash.number () < std::numeric_limits<nano::uint256_t>::max ())
+	{
+		return nano::topo_key{ current.topo_height, nano::block_hash{ current.hash.number () + 1 } };
+	}
+	if (current.topo_height < std::numeric_limits<uint64_t>::max ())
+	{
+		return nano::topo_key{ current.topo_height + 1, nano::block_hash{ 0 } };
+	}
+	return std::nullopt;
+}
+
 /*
  *
  */

--- a/nano/secure/common.cpp
+++ b/nano/secure/common.cpp
@@ -10,7 +10,6 @@
 #include <nano/secure/network_params.hpp>
 
 #include <boost/endian/conversion.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <limits>

--- a/nano/secure/common.hpp
+++ b/nano/secure/common.hpp
@@ -4,6 +4,7 @@
 #include <nano/lib/numbers.hpp>
 
 #include <memory>
+#include <optional>
 
 namespace nano
 {
@@ -46,6 +47,9 @@ public:
 	uint64_t topo_height{ 0 };
 	nano::block_hash hash{ 0 };
 };
+
+// Smallest topology key greater than current, or nullopt if current is the maximum value
+std::optional<topo_key> next_key (topo_key const & current);
 
 /**
  * Information on an unchecked block

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -31,8 +31,6 @@
 #include <nano/store/ledger/version.hpp>
 #include <nano/store/ledger_store.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <stack>
 
 #include <cryptopp/words.h>

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -14,8 +14,6 @@
 #include <nano/store/ledger_store.hpp>
 #include <nano/weights/bootstrap_weights.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <deque>
 #include <map>
 #include <memory>

--- a/nano/secure/ledger_processor.cpp
+++ b/nano/secure/ledger_processor.cpp
@@ -16,8 +16,6 @@
 #include <nano/store/ledger/topology.hpp>
 #include <nano/store/ledger_store.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 nano::ledger_processor::ledger_processor (nano::secure::write_transaction const & transaction_a, nano::ledger & ledger_a) :
 	transaction (transaction_a),
 	ledger (ledger_a)

--- a/nano/secure/network_params.hpp
+++ b/nano/secure/network_params.hpp
@@ -6,8 +6,6 @@
 #include <nano/lib/keypair.hpp>
 #include <nano/lib/numbers.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <chrono>
 #include <memory>
 

--- a/nano/secure/parallel_traversal.hpp
+++ b/nano/secure/parallel_traversal.hpp
@@ -3,6 +3,11 @@
 #include <nano/lib/thread_roles.hpp>
 #include <nano/lib/threading.hpp>
 
+#include <boost/multiprecision/cpp_int.hpp>
+
+#include <algorithm>
+#include <functional>
+#include <limits>
 #include <thread>
 #include <vector>
 

--- a/nano/secure/parallel_traversal.hpp
+++ b/nano/secure/parallel_traversal.hpp
@@ -3,8 +3,6 @@
 #include <nano/lib/thread_roles.hpp>
 #include <nano/lib/threading.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <algorithm>
 #include <functional>
 #include <limits>

--- a/nano/secure/pending_info.cpp
+++ b/nano/secure/pending_info.cpp
@@ -2,6 +2,8 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/pending_info.hpp>
 
+#include <ostream>
+
 nano::pending_info::pending_info (nano::account const & source_a, nano::amount const & amount_a, nano::epoch epoch_a) :
 	source (source_a),
 	amount (amount_a),
@@ -31,11 +33,6 @@ size_t nano::pending_info::db_size () const
 	return sizeof (source) + sizeof (amount) + sizeof (epoch);
 }
 
-bool nano::pending_info::operator== (nano::pending_info const & other_a) const
-{
-	return source == other_a.source && amount == other_a.amount && epoch == other_a.epoch;
-}
-
 nano::pending_key::pending_key (nano::account const & account_a, nano::block_hash const & hash_a) :
 	account (account_a),
 	hash (hash_a)
@@ -58,17 +55,23 @@ bool nano::pending_key::deserialize (nano::stream & stream_a)
 	return error;
 }
 
-bool nano::pending_key::operator== (nano::pending_key const & other_a) const
-{
-	return account == other_a.account && hash == other_a.hash;
-}
-
 nano::account const & nano::pending_key::key () const
 {
 	return account;
 }
 
-bool nano::pending_key::operator< (nano::pending_key const & other_a) const
+namespace nano
 {
-	return account == other_a.account ? hash < other_a.hash : account < other_a.account;
+std::ostream & operator<< (std::ostream & os, nano::pending_info const & info)
+{
+	int const epoch = nano::normalized_epoch (info.epoch);
+	os << "Source: " << info.source << ", Amount: " << info.amount.to_string_dec () << " Epoch: " << epoch;
+	return os;
+}
+
+std::ostream & operator<< (std::ostream & os, nano::pending_key const & key)
+{
+	os << "Account: " << key.account << ", Hash: " << key.hash;
+	return os;
+}
 }

--- a/nano/secure/pending_info.hpp
+++ b/nano/secure/pending_info.hpp
@@ -4,9 +4,9 @@
 #include <nano/lib/fwd.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/numbers_templ.hpp>
-#include <nano/secure/fwd.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
+#include <compare>
+#include <iosfwd>
 
 namespace nano
 {
@@ -19,40 +19,47 @@ class pending_info final
 public:
 	pending_info () = default;
 	pending_info (nano::account const &, nano::amount const &, nano::epoch);
-	size_t db_size () const;
-	bool deserialize (nano::stream &);
-	bool operator== (nano::pending_info const &) const;
-	nano::account source{}; // the account sending the funds
-	nano::amount amount{ 0 }; // amount receivable in this transaction
-	nano::epoch epoch{ nano::epoch::epoch_0 }; // epoch of sending block, this info is stored here to make it possible to prune the send block
 
-	friend std::ostream & operator<< (std::ostream & os, const nano::pending_info & info)
-	{
-		const int epoch = nano::normalized_epoch (info.epoch);
-		os << "Source: " << info.source << ", Amount: " << info.amount.to_string_dec () << " Epoch: " << epoch;
-		return os;
-	}
+	// Size of the serialized representation in the database
+	size_t db_size () const;
+
+	// Deserialize from stream, returns true on error
+	bool deserialize (nano::stream &);
+
+	bool operator== (nano::pending_info const &) const = default;
+
+	friend std::ostream & operator<< (std::ostream &, nano::pending_info const &);
+
+public:
+	nano::account source{}; // Account sending the funds
+	nano::amount amount{ 0 }; // Amount receivable in this transaction
+	nano::epoch epoch{ nano::epoch::epoch_0 }; // Epoch of the send block, stored here to allow pruning the send block
 };
 
-// This class represents the data written into the pending (receivable) database table key
-// the receiving account and hash of the send block identify a pending db table entry
+/**
+ * Represents the key of the pending (receivable) database table
+ * The receiving account and hash of the send block identify a pending table entry
+ */
 class pending_key final
 {
 public:
 	pending_key () = default;
 	pending_key (nano::account const &, nano::block_hash const &);
-	bool deserialize (nano::stream &);
-	bool operator== (nano::pending_key const &) const;
-	bool operator< (nano::pending_key const &) const;
-	nano::account const & key () const;
-	nano::account account{}; // receiving account
-	nano::block_hash hash{ 0 }; // hash of the send block
 
-	friend std::ostream & operator<< (std::ostream & os, const nano::pending_key & key)
-	{
-		os << "Account: " << key.account << ", Hash: " << key.hash;
-		return os;
-	}
+	// The receiving account, which groups the entries when scanning the table
+	nano::account const & key () const;
+
+	// Deserialize from stream, returns true on error
+	bool deserialize (nano::stream &);
+
+	// Orders by account, then hash, matching the database byte order; also provides a defaulted operator==
+	std::strong_ordering operator<=> (nano::pending_key const &) const = default;
+
+	friend std::ostream & operator<< (std::ostream &, nano::pending_key const &);
+
+public:
+	nano::account account{}; // Receiving account
+	nano::block_hash hash{ 0 }; // Hash of the send block
 };
 }
 
@@ -63,7 +70,7 @@ struct hash<::nano::pending_key>
 {
 	size_t operator() (::nano::pending_key const & value) const
 	{
-		return hash<::nano::uint512_union>{}({ ::nano::uint256_union{ value.account.number () }, value.hash });
+		return hash<::nano::uint512_union>{}({ value.account, value.hash });
 	}
 };
 }

--- a/nano/secure/receivable_iterator.cpp
+++ b/nano/secure/receivable_iterator.cpp
@@ -2,7 +2,5 @@
 #include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/secure/receivable_iterator_impl.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 template class nano::receivable_iterator<nano::ledger_set_any>;
 template class nano::receivable_iterator<nano::ledger_set_cemented>;

--- a/nano/secure/receivable_iterator_impl.hpp
+++ b/nano/secure/receivable_iterator_impl.hpp
@@ -2,8 +2,6 @@
 #include <nano/secure/pending_info.hpp>
 #include <nano/secure/receivable_iterator.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 template <typename Set>
 nano::receivable_iterator<Set>::receivable_iterator ()
 {

--- a/nano/secure/receivable_iterator_impl.hpp
+++ b/nano/secure/receivable_iterator_impl.hpp
@@ -2,6 +2,8 @@
 #include <nano/secure/pending_info.hpp>
 #include <nano/secure/receivable_iterator.hpp>
 
+#include <boost/multiprecision/cpp_int.hpp>
+
 template <typename Set>
 nano::receivable_iterator<Set>::receivable_iterator ()
 {

--- a/nano/secure/rep_weights.hpp
+++ b/nano/secure/rep_weights.hpp
@@ -5,8 +5,6 @@
 #include <nano/lib/utility.hpp>
 #include <nano/secure/fwd.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <memory>
 #include <shared_mutex>
 #include <unordered_map>

--- a/nano/store/crawler.hpp
+++ b/nano/store/crawler.hpp
@@ -10,52 +10,58 @@
 
 namespace nano::store
 {
+// Smallest key greater than current, or nullopt if current is the maximum value
+template <typename Key>
+	requires requires (Key const & key) { key.number (); }
+std::optional<Key> next_key (Key const & current)
+{
+	auto const next = inc_sat (current.number ());
+	if (next == current.number ())
+	{
+		return std::nullopt; // Saturated at the maximum value
+	}
+	return Key{ next };
+}
+
 /**
- * Traits to customize key handling for crawler iteration.
- * The default implementation assumes the iterator key is directly seekable.
- * Specialize this template for compound keys where seeking uses a subset of the key.
+ * Traits to customize group key handling for crawler iteration.
+ * The default implementation treats every entry as its own group.
+ * Specialize this template for compound keys where entries are grouped by a key prefix.
+ * Group keys must compare (==, <=>) consistently with the database byte order.
  */
 template <typename Key, typename Value>
 struct crawler_traits
 {
-	using seek_key_type = Key;
+	using group_key_type = Key;
 
-	// Create an iterator key from a seek key (for begin() calls)
-	static Key make_iterator_key (seek_key_type const & seek_key)
+	// Smallest full iterator key belonging to a group (for seeks)
+	static Key lower_bound_key (group_key_type const & group)
 	{
-		return seek_key;
+		return group;
 	}
 
-	// Extract the group key from an iterator key
-	static seek_key_type group_key (Key const & key)
+	// Extract the group key from a full iterator key
+	static group_key_type group_key (Key const & key)
 	{
 		return key;
 	}
 
-	// Compute the next group key
-	static seek_key_type next_group (seek_key_type const & current)
+	// Smallest key of the next group, nullopt when no further group is possible
+	static std::optional<group_key_type> next_group_key (group_key_type const & current)
 	{
-		return inc_sat (comparable (current));
-	}
-
-	// Get comparable value from key (for skip_to ordering)
-	static auto comparable (seek_key_type const & val)
-	{
-		return val.number ();
+		return next_key (current);
 	}
 };
 
 /**
  * Database cursor optimized for sequential scans with occasional random access.
  *
- * When processing sorted data (e.g., frontier lists from peers), consecutive keys are
- * often close together in the database. The crawler exploits this locality: both next()
- * and skip_to() first try a small number of sequential iterator increments. If the target
- * isn't found within that window, they fall back to an expensive database seek operation.
+ * When processing sorted data (e.g., frontier lists from peers), consecutive keys are often close together in the database.
+ * The crawler exploits this locality: group advancement and probing first try a small number of sequential iterator increments and only fall back to an expensive database seek when the target isn't found within that window.
  *
- * For compound keys (e.g., pending table's account+hash), entries can be grouped by
- * a key prefix via crawler_traits specialization. The next() method then advances to
- * the next distinct group rather than the next individual entry.
+ * For compound keys (e.g., pending table's account+hash), entries are grouped by a key prefix via crawler_traits specialization.
+ * operator++/next_entry() and find() operate on raw entries; next_group() and find_group() operate on whole groups.
+ * For simple keys every entry is its own group, so both levels coincide.
  */
 template <typename View, typename Transaction>
 class crawler
@@ -66,16 +72,16 @@ public:
 	using key_type = typename value_type::first_type;
 	using mapped_type = typename value_type::second_type;
 	using traits = crawler_traits<key_type, mapped_type>;
-	using seek_key_type = typename traits::seek_key_type;
+	using group_key_type = typename traits::group_key_type;
 
 	// Number of sequential iterations to try before falling back to seek
 	static constexpr size_t sequential_attempts = 10;
 
 public:
 	/**
-	 * Construct a crawler starting at the given seek key.
+	 * Construct a crawler positioned at the first entry with group key >= start.
 	 */
-	crawler (View const & view, Transaction & transaction, seek_key_type start = {}) :
+	crawler (View const & view, Transaction & transaction, group_key_type start = {}) :
 		view_{ view },
 		transaction_{ transaction },
 		it_{ view_.end (transaction_) },
@@ -84,13 +90,17 @@ public:
 		seek (start);
 	}
 
-	// Validity check
+	/**
+	 * @return true if the crawler is positioned at a valid entry
+	 */
 	explicit operator bool () const noexcept
 	{
 		return it_ != end_;
 	}
 
-	// Access current entry (precondition: valid)
+	/**
+	 * Access the current entry (precondition: valid).
+	 */
 	value_type const & operator* () const
 	{
 		release_assert (it_ != end_);
@@ -103,40 +113,52 @@ public:
 		return &(*it_);
 	}
 
-	crawler & operator++ ()
-	{
-		next ();
-		return *this;
-	}
-
-	// Get current group key (precondition: valid)
-	seek_key_type key () const
-	{
-		release_assert (it_ != end_);
-		return traits::group_key (it_->first);
-	}
-
-	// Get current full iterator key (precondition: valid)
-	key_type const & full_key () const
+	/**
+	 * @return full key of the current entry (precondition: valid)
+	 */
+	key_type const & key () const
 	{
 		release_assert (it_ != end_);
 		return it_->first;
 	}
 
 	/**
-	 * Seek to first entry >= target.
+	 * @return group key of the current entry (precondition: valid)
 	 */
-	void seek (seek_key_type const & target)
+	group_key_type group_key () const
 	{
-		it_ = view_.begin (transaction_, traits::make_iterator_key (target));
+		release_assert (it_ != end_);
+		return traits::group_key (it_->first);
 	}
 
 	/**
-	 * Move to the next logical entry (as defined by traits::group_key)
-	 * Tries sequential iteration before falling back to seek
+	 * Advance one raw entry, equivalent to next_entry ().
+	 */
+	crawler & operator++ ()
+	{
+		next_entry ();
+		return *this;
+	}
+
+	/**
+	 * Move to the next raw iterator entry, without group skipping.
 	 * @return true if still valid after advancing
 	 */
-	bool next ()
+	bool next_entry ()
+	{
+		if (it_ != end_)
+		{
+			++it_;
+		}
+		return it_ != end_;
+	}
+
+	/**
+	 * Move to the first entry of the next group, skipping the remaining entries of the current one.
+	 * Tries sequential iteration before falling back to seek.
+	 * @return true if still valid after advancing
+	 */
+	bool next_group ()
 	{
 		if (it_ == end_)
 		{
@@ -148,7 +170,7 @@ public:
 		// Try sequential iteration first
 		for (size_t count = 0; count < sequential_attempts && it_ != end_; ++count, ++it_)
 		{
-			if (traits::comparable (traits::group_key (it_->first)) != traits::comparable (starting_key))
+			if (traits::group_key (it_->first) != starting_key)
 			{
 				return true;
 			}
@@ -156,16 +178,14 @@ public:
 
 		if (it_ != end_)
 		{
-			// Sequential didn't reach next group, do a fresh seek
-			auto const next_key = traits::next_group (starting_key);
-
-			if (traits::comparable (next_key) > traits::comparable (starting_key))
+			// Sequential didn't reach the next group, do a fresh seek
+			if (auto const next = traits::next_group_key (starting_key))
 			{
-				seek (next_key);
+				seek (*next);
 			}
 			else
 			{
-				// Saturation: no more groups possible, move to end
+				// No group can exist past the maximum group key, move to end
 				it_ = view_.end (transaction_);
 			}
 		}
@@ -174,46 +194,90 @@ public:
 	}
 
 	/**
-	 * Skip to first entry with group key >= target (optimized seek)
-	 * Tries sequential iteration before falling back to seek
-	 * @return true if valid after skipping
+	 * Forward-only probe: advance to the first entry with key >= target.
+	 * A target behind the current position never matches and does not move the crawler.
+	 * @return pointer to the current entry if its key equals target, nullptr otherwise
 	 */
-	bool skip_to (seek_key_type const & target)
+	value_type const * find (key_type const & target)
 	{
 		if (it_ == end_)
 		{
-			return false;
+			return nullptr;
 		}
-
-		auto const target_val = traits::comparable (target);
 
 		// Try sequential iteration first
-		for (size_t count = 0; count < sequential_attempts && it_ != end_; ++count, ++it_)
+		for (size_t count = 0; it_ != end_; ++it_)
 		{
-			if (traits::comparable (traits::group_key (it_->first)) >= target_val)
+			// Never searches backwards, a target before the current position returns nullptr even if it exists
+			if (it_->first >= target)
 			{
-				return true;
+				return match_key (target);
+			}
+			if (++count >= sequential_attempts)
+			{
+				break;
 			}
 		}
+
+		// Sequential iteration ran off the end of the table, every entry was before the target
+		if (it_ == end_)
+		{
+			return nullptr;
+		}
+
+		// The window only saw entries before the target, the fallback seek must never move backwards
+		debug_assert (it_->first < target);
+
+		// Fall back to direct seek
+		it_ = view_.begin (transaction_, target);
+
+		return match_key (target);
+	}
+
+	/**
+	 * Forward-only probe: advance to the first entry with group key >= target.
+	 * A target behind the current group never matches and does not move the crawler.
+	 * @return pointer to the current entry if its group key equals target, nullptr otherwise
+	 */
+	value_type const * find_group (group_key_type const & target)
+	{
+		if (it_ == end_)
+		{
+			return nullptr;
+		}
+
+		// Try sequential iteration first
+		for (size_t count = 0; it_ != end_; ++it_)
+		{
+			// Never searches backwards, a target before the current position returns nullptr even if it exists
+			if (traits::group_key (it_->first) >= target)
+			{
+				return match_group (target);
+			}
+			if (++count >= sequential_attempts)
+			{
+				break;
+			}
+		}
+
+		// Sequential iteration ran off the end of the table, every group was before the target
+		if (it_ == end_)
+		{
+			return nullptr;
+		}
+
+		// The window only saw groups before the target, the fallback seek must never move backwards
+		debug_assert (traits::group_key (it_->first) < target);
 
 		// Fall back to direct seek
 		seek (target);
 
-		return it_ != end_;
-	}
-
-	/**
-	 * Seek back to the beginning of the range.
-	 */
-	void rewind ()
-	{
-		seek (seek_key_type{ 0 });
+		return match_group (target);
 	}
 
 	/**
 	 * Refresh the stored transaction and re-establish the iterator position.
-	 * After refresh, the crawler points to the same entry it was at before,
-	 * or the next valid entry if the original was deleted.
+	 * After refresh, the crawler points to the same entry it was at before, or the next valid entry if the original was deleted.
 	 */
 	void refresh ()
 	{
@@ -259,6 +323,33 @@ public:
 			return true;
 		}
 		return false;
+	}
+
+private:
+	// Seek to the first entry with group key >= target
+	void seek (group_key_type const & target)
+	{
+		it_ = view_.begin (transaction_, traits::lower_bound_key (target));
+	}
+
+	// Current entry if its key equals target, nullptr otherwise
+	value_type const * match_key (key_type const & target) const
+	{
+		if (it_ != end_ && it_->first == target)
+		{
+			return &(*it_);
+		}
+		return nullptr;
+	}
+
+	// Current entry if its group key equals target, nullptr otherwise
+	value_type const * match_group (group_key_type const & target) const
+	{
+		if (it_ != end_ && traits::group_key (it_->first) == target)
+		{
+			return &(*it_);
+		}
+		return nullptr;
 	}
 
 private:

--- a/nano/store/ledger/pending.cpp
+++ b/nano/store/ledger/pending.cpp
@@ -1,8 +1,6 @@
 #include <nano/secure/parallel_traversal.hpp>
 #include <nano/store/ledger/pending.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 namespace nano::store::ledger
 {
 pending_view::pending_view (nano::store::backend & backend_a) :

--- a/nano/store/ledger/pending.hpp
+++ b/nano/store/ledger/pending.hpp
@@ -42,18 +42,25 @@ private:
 
 /**
  * Specialization for pending table which has a compound key (account + hash).
- * Groups entries by account, so seek_key_type is nano::account.
+ * Groups entries by account, so group_key_type is nano::account.
  */
 template <>
-struct nano::store::crawler_traits<nano::pending_key, nano::pending_info> : nano::store::crawler_traits<nano::account, nano::pending_info>
+struct nano::store::crawler_traits<nano::pending_key, nano::pending_info>
 {
-	static nano::pending_key make_iterator_key (seek_key_type const & account)
+	using group_key_type = nano::account;
+
+	static nano::pending_key lower_bound_key (group_key_type const & account)
 	{
 		return nano::pending_key{ account, 0 };
 	}
 
-	static seek_key_type group_key (nano::pending_key const & key)
+	static group_key_type group_key (nano::pending_key const & key)
 	{
 		return key.account;
+	}
+
+	static std::optional<group_key_type> next_group_key (group_key_type const & current)
+	{
+		return next_key (current);
 	}
 };

--- a/nano/store/ledger/rep_weight.cpp
+++ b/nano/store/ledger/rep_weight.cpp
@@ -2,8 +2,6 @@
 #include <nano/secure/parallel_traversal.hpp>
 #include <nano/store/ledger/rep_weight.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <iostream>
 #include <stdexcept>
 

--- a/nano/store/ledger/topology.hpp
+++ b/nano/store/ledger/topology.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
 #include <nano/lib/numbers.hpp>
-#include <nano/lib/saturate.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/store/crawler.hpp>
 #include <nano/store/fwd.hpp>
 #include <nano/store/typed_iterator.hpp>
 #include <nano/store/typed_iterator_templ.hpp>
 
-#include <limits>
 #include <optional>
 
 namespace nano::store::ledger
@@ -42,38 +40,3 @@ private:
 	nano::store::backend & backend;
 };
 }
-
-/**
- * Specialization for the topology table whose key is the full topo_key (topo_height + hash).
- * Every key is its own group, so seek_key_type is the whole topo_key and ordering uses its operator<=>.
- */
-template <>
-struct nano::store::crawler_traits<nano::topo_key, std::nullptr_t>
-{
-	using seek_key_type = nano::topo_key;
-
-	static nano::topo_key make_iterator_key (seek_key_type const & key)
-	{
-		return key;
-	}
-
-	static seek_key_type group_key (nano::topo_key const & key)
-	{
-		return key;
-	}
-
-	static nano::topo_key comparable (seek_key_type const & key)
-	{
-		return key;
-	}
-
-	static seek_key_type next_group (seek_key_type const & current)
-	{
-		// Smallest key strictly greater than current: bump the hash, carrying into topo_height on overflow
-		if (current.hash.number () < std::numeric_limits<nano::uint256_t>::max ())
-		{
-			return nano::topo_key{ current.topo_height, nano::block_hash{ current.hash.number () + 1 } };
-		}
-		return nano::topo_key{ nano::inc_sat (current.topo_height), nano::block_hash{ 0 } };
-	}
-};

--- a/nano/store/ledger_upgrades.cpp
+++ b/nano/store/ledger_upgrades.cpp
@@ -14,8 +14,6 @@
 #include <nano/store/typed_iterator.hpp>
 #include <nano/store/typed_iterator_templ.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 namespace nano::store
 {
 nano::store::column_schema const ledger_store::schema_v21{

--- a/nano/store/meta.cpp
+++ b/nano/store/meta.cpp
@@ -3,8 +3,6 @@
 #include <nano/store/db_val_templ.hpp>
 #include <nano/store/meta.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 namespace nano::store
 {
 meta_view::meta_view (nano::store::backend & backend_a) :

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -11,7 +11,6 @@
 #include <gtest/gtest.h>
 
 #include <boost/iostreams/concepts.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 
 #include <atomic>
 #include <chrono>

--- a/nano/weights/bootstrap_weights.cpp
+++ b/nano/weights/bootstrap_weights.cpp
@@ -4,8 +4,6 @@
 #include <nano/weights/bootstrap_weights_beta.hpp>
 #include <nano/weights/bootstrap_weights_live.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 nano::bootstrap_weights nano::get_bootstrap_weights (nano::network_type type)
 {
 	std::vector<std::pair<std::string, std::string>> preconfigured;

--- a/nano/weights/bootstrap_weights.hpp
+++ b/nano/weights/bootstrap_weights.hpp
@@ -4,8 +4,6 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/numbers_templ.hpp>
 
-#include <boost/multiprecision/cpp_int.hpp>
-
 #include <unordered_map>
 
 /*


### PR DESCRIPTION
### Problems with the previous API

The crawler accumulated three call-site dialects (`++crawler`, `.next ()`, `.next_entry ()`, `skip_to` + equality check) because the interface conflated two cursors in one class:

- **`operator++` changed meaning per table.** It advanced one entry on simple-key tables but silently skipped to the next *account group* on pending, selected by an invisible traits specialization. Iterating pending with `++` looked like entry iteration and lost data — which is why `next_entry ()` existed as an escape hatch, and why no two call sites looked alike.
- **`skip_to` did half a job.** It returned "still valid", not "found", so every merge-join caller re-implemented the same `if (crawler && crawler->first == account)` dance — including picking the correct key form (`->first` vs `->first.account`) by hand, with nothing enforcing it.
- **Misleading accessors and dead surface.** `key ()` returned the *group* key (for pending: the account, not the entry key). `rewind`, public `seek`, `full_key` and `refresh_if_needed` had no production callers.
- **Boundary handling by convention.** `next_group_key` used a saturating increment, and callers had to detect saturation by comparing the result against the input — a contract smeared across two files. The traits' `comparable` projection predated `operator<=>` on the key types and duplicated what native comparisons already guarantee (memcmp order == database byte order).

### Changes

- `operator++` / `next_entry ()` always advance one raw entry; `next_group ()` / `group_key ()` / `find_group ()` are the explicit group-level operations; `key ()` now returns the full entry key.
- New probes `find (key)` and `find_group (group)` return the matching entry or `nullptr`, replacing `skip_to` + manual equality. Probes are forward-only; the fallback seek is guarded by a debug assert that the cursor is still before the target, and an exhausted window returns early instead of seeking.
- Traits slimmed to `lower_bound_key` / `group_key` / `next_group_key`; `next_group_key` returns `std::optional`, making "no next group" a type-level fact. `comparable` removed in favor of native key comparisons.
- `pending_key` gets a defaulted `operator<=>` (account, then hash — matching database order), replacing hand-written `<` / `==`; `pending_info.hpp` reorganized, ostream operators moved out of line, includes trimmed.
- Call sites updated (`backlog_scan`, `frontier_strategy`, `database_scan_index`); migration loops (extended index, topo index, v26 upgrade) unchanged. Crawler test suite rewritten: 38 cases, one concern each, both backends.

No functional changes, with one minor exception: frontier processing now probes the pending table lazily (only for accounts missing from the ledger), which skips pointless probes in the common case.