### PR TITLE
Include active blocks by default in unconfirmed receivable queries

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1059,8 +1059,8 @@ struct receivable_options
 
 /*
  * Collects one account's receivable entries into a response subtree.
- * Sorted queries return entries by descending amount (hash descending on ties), applying offset and count in that order;
- * unsorted queries emit in send hash order while scanning, bounded by count.
+ * Sorted queries return entries by descending amount (hash descending on ties), unsorted queries emit in send hash order while scanning.
+ * In both modes offset and count apply, in that order, to the entries passing the confirmation and threshold filters.
  * The extended receivable index accelerates sorted queries when enabled, the fallback sort produces identical responses.
  */
 boost::property_tree::ptree collect_receivables (nano::node & node, nano::secure::transaction & transaction, nano::account const & account, receivable_options const & options)
@@ -1142,21 +1142,24 @@ boost::property_tree::ptree collect_receivables (nano::node & node, nano::secure
 	}
 	else
 	{
-		// Unsorted path: emit in send hash order while scanning, bounded by count; offset skips confirmed entries before the threshold filter
+		// Unsorted path: emit in send hash order while scanning, bounded by count
 		for (auto i (node.store.pending.begin (transaction, nano::pending_key (account, 0))), n (node.store.pending.end (transaction)); i != n && i->first.account == account && receivables.size () < options.count; ++i)
 		{
-			if (block_confirmed (node, transaction, i->first.hash, options.include_active, options.include_only_confirmed))
+			// Confirmation requirements and threshold filter entries without consuming offset or count
+			if (!block_confirmed (node, transaction, i->first.hash, options.include_active, options.include_only_confirmed))
 			{
-				if (offset_counter > 0)
-				{
-					--offset_counter;
-					continue;
-				}
-				if (options.simple || i->second.amount.number () >= options.threshold.number ())
-				{
-					emit (i->first.hash, i->second);
-				}
+				continue;
 			}
+			if (!options.simple && i->second.amount.number () < options.threshold.number ())
+			{
+				continue;
+			}
+			if (offset_counter > 0)
+			{
+				--offset_counter;
+				continue;
+			}
+			emit (i->first.hash, i->second);
 		}
 	}
 	return receivables;

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1177,8 +1177,9 @@ void nano::json_handler::accounts_receivable ()
 	auto count (count_optional_impl ());
 	auto threshold (threshold_optional_impl ());
 	bool const source = request.get<bool> ("source", false);
-	bool const include_active = request.get<bool> ("include_active", false);
 	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
+	// Unconfirmed queries include blocks in active elections unless include_active explicitly excludes them
+	bool const include_active = request.get<bool> ("include_active", !include_only_confirmed);
 	bool const sorting = request.get<bool> ("sorting", false);
 	auto simple (threshold.is_zero () && !source && !sorting); // if simple, response is a list of hashes for each account
 	receivable_options const options{
@@ -3385,8 +3386,9 @@ void nano::json_handler::receivable ()
 	auto threshold (threshold_optional_impl ());
 	bool const source = request.get<bool> ("source", false);
 	bool const min_version = request.get<bool> ("min_version", false);
-	bool const include_active = request.get<bool> ("include_active", false);
 	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
+	// Unconfirmed queries include blocks in active elections unless include_active explicitly excludes them
+	bool const include_active = request.get<bool> ("include_active", !include_only_confirmed);
 	bool const sorting = request.get<bool> ("sorting", false);
 	auto simple (threshold.is_zero () && !source && !min_version && !sorting); // if simple, response is a list of hashes
 	if (!ec)
@@ -3417,8 +3419,9 @@ void nano::json_handler::pending_exists ()
 void nano::json_handler::receivable_exists ()
 {
 	auto hash (hash_impl ());
-	bool const include_active = request.get<bool> ("include_active", false);
 	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
+	// Unconfirmed queries include blocks in active elections unless include_active explicitly excludes them
+	bool const include_active = request.get<bool> ("include_active", !include_only_confirmed);
 	if (!ec)
 	{
 		auto transaction = node.ledger.tx_begin_read ();
@@ -5020,8 +5023,9 @@ void nano::json_handler::wallet_receivable ()
 	auto threshold (threshold_optional_impl ());
 	bool const source = request.get<bool> ("source", false);
 	bool const min_version = request.get<bool> ("min_version", false);
-	bool const include_active = request.get<bool> ("include_active", false);
 	bool const include_only_confirmed = request.get<bool> ("include_only_confirmed", true);
+	// Unconfirmed queries include blocks in active elections unless include_active explicitly excludes them
+	bool const include_active = request.get<bool> ("include_active", !include_only_confirmed);
 	if (!ec)
 	{
 		boost::property_tree::ptree pending;

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -143,6 +143,7 @@ TEST (rpc, receivable_unconfirmed)
 {
 	nano::test::system system;
 	nano::node_config config;
+	// Disable the backlog scan so the test controls election activity
 	config.backlog_scan->enable = false;
 	auto node = add_ipc_enabled_node (system, config);
 	auto chain = nano::test::setup_chain (system, *node, 1, nano::dev::genesis_key, false);
@@ -157,9 +158,51 @@ TEST (rpc, receivable_unconfirmed)
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
+	// Unconfirmed queries include blocks in active elections by default
+	ASSERT_NE (nullptr, nano::test::start_election (system, *node, block1->hash ()));
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
+	// Explicitly excluding active blocks drops the entry while its election is running
+	request.put ("include_active", "false");
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
+	request.put ("include_active", "true");
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 	nano::test::confirm (node->ledger, block1);
 	request.put ("include_only_confirmed", "true");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
+}
+
+/*
+ * Unconfirmed existence queries include blocks in active elections by default, explicit include_active=false excludes them
+ */
+TEST (rpc, receivable_exists_include_active)
+{
+	nano::test::system system;
+	nano::node_config config;
+	// Disable the backlog scan so the test controls election activity
+	config.backlog_scan->enable = false;
+	auto node = add_ipc_enabled_node (system, config);
+	auto chain = nano::test::setup_chain (system, *node, 1, nano::dev::genesis_key, false);
+	auto block1 = chain[0];
+	ASSERT_NE (nullptr, nano::test::start_election (system, *node, block1->hash ()));
+
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "receivable_exists");
+	request.put ("hash", block1->hash ().to_string ());
+	{
+		auto response = wait_response (system, rpc_ctx, request);
+		ASSERT_EQ ("0", response.get<std::string> ("exists"));
+	}
+	request.put ("include_only_confirmed", "false");
+	{
+		auto response = wait_response (system, rpc_ctx, request);
+		ASSERT_EQ ("1", response.get<std::string> ("exists"));
+	}
+	request.put ("include_active", "false");
+	{
+		auto response = wait_response (system, rpc_ctx, request);
+		ASSERT_EQ ("0", response.get<std::string> ("exists"));
+	}
 }
 
 /*TEST (rpc, amounts)
@@ -513,8 +556,6 @@ TEST (rpc, receivable_sorting_tie_parity)
 		nano::test::system system;
 		nano::node_config config = system.default_config ();
 		config.extended_ledger_index = extended_index;
-		// Disable the backlog scan so no elections start; blocks with active elections are filtered from unconfirmed receivable responses
-		config.backlog_scan->enable = false;
 		auto node = add_ipc_enabled_node (system, config);
 		ASSERT_EQ (extended_index, node->ledger.flags.account_receivable_by_amount_index);
 		ASSERT_NO_FATAL_FAILURE (setup_tied_receivables (*node, key1.pub, sends));
@@ -633,10 +674,7 @@ TEST (rpc, receivable_sorting_confirmed_offset_parity)
 TEST (rpc, receivable_unsorted_offset_after_threshold)
 {
 	nano::test::system system;
-	nano::node_config config = system.default_config ();
-	// Disable the backlog scan so no elections start; blocks with active elections are filtered from unconfirmed receivable responses
-	config.backlog_scan->enable = false;
-	auto node = add_ipc_enabled_node (system, config);
+	auto node = add_ipc_enabled_node (system);
 	nano::block_builder builder;
 
 	// Pick a destination for which the below-threshold send sorts first in hash order, so it would consume the offset if it were not filtered first
@@ -716,8 +754,6 @@ TEST (rpc, accounts_receivable_sorting_top_parity)
 		nano::test::system system;
 		nano::node_config config = system.default_config ();
 		config.extended_ledger_index = extended_index;
-		// Disable the backlog scan so no elections start; blocks with active elections are filtered from unconfirmed receivable responses
-		config.backlog_scan->enable = false;
 		auto node = add_ipc_enabled_node (system, config);
 		ASSERT_EQ (extended_index, node->ledger.flags.account_receivable_by_amount_index);
 		ASSERT_NO_FATAL_FAILURE (setup_tied_receivables (*node, key1.pub, sends));
@@ -835,6 +871,7 @@ TEST (rpc, accounts_receivable_confirmed)
 {
 	nano::test::system system;
 	nano::node_config config;
+	// Disable the backlog scan so the test controls election activity
 	config.backlog_scan->enable = false;
 	auto node = add_ipc_enabled_node (system, config);
 	auto chain = nano::test::setup_chain (system, *node, 1, nano::dev::genesis_key, false);
@@ -853,6 +890,14 @@ TEST (rpc, accounts_receivable_confirmed)
 	request.put ("include_only_confirmed", "true");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
+	// Unconfirmed queries include blocks in active elections by default
+	ASSERT_NE (nullptr, nano::test::start_election (system, *node, block1->hash ()));
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
+	// Explicitly excluding active blocks drops the entry while its election is running
+	request.put ("include_active", "false");
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
+	request.put ("include_active", "true");
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 	nano::test::confirm (node->ledger, block1);
 	request.put ("include_only_confirmed", "true");

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -627,10 +627,10 @@ TEST (rpc, receivable_sorting_confirmed_offset_parity)
 }
 
 /*
- * Unsorted queries apply the offset to confirmed entries in send hash order before the threshold filter,
- * so a confirmed entry below the threshold still consumes the offset
+ * Unsorted queries apply the threshold filter before the offset,
+ * so a below-threshold entry neither appears in the response nor consumes the offset
  */
-TEST (rpc, receivable_unsorted_offset_before_threshold)
+TEST (rpc, receivable_unsorted_offset_after_threshold)
 {
 	nano::test::system system;
 	nano::node_config config = system.default_config ();
@@ -639,9 +639,9 @@ TEST (rpc, receivable_unsorted_offset_before_threshold)
 	auto node = add_ipc_enabled_node (system, config);
 	nano::block_builder builder;
 
-	// Pick a destination for which the below-threshold send sorts first in hash order, making the quirk observable
+	// Pick a destination for which the below-threshold send sorts first in hash order, so it would consume the offset if it were not filtered first
 	nano::keypair key1;
-	std::shared_ptr<nano::block> send_low, send_high;
+	std::shared_ptr<nano::block> send_low, send_high1, send_high2;
 	do
 	{
 		key1 = nano::keypair{};
@@ -654,32 +654,52 @@ TEST (rpc, receivable_unsorted_offset_before_threshold)
 				   .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
 				   .work (*node->work_generate_blocking (nano::dev::genesis->hash ()))
 				   .build ();
-		send_high = builder.state ()
-					.account (nano::dev::genesis_key.pub)
-					.previous (send_low->hash ())
-					.representative (nano::dev::genesis_key.pub)
-					.balance (nano::dev::constants.genesis_amount - 101)
-					.link (key1.pub)
-					.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-					.work (*node->work_generate_blocking (send_low->hash ()))
-					.build ();
-	} while (send_low->hash ().number () > send_high->hash ().number ());
+		send_high1 = builder.state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (send_low->hash ())
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - 101)
+					 .link (key1.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*node->work_generate_blocking (send_low->hash ()))
+					 .build ();
+		send_high2 = builder.state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (send_high1->hash ())
+					 .representative (nano::dev::genesis_key.pub)
+					 .balance (nano::dev::constants.genesis_amount - 301)
+					 .link (key1.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*node->work_generate_blocking (send_high1->hash ()))
+					 .build ();
+	} while (send_low->hash ().number () > send_high1->hash ().number () || send_low->hash ().number () > send_high2->hash ().number ());
 	ASSERT_EQ (nano::block_status::progress, node->process (send_low));
-	ASSERT_EQ (nano::block_status::progress, node->process (send_high));
+	ASSERT_EQ (nano::block_status::progress, node->process (send_high1));
+	ASSERT_EQ (nano::block_status::progress, node->process (send_high2));
+
+	// The above-threshold sends in hash ascending order, matching the unsorted scan; fixed-width hex compares like the numeric hash
+	std::vector<std::pair<std::string, std::string>> qualifying{ { send_high1->hash ().to_string (), "100" }, { send_high2->hash ().to_string (), "200" } };
+	std::sort (qualifying.begin (), qualifying.end ());
 
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "receivable");
 	request.put ("account", key1.pub.to_account ());
-	// The sends deliberately stay unconfirmed, so the query must accept unconfirmed receivables
+	// The sends deliberately stay unconfirmed, so the queries must accept unconfirmed receivables
 	request.put ("include_only_confirmed", "false");
 	request.put ("threshold", 50);
+	{
+		auto response = wait_response (system, rpc_ctx, request);
+		// The threshold alone drops the 1 raw send
+		ASSERT_EQ (qualifying, blocks_of (response.get_child ("blocks")));
+	}
 	request.put ("offset", 1);
-	auto response = wait_response (system, rpc_ctx, request);
-
-	// The offset consumes the below-threshold 1 raw send, leaving the 100 raw send in the response
-	std::vector<std::pair<std::string, std::string>> expected{ { send_high->hash ().to_string (), "100" } };
-	ASSERT_EQ (expected, blocks_of (response.get_child ("blocks")));
+	{
+		auto response = wait_response (system, rpc_ctx, request);
+		// The offset skips the first above-threshold send; the below-threshold send does not consume it
+		std::vector<std::pair<std::string, std::string>> expected{ qualifying[1] };
+		ASSERT_EQ (expected, blocks_of (response.get_child ("blocks")));
+	}
 }
 
 /*

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -3516,6 +3516,51 @@ TEST (rpc, wallet_receivable)
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
 }
 
+/*
+ * Unconfirmed wallet queries include blocks in active elections by default, explicit include_active=false excludes them
+ */
+TEST (rpc, wallet_receivable_include_active)
+{
+	nano::test::system system;
+	nano::node_config config;
+	// Disable the backlog scan so the test controls election activity
+	config.backlog_scan->enable = false;
+	auto node = add_ipc_enabled_node (system, config);
+	nano::keypair key1;
+	// Only the destination key joins the wallet, so the node holds no voting weight and the election stays active
+	system.wallet (0)->insert_adhoc (key1.prv);
+	nano::block_builder builder;
+	auto send = builder.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - 100)
+				.link (key1.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*node->work_generate_blocking (nano::dev::genesis->hash ()))
+				.build ();
+	ASSERT_EQ (nano::block_status::progress, node->process (send));
+	ASSERT_NE (nullptr, nano::test::start_election (system, *node, send->hash ()));
+
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_receivable");
+	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
+	request.put ("include_only_confirmed", "false");
+	{
+		auto response = wait_response (system, rpc_ctx, request);
+		ASSERT_EQ (1, response.get_child ("blocks").size ());
+		auto entry = response.get_child ("blocks").front ();
+		ASSERT_EQ (key1.pub.to_account (), entry.first);
+		ASSERT_EQ (send->hash ().to_string (), entry.second.begin ()->second.get<std::string> (""));
+	}
+	request.put ("include_active", "false");
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
+	request.put ("include_active", "true");
+	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 1));
+}
+
 TEST (rpc, receive_minimum)
 {
 	nano::test::system system;


### PR DESCRIPTION
Stacked on #5117, which should merge first — the first commit here is that PR's change.

Querying receivable RPCs with `include_only_confirmed=false` still excluded any unconfirmed block that happened to be in an active election, because `include_active` defaulted to `false` unconditionally. Callers asking for unconfirmed entries therefore received responses that depended on election scheduling timing, and several tests had to disable the backlog scan just to keep unconfirmed responses deterministic.

`include_active` now defaults to the complement of `include_only_confirmed` in `receivable`, `accounts_receivable`, `receivable_exists` and `wallet_receivable` (plus their deprecated `pending` aliases): confirmed-only queries are unaffected (`include_active` has no effect there), while unconfirmed queries include blocks in active elections unless the caller passes `include_active=false` explicitly. The old filtering remains reachable through that explicit flag.

Test changes:
- `receivable_unconfirmed` and `accounts_receivable_confirmed` gain an election phase: an entry with an active election is returned by default, disappears with explicit `include_active=false`, and returns with explicit `include_active=true`.
- New `receivable_exists_include_active` and `wallet_receivable_include_active` cover the same matrix for the remaining two handlers. Neither flag combination was previously tested anywhere — no test passed `include_active` at all.
- The backlog-scan disabling is removed from `receivable_sorting_tie_parity`, `accounts_receivable_sorting_top_parity` and `receivable_unsorted_offset_after_threshold`, since unconfirmed responses no longer depend on election state with default flags.

The `include_active` default documented on docs.nano.org ("false by default") needs a corresponding update once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
