### PR TITLE
Persist ledger pruning state as ledger flag

### DIFF
--- a/nano/core_test/block_store.cpp
+++ b/nano/core_test/block_store.cpp
@@ -1672,22 +1672,22 @@ TEST (block_store, meta_flags)
 	auto const key = static_cast<nano::store::meta_key> (99);
 	{
 		auto txn = store->tx_begin_read ();
-		ASSERT_FALSE (store->version.get_flag (txn, key));
+		ASSERT_FALSE (store->meta.get_flag (txn, key));
 	}
 	{
 		auto txn = store->tx_begin_write ();
-		store->version.put_flag (txn, key, true);
+		store->meta.put_flag (txn, key, true);
 	}
 	{
 		auto txn = store->tx_begin_read ();
-		ASSERT_TRUE (store->version.get_flag (txn, key));
+		ASSERT_TRUE (store->meta.get_flag (txn, key));
 	}
 	{
 		auto txn = store->tx_begin_write ();
-		store->version.put_flag (txn, key, false);
+		store->meta.put_flag (txn, key, false);
 	}
 	{
 		auto txn = store->tx_begin_read ();
-		ASSERT_FALSE (store->version.get_flag (txn, key));
+		ASSERT_FALSE (store->meta.get_flag (txn, key));
 	}
 }

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5885,7 +5885,7 @@ TEST (ledger, copy_to_rocksdb)
 		store->peer.put (transaction, endpoint_key, 37);
 		store->pending.put (transaction, nano::pending_key (nano::dev::genesis_key.pub, send->hash ()), nano::pending_info (nano::dev::genesis_key.pub, 100, nano::epoch::epoch_0));
 		store->pruned.put (transaction, send->hash ());
-		store->version.put_version (transaction, version);
+		store->meta.put_version (transaction, version);
 		send->sideband_set ({});
 		store->block.put (transaction, send->hash (), *send);
 		store->final_vote.put (transaction, send->qualified_root (), nano::block_hash (2));
@@ -5922,7 +5922,7 @@ TEST (ledger, copy_to_rocksdb)
 		ASSERT_EQ (*send, *block1);
 
 		ASSERT_TRUE (rocksdb_store->peer.exists (rocksdb_transaction, endpoint_key));
-		ASSERT_EQ (rocksdb_store->version.get_version (rocksdb_transaction), version);
+		ASSERT_EQ (rocksdb_store->meta.get_version (rocksdb_transaction), version);
 
 		nano::confirmation_height_info confirmation_height_info;
 		ASSERT_FALSE (rocksdb_store->confirmation_height.get (rocksdb_transaction, nano::dev::genesis_key.pub, confirmation_height_info));
@@ -7073,7 +7073,7 @@ TEST (ledger, topo_height_unindexed_dependency_propagates_zero)
 	}
 	{
 		auto txn = store->tx_begin_write ();
-		store->version.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
+		store->meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
 	}
 
 	std::shared_ptr<nano::block> send;
@@ -7098,7 +7098,7 @@ TEST (ledger, topo_height_unindexed_dependency_propagates_zero)
 
 	{
 		auto txn = store->tx_begin_write ();
-		store->version.put_flag (txn, nano::store::meta_key::topo_index_enabled, true);
+		store->meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, true);
 	}
 	{
 		nano::ledger ledger{ *store, nano::dev::network_params, stats, logger };
@@ -7135,7 +7135,7 @@ TEST (ledger, topo_height_disabled_flag_skips_indexing)
 	}
 	{
 		auto txn = store->tx_begin_write ();
-		store->version.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
+		store->meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
 	}
 
 	nano::ledger ledger{ *store, nano::dev::network_params, stats, logger };
@@ -7189,7 +7189,7 @@ TEST (ledger, populate_topo_index_legacy_chain)
 	}
 	{
 		auto txn = store->tx_begin_write ();
-		store->version.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
+		store->meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
 	}
 
 	// Build the chain with the flag disabled so every block lands with topo_height = 0
@@ -7301,7 +7301,7 @@ TEST (ledger, populate_topo_index_state_blocks)
 	}
 	{
 		auto txn = store->tx_begin_write ();
-		store->version.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
+		store->meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
 	}
 
 	std::shared_ptr<nano::block> send;
@@ -7411,7 +7411,7 @@ TEST (ledger, populate_topo_index_with_epoch_blocks)
 	}
 	{
 		auto txn = store->tx_begin_write ();
-		store->version.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
+		store->meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
 	}
 
 	std::shared_ptr<nano::block> send;
@@ -7551,7 +7551,7 @@ TEST (ledger, populate_topo_index_mixed_indexed_and_unindexed)
 	// Flip the flag off so the next batch lands unindexed
 	{
 		auto txn = store->tx_begin_write ();
-		store->version.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
+		store->meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
 	}
 
 	// Phase B: process more blocks with the flag off -- topo_height must stay 0
@@ -7690,7 +7690,7 @@ TEST (ledger, drop_topo_index)
 		ASSERT_FALSE (store->topology.exists (txn, { 1, nano::dev::genesis->hash () }));
 		ASSERT_FALSE (store->topology.exists (txn, { 2, send->hash () }));
 		ASSERT_FALSE (store->topology.exists (txn, { 3, open->hash () }));
-		ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::topo_index_enabled));
+		ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::topo_index_enabled));
 		ASSERT_TRUE (store->block.exists (txn, send->hash ()));
 		ASSERT_TRUE (store->block.exists (txn, open->hash ()));
 	}

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5078,9 +5078,7 @@ TEST (ledger, dependencies_cemented_pruning)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	// Topo index is incompatible with pruning
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_topo_index = false });
-	ledger.pruning = true;
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
 	auto transaction = ledger.tx_begin_write ();
 	nano::block_builder builder;
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -5150,7 +5148,8 @@ TEST (ledger, block_confirmed)
 
 TEST (ledger, cache)
 {
-	auto ctx = nano::test::ledger_empty ();
+	// Pruning-enabled so the pruned count cache can be exercised as well
+	auto ctx = nano::test::ledger_empty (nano::ledger_options{ .enable_pruning = true });
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto & stats = ctx.stats ();
@@ -5255,9 +5254,7 @@ TEST (ledger, pruning_action)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	// Topo index is incompatible with pruning
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_topo_index = false });
-	ledger.pruning = true;
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5296,10 +5293,6 @@ TEST (ledger, pruning_action)
 	ASSERT_TRUE (ledger.any.pending_get (transaction, nano::pending_key{ nano::dev::genesis_key.pub, send1->hash () }));
 	ASSERT_FALSE (ledger.any.block_exists (transaction, send1->hash ()));
 	ASSERT_TRUE (ledger.any.block_exists_or_pruned (transaction, send1->hash ()));
-	// Pruned ledger start without proper flags emulation
-	ledger.pruning = false;
-	ASSERT_TRUE (ledger.any.block_exists_or_pruned (transaction, send1->hash ()));
-	ledger.pruning = true;
 	ASSERT_TRUE (store->pruned.exists (transaction, send1->hash ()));
 	ASSERT_TRUE (ledger.any.block_exists (transaction, nano::dev::genesis->hash ()));
 	ASSERT_TRUE (ledger.any.block_exists (transaction, send2->hash ()));
@@ -5340,9 +5333,7 @@ TEST (ledger, pruning_large_chain)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	// Topo index is incompatible with pruning
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_topo_index = false });
-	ledger.pruning = true;
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	size_t send_receive_pairs (20);
@@ -5395,9 +5386,7 @@ TEST (ledger, pruning_source_rollback)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	// Topo index is incompatible with pruning
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_topo_index = false });
-	ledger.pruning = true;
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5483,9 +5472,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	// Topo index is incompatible with pruning
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_topo_index = false });
-	ledger.pruning = true;
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5596,9 +5583,7 @@ TEST (ledger, pruning_legacy_blocks)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	// Topo index is incompatible with pruning
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_topo_index = false });
-	ledger.pruning = true;
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
 	nano::keypair key1;
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -5682,9 +5667,7 @@ TEST (ledger, pruning_safe_functions)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	// Topo index is incompatible with pruning
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_topo_index = false });
-	ledger.pruning = true;
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5733,9 +5716,7 @@ TEST (ledger, random_blocks)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	// Topo index is incompatible with pruning
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_topo_index = false });
-	ledger.pruning = true;
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -5078,7 +5078,7 @@ TEST (ledger, dependencies_cemented_pruning)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	auto transaction = ledger.tx_begin_write ();
 	nano::block_builder builder;
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -5149,7 +5149,7 @@ TEST (ledger, block_confirmed)
 TEST (ledger, cache)
 {
 	// Pruning-enabled so the pruned count cache can be exercised as well
-	auto ctx = nano::test::ledger_empty (nano::ledger_options{ .enable_pruning = true });
+	auto ctx = nano::test::ledger_empty (nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	auto & ledger = ctx.ledger ();
 	auto & store = ctx.store ();
 	auto & stats = ctx.stats ();
@@ -5249,12 +5249,136 @@ TEST (ledger, cache)
 	}
 }
 
+// Test that seeding a fresh ledger as pruned persists the pruning flag across reopens
+TEST (ledger, pruning_flag_persists)
+{
+	nano::logger logger;
+	nano::stats stats{ logger };
+	auto path (nano::unique_path ());
+
+	// Fresh ledger seeded as pruned, without the topo index
+	{
+		auto store = nano::test::make_store (logger, stats, path);
+		nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
+		ASSERT_TRUE (ledger.flags.pruning);
+		ASSERT_FALSE (ledger.flags.topo_index);
+	}
+
+	// Reopening without any options keeps the ledger pruned, the persisted flag is authoritative
+	{
+		auto store = nano::test::make_store (logger, stats, path);
+		nano::ledger ledger (*store, nano::dev::network_params, stats, logger);
+		ASSERT_TRUE (ledger.flags.pruning);
+		ASSERT_FALSE (ledger.flags.topo_index);
+	}
+}
+
+// Test that requesting pruning on an existing compatible ledger performs a persistent one-way transition
+TEST (ledger, pruning_flag_transition)
+{
+	nano::logger logger;
+	nano::stats stats{ logger };
+	auto path (nano::unique_path ());
+
+	// Seed a fresh ledger without the topo index and without pruning
+	{
+		auto store = nano::test::make_store (logger, stats, path);
+		nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_topo_index = false });
+		ASSERT_FALSE (ledger.flags.pruning);
+	}
+
+	// Reopening with pruning requested permanently marks the ledger as pruned
+	// The topo option is irrelevant here, it only matters when seeding a fresh ledger
+	{
+		auto store = nano::test::make_store (logger, stats, path);
+		nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
+		ASSERT_TRUE (ledger.flags.pruning);
+	}
+
+	// The transition must be persisted, not just reflected in the in-memory flags
+	{
+		auto store = nano::test::make_store (logger, stats, path);
+		nano::ledger ledger (*store, nano::dev::network_params, stats, logger);
+		ASSERT_TRUE (ledger.flags.pruning);
+	}
+}
+
+// Test that a ledger with conflicting pruning and topo index flags can be recovered with drop_topo_index
+TEST (ledger, pruning_flag_recovery_topo)
+{
+	nano::logger logger;
+	nano::stats stats{ logger };
+	auto path (nano::unique_path ());
+
+	// Seed a normal ledger with the topo index, then fabricate the invalid state by marking it as pruned directly
+	{
+		auto store = nano::test::make_store (logger, stats, path);
+		nano::ledger ledger (*store, nano::dev::network_params, stats, logger);
+		ASSERT_TRUE (ledger.flags.topo_index);
+
+		auto txn = store->tx_begin_write ();
+		store->meta.put_flag (txn, nano::store::meta_key::pruning_enabled, true);
+	}
+
+	// Recovery tooling opens without load-time checks and drops the offending index
+	{
+		auto store = nano::test::make_store (logger, stats, path);
+		nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .generate_cache = nano::generate_cache_flags::all_disabled () });
+		ASSERT_TRUE (ledger.flags.pruning);
+		ASSERT_TRUE (ledger.flags.topo_index);
+		ledger.drop_topo_index ();
+	}
+
+	// A regular checked open now succeeds with only pruning enabled
+	{
+		auto store = nano::test::make_store (logger, stats, path);
+		nano::ledger ledger (*store, nano::dev::network_params, stats, logger);
+		ASSERT_TRUE (ledger.flags.pruning);
+		ASSERT_FALSE (ledger.flags.topo_index);
+	}
+}
+
+// Test that a ledger with conflicting pruning and extended index flags can be recovered with drop_extended_ledger_indices
+TEST (ledger, pruning_flag_recovery_extended)
+{
+	nano::logger logger;
+	nano::stats stats{ logger };
+	auto path (nano::unique_path ());
+
+	// Seed a ledger with extended indices, then fabricate the invalid state by marking it as pruned directly
+	{
+		auto store = nano::test::make_store (logger, stats, path);
+		nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_topo_index = false, .enable_extended_ledger_index = true });
+		ASSERT_TRUE (ledger.flags.all_extended_ledger_indices_enabled ());
+
+		auto txn = store->tx_begin_write ();
+		store->meta.put_flag (txn, nano::store::meta_key::pruning_enabled, true);
+	}
+
+	// Recovery tooling opens without load-time checks and drops the offending indices
+	{
+		auto store = nano::test::make_store (logger, stats, path);
+		nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .generate_cache = nano::generate_cache_flags::all_disabled () });
+		ASSERT_TRUE (ledger.flags.pruning);
+		ASSERT_TRUE (ledger.flags.any_extended_ledger_index_enabled ());
+		ledger.drop_extended_ledger_indices ();
+	}
+
+	// A regular checked open now succeeds with only pruning enabled
+	{
+		auto store = nano::test::make_store (logger, stats, path);
+		nano::ledger ledger (*store, nano::dev::network_params, stats, logger);
+		ASSERT_TRUE (ledger.flags.pruning);
+		ASSERT_FALSE (ledger.flags.any_extended_ledger_index_enabled ());
+	}
+}
+
 TEST (ledger, pruning_action)
 {
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5333,7 +5457,7 @@ TEST (ledger, pruning_large_chain)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	size_t send_receive_pairs (20);
@@ -5386,7 +5510,7 @@ TEST (ledger, pruning_source_rollback)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5472,7 +5596,7 @@ TEST (ledger, pruning_source_rollback_legacy)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5583,7 +5707,7 @@ TEST (ledger, pruning_legacy_blocks)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	nano::keypair key1;
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
@@ -5667,7 +5791,7 @@ TEST (ledger, pruning_safe_functions)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;
@@ -5716,7 +5840,7 @@ TEST (ledger, random_blocks)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	auto transaction = ledger.tx_begin_write ();
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::block_builder builder;

--- a/nano/core_test/ledger_cement.cpp
+++ b/nano/core_test/ledger_cement.cpp
@@ -767,9 +767,7 @@ TEST (ledger_cement, pruned_source)
 	auto path (nano::unique_path ());
 	auto store = nano::test::make_store (system.logger, system.stats, path);
 
-	// Topo index is incompatible with pruning
-	nano::ledger ledger (*store, nano::dev::network_params, system.stats, system.logger, nano::ledger_options{ .enable_topo_index = false });
-	ledger.pruning = true;
+	nano::ledger ledger (*store, nano::dev::network_params, system.stats, system.logger, nano::ledger_options{ .enable_pruning = true });
 	nano::store::write_queue write_queue;
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1, key2;

--- a/nano/core_test/ledger_cement.cpp
+++ b/nano/core_test/ledger_cement.cpp
@@ -767,7 +767,7 @@ TEST (ledger_cement, pruned_source)
 	auto path (nano::unique_path ());
 	auto store = nano::test::make_store (system.logger, system.stats, path);
 
-	nano::ledger ledger (*store, nano::dev::network_params, system.stats, system.logger, nano::ledger_options{ .enable_pruning = true });
+	nano::ledger ledger (*store, nano::dev::network_params, system.stats, system.logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	nano::store::write_queue write_queue;
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1, key2;

--- a/nano/core_test/ledger_extended_index.cpp
+++ b/nano/core_test/ledger_extended_index.cpp
@@ -428,10 +428,10 @@ TEST (ledger_extended_index, fresh_ledger_enables_flags)
 	ASSERT_TRUE (ledger.flags.all_extended_ledger_indices_enabled ());
 
 	auto txn = ledger.tx_begin_read ();
-	ASSERT_TRUE (store->version.get_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled));
-	ASSERT_TRUE (store->version.get_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled));
-	ASSERT_TRUE (store->version.get_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled));
-	ASSERT_TRUE (store->version.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled));
+	ASSERT_TRUE (store->meta.get_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled));
+	ASSERT_TRUE (store->meta.get_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled));
+	ASSERT_TRUE (store->meta.get_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled));
+	ASSERT_TRUE (store->meta.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled));
 
 	ASSERT_TRUE (store->extended.account_delegator_by_weight.present ());
 	ASSERT_TRUE (store->extended.account_receivable_by_amount.present ());
@@ -462,10 +462,10 @@ TEST (ledger_extended_index, disabled_by_default)
 	ASSERT_FALSE (ledger.flags.any_extended_ledger_index_enabled ());
 
 	auto txn = ledger.tx_begin_read ();
-	ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled));
-	ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled));
-	ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled));
-	ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled));
+	ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled));
+	ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled));
+	ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled));
+	ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled));
 	ASSERT_FALSE (store->extended.account_delegator_by_weight.present ());
 	ASSERT_FALSE (store->extended.account_receivable_by_amount.present ());
 	ASSERT_FALSE (store->extended.receive_block_by_send_block.present ());
@@ -727,10 +727,10 @@ TEST (ledger_extended_index, single_index_populate_and_mixed_flags)
 	ASSERT_FALSE (ledger.flags.all_extended_ledger_indices_enabled ());
 	{
 		auto txn = ledger.tx_begin_read ();
-		ASSERT_TRUE (store->version.get_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled));
-		ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled));
-		ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled));
-		ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled));
+		ASSERT_TRUE (store->meta.get_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled));
+		ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled));
+		ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled));
+		ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled));
 		ASSERT_EQ (2, store->extended.receive_block_by_send_block.count (txn));
 		ASSERT_EQ (open1->hash (), store->extended.receive_block_by_send_block.get (txn, send1->hash ()).value ());
 		ASSERT_TRUE (store->extended.receive_block_by_send_block.present ());
@@ -1361,10 +1361,10 @@ TEST (ledger_extended_index, drop_and_repopulate)
 		ledger.drop_extended_ledger_indices ();
 		ASSERT_FALSE (ledger.flags.any_extended_ledger_index_enabled ());
 		auto txn = ledger.tx_begin_read ();
-		ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled));
-		ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled));
-		ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled));
-		ASSERT_FALSE (store->version.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled));
+		ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled));
+		ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled));
+		ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled));
+		ASSERT_FALSE (store->meta.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled));
 		ASSERT_FALSE (store->extended.account_delegator_by_weight.present ());
 		ASSERT_FALSE (store->extended.account_receivable_by_amount.present ());
 		ASSERT_FALSE (store->extended.receive_block_by_send_block.present ());
@@ -1450,7 +1450,7 @@ TEST (ledger_extended_index, drop_recovers_from_missing_table)
 	{
 		auto store = nano::test::make_store (logger, stats, path);
 		store->extended.account_delegator_by_weight.drop ();
-		ASSERT_TRUE (store->version.get_flag (store->tx_begin_read (), nano::store::meta_key::account_delegator_by_weight_index_enabled));
+		ASSERT_TRUE (store->meta.get_flag (store->tx_begin_read (), nano::store::meta_key::account_delegator_by_weight_index_enabled));
 
 		// Without the consistency check the ledger opens on the corrupted store and can drop the indices
 		nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .generate_cache = nano::generate_cache_flags::all_disabled () });
@@ -1490,7 +1490,7 @@ TEST (ledger_extended_index, read_only_open_without_extended_tables)
 		auto backend = nano::test::make_backend (path);
 		nano::store::ledger_store store{ std::move (backend), nano::store::open_mode::read_only, stats, logger };
 		auto txn = store.tx_begin_read ();
-		ASSERT_FALSE (store.version.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled));
+		ASSERT_FALSE (store.meta.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled));
 		ASSERT_FALSE (store.extended.account_delegator_by_weight.present ());
 		ASSERT_FALSE (store.extended.account_receivable_by_amount.present ());
 		ASSERT_FALSE (store.extended.receive_block_by_send_block.present ());

--- a/nano/core_test/ledger_upgrades.cpp
+++ b/nano/core_test/ledger_upgrades.cpp
@@ -184,7 +184,7 @@ TEST (ledger_upgrades, current_version_read_only)
 	nano::test::default_logger ());
 
 	auto tx = store.tx_begin_read ();
-	ASSERT_EQ (store.version.get_version (tx), nano::store::ledger_store::version_current);
+	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
 
 	// Verify we can read genesis account
 	nano::account_info info;
@@ -217,7 +217,7 @@ TEST (ledger_upgrades, current_version_no_upgrade)
 	nano::test::default_logger ());
 
 	auto tx = store.tx_begin_read ();
-	ASSERT_EQ (store.version.get_version (tx), nano::store::ledger_store::version_current);
+	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
 }
 
 namespace
@@ -367,7 +367,7 @@ TEST (ledger_upgrades, upgrade_v22_to_v23_rep_weights)
 
 	// Verify rep weights were correctly calculated
 	auto tx = store.tx_begin_read ();
-	ASSERT_EQ (store.version.get_version (tx), nano::store::ledger_store::version_current);
+	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
 
 	// rep_a should have weight from account_1 + account_2 = 1000 + 500 = 1500
 	ASSERT_EQ (store.rep_weight.get (tx, rep_a), 1500);
@@ -521,7 +521,7 @@ TEST (ledger_upgrades, upgrade_v22_to_v23_stale_rep_weights)
 
 	// Verify rep weights are correct (not corrupted by stale data)
 	auto tx = store.tx_begin_read ();
-	ASSERT_EQ (store.version.get_version (tx), nano::store::ledger_store::version_current);
+	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
 
 	// rep_a should have correct weight from account_1 = 1000 (not stale 999999)
 	ASSERT_EQ (store.rep_weight.get (tx, rep_a), 1000);
@@ -711,7 +711,7 @@ TEST (ledger_upgrades, upgrade_v24_to_v25)
 	auto tx = store.tx_begin_read ();
 
 	// Verify version
-	ASSERT_EQ (store.version.get_version (tx), nano::store::ledger_store::version_current);
+	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
 
 	// Verify successor table has the correct entry for block1 -> block2
 	auto successor_result = store.successor.get (tx, block1->hash ());
@@ -882,8 +882,8 @@ TEST (ledger_upgrades, upgrade_v25_to_v26)
 	auto tx = store.tx_begin_read ();
 
 	// Verify version is now 26
-	ASSERT_EQ (store.version.get_version (tx), nano::store::ledger_store::version_current);
-	ASSERT_EQ (store.version.get_version (tx), 26);
+	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
+	ASSERT_EQ (store.meta.get_version (tx), 26);
 
 	// Verify blocks are readable with new format
 	auto stored_block1 = store.block.get (tx, block1->hash ());
@@ -970,7 +970,7 @@ TEST (ledger_upgrades, upgrade_v25_to_v26_interrupted)
 
 	auto tx = store.tx_begin_read ();
 
-	ASSERT_EQ (store.version.get_version (tx), 26);
+	ASSERT_EQ (store.meta.get_version (tx), 26);
 
 	// Both blocks should be readable
 	auto stored_block1 = store.block.get (tx, block1->hash ());
@@ -1017,7 +1017,7 @@ TEST (ledger_upgrades, full_upgrade_v21_to_current)
 
 	// Verify final version
 	auto tx = store.tx_begin_read ();
-	ASSERT_EQ (store.version.get_version (tx), nano::store::ledger_store::version_current);
+	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
 
 	// Verify account still exists
 	nano::account_info account_info;
@@ -1079,7 +1079,7 @@ TEST (ledger_upgrades, upgrade_backup)
 
 	// Verify version was upgraded
 	auto tx = store.tx_begin_read ();
-	ASSERT_EQ (store.version.get_version (tx), nano::store::ledger_store::version_current);
+	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
 
 	// Verify backup was created
 	ASSERT_TRUE (backup_exists ());

--- a/nano/core_test/ledger_upgrades.cpp
+++ b/nano/core_test/ledger_upgrades.cpp
@@ -15,6 +15,7 @@
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/block.hpp>
 #include <nano/store/ledger/pending.hpp>
+#include <nano/store/ledger/pruned.hpp>
 #include <nano/store/ledger/rep_weight.hpp>
 #include <nano/store/ledger/successor.hpp>
 #include <nano/store/ledger/version.hpp>
@@ -799,6 +800,28 @@ public:
 	std::filesystem::path path;
 	std::unique_ptr<nano::store::backend> backend;
 };
+
+class legacy_database_v26
+{
+public:
+	legacy_database_v26 (std::filesystem::path const & path_a) :
+		path{ path_a },
+		backend{ nano::test::make_backend (path_a) }
+	{
+		backend->create (nano::store::ledger_store::schema_v26, 26);
+		backend->open (nano::store::ledger_store::schema_v26, nano::store::open_mode::read_write);
+	}
+
+	void add_pruned (nano::block_hash const & hash)
+	{
+		auto tx = backend->tx_begin_write ();
+		auto status = backend->put (tx, nano::store::table::pruned, hash, nullptr);
+		backend->release_assert_success (status);
+	}
+
+	std::filesystem::path path;
+	std::unique_ptr<nano::store::backend> backend;
+};
 }
 
 /*
@@ -881,9 +904,8 @@ TEST (ledger_upgrades, upgrade_v25_to_v26)
 
 	auto tx = store.tx_begin_read ();
 
-	// Verify version is now 26
+	// Upgrade chain continues past v26 up to the current version
 	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
-	ASSERT_EQ (store.meta.get_version (tx), 26);
 
 	// Verify blocks are readable with new format
 	auto stored_block1 = store.block.get (tx, block1->hash ());
@@ -970,7 +992,7 @@ TEST (ledger_upgrades, upgrade_v25_to_v26_interrupted)
 
 	auto tx = store.tx_begin_read ();
 
-	ASSERT_EQ (store.meta.get_version (tx), 26);
+	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
 
 	// Both blocks should be readable
 	auto stored_block1 = store.block.get (tx, block1->hash ());
@@ -987,6 +1009,54 @@ TEST (ledger_upgrades, upgrade_v25_to_v26_interrupted)
 	auto successor_result = store.successor.get (tx, block1->hash ());
 	ASSERT_TRUE (successor_result.has_value ());
 	ASSERT_EQ (*successor_result, block2->hash ());
+}
+
+/*
+ * Test v26 to v27 upgrade: a ledger with pruned entries gets the persisted pruning flag
+ */
+TEST (ledger_upgrades, upgrade_v26_to_v27_pruned)
+{
+	auto const path = nano::unique_path ();
+	{
+		legacy_database_v26 legacy_db{ path };
+		legacy_db.add_pruned (nano::block_hash{ 42 });
+	}
+
+	// Open through ledger_store which should trigger upgrade
+	nano::store::ledger_store store (
+	nano::test::make_backend (path),
+	nano::store::open_mode::read_write,
+	nano::test::default_stats (),
+	nano::test::default_logger ());
+
+	auto tx = store.tx_begin_read ();
+	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
+	ASSERT_TRUE (store.meta.get_flag (tx, nano::store::meta_key::pruning_enabled));
+
+	// Pruned entries survive the upgrade
+	ASSERT_TRUE (store.pruned.exists (tx, nano::block_hash{ 42 }));
+}
+
+/*
+ * Test v26 to v27 upgrade: a ledger without pruned entries stays unmarked
+ */
+TEST (ledger_upgrades, upgrade_v26_to_v27_unpruned)
+{
+	auto const path = nano::unique_path ();
+	{
+		legacy_database_v26 legacy_db{ path };
+	}
+
+	// Open through ledger_store which should trigger upgrade
+	nano::store::ledger_store store (
+	nano::test::make_backend (path),
+	nano::store::open_mode::read_write,
+	nano::test::default_stats (),
+	nano::test::default_logger ());
+
+	auto tx = store.tx_begin_read ();
+	ASSERT_EQ (store.meta.get_version (tx), nano::store::ledger_store::version_current);
+	ASSERT_FALSE (store.meta.get_flag (tx, nano::store::meta_key::pruning_enabled));
 }
 
 /*

--- a/nano/core_test/voting_policy.cpp
+++ b/nano/core_test/voting_policy.cpp
@@ -1427,9 +1427,7 @@ TEST (voting_policy, pruned_dependency)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	// Topo index is incompatible with pruning
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_topo_index = false });
-	ledger.pruning = true;
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
 	nano::voting_policy policy{ ledger };
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;

--- a/nano/core_test/voting_policy.cpp
+++ b/nano/core_test/voting_policy.cpp
@@ -1427,7 +1427,7 @@ TEST (voting_policy, pruned_dependency)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	nano::voting_policy policy{ ledger };
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	nano::keypair key1;

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1452,7 +1452,7 @@ int main (int argc, char * const * argv)
 				nano::block_hash calculated_hash (0);
 				auto block = node->ledger.any.block_get (transaction, hash); // Block data
 				uint64_t height (0);
-				if (node->ledger.pruning && confirmation_height_info.height != 0)
+				if (node->ledger.flags.pruning && confirmation_height_info.height != 0)
 				{
 					hash = confirmation_height_info.frontier;
 					block = node->ledger.any.block_get (transaction, hash);
@@ -1537,7 +1537,7 @@ int main (int argc, char * const * argv)
 							}
 							if (node->ledger.is_epoch_link (state_block.hashables.link))
 							{
-								if ((state_block.hashables.balance == prev_balance && !error_or_pruned) || (node->ledger.pruning && error_or_pruned && block->sideband ().details.is_epoch))
+								if ((state_block.hashables.balance == prev_balance && !error_or_pruned) || (node->ledger.flags.pruning && error_or_pruned && block->sideband ().details.is_epoch))
 								{
 									invalid = validate_message (node->ledger.epoch_signer (block->link_field ().value ()), hash, block->block_signature ());
 								}
@@ -1558,7 +1558,7 @@ int main (int argc, char * const * argv)
 					else
 					{
 						auto prev_balance = node->ledger.any.block_balance (transaction, block->previous ());
-						if (!node->ledger.pruning || prev_balance)
+						if (!node->ledger.flags.pruning || prev_balance)
 						{
 							if (block->balance () < prev_balance.value ())
 							{
@@ -1595,7 +1595,7 @@ int main (int argc, char * const * argv)
 						print_error_message (boost::str (boost::format ("Incorrect sideband block details for block %1%\n") % hash.to_string ()));
 					}
 					// Check link epoch version
-					if (sideband.details.is_receive && (!node->ledger.pruning || !node->store.pruned.exists (transaction, block->source ())))
+					if (sideband.details.is_receive && (!node->ledger.flags.pruning || !node->store.pruned.exists (transaction, block->source ())))
 					{
 						if (sideband.source_epoch != node->ledger.version (*block))
 						{
@@ -1693,7 +1693,7 @@ int main (int argc, char * const * argv)
 
 			// Validate total block count
 			auto ledger_block_count (node->store.block.count (transaction));
-			if (node->flags.enable_pruning)
+			if (node->ledger.flags.pruning)
 			{
 				block_count += 1; // Add disconnected genesis block
 			}
@@ -1718,7 +1718,7 @@ int main (int argc, char * const * argv)
 				bool pruned (false);
 				if (block == nullptr)
 				{
-					pruned = node->ledger.pruning && node->store.pruned.exists (transaction, key.hash);
+					pruned = node->ledger.flags.pruning && node->store.pruned.exists (transaction, key.hash);
 					if (!pruned)
 					{
 						print_error_message (boost::str (boost::format ("Pending block does not exist %1%\n") % key.hash.to_string ()));
@@ -1728,7 +1728,7 @@ int main (int argc, char * const * argv)
 				{
 					// Check if pending destination is correct
 					nano::account destination{};
-					bool previous_pruned = node->ledger.pruning && node->store.pruned.exists (transaction, block->previous ());
+					bool previous_pruned = node->ledger.flags.pruning && node->store.pruned.exists (transaction, block->previous ());
 					if (previous_pruned)
 					{
 						block = node->ledger.any.block_get (transaction, key.hash);

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -640,11 +640,11 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 
 					auto txn = store.tx_begin_read ();
 
-					bool const topo_index = store.version.get_flag (txn, nano::store::meta_key::topo_index_enabled);
-					bool const account_delegator_by_weight_index = store.version.get_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled);
-					bool const account_receivable_by_amount_index = store.version.get_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled);
-					bool const receive_block_by_send_block_index = store.version.get_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled);
-					bool const account_block_by_height_index = store.version.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled);
+					bool const topo_index = store.meta.get_flag (txn, nano::store::meta_key::topo_index_enabled);
+					bool const account_delegator_by_weight_index = store.meta.get_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled);
+					bool const account_receivable_by_amount_index = store.meta.get_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled);
+					bool const receive_block_by_send_block_index = store.meta.get_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled);
+					bool const account_block_by_height_index = store.meta.get_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled);
 
 					std::cout << "Path:             " << store.get_database_path () << std::endl;
 					std::cout << "Backend:          " << store.get_vendor () << std::endl;

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -146,7 +146,7 @@ void nano::add_node_flag_options (boost::program_options::options_description & 
 		("disable_tcp_realtime", "Disables TCP realtime connections")
 		("disable_search_pending", "Disables the periodic search for pending transactions")
 		("disable_topo_index", "Initialize a fresh ledger without the topology index. Required for pruning. Has no effect on an existing ledger; use --drop_topo_index to disable on an existing ledger.")
-		("enable_pruning", "Enable experimental ledger pruning")
+		("enable_pruning", "Enable experimental ledger pruning. Permanently marks the ledger as pruned on first use; subsequent launches keep pruning even without this flag")
 		("peering_only", "Run as a peering-only node: keep a genesis-only ledger, run no ledger subsystems, and participate only in the peer-to-peer network (peer discovery/bootstrap)")
 		("enable_rpc", "Enable RPC")
 		("enable_voting", "Enable voting")
@@ -640,6 +640,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 
 					auto txn = store.tx_begin_read ();
 
+					bool const pruning = store.meta.get_flag (txn, nano::store::meta_key::pruning_enabled);
 					bool const topo_index = store.meta.get_flag (txn, nano::store::meta_key::topo_index_enabled);
 					bool const account_delegator_by_weight_index = store.meta.get_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled);
 					bool const account_receivable_by_amount_index = store.meta.get_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled);
@@ -658,11 +659,12 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 					}
 
 					std::cout << "Flags:" << std::endl;
-					std::cout << "  topo_index:                          " << (topo_index ? "enabled" : "disabled") << std::endl;
+					std::cout << "  pruning:                            " << (pruning ? "enabled" : "disabled") << std::endl;
+					std::cout << "  topo_index:                         " << (topo_index ? "enabled" : "disabled") << std::endl;
 					std::cout << "  account_delegator_by_weight_index:  " << (account_delegator_by_weight_index ? "enabled" : "disabled") << std::endl;
 					std::cout << "  account_receivable_by_amount_index: " << (account_receivable_by_amount_index ? "enabled" : "disabled") << std::endl;
-					std::cout << "  receive_block_by_send_block_index:   " << (receive_block_by_send_block_index ? "enabled" : "disabled") << std::endl;
-					std::cout << "  account_block_by_height_index:  " << (account_block_by_height_index ? "enabled" : "disabled") << std::endl;
+					std::cout << "  receive_block_by_send_block_index:  " << (receive_block_by_send_block_index ? "enabled" : "disabled") << std::endl;
+					std::cout << "  account_block_by_height_index:      " << (account_block_by_height_index ? "enabled" : "disabled") << std::endl;
 					std::cout << "Counts:" << std::endl;
 					std::cout << "  blocks:         " << store.block.count (txn) << std::endl;
 					std::cout << "  accounts:       " << store.account.count (txn) << std::endl;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1577,7 +1577,7 @@ void nano::json_handler::block_count ()
 	response_l.put ("count", std::to_string (node.ledger.block_count ()));
 	response_l.put ("unchecked", std::to_string (node.unchecked.count ()));
 	response_l.put ("cemented", std::to_string (node.ledger.cemented_count ()));
-	if (node.flags.enable_pruning)
+	if (node.ledger.flags.pruning)
 	{
 		response_l.put ("full", std::to_string (node.ledger.block_count () - node.ledger.pruned_count ()));
 		response_l.put ("pruned", std::to_string (node.ledger.pruned_count ()));
@@ -3632,7 +3632,7 @@ void nano::json_handler::pruned_exists ()
 	if (!ec)
 	{
 		auto transaction (node.store.tx_begin_read ());
-		if (node.ledger.pruning)
+		if (node.ledger.flags.pruning)
 		{
 			auto exists (node.store.pruned.exists (transaction, hash));
 			response_l.put ("exists", exists ? "1" : "0");

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -124,10 +124,10 @@ nano::node::node (std::filesystem::path const & application_path_a, nano::node_c
 	.generate_cache = flags_a.generate_cache,
 	.min_rep_weight = config.representative_vote_weight_minimum.number (),
 	.max_backlog = config.max_backlog,
-	// Topo index is incompatible with pruning, so disable it on fresh ledgers when pruning is on
-	// For existing ledgers the persisted meta flag wins, so this only affects first-init
-	.enable_topo_index = !(flags_a.enable_pruning || flags_a.disable_topo_index),
-	.enable_extended_ledger_index = config.extended_ledger_index && !flags_a.enable_pruning && !flags_a.inactive_node }) },
+	// Pruning takes precedence over the index options inside the ledger; persisted flags win on existing ledgers
+	.enable_pruning = flags_a.enable_pruning,
+	.enable_topo_index = !flags_a.disable_topo_index,
+	.enable_extended_ledger_index = config.extended_ledger_index && !flags_a.inactive_node }) },
 	ledger{ *ledger_impl },
 	runner_impl{ std::make_unique<nano::thread_runner> (io_ctx_shared, logger, config.io_threads) },
 	runner{ *runner_impl },
@@ -448,32 +448,38 @@ nano::node::node (std::filesystem::path const & application_path_a, nano::node_c
 		}
 	}
 
-	ledger.pruning = flags.enable_pruning || store.pruned.count (store.tx_begin_read ()) > 0;
-
-	if (ledger.pruning)
+	// The persisted ledger pruning flag is authoritative; --enable_pruning only requests the one-way transition
+	// Gated on !flags.inactive_node so CLI utilities can still open the ledger without transitioning it
+	if ((flags.enable_pruning || ledger.flags.pruning) && !flags.inactive_node)
 	{
-		// Gated on !flags.inactive_node so CLI utilities can still open the ledger
-		if (config.enable_voting && !flags.inactive_node)
+		if (config.enable_voting)
 		{
-			logger.critical (nano::log::type::node, "Incompatibility detected between config node.enable_voting and existing pruned blocks");
+			logger.critical (nano::log::type::node, "Config node.enable_voting is incompatible with ledger pruning");
 			std::exit (1);
 		}
-		if (!flags.enable_pruning && !flags.inactive_node)
+		if (config.extended_ledger_index)
 		{
-			logger.critical (nano::log::type::node, "To start node with existing pruned blocks use launch flag --enable_pruning");
+			logger.critical (nano::log::type::node, "Config node.extended_ledger_index is incompatible with ledger pruning");
 			std::exit (1);
 		}
-		if (ledger.flags.topo_index && !flags.inactive_node)
+	}
+	if (flags.enable_pruning && !ledger.flags.pruning && !flags.inactive_node)
+	{
+		if (ledger.flags.topo_index)
 		{
-			logger.critical (nano::log::type::node, "Incompatibility detected between topological index and ledger pruning. To proceed, either disable pruning, or run the node with --drop_topo_index to remove the topology index.");
+			logger.critical (nano::log::type::node, "Ledger pruning is incompatible with the topology index. To proceed, run the node with --drop_topo_index to remove the topology index.");
 			std::exit (1);
 		}
-		if (ledger.flags.any_extended_ledger_index_enabled () && !flags.inactive_node)
+		if (ledger.flags.any_extended_ledger_index_enabled ())
 		{
-			logger.critical (nano::log::type::node, "Incompatibility detected between extended ledger indices and ledger pruning. To proceed, either disable pruning, or run the node with --drop_extended_ledger_indices to remove the extended ledger indices.");
+			logger.critical (nano::log::type::node, "Ledger pruning is incompatible with extended ledger indices. To proceed, run the node with --drop_extended_ledger_indices to remove the extended ledger indices.");
 			std::exit (1);
 		}
 
+		ledger.enable_pruning ();
+	}
+	if (ledger.flags.pruning)
+	{
 		logger.warn (nano::log::type::node, "WARNING: Ledger pruning is enabled. This feature is experimental and may result in node instability! Please see release notes for more information.");
 	}
 
@@ -916,7 +922,7 @@ nano::bootstrap_weights nano::node::get_bootstrap_weights () const
 void nano::node::bootstrap_block (const nano::block_hash & hash)
 {
 	// If we are running pruning node check if block was not already pruned
-	if (!ledger.pruning || !store.pruned.exists (store.tx_begin_read (), hash))
+	if (!ledger.flags.pruning || !store.pruned.exists (store.tx_begin_read (), hash))
 	{
 		// We don't have the block, try to bootstrap it
 		// TODO: Use ascending bootstrapper to bootstrap block hash
@@ -962,7 +968,7 @@ nano::messages::telemetry_data nano::node::local_telemetry () const
 	telemetry_data.pre_release_version = nano::get_pre_release_node_version ();
 	telemetry_data.maker = flags.peering_only
 	? nano::messages::telemetry_maker::nf_peering_node
-	: (ledger.pruning ? nano::messages::telemetry_maker::nf_pruned_node : nano::messages::telemetry_maker::nf_node);
+	: (ledger.flags.pruning ? nano::messages::telemetry_maker::nf_pruned_node : nano::messages::telemetry_maker::nf_node);
 	telemetry_data.timestamp = std::chrono::system_clock::now ();
 	telemetry_data.active_difficulty = default_difficulty (nano::work_version::work_1);
 	telemetry_data.database_backend = nano::messages::to_telemetry_database_backend (config.database_backend);

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -886,7 +886,7 @@ std::shared_ptr<nano::transport::channel> nano::node::create_null_channel ()
 
 uint64_t nano::node::store_version () const
 {
-	return store.version.get_version (store.tx_begin_read ());
+	return store.meta.get_version (store.tx_begin_read ());
 }
 
 nano::node_capabilities_flags nano::node::get_capabilities () const

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -124,7 +124,7 @@ nano::node::node (std::filesystem::path const & application_path_a, nano::node_c
 	.generate_cache = flags_a.generate_cache,
 	.min_rep_weight = config.representative_vote_weight_minimum.number (),
 	.max_backlog = config.max_backlog,
-	// Pruning takes precedence over the index options inside the ledger; persisted flags win on existing ledgers
+	// Auto-populating extended indices is a live node behavior, hence the inactive_node gate
 	.enable_pruning = flags_a.enable_pruning,
 	.enable_topo_index = !flags_a.disable_topo_index,
 	.enable_extended_ledger_index = config.extended_ledger_index && !flags_a.inactive_node }) },
@@ -448,38 +448,16 @@ nano::node::node (std::filesystem::path const & application_path_a, nano::node_c
 		}
 	}
 
-	// The persisted ledger pruning flag is authoritative; --enable_pruning only requests the one-way transition
-	// Gated on !flags.inactive_node so CLI utilities can still open the ledger without transitioning it
-	if ((flags.enable_pruning || ledger.flags.pruning) && !flags.inactive_node)
+	// The pruning transition is applied by the ledger itself, only the operational conflicts are checked here
+	if (ledger.flags.pruning)
 	{
-		if (config.enable_voting)
+		// Gated on !flags.inactive_node so CLI utilities can still open the ledger
+		if (config.enable_voting && !flags.inactive_node)
 		{
 			logger.critical (nano::log::type::node, "Config node.enable_voting is incompatible with ledger pruning");
 			std::exit (1);
 		}
-		if (config.extended_ledger_index)
-		{
-			logger.critical (nano::log::type::node, "Config node.extended_ledger_index is incompatible with ledger pruning");
-			std::exit (1);
-		}
-	}
-	if (flags.enable_pruning && !ledger.flags.pruning && !flags.inactive_node)
-	{
-		if (ledger.flags.topo_index)
-		{
-			logger.critical (nano::log::type::node, "Ledger pruning is incompatible with the topology index. To proceed, run the node with --drop_topo_index to remove the topology index.");
-			std::exit (1);
-		}
-		if (ledger.flags.any_extended_ledger_index_enabled ())
-		{
-			logger.critical (nano::log::type::node, "Ledger pruning is incompatible with extended ledger indices. To proceed, run the node with --drop_extended_ledger_indices to remove the extended ledger indices.");
-			std::exit (1);
-		}
 
-		ledger.enable_pruning ();
-	}
-	if (ledger.flags.pruning)
-	{
 		logger.warn (nano::log::type::node, "WARNING: Ledger pruning is enabled. This feature is experimental and may result in node instability! Please see release notes for more information.");
 	}
 

--- a/nano/node/pruning.cpp
+++ b/nano/node/pruning.cpp
@@ -29,7 +29,8 @@ void nano::pruning::start ()
 {
 	debug_assert (!thread.joinable ());
 
-	if (!flags.enable_pruning)
+	// The persisted ledger flag is authoritative, a pruned ledger is always actively pruning
+	if (!ledger.flags.pruning)
 	{
 		return;
 	}

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1032,7 +1032,7 @@ std::string nano_qt::status::text ()
 	count_string += ", Unchecked: " + std::to_string (unchecked);
 	count_string += ", Cemented: " + std::to_string (cemented);
 
-	if (wallet.node.flags.enable_pruning)
+	if (wallet.node.ledger.flags.pruning)
 	{
 		count_string += ", Full: " + std::to_string (wallet.wallet_m->wallets.node.ledger.block_count () - wallet.wallet_m->wallets.node.ledger.pruned_count ());
 		count_string += ", Pruned: " + std::to_string (wallet.wallet_m->wallets.node.ledger.pruned_count ());

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -508,9 +508,7 @@ TEST (history, pruned_source)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger);
-	ledger.drop_topo_index (); // Topo index is incompatible with pruning
-	ledger.pruning = true;
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
 	nano::block_hash next_pruning;
 	// Basic pruning for legacy blocks. Previous block is pruned, source is pruned
 	{

--- a/nano/qt_test/qt.cpp
+++ b/nano/qt_test/qt.cpp
@@ -508,7 +508,7 @@ TEST (history, pruned_source)
 	nano::logger logger;
 	nano::stats stats{ logger };
 	auto store = nano::test::make_store (logger, stats);
-	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true });
+	nano::ledger ledger (*store, nano::dev::network_params, stats, logger, nano::ledger_options{ .enable_pruning = true, .enable_topo_index = false });
 	nano::block_hash next_pruning;
 	// Basic pruning for legacy blocks. Previous block is pruned, source is pruned
 	{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -1906,7 +1906,7 @@ TEST (rpc, version)
 	ASSERT_EQ ("1", response1.json.get<std::string> ("rpc_version"));
 	{
 		auto transaction (node1->store.tx_begin_read ());
-		ASSERT_EQ (std::to_string (node1->store.version.get_version (transaction)), response1.json.get<std::string> ("store_version"));
+		ASSERT_EQ (std::to_string (node1->store.meta.get_version (transaction)), response1.json.get<std::string> ("store_version"));
 	}
 	ASSERT_EQ (std::to_string (node1->network_params.network.protocol_version), response1.json.get<std::string> ("protocol_version"));
 	ASSERT_EQ (boost::str (boost::format ("Nano %1%") % NANO_VERSION_STRING), response1.json.get<std::string> ("node_vendor"));

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -94,7 +94,12 @@ void nano::ledger::seed_genesis (nano::store::ledger_store & store, nano::store:
 
 	store.rep_weight.put (txn, constants.genesis->account (), std::numeric_limits<nano::uint128_t>::max ());
 
-	if (options.enable_topo_index)
+	if (options.enable_pruning)
+	{
+		// Pruning is incompatible with the topo index, so a pruned ledger is seeded without one
+		store.meta.put_flag (txn, nano::store::meta_key::pruning_enabled, true);
+	}
+	else if (options.enable_topo_index)
 	{
 		store.topology.put (txn, { /* topo_height */ 1, /* hash */ constants.genesis->hash () });
 		store.meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, true);
@@ -126,23 +131,27 @@ void nano::ledger::initialize ()
 	// Load ledger flags
 	{
 		auto const transaction = store.tx_begin_read ();
+		flags.pruning = store.meta.get_flag (transaction, nano::store::meta_key::pruning_enabled);
 		flags.topo_index = store.meta.get_flag (transaction, nano::store::meta_key::topo_index_enabled);
 		flags.account_delegator_by_weight_index = store.meta.get_flag (transaction, nano::store::meta_key::account_delegator_by_weight_index_enabled);
 		flags.account_receivable_by_amount_index = store.meta.get_flag (transaction, nano::store::meta_key::account_receivable_by_amount_index_enabled);
 		flags.receive_block_by_send_block_index = store.meta.get_flag (transaction, nano::store::meta_key::receive_block_by_send_block_index_enabled);
 		flags.account_block_by_height_index = store.meta.get_flag (transaction, nano::store::meta_key::account_block_by_height_index_enabled);
 
-		logger.debug (nano::log::type::ledger, "Ledger flags loaded: topo_index={}, account_delegator_by_weight={}, account_receivable_by_amount={}, receive_block_by_send_block={}, account_block_by_height={}",
+		logger.debug (nano::log::type::ledger, "Ledger flags loaded: pruning={}, topo_index={}, account_delegator_by_weight={}, account_receivable_by_amount={}, receive_block_by_send_block={}, account_block_by_height={}",
+		flags.pruning,
 		flags.topo_index,
 		flags.account_delegator_by_weight_index,
 		flags.account_receivable_by_amount_index,
 		flags.receive_block_by_send_block_index,
 		flags.account_block_by_height_index);
 
-		// A persisted index flag must never be set without its backing table
-		// Skipped without the consistency check so --drop_extended_ledger_indices can still recover such a store
+		// Persisted flags must form a valid combination and every index flag needs its backing table
+		// Skipped without the consistency check so the --drop_* recovery commands can still open such a store
 		if (options.generate_cache.consistency_check)
 		{
+			release_assert (!(flags.pruning && flags.topo_index), "ledger has both pruning and the topology index enabled, run --drop_topo_index to recover");
+			release_assert (!(flags.pruning && flags.any_extended_ledger_index_enabled ()), "ledger has both pruning and extended ledger indices enabled, run --drop_extended_ledger_indices to recover");
 			release_assert (!flags.account_delegator_by_weight_index || store.extended.account_delegator_by_weight.present (), "delegator weight index flag is set but its table is absent, run --drop_extended_ledger_indices to recover");
 			release_assert (!flags.account_receivable_by_amount_index || store.extended.account_receivable_by_amount.present (), "receivable amount index flag is set but its table is absent, run --drop_extended_ledger_indices to recover");
 			release_assert (!flags.receive_block_by_send_block_index || store.extended.receive_block_by_send_block.present (), "receive block lookup index flag is set but its table is absent, run --drop_extended_ledger_indices to recover");
@@ -197,6 +206,12 @@ void nano::ledger::initialize ()
 		cache.pruned_count = store.pruned.count (transaction);
 
 		logger.debug (nano::log::type::ledger, "Pruned count cache generated");
+
+		// The persisted pruning flag is authoritative, pruned entries must never exist without it
+		if (options.generate_cache.consistency_check)
+		{
+			release_assert (flags.pruning || cache.pruned_count == 0, "ledger contains pruned blocks but is not marked as pruned", std::to_string (cache.pruned_count));
+		}
 	}
 
 	if (generate_cache_flags.reps)
@@ -938,8 +953,30 @@ std::shared_ptr<nano::block> nano::ledger::forked_block (secure::transaction con
 	return result;
 }
 
+void nano::ledger::enable_pruning ()
+{
+	release_assert (store.get_mode () != nano::store::open_mode::read_only, "pruning cannot be enabled while the backend is opened in read-only mode");
+	release_assert (!flags.topo_index, "pruning is incompatible with the topology index, drop it first");
+	release_assert (!flags.any_extended_ledger_index_enabled (), "pruning is incompatible with extended ledger indices, drop them first");
+
+	if (flags.pruning)
+	{
+		return;
+	}
+
+	{
+		auto txn = tx_begin_write ();
+		store.meta.put_flag (txn, nano::store::meta_key::pruning_enabled, true);
+	}
+	flags.pruning = true;
+
+	logger.info (nano::log::type::ledger, "Ledger permanently marked as pruned");
+}
+
 uint64_t nano::ledger::pruning_action (secure::write_transaction & transaction_a, nano::block_hash const & hash_a, uint64_t const batch_size_a)
 {
+	debug_assert (flags.pruning);
+
 	uint64_t pruned_count (0);
 	nano::block_hash hash (hash_a);
 	while (!hash.is_zero () && hash != constants.genesis->hash ())
@@ -951,10 +988,6 @@ uint64_t nano::ledger::pruning_action (secure::write_transaction & transaction_a
 
 			del_block (transaction_a, hash, *block_l);
 			store.pruned.put (transaction_a, hash);
-			if (block_l->sideband ().topo_height != 0)
-			{
-				store.topology.del (transaction_a, { block_l->sideband ().topo_height, hash });
-			}
 
 			hash = block_l->previous ();
 			++pruned_count;

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -76,6 +76,7 @@ void nano::ledger::seed_genesis (nano::store::ledger_store & store, nano::store:
 {
 	release_assert (store.empty (txn), "attempt to seed a non-empty ledger store");
 	release_assert (constants.genesis->has_sideband ());
+	release_assert (!(options.enable_pruning && options.enable_topo_index), "pruning is incompatible with the topo index, initialize a pruned ledger with --disable_topo_index");
 
 	store.block.put (txn, constants.genesis->hash (), *constants.genesis);
 
@@ -96,10 +97,9 @@ void nano::ledger::seed_genesis (nano::store::ledger_store & store, nano::store:
 
 	if (options.enable_pruning)
 	{
-		// Pruning is incompatible with the topo index, so a pruned ledger is seeded without one
 		store.meta.put_flag (txn, nano::store::meta_key::pruning_enabled, true);
 	}
-	else if (options.enable_topo_index)
+	if (options.enable_topo_index)
 	{
 		store.topology.put (txn, { /* topo_height */ 1, /* hash */ constants.genesis->hash () });
 		store.meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, true);
@@ -157,6 +157,12 @@ void nano::ledger::initialize ()
 			release_assert (!flags.receive_block_by_send_block_index || store.extended.receive_block_by_send_block.present (), "receive block lookup index flag is set but its table is absent, run --drop_extended_ledger_indices to recover");
 			release_assert (!flags.account_block_by_height_index || store.extended.account_block_by_height.present (), "account block height index flag is set but its table is absent, run --drop_extended_ledger_indices to recover");
 		}
+	}
+
+	// Apply the requested one-way pruning transition, making the pruning flag authoritative from here on
+	if (options.enable_pruning)
+	{
+		enable_pruning ();
 	}
 
 	auto const & generate_cache_flags = options.generate_cache;
@@ -955,14 +961,14 @@ std::shared_ptr<nano::block> nano::ledger::forked_block (secure::transaction con
 
 void nano::ledger::enable_pruning ()
 {
-	release_assert (store.get_mode () != nano::store::open_mode::read_only, "pruning cannot be enabled while the backend is opened in read-only mode");
-	release_assert (!flags.topo_index, "pruning is incompatible with the topology index, drop it first");
-	release_assert (!flags.any_extended_ledger_index_enabled (), "pruning is incompatible with extended ledger indices, drop them first");
-
 	if (flags.pruning)
 	{
 		return;
 	}
+
+	release_assert (store.get_mode () != nano::store::open_mode::read_only, "pruning cannot be enabled while the backend is opened in read-only mode");
+	release_assert (!flags.topo_index, "pruning is incompatible with the topology index, run --drop_topo_index first");
+	release_assert (!flags.any_extended_ledger_index_enabled (), "pruning is incompatible with extended ledger indices, run --drop_extended_ledger_indices first");
 
 	{
 		auto txn = tx_begin_write ();

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -97,10 +97,10 @@ void nano::ledger::seed_genesis (nano::store::ledger_store & store, nano::store:
 	if (options.enable_topo_index)
 	{
 		store.topology.put (txn, { /* topo_height */ 1, /* hash */ constants.genesis->hash () });
-		store.version.put_flag (txn, nano::store::meta_key::topo_index_enabled, true);
+		store.meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, true);
 	}
 
-	store.version.put_version (txn, nano::store::ledger_store::version_current);
+	store.meta.put_version (txn, nano::store::ledger_store::version_current);
 }
 
 void nano::ledger::initialize ()
@@ -126,11 +126,11 @@ void nano::ledger::initialize ()
 	// Load ledger flags
 	{
 		auto const transaction = store.tx_begin_read ();
-		flags.topo_index = store.version.get_flag (transaction, nano::store::meta_key::topo_index_enabled);
-		flags.account_delegator_by_weight_index = store.version.get_flag (transaction, nano::store::meta_key::account_delegator_by_weight_index_enabled);
-		flags.account_receivable_by_amount_index = store.version.get_flag (transaction, nano::store::meta_key::account_receivable_by_amount_index_enabled);
-		flags.receive_block_by_send_block_index = store.version.get_flag (transaction, nano::store::meta_key::receive_block_by_send_block_index_enabled);
-		flags.account_block_by_height_index = store.version.get_flag (transaction, nano::store::meta_key::account_block_by_height_index_enabled);
+		flags.topo_index = store.meta.get_flag (transaction, nano::store::meta_key::topo_index_enabled);
+		flags.account_delegator_by_weight_index = store.meta.get_flag (transaction, nano::store::meta_key::account_delegator_by_weight_index_enabled);
+		flags.account_receivable_by_amount_index = store.meta.get_flag (transaction, nano::store::meta_key::account_receivable_by_amount_index_enabled);
+		flags.receive_block_by_send_block_index = store.meta.get_flag (transaction, nano::store::meta_key::receive_block_by_send_block_index_enabled);
+		flags.account_block_by_height_index = store.meta.get_flag (transaction, nano::store::meta_key::account_block_by_height_index_enabled);
 
 		logger.debug (nano::log::type::ledger, "Ledger flags loaded: topo_index={}, account_delegator_by_weight={}, account_receivable_by_amount={}, receive_block_by_send_block={}, account_block_by_height={}",
 		flags.topo_index,

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -43,7 +43,6 @@ struct ledger_options
 	nano::generate_cache_flags generate_cache{};
 	nano::uint128_t min_rep_weight{ 0 };
 	uint64_t max_backlog{ 0 };
-	// Seeds fresh ledgers as pruned and blocks index population; takes precedence over the index options below
 	bool enable_pruning{ false };
 	bool enable_topo_index{ true };
 	bool enable_extended_ledger_index{ false };

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -35,17 +35,26 @@ private:
 	std::atomic<uint64_t> account_count{ 0 };
 };
 
+/**
+ * Ledger behavior requested by the caller at construction
+ */
 struct ledger_options
 {
 	nano::generate_cache_flags generate_cache{};
 	nano::uint128_t min_rep_weight{ 0 };
 	uint64_t max_backlog{ 0 };
+	// Seeds fresh ledgers as pruned and blocks index population; takes precedence over the index options below
+	bool enable_pruning{ false };
 	bool enable_topo_index{ true };
 	bool enable_extended_ledger_index{ false };
 };
 
+/**
+ * Persisted properties of the ledger data, loaded from the store and authoritative
+ */
 struct ledger_flags
 {
+	bool pruning{ false };
 	bool topo_index{ false };
 	bool account_delegator_by_weight_index{ false };
 	bool account_receivable_by_amount_index{ false };
@@ -150,6 +159,12 @@ public:
 
 public: // Index management
 	/**
+	 * Permanently mark the ledger as pruned; one-way, idempotent.
+	 * Requires the topology index and all extended ledger indices to be disabled.
+	 */
+	void enable_pruning ();
+
+	/**
 	 * Walk every block in the ledger, compute and persist its topology height, then enable the topology index flag
 	 * Intended as a one-time offline upgrade for ledgers initialized before the topology index existed
 	 */
@@ -214,7 +229,6 @@ public:
 
 public:
 	uint64_t const max_backlog_size{ 0 };
-	bool pruning{ false };
 
 	nano::bootstrap_weights bootstrap_weights{};
 

--- a/nano/secure/ledger_extended_index.cpp
+++ b/nano/secure/ledger_extended_index.cpp
@@ -15,6 +15,16 @@
 // Populate missing extended ledger indices when requested by options; persisted index flags remain authoritative otherwise
 void nano::ledger::initialize_extended_ledger_indices ()
 {
+	// Extended ledger indices are incompatible with pruning, never populate on a (to-be-)pruned ledger
+	if (flags.pruning || options.enable_pruning)
+	{
+		if (options.enable_extended_ledger_index)
+		{
+			logger.error (nano::log::type::ledger, "Extended ledger index is enabled in config but is incompatible with ledger pruning; indices will not be populated");
+		}
+		return;
+	}
+
 	if (options.enable_extended_ledger_index && !flags.all_extended_ledger_indices_enabled ())
 	{
 		if (store.get_mode () == nano::store::open_mode::read_only)
@@ -34,6 +44,8 @@ void nano::ledger::initialize_extended_ledger_indices ()
 
 void nano::ledger::populate_extended_ledger_indices ()
 {
+	release_assert (!flags.pruning, "extended ledger indices cannot be populated on a pruned ledger");
+
 	logger.info (nano::log::type::ledger_upgrade, "Populating extended ledger indices...");
 
 	if (!flags.account_delegator_by_weight_index)

--- a/nano/secure/ledger_extended_index.cpp
+++ b/nano/secure/ledger_extended_index.cpp
@@ -15,15 +15,7 @@
 // Populate missing extended ledger indices when requested by options; persisted index flags remain authoritative otherwise
 void nano::ledger::initialize_extended_ledger_indices ()
 {
-	// Extended ledger indices are incompatible with pruning, never populate on a (to-be-)pruned ledger
-	if (flags.pruning || options.enable_pruning)
-	{
-		if (options.enable_extended_ledger_index)
-		{
-			logger.error (nano::log::type::ledger, "Extended ledger index is enabled in config but is incompatible with ledger pruning; indices will not be populated");
-		}
-		return;
-	}
+	release_assert (!(options.enable_extended_ledger_index && flags.pruning), "extended ledger index is incompatible with ledger pruning, remove extended_ledger_index from node config");
 
 	if (options.enable_extended_ledger_index && !flags.all_extended_ledger_indices_enabled ())
 	{

--- a/nano/secure/ledger_extended_index.cpp
+++ b/nano/secure/ledger_extended_index.cpp
@@ -64,10 +64,10 @@ void nano::ledger::drop_extended_ledger_indices ()
 
 	{
 		auto txn = store.tx_begin_write ();
-		store.version.put_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled, false);
-		store.version.put_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled, false);
-		store.version.put_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled, false);
-		store.version.put_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled, false);
+		store.meta.put_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled, false);
+		store.meta.put_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled, false);
+		store.meta.put_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled, false);
+		store.meta.put_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled, false);
 	}
 
 	logger.info (nano::log::type::ledger_upgrade, "Dropping delegator weight index...");
@@ -140,7 +140,7 @@ void nano::ledger::populate_receive_block_by_send_block_index ()
 				crawler.refresh ();
 			}
 		}
-		store.version.put_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled, true);
+		store.meta.put_flag (txn, nano::store::meta_key::receive_block_by_send_block_index_enabled, true);
 	}
 
 	flags.receive_block_by_send_block_index = true;
@@ -194,7 +194,7 @@ void nano::ledger::populate_account_block_by_height_index ()
 			}
 		}
 		release_assert (processed == total_blocks, "account block height index entry count mismatch");
-		store.version.put_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled, true);
+		store.meta.put_flag (txn, nano::store::meta_key::account_block_by_height_index_enabled, true);
 	}
 
 	flags.account_block_by_height_index = true;
@@ -242,7 +242,7 @@ void nano::ledger::populate_account_delegator_by_weight_index ()
 				crawler.refresh ();
 			}
 		}
-		store.version.put_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled, true);
+		store.meta.put_flag (txn, nano::store::meta_key::account_delegator_by_weight_index_enabled, true);
 	}
 
 	flags.account_delegator_by_weight_index = true;
@@ -290,7 +290,7 @@ void nano::ledger::populate_account_receivable_by_amount_index ()
 				crawler.refresh ();
 			}
 		}
-		store.version.put_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled, true);
+		store.meta.put_flag (txn, nano::store::meta_key::account_receivable_by_amount_index_enabled, true);
 	}
 
 	flags.account_receivable_by_amount_index = true;

--- a/nano/secure/ledger_topo_index.cpp
+++ b/nano/secure/ledger_topo_index.cpp
@@ -19,6 +19,7 @@
 void nano::ledger::populate_topo_index ()
 {
 	release_assert (!flags.topo_index, "populate_topo_index called when topo_index is already enabled");
+	release_assert (!flags.pruning, "the topology index cannot be populated on a pruned ledger");
 
 	logger.info (nano::log::type::ledger_upgrade, "Populating topology index...");
 

--- a/nano/secure/ledger_topo_index.cpp
+++ b/nano/secure/ledger_topo_index.cpp
@@ -249,7 +249,7 @@ void nano::ledger::populate_topo_index ()
 	// Flip the flag only after both phases commit
 	{
 		auto txn = tx_begin_write ();
-		store.version.put_flag (txn, nano::store::meta_key::topo_index_enabled, true);
+		store.meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, true);
 	}
 	flags.topo_index = true;
 
@@ -265,7 +265,7 @@ void nano::ledger::drop_topo_index ()
 	// Disable the persisted flag first so a crash cannot leave the index marked as enabled after the topology table has been cleared
 	{
 		auto txn = tx_begin_write ();
-		store.version.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
+		store.meta.put_flag (txn, nano::store::meta_key::topo_index_enabled, false);
 	}
 	store.topology.clear ();
 

--- a/nano/store/fwd.hpp
+++ b/nano/store/fwd.hpp
@@ -31,5 +31,5 @@ class successor_view;
 class rep_weight_view;
 class topology_view;
 
-using version_view = nano::store::meta_view;
+using meta_view = nano::store::meta_view;
 }

--- a/nano/store/ledger_store.cpp
+++ b/nano/store/ledger_store.cpp
@@ -224,6 +224,9 @@ void ledger_store::perform_upgrades (nano::store::backend_meta db_meta)
 			upgrade_v25_to_v26 ();
 			[[fallthrough]];
 		case 26:
+			upgrade_v26_to_v27 ();
+			[[fallthrough]];
+		case 27:
 			break;
 		default:
 			release_assert (false, "invalid ledger database version for upgrade", std::to_string (db_meta.version));

--- a/nano/store/ledger_store.cpp
+++ b/nano/store/ledger_store.cpp
@@ -66,7 +66,7 @@ ledger_store::ledger_store (std::unique_ptr<nano::store::backend> backend_a, nan
 	confirmation_height_impl{ std::make_unique<nano::store::ledger::confirmation_height_view> (*backend_impl) },
 	final_vote_impl{ std::make_unique<nano::store::ledger::final_vote_view> (*backend_impl) },
 	topology_impl{ std::make_unique<nano::store::ledger::topology_view> (*backend_impl) },
-	version_impl{ std::make_unique<nano::store::ledger::version_view> (*backend_impl) },
+	meta_impl{ std::make_unique<nano::store::ledger::meta_view> (*backend_impl) },
 	account_block_by_height_impl{ std::make_unique<nano::store::ledger::account_block_by_height_view> (*backend_impl) },
 	account_delegator_by_weight_impl{ std::make_unique<nano::store::ledger::account_delegator_by_weight_view> (*backend_impl) },
 	account_receivable_by_amount_impl{ std::make_unique<nano::store::ledger::account_receivable_by_amount_view> (*backend_impl) },
@@ -83,7 +83,7 @@ ledger_store::ledger_store (std::unique_ptr<nano::store::backend> backend_a, nan
 	confirmation_height{ *confirmation_height_impl },
 	final_vote{ *final_vote_impl },
 	topology{ *topology_impl },
-	version{ *version_impl },
+	meta{ *meta_impl },
 	extended{
 		.account_block_by_height = *account_block_by_height_impl,
 		.account_delegator_by_weight = *account_delegator_by_weight_impl,
@@ -101,36 +101,36 @@ ledger_store::ledger_store (std::unique_ptr<nano::store::backend> backend_a, nan
 
 	bool needs_upgrade = false;
 	bool fresh_db = false;
-	backend_meta meta{};
+	backend_meta db_meta{};
 
 	if (auto meta_opt = backend.fetch_meta ())
 	{
-		meta = *meta_opt;
+		db_meta = *meta_opt;
 
-		logger.debug (nano::log::type::ledger_store, "Ledger database version: {}", meta.version);
+		logger.debug (nano::log::type::ledger_store, "Ledger database version: {}", db_meta.version);
 
 		// Prevent opening future database versions
-		if (meta.version > version_current)
+		if (db_meta.version > version_current)
 		{
-			logger.error (nano::log::type::ledger_store, "The version of the ledger database ({}) is higher than the current ({}) which is supported. Either upgrade your node software or use a different database.", meta.version, version_current);
+			logger.error (nano::log::type::ledger_store, "The version of the ledger database ({}) is higher than the current ({}) which is supported. Either upgrade your node software or use a different database.", db_meta.version, version_current);
 
-			throw std::runtime_error ("Ledger version " + std::to_string (meta.version) + " is higher than current version " + std::to_string (version_current));
+			throw std::runtime_error ("Ledger version " + std::to_string (db_meta.version) + " is higher than current version " + std::to_string (version_current));
 		}
 
 		// Minimum supported upgrade version check
-		if (meta.version < version_minimum)
+		if (db_meta.version < version_minimum)
 		{
-			logger.error (nano::log::type::ledger_store, "The version of the ledger database ({}) is lower than the minimum ({}) which is supported for upgrades. Perform an intermediate upgrade with an older node version or perform a fresh bootstrap.", meta.version, version_minimum);
+			logger.error (nano::log::type::ledger_store, "The version of the ledger database ({}) is lower than the minimum ({}) which is supported for upgrades. Perform an intermediate upgrade with an older node version or perform a fresh bootstrap.", db_meta.version, version_minimum);
 
-			throw std::runtime_error ("Ledger version " + std::to_string (meta.version) + " is lower than minimum supported version " + std::to_string (version_minimum));
+			throw std::runtime_error ("Ledger version " + std::to_string (db_meta.version) + " is lower than minimum supported version " + std::to_string (version_minimum));
 		}
 
 		// Check if upgrade is needed
-		if (meta.version < version_current)
+		if (db_meta.version < version_current)
 		{
 			needs_upgrade = true;
 
-			logger.info (nano::log::type::ledger_store, "The ledger database needs to be upgraded from version {} to {}", meta.version, version_current);
+			logger.info (nano::log::type::ledger_store, "The ledger database needs to be upgraded from version {} to {}", db_meta.version, version_current);
 		}
 	}
 	else
@@ -139,7 +139,7 @@ ledger_store::ledger_store (std::unique_ptr<nano::store::backend> backend_a, nan
 
 		logger.info (nano::log::type::ledger_store, "No existing ledger found, a new database will be created.");
 	}
-	release_assert (meta.version > 0 || fresh_db);
+	release_assert (db_meta.version > 0 || fresh_db);
 
 	if (needs_upgrade || fresh_db)
 	{
@@ -162,7 +162,7 @@ ledger_store::ledger_store (std::unique_ptr<nano::store::backend> backend_a, nan
 			logger.info (nano::log::type::ledger_store, "Ledger backup completed, continuing with upgrade...");
 		}
 
-		perform_upgrades (meta);
+		perform_upgrades (db_meta);
 	}
 
 	if (fresh_db)
@@ -201,12 +201,12 @@ bool ledger_store::empty (nano::store::transaction const & txn) const
 	return true;
 }
 
-void ledger_store::perform_upgrades (nano::store::backend_meta meta)
+void ledger_store::perform_upgrades (nano::store::backend_meta db_meta)
 {
-	debug_assert (meta.version < version_current, "perform_upgrades called but no upgrade is necessary");
-	release_assert (meta.version >= version_minimum, "perform_upgrades called but version is below minimum supported version", std::to_string (meta.version));
+	debug_assert (db_meta.version < version_current, "perform_upgrades called but no upgrade is necessary");
+	release_assert (db_meta.version >= version_minimum, "perform_upgrades called but version is below minimum supported version", std::to_string (db_meta.version));
 
-	switch (meta.version)
+	switch (db_meta.version)
 	{
 		case 21:
 			upgrade_v21_to_v22 ();
@@ -226,13 +226,13 @@ void ledger_store::perform_upgrades (nano::store::backend_meta meta)
 		case 26:
 			break;
 		default:
-			release_assert (false, "invalid ledger database version for upgrade", std::to_string (meta.version));
+			release_assert (false, "invalid ledger database version for upgrade", std::to_string (db_meta.version));
 	}
 }
 
 uint64_t ledger_store::get_version () const
 {
-	return version.get_version (backend.tx_begin_read ());
+	return meta.get_version (backend.tx_begin_read ());
 }
 
 std::string ledger_store::get_vendor () const

--- a/nano/store/ledger_store.hpp
+++ b/nano/store/ledger_store.hpp
@@ -42,6 +42,7 @@ public: // Upgrades
 	void upgrade_v23_to_v24 ();
 	void upgrade_v24_to_v25 ();
 	void upgrade_v25_to_v26 ();
+	void upgrade_v26_to_v27 ();
 
 public:
 	nano::store::write_queue write_queue; // TODO: Shouldn't be public
@@ -97,7 +98,7 @@ public:
 
 public:
 	static nano::store::backend_version_t constexpr version_minimum{ 21 };
-	static nano::store::backend_version_t constexpr version_current{ 26 };
+	static nano::store::backend_version_t constexpr version_current{ 27 };
 
 public:
 	static nano::store::column_schema const schema_current;
@@ -106,5 +107,6 @@ public:
 	static nano::store::column_schema const schema_v23;
 	static nano::store::column_schema const schema_v24;
 	static nano::store::column_schema const schema_v25;
+	static nano::store::column_schema const schema_v26;
 };
 };

--- a/nano/store/ledger_store.hpp
+++ b/nano/store/ledger_store.hpp
@@ -63,7 +63,7 @@ private:
 	std::unique_ptr<nano::store::ledger::confirmation_height_view> confirmation_height_impl;
 	std::unique_ptr<nano::store::ledger::final_vote_view> final_vote_impl;
 	std::unique_ptr<nano::store::ledger::topology_view> topology_impl;
-	std::unique_ptr<nano::store::ledger::version_view> version_impl;
+	std::unique_ptr<nano::store::ledger::meta_view> meta_impl;
 
 	// Extended ledger tables
 	std::unique_ptr<nano::store::ledger::account_block_by_height_view> account_block_by_height_impl;
@@ -84,7 +84,7 @@ public:
 	nano::store::ledger::confirmation_height_view & confirmation_height;
 	nano::store::ledger::final_vote_view & final_vote;
 	nano::store::ledger::topology_view & topology;
-	nano::store::ledger::version_view & version;
+	nano::store::ledger::meta_view & meta;
 
 	// Extended ledger tables
 	struct

--- a/nano/store/ledger_upgrades.cpp
+++ b/nano/store/ledger_upgrades.cpp
@@ -84,6 +84,26 @@ nano::store::column_schema const ledger_store::schema_v25{
 	{ nano::store::table::meta, "meta" }
 };
 
+nano::store::column_schema const ledger_store::schema_v26{
+	{ nano::store::table::blocks, "blocks" },
+	{ nano::store::table::accounts, "accounts" },
+	{ nano::store::table::pending, "pending" },
+	{ nano::store::table::rep_weights, "rep_weights" },
+	{ nano::store::table::online_weight, "online_weight" },
+	{ nano::store::table::pruned, "pruned" },
+	{ nano::store::table::successor, "successor" },
+	{ nano::store::table::peers, "peers" },
+	{ nano::store::table::confirmation_height, "confirmation_height" },
+	{ nano::store::table::final_votes, "final_votes" },
+	{ nano::store::table::topology, "topology" },
+	{ nano::store::table::meta, "meta" },
+	// Extended ledger tables, created on demand when the corresponding index gets populated
+	{ nano::store::table::account_block_by_height, "account_block_by_height", nano::store::table_kind::optional },
+	{ nano::store::table::account_delegator_by_weight, "account_delegator_by_weight", nano::store::table_kind::optional },
+	{ nano::store::table::account_receivable_by_amount, "account_receivable_by_amount", nano::store::table_kind::optional },
+	{ nano::store::table::receive_block_by_send_block, "receive_block_by_send_block", nano::store::table_kind::optional }
+};
+
 // Drop unchecked table
 void ledger_store::upgrade_v21_to_v22 ()
 {
@@ -364,5 +384,33 @@ void ledger_store::upgrade_v25_to_v26 ()
 	backend.close ();
 
 	logger.info (nano::log::type::ledger_upgrade, "Upgrading database from v25 to v26 completed");
+}
+
+// Record the ledger pruning state in a persisted meta flag, derived from the presence of pruned block entries
+void ledger_store::upgrade_v26_to_v27 ()
+{
+	logger.info (nano::log::type::ledger_upgrade, "Upgrading database from v26 to v27...");
+
+	backend.open (schema_v26, nano::store::open_mode::read_write);
+	{
+		release_assert (backend.get_version (backend.tx_begin_read ()) == 26, "unexpected version during upgrade", std::to_string (backend.get_version (backend.tx_begin_read ())));
+
+		bool is_pruned = false;
+		{
+			auto read_txn = backend.tx_begin_read ();
+			is_pruned = backend.begin (read_txn, nano::store::table::pruned) != backend.end (read_txn, nano::store::table::pruned);
+		}
+
+		auto transaction = backend.tx_begin_write ();
+		if (is_pruned)
+		{
+			logger.info (nano::log::type::ledger_upgrade, "Ledger contains pruned blocks, marking it as pruned");
+			meta.put_flag (transaction, nano::store::meta_key::pruning_enabled, true);
+		}
+		meta.put_version (transaction, 27);
+	}
+	backend.close ();
+
+	logger.info (nano::log::type::ledger_upgrade, "Upgrading database from v26 to v27 completed");
 }
 }

--- a/nano/store/ledger_upgrades.cpp
+++ b/nano/store/ledger_upgrades.cpp
@@ -168,7 +168,7 @@ void ledger_store::upgrade_v22_to_v23 ()
 		});
 
 		logger.info (nano::log::type::ledger_upgrade, "Done processing {} accounts", processed);
-		version.put_version (transaction, 23);
+		meta.put_version (transaction, 23);
 	}
 	backend.close ();
 
@@ -188,7 +188,7 @@ void ledger_store::upgrade_v23_to_v24 ()
 		release_assert (dropped, "failed to drop frontiers table during upgrade");
 
 		auto transaction = backend.tx_begin_write ();
-		version.put_version (transaction, 24);
+		meta.put_version (transaction, 24);
 	}
 	backend.close ();
 
@@ -246,7 +246,7 @@ void ledger_store::upgrade_v24_to_v25 ()
 		});
 
 		logger.info (nano::log::type::ledger_upgrade, "Done processing {} blocks", processed);
-		version.put_version (transaction, 25);
+		meta.put_version (transaction, 25);
 	}
 	backend.close ();
 
@@ -358,7 +358,7 @@ void ledger_store::upgrade_v25_to_v26 ()
 		crawler.refresh ();
 
 		logger.info (nano::log::type::ledger_upgrade, "Done processing {} blocks ({} converted, {} already upgraded)", processed + skipped, processed, skipped);
-		version.put_version (transaction, 26);
+		meta.put_version (transaction, 26);
 	}
 
 	backend.close ();

--- a/nano/store/meta.hpp
+++ b/nano/store/meta.hpp
@@ -10,10 +10,13 @@ namespace nano::store
 {
 enum class meta_key : uint64_t
 {
+	// Database schema
 	version = 1,
+
+	// Ledger feature flags
 	topo_index_enabled = 8,
 
-	// Extended ledger indices
+	// Extended ledger index flags
 	receive_block_by_send_block_index_enabled = 16,
 	account_receivable_by_amount_index_enabled = 17,
 	account_delegator_by_weight_index_enabled = 18,

--- a/nano/store/meta.hpp
+++ b/nano/store/meta.hpp
@@ -15,6 +15,7 @@ enum class meta_key : uint64_t
 
 	// Ledger feature flags
 	topo_index_enabled = 8,
+	pruning_enabled = 9,
 
 	// Extended ledger index flags
 	receive_block_by_send_block_index_enabled = 16,

--- a/nano/test_common/ledger_context.cpp
+++ b/nano/test_common/ledger_context.cpp
@@ -5,9 +5,9 @@
 #include <nano/node/nodeconfig.hpp>
 #include <nano/test_common/ledger_context.hpp>
 
-nano::test::ledger_context::ledger_context (std::deque<std::shared_ptr<nano::block>> && blocks) :
+nano::test::ledger_context::ledger_context (std::deque<std::shared_ptr<nano::block>> && blocks, nano::ledger_options options) :
 	store_m{ nano::make_store (logger_m, stats_m, nano::unique_path (), nano::dev::constants, false, true, nano::node_config{}) },
-	ledger_m{ *store_m, nano::dev::network_params, stats_m, logger_m },
+	ledger_m{ *store_m, nano::dev::network_params, stats_m, logger_m, options },
 	blocks_m{ blocks },
 	pool_m{ nano::dev::network_params.network, 1 }
 {
@@ -53,9 +53,9 @@ nano::work_pool & nano::test::ledger_context::pool ()
  * Ledger facotries
  */
 
-auto nano::test::ledger_empty () -> ledger_context
+auto nano::test::ledger_empty (nano::ledger_options options) -> ledger_context
 {
-	return ledger_context{};
+	return ledger_context{ {}, options };
 }
 
 auto nano::test::ledger_send_receive () -> ledger_context

--- a/nano/test_common/ledger_context.hpp
+++ b/nano/test_common/ledger_context.hpp
@@ -14,7 +14,7 @@ class ledger_context
 public:
 	/** 'blocks' initialises the ledger with each block in-order
 		Blocks must all return process_result::progress when processed */
-	ledger_context (std::deque<std::shared_ptr<nano::block>> && blocks = std::deque<std::shared_ptr<nano::block>>{});
+	ledger_context (std::deque<std::shared_ptr<nano::block>> && blocks = std::deque<std::shared_ptr<nano::block>>{}, nano::ledger_options options = {});
 
 	nano::ledger & ledger ();
 	nano::store::ledger_store & store ();
@@ -33,7 +33,7 @@ private:
 };
 
 /** Only a genesis block */
-ledger_context ledger_empty ();
+ledger_context ledger_empty (nano::ledger_options options = {});
 /** Send/receive pair of state blocks on the genesis account */
 ledger_context ledger_send_receive ();
 /** Send/receive pair of legacy blocks on the genesis account */


### PR DESCRIPTION
Previously the pruning state of a ledger was inferred at every startup from the `--enable_pruning` launch flag combined with a scan of the `pruned` table, and the incompatibility checks against the topo and extended ledger indices were scattered across the node constructor, CLI parsing and ledger internals. This had several concrete problems:

- `--enable_pruning` had to be passed on every launch; forgetting it either refused to start or silently reverted a not-yet-pruned node to non-pruning mode
- Extended index auto-population could run on a pruned ledger before the node detected the pruning state, since the pruned-table scan happens after ledger construction
- CLI utilities opening a pruned ledger without the flag miscounted blocks in `--validate_blocks`
- Every startup paid an O(n) `pruned.count()` scan just to answer a yes/no question

## Changes

- New persisted `pruning_enabled` meta flag, loaded into `ledger_flags.pruning` alongside the index flags; the persisted flag is authoritative
- Ledger upgrade v26 → v27 derives the flag from the presence of pruned entries; no data rewrite
- `ledger_options.enable_pruning` expresses the request: fresh ledgers are seeded as pruned, existing ledgers go through the one-way `ledger::enable_pruning ()` transition during initialization, right after flags are loaded — from that point on every downstream check reads a single source of truth
- Validation happens at the layer that has the inputs:
  - `seed_genesis` asserts option coherence (pruning × topo index)
  - after flag load, persisted-state invariants are asserted (pruning × indices, index flag × backing table, pruned entries × pruning flag), gated on the consistency check so `--drop_*` recovery commands can still open a broken store
  - transition and populate operations assert their preconditions with the CLI remedy in the message
- The node constructor passes raw intent and keeps only the operational check (`enable_voting` × pruned ledger); the startup pruned-table scan, the flag-derivation logic and the scattered conflict exits are removed
- The pruning worker starts based on the ledger flag instead of the launch flag
- `--database_info` reports the pruning flag

## Behavior changes

- `--enable_pruning` is now one-way: the first use permanently marks the ledger as pruned and later launches keep pruning without the flag; the "To start node with existing pruned blocks use launch flag --enable_pruning" error is gone
- Initializing a fresh pruned ledger requires `--disable_topo_index`, as the topo index is enabled by default and the contradictory request is rejected instead of silently resolved
- Enabling pruning on a ledger with topo or extended indices fails with instructions to run the corresponding `--drop_*` command first

## Tests

- v26 → v27 upgrade cases for pruned and unpruned ledgers
- Pruning persists across restarts without the launch flag; transition works on an existing compatible ledger
- Direct-ledger pruning tests migrated from the removed `ledger.pruning` member to `ledger_options{ .enable_pruning = true, .enable_topo_index = false }`