### PR TITLE
Fix deterministic wallet restore skipping the next account

### DIFF
--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -1057,6 +1057,33 @@ TEST (wallet, deterministic_restore)
 	ASSERT_TRUE (wallet->exists (pub));
 }
 
+/*
+ * A restore must pick up a payment to the account at the wallet's stored deterministic index, i.e. the next account to be handed out.
+ * A scan that starts past the stored index misses exactly this account, leaving received funds invisible after a seed restore
+ */
+TEST (wallet, deterministic_restore_next)
+{
+	nano::test::system system (1);
+	auto wallet (system.wallet (0));
+	nano::raw_key seed1;
+	seed1 = 1;
+	wallet->change_seed (seed1);
+	ASSERT_EQ (1, wallet->get_deterministic_index ());
+	// The next deterministic account receives a block before it exists in the wallet
+	auto prv = nano::deterministic_key (seed1, 1);
+	auto pub = nano::pub_key (prv);
+	wallet->insert_adhoc (nano::dev::genesis_key.prv, false);
+	auto block (wallet->send_action (nano::dev::genesis_key.pub, pub, 100));
+	ASSERT_NE (nullptr, block);
+	ASSERT_TIMELY (5s, nano::test::exists (*system.nodes[0], { block }));
+	wallet->deterministic_restore ();
+	ASSERT_EQ (2, wallet->get_deterministic_index ());
+	ASSERT_TRUE (wallet->exists (pub));
+	// A repeated restore finds nothing further and leaves the index unchanged
+	wallet->deterministic_restore ();
+	ASSERT_EQ (2, wallet->get_deterministic_index ());
+}
+
 TEST (wallet, epoch_2_validation)
 {
 	nano::test::system system (1);

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -532,12 +532,14 @@ nano::public_key wallet_store::deterministic_insert (nano::store::write_transact
 	auto index (deterministic_index_get (transaction_a));
 	auto prv = deterministic_key (transaction_a, index);
 	nano::public_key result (nano::pub_key (prv));
+	// The indexed overload inserts without moving the cursor, so accounts may already exist at or above it; skip them rather than hand back an existing account
 	while (exists (transaction_a, result))
 	{
 		++index;
 		prv = deterministic_key (transaction_a, index);
 		result = nano::pub_key (prv);
 	}
+	// A deterministic entry is tagged by a marker carrying its account index in the low 32 bits
 	uint64_t marker (1);
 	marker <<= 32;
 	marker |= index;
@@ -547,6 +549,7 @@ nano::public_key wallet_store::deterministic_insert (nano::store::write_transact
 	return result;
 }
 
+// Random access counterpart of the allocating overload above: the cursor stays put, otherwise inserting a high index would strand every account below it
 nano::public_key wallet_store::deterministic_insert (nano::store::write_transaction const & transaction_a, uint32_t const index)
 {
 	auto prv = deterministic_key (transaction_a, index);
@@ -1412,6 +1415,25 @@ nano::public_key wallet::change_seed (nano::raw_key const & prv_a, uint32_t coun
 	return result;
 }
 
+std::optional<nano::public_key> wallet::deterministic_insert_up_to_impl (nano::store::write_transaction const & transaction_a, uint32_t last)
+{
+	std::optional<nano::public_key> account;
+	// The stored index is re-read each round because an insert skips over indexes whose accounts already exist
+	for (uint64_t index = store.deterministic_index_get (transaction_a); index <= last;)
+	{
+		// Disable work generation to prevent weak CPU nodes stuck
+		account = deterministic_insert_impl (transaction_a, false);
+		uint64_t next = store.deterministic_index_get (transaction_a);
+		// The index wraps at the end of its range, stop instead of inserting forever
+		if (next <= index)
+		{
+			break;
+		}
+		index = next;
+	}
+	return account;
+}
+
 nano::public_key wallet::change_seed_impl (nano::store::write_transaction const & transaction_a, nano::raw_key const & prv_a, uint32_t count)
 {
 	logger.info (nano::log::type::wallet, "Changing wallet seed");
@@ -1435,10 +1457,9 @@ nano::public_key wallet::change_seed_impl (nano::store::write_transaction const 
 	}
 	if (last)
 	{
-		while (store.deterministic_index_get (transaction_a) <= *last)
+		if (auto inserted = deterministic_insert_up_to_impl (transaction_a, *last))
 		{
-			// Disable work generation to prevent weak CPU nodes stuck
-			account = deterministic_insert_impl (transaction_a, false);
+			account = *inserted;
 		}
 	}
 
@@ -1461,11 +1482,7 @@ void wallet::deterministic_restore_impl (nano::store::write_transaction const & 
 	// Scan the ledger for used accounts beyond those already inserted
 	if (auto last = deterministic_check_impl (transaction_a, store.deterministic_index_get (transaction_a)))
 	{
-		while (store.deterministic_index_get (transaction_a) <= *last)
-		{
-			// Disable work generation to prevent weak CPU nodes stuck
-			deterministic_insert_impl (transaction_a, false);
-		}
+		deterministic_insert_up_to_impl (transaction_a, *last);
 	}
 }
 

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1365,16 +1365,17 @@ void wallet::init_free_accounts_impl (nano::store::transaction const & transacti
 	}
 }
 
-uint32_t wallet::deterministic_check (uint32_t index)
+std::optional<uint32_t> wallet::deterministic_check (uint32_t index)
 {
 	auto transaction = wallets.tx_begin_read ();
 	return deterministic_check_impl (transaction, index);
 }
 
-uint32_t wallet::deterministic_check_impl (nano::store::transaction const & transaction_a, uint32_t index)
+std::optional<uint32_t> wallet::deterministic_check_impl (nano::store::transaction const & transaction_a, uint32_t index)
 {
 	auto ledger_txn = wallets.ledger.tx_begin_read ();
-	for (uint32_t i (index + 1), n (index + 64); i < n; ++i)
+	std::optional<uint32_t> result;
+	for (uint32_t i (index), n (index + deterministic_check_gap); i < n; ++i)
 	{
 		auto prv = store.deterministic_key (transaction_a, i);
 		nano::keypair pair (prv.to_string ());
@@ -1382,10 +1383,9 @@ uint32_t wallet::deterministic_check_impl (nano::store::transaction const & tran
 		auto latest (wallets.ledger.any.account_head (ledger_txn, pair.pub));
 		if (!latest.is_zero ())
 		{
-			index = i;
-			// i + 64 - Check additional 64 accounts
-			// i/64 - Check additional accounts for large wallets. I.e. 64000/64 = 1000 accounts to check
-			n = i + 64 + (i / 64);
+			result = i;
+			// Scan a full gap beyond the hit, plus i/gap extra for large wallets
+			n = i + 1 + deterministic_check_gap + (i / deterministic_check_gap);
 		}
 		else
 		{
@@ -1393,12 +1393,12 @@ uint32_t wallet::deterministic_check_impl (nano::store::transaction const & tran
 			auto current = wallets.ledger.any.receivable_upper_bound (ledger_txn, pair.pub, 0);
 			if (current != wallets.ledger.any.receivable_end ())
 			{
-				index = i;
-				n = i + 64 + (i / 64);
+				result = i;
+				n = i + 1 + deterministic_check_gap + (i / deterministic_check_gap);
 			}
 		}
 	}
-	return index;
+	return result;
 }
 
 nano::public_key wallet::change_seed (nano::raw_key const & prv_a, uint32_t count)
@@ -1417,16 +1417,29 @@ nano::public_key wallet::change_seed_impl (nano::store::write_transaction const 
 	logger.info (nano::log::type::wallet, "Changing wallet seed");
 
 	store.seed_set (transaction_a, prv_a);
+	// The wallet contains at least the first seed account
 	auto account = deterministic_insert_impl (transaction_a);
+	// An explicit count requests accounts 0..count inclusive, otherwise the ledger scan finds the highest account in use
+	std::optional<uint32_t> last;
 	if (count == 0)
 	{
-		count = deterministic_check_impl (transaction_a, 0);
-		logger.info (nano::log::type::wallet, "Auto-detected {} accounts to generate from seed", count);
+		last = deterministic_check_impl (transaction_a, store.deterministic_index_get (transaction_a));
+		if (last)
+		{
+			logger.info (nano::log::type::wallet, "Auto-detected used accounts up to index {} to restore from seed", *last);
+		}
 	}
-	for (uint32_t i (0); i < count; ++i)
+	else
 	{
-		// Disable work generation to prevent weak CPU nodes stuck
-		account = deterministic_insert_impl (transaction_a, false);
+		last = count;
+	}
+	if (last)
+	{
+		while (store.deterministic_index_get (transaction_a) <= *last)
+		{
+			// Disable work generation to prevent weak CPU nodes stuck
+			account = deterministic_insert_impl (transaction_a, false);
+		}
 	}
 
 	logger.info (nano::log::type::wallet, "Completed changing wallet seed and generating accounts");
@@ -1445,12 +1458,14 @@ void wallet::deterministic_restore ()
 
 void wallet::deterministic_restore_impl (nano::store::write_transaction const & transaction_a)
 {
-	auto index (store.deterministic_index_get (transaction_a));
-	auto new_index (deterministic_check_impl (transaction_a, index));
-	for (uint32_t i (index); i <= new_index && index != new_index; ++i)
+	// Scan the ledger for used accounts beyond those already inserted
+	if (auto last = deterministic_check_impl (transaction_a, store.deterministic_index_get (transaction_a)))
 	{
-		// Disable work generation to prevent weak CPU nodes stuck
-		deterministic_insert_impl (transaction_a, false);
+		while (store.deterministic_index_get (transaction_a) <= *last)
+		{
+			// Disable work generation to prevent weak CPU nodes stuck
+			deterministic_insert_impl (transaction_a, false);
+		}
 	}
 }
 

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -175,8 +175,10 @@ public:
 	// Seed management
 	nano::result<nano::raw_key> get_seed () const;
 	nano::public_key change_seed (nano::raw_key const & seed, uint32_t count = 0);
+	// Inserts accounts up to the highest one with ledger activity
 	void deterministic_restore ();
-	uint32_t deterministic_check (uint32_t index);
+	// Scans accounts from index, returns the highest index with ledger activity, if any
+	std::optional<uint32_t> deterministic_check (uint32_t index);
 	uint32_t get_deterministic_index () const;
 
 	// Representative management
@@ -236,12 +238,16 @@ private:
 	void work_update_impl (nano::store::write_transaction const &, nano::account const & account, nano::root const & root, uint64_t work);
 	bool search_receivable_impl (nano::store::transaction const &);
 	void init_free_accounts_impl (nano::store::transaction const &);
-	uint32_t deterministic_check_impl (nano::store::transaction const &, uint32_t index);
+	std::optional<uint32_t> deterministic_check_impl (nano::store::transaction const &, uint32_t index);
 	nano::public_key change_seed_impl (nano::store::write_transaction const &, nano::raw_key const & seed, uint32_t count = 0);
 	void deterministic_restore_impl (nano::store::write_transaction const &);
 
 private:
 	nano::locked<std::unordered_set<nano::account>> representatives;
+
+public:
+	// Consecutive unused accounts scanned past the last used one before a seed scan gives up
+	static uint32_t constexpr deterministic_check_gap{ 64 };
 
 	friend class wallets;
 };

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -73,7 +73,9 @@ public:
 	nano::raw_key seed (nano::store::transaction const &) const;
 	void seed_set (nano::store::write_transaction const &, nano::raw_key const & seed);
 	nano::wallet::key_type key_type (nano::wallet::wallet_value const &) const;
+	// Allocates the next account: inserts at the stored index and advances it, skipping indexes whose accounts already exist
 	nano::public_key deterministic_insert (nano::store::write_transaction const &);
+	// Materializes one account at an explicit index, leaving the stored index alone so sequential allocation still fills the indexes below it
 	nano::public_key deterministic_insert (nano::store::write_transaction const &, uint32_t index);
 	nano::raw_key deterministic_key (nano::store::transaction const &, uint32_t index) const;
 	uint32_t deterministic_index_get (nano::store::transaction const &) const;
@@ -229,17 +231,28 @@ public:
 	nano::wallet::wallets & wallets;
 	nano::logger & logger;
 
-private:
-	// Internal implementation methods (accept transactions for batching scenarios)
+private: // Internal implementation methods (accept transactions for batching scenarios)
+	// Attempts to unlock with the password and queues a receivable search on success, returns true if the password was wrong
 	bool enter_password_impl (nano::store::transaction const &, std::string const & password);
+	// Adds a watch-only account, returns true if the key is not a valid public key
 	bool insert_watch_impl (nano::store::write_transaction const &, nano::public_key const & pub);
+	// Inserts the account at the stored deterministic index and advances it
 	nano::public_key deterministic_insert_impl (nano::store::write_transaction const &, bool generate_work = true);
+	// Inserts the account at an explicit index, leaving the stored index untouched
 	nano::public_key deterministic_insert_impl (nano::store::write_transaction const &, uint32_t index, bool generate_work = true);
+	// Caches work for an account, discarding it if the root is no longer the account frontier
 	void work_update_impl (nano::store::write_transaction const &, nano::account const & account, nano::root const & root, uint64_t work);
+	// Receives confirmed receivables above the receive minimum and starts elections for unconfirmed ones, returns true if the wallet is locked
 	bool search_receivable_impl (nano::store::transaction const &);
+	// Rebuilds the set of accounts available for spending from the wallet store
 	void init_free_accounts_impl (nano::store::transaction const &);
+	// Scans accounts from index, returns the highest index with ledger activity, if any
 	std::optional<uint32_t> deterministic_check_impl (nano::store::transaction const &, uint32_t index);
+	// Inserts accounts until every index up to and including last exists, returns the last account inserted
+	std::optional<nano::public_key> deterministic_insert_up_to_impl (nano::store::write_transaction const &, uint32_t last);
+	// Replaces the seed and inserts accounts 0..count, or up to the highest account in use when count is 0
 	nano::public_key change_seed_impl (nano::store::write_transaction const &, nano::raw_key const & seed, uint32_t count = 0);
+	// Inserts accounts up to the highest one with ledger activity
 	void deterministic_restore_impl (nano::store::write_transaction const &);
 
 private:


### PR DESCRIPTION
`deterministic_restore` never inspected the account at the wallet's stored deterministic index — the very next account to be handed out. The scan started at `index + 1`, so a wallet whose next account had received funds restored nothing and left those funds invisible.

The ambiguous return convention was what made this hard to see. `deterministic_check` returned the highest used index, signalling "nothing found" by echoing its argument back, so `check(N) == N` meant either "account N is used" or "nothing found". The restore loop tried to disambiguate with `i <= new_index && index != new_index` and guessed wrong in exactly the "found at N" case.

`deterministic_check` now returns `std::optional<uint32_t>`: the highest index with ledger activity, or `nullopt` when the scan finds nothing. Both callers become a guard plus an inclusive loop:

```cpp
if (auto last = deterministic_check_impl (transaction_a, store.deterministic_index_get (transaction_a)))
{
    while (store.deterministic_index_get (transaction_a) <= *last) { ... }
}
```

`change_seed` keeps its documented behavior: an explicit `count` still requests accounts `0..count` inclusive, and the auto-detect path now scans from the stored index rather than from 0. Its log line reports the highest detected index instead of a count of additional accounts.

Two incidental fixes in the scan itself: both gap windows were checking 63 candidates while their comments claimed 64, and the bare `64` literals are now a named `deterministic_check_gap` constant. The 64 is a gap limit in the HD-wallet sense — how many consecutive unused accounts to scan past the last used one before giving up — and predates the RaiBlocks rename with no recorded rationale.

Verification: `wallet.deterministic_restore_next` covers a payment to the account at the wallet's stored index. Against the current `develop` implementation it fails on both LMDB and RocksDB:

```
nano/core_test/wallet.cpp:1080: Failure
Expected equality of these values:
  2
  wallet->get_deterministic_index ()
    Which is: 1
```

With the fix it passes, as do all 49 `wallet.*`/`wallets.*` core tests and the seed-related RPC tests on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
