### PR TITLE
Bound the account count accepted by wallet RPC commands

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -55,8 +55,8 @@
 
 namespace
 {
-// Maximum accounts one RPC call may create
-uint64_t constexpr max_accounts_per_request = 100000;
+// Maximum count accepted by account creating RPC commands
+uint64_t constexpr max_account_count_per_request = 100000;
 }
 
 namespace
@@ -988,7 +988,7 @@ void nano::json_handler::accounts_create ()
 	node.workers.post (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
 		auto wallet = rpc_l->wallet_impl ();
 		auto count = rpc_l->count_impl ();
-		if (!rpc_l->ec && count > max_accounts_per_request)
+		if (!rpc_l->ec && count > max_account_count_per_request)
 		{
 			rpc_l->ec = nano::error_common::invalid_count;
 		}
@@ -4752,9 +4752,9 @@ void nano::json_handler::wallet_change_seed ()
 			nano::raw_key seed;
 			if (!seed.decode_hex (seed_text))
 			{
-				// Count is the highest index to restore, so the seed yields one more account than its value
+				// Count is the number of accounts added beyond the first, so the seed yields one more account than its value
 				auto count (rpc_l->count_optional_impl (0));
-				if (!rpc_l->ec && count > max_accounts_per_request)
+				if (!rpc_l->ec && count > max_account_count_per_request)
 				{
 					rpc_l->ec = nano::error_common::invalid_count;
 				}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -55,6 +55,12 @@
 
 namespace
 {
+// Maximum accounts one RPC call may create
+uint64_t constexpr max_accounts_per_request = 100000;
+}
+
+namespace
+{
 void construct_json (nano::container_info_component * component, boost::property_tree::ptree & parent);
 using ipc_json_handler_no_arg_func_map = std::unordered_map<std::string, std::function<void (nano::json_handler *)>>;
 ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ();
@@ -982,6 +988,10 @@ void nano::json_handler::accounts_create ()
 	node.workers.post (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
 		auto wallet = rpc_l->wallet_impl ();
 		auto count = rpc_l->count_impl ();
+		if (!rpc_l->ec && count > max_accounts_per_request)
+		{
+			rpc_l->ec = nano::error_common::invalid_count;
+		}
 		if (!rpc_l->ec)
 		{
 			bool const generate_work = rpc_l->request.get<bool> ("work", false);
@@ -4742,19 +4752,28 @@ void nano::json_handler::wallet_change_seed ()
 			nano::raw_key seed;
 			if (!seed.decode_hex (seed_text))
 			{
-				auto count (static_cast<uint32_t> (rpc_l->count_optional_impl (0)));
-				if (!wallet->is_locked ())
+				// Count is the highest index to restore, so the seed yields one more account than its value
+				auto count (rpc_l->count_optional_impl (0));
+				if (!rpc_l->ec && count > max_accounts_per_request)
 				{
-					nano::public_key account (wallet->change_seed (seed, count));
-					rpc_l->response_l.put ("success", "");
-					rpc_l->response_l.put ("last_restored_account", account.to_account ());
-					auto index (wallet->get_deterministic_index ());
-					debug_assert (index > 0);
-					rpc_l->response_l.put ("restored_count", std::to_string (index));
+					rpc_l->ec = nano::error_common::invalid_count;
 				}
-				else
+				// Validate before touching the wallet, a rejected count must leave the existing seed in place
+				if (!rpc_l->ec)
 				{
-					rpc_l->ec = nano::error_common::wallet_locked;
+					if (!wallet->is_locked ())
+					{
+						nano::public_key account (wallet->change_seed (seed, static_cast<uint32_t> (count)));
+						rpc_l->response_l.put ("success", "");
+						rpc_l->response_l.put ("last_restored_account", account.to_account ());
+						auto index (wallet->get_deterministic_index ());
+						debug_assert (index > 0);
+						rpc_l->response_l.put ("restored_count", std::to_string (index));
+					}
+					else
+					{
+						rpc_l->ec = nano::error_common::wallet_locked;
+					}
 				}
 			}
 			else

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2707,6 +2707,37 @@ TEST (rpc, wallet_change_seed)
 	ASSERT_EQ ("1", response.get<std::string> ("restored_count"));
 }
 
+/*
+ * Counts above the per-request account limit are rejected, including one past the 32 bit range that used to be truncated into a ledger scan.
+ * A rejected request must leave the existing seed in place
+ */
+TEST (rpc, wallet_change_seed_count_limit)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto const rpc_ctx = add_rpc (system, node);
+	auto seed_before = system.wallet (0)->get_seed ();
+	ASSERT_TRUE (seed_before);
+
+	nano::raw_key seed;
+	nano::random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_change_seed");
+	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("seed", seed.to_string ());
+	// The last value is 2^32, which truncated to zero and silently restored by ledger scan instead
+	for (auto const * count : { "100001", "4294967295", "4294967296" })
+	{
+		request.put ("count", count);
+		auto response = wait_response (system, rpc_ctx, request);
+		ASSERT_EQ (std::error_code (nano::error_common::invalid_count).message (), response.get<std::string> ("error"));
+	}
+
+	auto seed_after = system.wallet (0)->get_seed ();
+	ASSERT_TRUE (seed_after);
+	ASSERT_EQ (seed_before.value (), seed_after.value ());
+}
+
 TEST (rpc, wallet_frontiers)
 {
 	nano::test::system system0;
@@ -5098,6 +5129,24 @@ TEST (rpc, accounts_create)
 		ASSERT_TRUE (system.wallet (0)->exists (account));
 	}
 	ASSERT_EQ (8, accounts.size ());
+}
+
+// A count above the per-request account limit is rejected before any account is created
+TEST (rpc, accounts_create_count_limit)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto const rpc_ctx = add_rpc (system, node);
+	auto accounts_before = system.wallet (0)->accounts ().size ();
+
+	boost::property_tree::ptree request;
+	request.put ("action", "accounts_create");
+	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("count", "100001");
+	auto response = wait_response (system, rpc_ctx, request);
+
+	ASSERT_EQ (std::error_code (nano::error_common::invalid_count).message (), response.get<std::string> ("error"));
+	ASSERT_EQ (accounts_before, system.wallet (0)->accounts ().size ());
 }
 
 TEST (rpc, accounts_create_locked)

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2708,10 +2708,10 @@ TEST (rpc, wallet_change_seed)
 }
 
 /*
- * Counts above the per-request account limit are rejected, including one past the 32 bit range that used to be truncated into a ledger scan.
+ * Counts above the per-request account limit are rejected, as are counts past the 32 bit range and counts that do not parse.
  * A rejected request must leave the existing seed in place
  */
-TEST (rpc, wallet_change_seed_count_limit)
+TEST (rpc, wallet_change_seed_count_rejected)
 {
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
@@ -2725,8 +2725,8 @@ TEST (rpc, wallet_change_seed_count_limit)
 	request.put ("action", "wallet_change_seed");
 	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
 	request.put ("seed", seed.to_string ());
-	// The last value is 2^32, which truncated to zero and silently restored by ledger scan instead
-	for (auto const * count : { "100001", "4294967295", "4294967296" })
+	// 2^32 used to truncate to zero and silently restore by ledger scan; the trailing garbage parses as 12 before failing, which used to restore 12 accounts
+	for (auto const * count : { "100001", "4294967295", "4294967296", "12abc" })
 	{
 		request.put ("count", count);
 		auto response = wait_response (system, rpc_ctx, request);


### PR DESCRIPTION
`accounts_create` and `wallet_change_seed` both loop over a caller-supplied count creating accounts, with no upper bound. A large count leaves the wallet unusable for the duration of the request, and the parameter accepts anything that parses into 64 bits.

`wallet_change_seed` had a second problem: it truncated its `uint64` count into a `uint32`, so `count=4294967296` became `0` — which selects auto-detect, a different operation than the caller asked for. Any multiple of 2^32 behaved the same way.

Both handlers now reject counts above `max_accounts_per_request` (100000) with `invalid_count`, following the range check `account_create` already applies to its `index` parameter.

`wallet_change_seed` additionally validates before touching the wallet. `count_optional_impl` sets `ec` on a malformed count, but the handler ignored it and replaced the seed anyway, surfacing the error only after the change had been made. A rejected request now leaves the existing seed in place.

Tests:
- `accounts_create_count_limit` asserts the request is rejected and no account is created.
- `wallet_change_seed_count_rejected` drives `100001`, `4294967295`, `4294967296` and `12abc`, asserting each is rejected and that the existing seed survives. The last two are the interesting ones: `4294967296` previously truncated into a ledger scan, and `12abc` parses as `12` before failing on the trailing garbage, so it previously replaced the seed and created 12 accounts while returning "Invalid count" to the caller.

Verified against `develop` with the malformed count in isolation — the seed is replaced despite the error response:

```
nano/rpc_test/rpc.cpp:2738: Failure
Expected equality of these values:
  seed_before.value ()
    Which is: B85BEB2CD72CA115AAE131720BC2B0CB4C67F2CE2FCA835A2FE5432C2F8D6D90
  seed_after.value ()
    Which is: 62020C2CAE2B571F95199A8396D9E4B045F9E901A3C6A4870459BF297C8E642F
```

Related to #5119, which guards the same overflow one layer down in `wallet::change_seed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
