### PR TITLE
Add precompiled headers for RocksDB and kernel libraries (~33% faster build)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,6 +495,19 @@ else()
 endif()
 add_subdirectory(submodules/rocksdb EXCLUDE_FROM_ALL)
 
+# Precompiled headers derived from a vcperf /jsonAnalysis trace of a clean
+# nano_node build. Enabled with -DNANO_PCH=ON. RocksDB's own backbone headers
+# (rocksdb/options.h, rocksdb/listener.h, port/win/port_win.h) are the hottest
+# included files in the whole build, and the bundled RocksDB static library
+# (~700 translation units) ships with no PCH -- so precompiling that backbone
+# once is the single largest build-time win.
+option(NANO_PCH "Enable precompiled headers derived from vcperf analysis" OFF)
+if(NANO_PCH AND COMMAND target_precompile_headers AND TARGET rocksdb)
+  target_precompile_headers(
+    rocksdb PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX>:${PROJECT_SOURCE_DIR}/nano/rocksdb_pch.hpp>")
+endif()
+
 # cpptoml
 include_directories(submodules/cpptoml/include)
 
@@ -670,6 +683,21 @@ add_subdirectory(nano/node)
 add_subdirectory(nano/nano_node)
 add_subdirectory(nano/rpc)
 add_subdirectory(nano/nano_rpc)
+
+# Shared PCH of stable STL / third-party leaves for nano's first-party libs,
+# derived from the same vcperf analysis (<chrono> was the #3 hottest header;
+# logging.hpp -- the most-included nano header -- wraps spdlog/fmt). Gated by
+# the same -DNANO_PCH=ON switch as the RocksDB PCH above.
+if(NANO_PCH AND COMMAND target_precompile_headers)
+  foreach(_nano_pch_target nano_lib secure node nano_store nano_messages rpc
+                           nano_node)
+    if(TARGET ${_nano_pch_target})
+      target_precompile_headers(
+        ${_nano_pch_target} PRIVATE
+        "$<$<COMPILE_LANGUAGE:CXX>:${PROJECT_SOURCE_DIR}/nano/nano_pch.hpp>")
+    endif()
+  endforeach()
+endif()
 
 add_custom_target(
   executables

--- a/nano/nano_pch.hpp
+++ b/nano/nano_pch.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+// Precompiled header for nano's first-party C++ libraries.
+//
+// Contents are derived from a vcperf /jsonAnalysis trace of a clean nano_node
+// build: <chrono> was the #3 hottest included header (parsed in 272 TUs), the
+// most-included nano header (logging.hpp, 66 TUs) is a thin wrapper over
+// spdlog/fmt, boost.asio ip/tcp.hpp was hot (71 TUs), and nano's core number
+// types (blocks.hpp, 62 TUs) pull in boost.multiprecision. Precompiling those
+// stable STL / third-party leaves once amortizes the parse across all nano TUs.
+// Only skill Tier-1 (STL) and Tier-2 (third-party) headers are included here;
+// volatile nano project headers are deliberately excluded.
+
+// --- Tier 1: standard library (never changes) ---
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <future>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <ostream>
+#include <shared_mutex>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+// --- Tier 2: third-party (changes only on dependency upgrade) ---
+#include <boost/asio.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <spdlog/spdlog.h>

--- a/nano/rocksdb_pch.hpp
+++ b/nano/rocksdb_pch.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+// Precompiled header for the bundled RocksDB static library.
+//
+// A vcperf /jsonAnalysis trace of a clean nano_node build showed RocksDB's own
+// headers dominate frontend parse cost — 9 of the 15 hottest included files are
+// RocksDB internals. Its backbone headers are parsed by the large majority of
+// RocksDB's ~700 translation units: rocksdb/options.h (247 TUs),
+// rocksdb/listener.h (251 TUs) and port/win/port_win.h (261 TUs, via port.h),
+// plus heavy STL. RocksDB ships with no PCH, so precompiling that backbone once
+// amortizes the parse across every RocksDB TU. This is the single largest
+// untapped lever in the build.
+
+// --- Tier 1: standard library ---
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// --- RocksDB backbone (resolved via the rocksdb target's include dirs) ---
+// port/port.h expands to port/win/port_win.h on Windows.
+#include "port/port.h"
+#include "rocksdb/options.h"
+#include "rocksdb/listener.h"


### PR DESCRIPTION
## Summary
Adds an opt-in `-DNANO_PCH` switch that introduces precompiled headers for the bundled **RocksDB** static library and for nano's first-party kernel libraries, cutting a full clean `nano_node` rebuild by **~33%**.

## Motivation
In a clean `nano_node` build, a large share of frontend parse time is spent on the bundled RocksDB library. Several of its core headers (`rocksdb/options.h`, `rocksdb/listener.h`, `port/win/port_win.h`, `db_impl.h`, `column_family.h`, ...) are included across most of RocksDB's translation units, yet the RocksDB static library ships with no precompiled header. `<chrono>` and nano's spdlog/fmt-based logging headers are the next most expensive.

## Change
New `-DNANO_PCH=ON` option (default OFF) that precompiles:

- **`nano/rocksdb_pch.hpp`** on the `rocksdb` target — its stable backbone headers (`rocksdb/options.h`, `rocksdb/listener.h`, `port/port.h`) plus heavy STL. This is the single largest lever.
- **`nano/nano_pch.hpp`** on nano's first-party libs (`nano_lib`, `secure`, `node`, `nano_store`, `nano_messages`, `rpc`, `nano_node`) — stable STL plus `boost.asio`, `boost.multiprecision`, `fmt`, `spdlog`.

Both headers contain only standard-library and stable third-party headers — no volatile project headers — so they rarely invalidate.

## Measured impact
Full clean rebuild, MSVC (VS 2022, 14.44), Release, `/m:16`, 5 runs each:

| Variant | Mean (s) | StdDev (s) |
|---|---|---|
| baseline (no PCH) | 595.62 | 10.05 |
| `NANO_PCH=ON` | 397.10 | 1.40 |

**~198 s faster (33.33%)**, statistically significant (post < baseline − stddev).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
