### PR TITLE
Validate wallet_change_seed count before replacing the seed

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4742,19 +4742,28 @@ void nano::json_handler::wallet_change_seed ()
 			nano::raw_key seed;
 			if (!seed.decode_hex (seed_text))
 			{
-				auto count (static_cast<uint32_t> (rpc_l->count_optional_impl (0)));
-				if (!wallet->is_locked ())
+				// Count is the number of accounts added beyond the first, and is restored as a 32 bit index
+				auto count (rpc_l->count_optional_impl (0));
+				if (!rpc_l->ec && count > static_cast<uint64_t> (std::numeric_limits<uint32_t>::max ()))
 				{
-					nano::public_key account (wallet->change_seed (seed, count));
-					rpc_l->response_l.put ("success", "");
-					rpc_l->response_l.put ("last_restored_account", account.to_account ());
-					auto index (wallet->get_deterministic_index ());
-					debug_assert (index > 0);
-					rpc_l->response_l.put ("restored_count", std::to_string (index));
+					rpc_l->ec = nano::error_common::invalid_count;
 				}
-				else
+				// Validate before touching the wallet, a rejected count must leave the existing seed in place
+				if (!rpc_l->ec)
 				{
-					rpc_l->ec = nano::error_common::wallet_locked;
+					if (!wallet->is_locked ())
+					{
+						nano::public_key account (wallet->change_seed (seed, static_cast<uint32_t> (count)));
+						rpc_l->response_l.put ("success", "");
+						rpc_l->response_l.put ("last_restored_account", account.to_account ());
+						auto index (wallet->get_deterministic_index ());
+						debug_assert (index > 0);
+						rpc_l->response_l.put ("restored_count", std::to_string (index));
+					}
+					else
+					{
+						rpc_l->ec = nano::error_common::wallet_locked;
+					}
 				}
 			}
 			else

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2707,6 +2707,39 @@ TEST (rpc, wallet_change_seed)
 	ASSERT_EQ ("1", response.get<std::string> ("restored_count"));
 }
 
+/*
+ * Counts that do not fit a 32 bit index and counts that do not parse are rejected.
+ * A rejected request must leave the existing seed in place
+ */
+TEST (rpc, wallet_change_seed_count_rejected)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto const rpc_ctx = add_rpc (system, node);
+	auto seed_before = system.wallet (0)->get_seed ();
+	ASSERT_TRUE (seed_before);
+
+	nano::raw_key seed;
+	nano::random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_change_seed");
+	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("seed", seed.to_string ());
+	// 2^32 truncated to zero and silently restored by ledger scan; the trailing garbage parses as 12 before failing, which restored 12 accounts
+	for (auto const * count : { "4294967296", "12abc" })
+	{
+		request.put ("count", count);
+		auto response = wait_response (system, rpc_ctx, request);
+		auto error = response.get_optional<std::string> ("error");
+		ASSERT_TRUE (error) << "count " << count << " was accepted";
+		ASSERT_EQ (std::error_code (nano::error_common::invalid_count).message (), error.value ());
+	}
+
+	auto seed_after = system.wallet (0)->get_seed ();
+	ASSERT_TRUE (seed_after);
+	ASSERT_EQ (seed_before.value (), seed_after.value ());
+}
+
 TEST (rpc, wallet_frontiers)
 {
 	nano::test::system system0;


### PR DESCRIPTION
`wallet_change_seed` accepts a `count` parameter that it mishandles in two ways.

**The count is truncated rather than range checked.** `count_optional_impl` returns a `uint64_t` which was cast straight to `uint32_t`, so `count=4294967296` became `0` — and `0` selects auto-detect, a different operation than the caller requested. Any multiple of 2^32 behaved the same way. The count is now rejected with `invalid_count` when it does not fit a 32 bit index, matching the range check `account_create` already applies to its `index` parameter.

**A count that fails to parse still changed the seed.** `count_optional_impl` sets `ec` on a malformed count, but the handler ignored it and replaced the seed anyway, surfacing the error only afterwards. Worse, `decode_unsigned` assigns to its out-parameter before failing on trailing garbage, so `count=12abc` replaced the seed *and* created 12 accounts while returning "Invalid count" to the caller — who has no reason to suspect their seed is gone. The count is now validated before the wallet is touched.

`wallet_change_seed` is the only handler affected; `accounts_create` already guarded on `ec` after parsing its count.

`wallet_change_seed_count_rejected` drives both values and asserts the existing seed survives. Verified against `develop`: `4294967296` is accepted outright,

```
nano/rpc_test/rpc.cpp:2734: Failure
Value of: error
  Actual: false
Expected: true
count 4294967296 was accepted
```

and `12abc` replaces the seed despite the error response,

```
nano/rpc_test/rpc.cpp:2740: Failure
Expected equality of these values:
  seed_before.value ()  Which is: 1F74D818C152BDF10C9B2BD8D49118D1D1BCE3A7FA92B167FF02D6EC8169BEEC
  seed_after.value ()   Which is: 6BAC47D0F3EAFF87C52FDEBE20B062C775B22AF653292522F56E05A671A9F482
```

This is the correctness half of #5121, split out so it can land independently of the resource limit that PR proposes. #5121 will need a rebase once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
