### PR TITLE
Fix coverage flow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       LCOV: 1
       COMPILER: gcc
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         TEST_USE_ROCKSDB: [0, 1]
@@ -29,16 +29,15 @@ jobs:
           submodules: "recursive"
       - name: Fetch Deps
         run: |
-          sudo apt-get update -qq && sudo apt-get install -yqq build-essential g++ wget python zlib1g-dev qt5-default \
+          sudo apt-get update -qq
+          sudo apt-get install -yqq build-essential g++ wget python3 zlib1g-dev cmake \
+          qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools \
           valgrind xorg xvfb xauth xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic ocl-icd-opencl-dev \
           git lcov python3-pip
-          wget -O cmake_install.sh https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.sh
-          chmod +x cmake_install.sh
-          sudo ./cmake_install.sh --prefix=/usr --exclude-subdir --skip-license
       - name: Build and Test
         env:
           TEST_USE_ROCKSDB: ${{ matrix.TEST_USE_ROCKSDB }}
-        run: ./ci/build-ci.sh /usr/lib/x86_64-linux=gnu/cmake/Qt5
+        run: ./ci/build-ci.sh /usr/lib/x86_64-linux-gnu/cmake/Qt5
       - uses: coverallsapp/github-action@8cbef1dea373ebce56de0a14c68d6267baa10b44
         with:
           github-token: ${{ secrets.github_token }}
@@ -46,7 +45,7 @@ jobs:
           parallel: true
   finish:
     needs: coverage_test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: coverallsapp/github-action@8cbef1dea373ebce56de0a14c68d6267baa10b44
         with:


### PR DESCRIPTION
The coverage job ran on the retired ubuntu-20.04 runner and could no longer start. 
Bumped to ubuntu-22.04, fix the Qt5 path typo(linux=gnu -> linux-gnu)
Replaced stale deps (python, qt5-default, pinned CMake 3.15.4) with their maintained equivalents from prepare.sh.

Co-Authored-By: Claude Opus 4.8