### PR TITLE
Apply receivable RPC offset after threshold filtering

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1059,8 +1059,8 @@ struct receivable_options
 
 /*
  * Collects one account's receivable entries into a response subtree.
- * Sorted queries return entries by descending amount (hash descending on ties), applying offset and count in that order;
- * unsorted queries emit in send hash order while scanning, bounded by count.
+ * Sorted queries return entries by descending amount (hash descending on ties), unsorted queries emit in send hash order while scanning.
+ * In both modes offset and count apply, in that order, to the entries passing the confirmation and threshold filters.
  * The extended receivable index accelerates sorted queries when enabled, the fallback sort produces identical responses.
  */
 boost::property_tree::ptree collect_receivables (nano::node & node, nano::secure::transaction & transaction, nano::account const & account, receivable_options const & options)
@@ -1142,21 +1142,24 @@ boost::property_tree::ptree collect_receivables (nano::node & node, nano::secure
 	}
 	else
 	{
-		// Unsorted path: emit in send hash order while scanning, bounded by count; offset skips confirmed entries before the threshold filter
+		// Unsorted path: emit in send hash order while scanning, bounded by count
 		for (auto i (node.store.pending.begin (transaction, nano::pending_key (account, 0))), n (node.store.pending.end (transaction)); i != n && i->first.account == account && receivables.size () < options.count; ++i)
 		{
-			if (block_confirmed (node, transaction, i->first.hash, options.include_active, options.include_only_confirmed))
+			// Confirmation requirements and threshold filter entries without consuming offset or count
+			if (!block_confirmed (node, transaction, i->first.hash, options.include_active, options.include_only_confirmed))
 			{
-				if (offset_counter > 0)
-				{
-					--offset_counter;
-					continue;
-				}
-				if (options.simple || i->second.amount.number () >= options.threshold.number ())
-				{
-					emit (i->first.hash, i->second);
-				}
+				continue;
 			}
+			if (!options.simple && i->second.amount.number () < options.threshold.number ())
+			{
+				continue;
+			}
+			if (offset_counter > 0)
+			{
+				--offset_counter;
+				continue;
+			}
+			emit (i->first.hash, i->second);
 		}
 	}
 	return receivables;

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -627,10 +627,10 @@ TEST (rpc, receivable_sorting_confirmed_offset_parity)
 }
 
 /*
- * Unsorted queries apply the offset to confirmed entries in send hash order before the threshold filter,
- * so a confirmed entry below the threshold still consumes the offset
+ * Unsorted queries apply the threshold filter before the offset,
+ * so a below-threshold entry neither appears in the response nor consumes the offset
  */
-TEST (rpc, receivable_unsorted_offset_before_threshold)
+TEST (rpc, receivable_unsorted_offset_after_threshold)
 {
 	nano::test::system system;
 	nano::node_config config = system.default_config ();
@@ -639,9 +639,9 @@ TEST (rpc, receivable_unsorted_offset_before_threshold)
 	auto node = add_ipc_enabled_node (system, config);
 	nano::block_builder builder;
 
-	// Pick a destination for which the below-threshold send sorts first in hash order, making the quirk observable
+	// Pick a destination for which the below-threshold send sorts first in hash order, so it would consume the offset if it were not filtered first
 	nano::keypair key1;
-	std::shared_ptr<nano::block> send_low, send_high;
+	std::shared_ptr<nano::block> send_low, send_high1, send_high2;
 	do
 	{
 		key1 = nano::keypair{};
@@ -654,32 +654,52 @@ TEST (rpc, receivable_unsorted_offset_before_threshold)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*node->work_generate_blocking (nano::dev::genesis->hash ()))
 				   .build ();
-		send_high = builder.state ()
-					.account (nano::dev::genesis_key.pub)
-					.previous (send_low->hash ())
-					.representative (nano::dev::genesis_key.pub)
-					.balance (nano::dev::constants.genesis_amount - 101)
-					.link (key1.pub)
-					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*node->work_generate_blocking (send_low->hash ()))
-					.build ();
-	} while (send_low->hash ().number () > send_high->hash ().number ());
+		send_high1 = builder.state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (send_low->hash ())
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - 101)
+					 .link (key1.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*node->work_generate_blocking (send_low->hash ()))
+					 .build ();
+		send_high2 = builder.state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (send_high1->hash ())
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - 301)
+					 .link (key1.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*node->work_generate_blocking (send_high1->hash ()))
+					 .build ();
+	} while (send_low->hash ().number () > send_high1->hash ().number () || send_low->hash ().number () > send_high2->hash ().number ());
 	ASSERT_EQ (nano::block_status::progress, node->process (send_low));
-	ASSERT_EQ (nano::block_status::progress, node->process (send_high));
+	ASSERT_EQ (nano::block_status::progress, node->process (send_high1));
+	ASSERT_EQ (nano::block_status::progress, node->process (send_high2));
+
+	// The above-threshold sends in hash ascending order, matching the unsorted scan; fixed-width hex compares like the numeric hash
+	std::vector<std::pair<std::string, std::string>> qualifying{ { send_high1->hash ().to_string (), "100" }, { send_high2->hash ().to_string (), "200" } };
+	std::sort (qualifying.begin (), qualifying.end ());
 
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "receivable");
 	request.put ("account", key1.pub.to_account ());
-	// The sends deliberately stay unconfirmed, so the query must accept unconfirmed receivables
+	// The sends deliberately stay unconfirmed, so the queries must accept unconfirmed receivables
 	request.put ("include_only_confirmed", "false");
 	request.put ("threshold", 50);
+	{
+		auto response = wait_response (system, rpc_ctx, request);
+		// The threshold alone drops the 1 raw send
+		ASSERT_EQ (qualifying, blocks_of (response.get_child ("blocks")));
+	}
 	request.put ("offset", 1);
-	auto response = wait_response (system, rpc_ctx, request);
-
-	// The offset consumes the below-threshold 1 raw send, leaving the 100 raw send in the response
-	std::vector<std::pair<std::string, std::string>> expected{ { send_high->hash ().to_string (), "100" } };
-	ASSERT_EQ (expected, blocks_of (response.get_child ("blocks")));
+	{
+		auto response = wait_response (system, rpc_ctx, request);
+		// The offset skips the first above-threshold send; the below-threshold send does not consume it
+		std::vector<std::pair<std::string, std::string>> expected{ qualifying[1] };
+		ASSERT_EQ (expected, blocks_of (response.get_child ("blocks")));
+	}
 }
 
 /*


### PR DESCRIPTION
The unsorted path of the `receivable` RPC consumed the `offset` on every confirmed entry before checking the `threshold`, so entries below the threshold silently consumed the offset. Both sorted paths (extended-index and fallback) already applied the offset only to entries passing the filters, making the three paths inconsistent with each other.

`collect_receivables` now applies the confirmation and threshold filters before the offset in the unsorted path as well, so offset and count uniformly apply, in that order, to the filtered entries in all modes.

This is an observable behavior change for `receivable` (and the deprecated `pending` alias) when `offset` and `threshold` are combined without `sorting`: the offset now skips qualifying entries instead of arbitrary confirmed ones. `accounts_receivable` shares the helper but does not accept an offset parameter, so its responses are unchanged.

The characterization test `receivable_unsorted_offset_before_threshold`, which locked in the old behavior, is replaced by `receivable_unsorted_offset_after_threshold`: it arranges a below-threshold receivable that sorts first in hash order — the exact case the old code mishandled — and asserts it neither appears in the response nor consumes the offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
