### PR TITLE
Fix coverage flow part 2

### DIFF
--- a/coverage/CMakeLists.txt
+++ b/coverage/CMakeLists.txt
@@ -3,7 +3,7 @@ add_custom_target(
   COMMAND echo "CLEANING COUNTERS"
   COMMAND ${LCOV_PATH} --directory . --zerocounter -q
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  DEPENDS build_tests)
+  DEPENDS all_tests)
 
 add_custom_target(
   coverage_tests


### PR DESCRIPTION
The weekly coverage CI flow was fixed in https://github.com/nanocurrency/nano-node/pull/5113
That PR got the Coverage Reports workflow running again but it is now failing execution because it is referencing a target that was renamed several years ago
One thing to notice: The Coveralls project appears to be unregistered at https://coveralls.io . It may need re-registration