### PR TITLE
Add threshold option to representatives RPC and representative_count command

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3763,6 +3763,8 @@ void nano::json_handler::receive_minimum_set ()
 void nano::json_handler::representatives ()
 {
 	auto count (count_optional_impl ());
+	auto threshold (threshold_optional_impl ());
+
 	if (!ec)
 	{
 		bool const sorting = request.get<bool> ("sorting", false);
@@ -3770,13 +3772,15 @@ void nano::json_handler::representatives ()
 		auto rep_amounts = node.ledger.rep_weights.get_rep_amounts ();
 		if (!sorting) // Simple
 		{
-			std::map<nano::account, nano::uint128_t> ordered (rep_amounts.begin (), rep_amounts.end ());
 			for (auto & rep_amount : rep_amounts)
 			{
 				auto const & account (rep_amount.first);
 				auto const & amount (rep_amount.second);
+				if (amount < threshold.number ())
+				{
+					continue;
+				}
 				representatives.put (account.to_account (), amount.convert_to<std::string> ());
-
 				if (representatives.size () > count)
 				{
 					break;
@@ -3786,11 +3790,14 @@ void nano::json_handler::representatives ()
 		else // Sorting
 		{
 			std::vector<std::pair<nano::uint128_t, std::string>> representation;
-
 			for (auto & rep_amount : rep_amounts)
 			{
 				auto const & account (rep_amount.first);
 				auto const & amount (rep_amount.second);
+				if (amount < threshold.number ())
+				{
+					continue;
+				}
 				representation.emplace_back (amount, account.to_account ());
 			}
 			std::sort (representation.begin (), representation.end ());
@@ -3801,6 +3808,15 @@ void nano::json_handler::representatives ()
 			}
 		}
 		response_l.add_child ("representatives", representatives);
+	}
+	response_errors ();
+}
+
+void nano::json_handler::representative_count ()
+{
+	if (!ec)
+	{
+		response_l.put ("count", std::to_string (node.ledger.rep_weights.get_rep_amounts ().size ()));
 	}
 	response_errors ();
 }
@@ -5591,6 +5607,7 @@ ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ()
 	no_arg_funcs.emplace ("receive_minimum", &nano::json_handler::receive_minimum);
 	no_arg_funcs.emplace ("receive_minimum_set", &nano::json_handler::receive_minimum_set);
 	no_arg_funcs.emplace ("representatives", &nano::json_handler::representatives);
+	no_arg_funcs.emplace ("representative_count", &nano::json_handler::representative_count);
 	no_arg_funcs.emplace ("representatives_online", &nano::json_handler::representatives_online);
 	no_arg_funcs.emplace ("republish", &nano::json_handler::republish);
 	no_arg_funcs.emplace ("search_pending", &nano::json_handler::search_pending);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3818,13 +3818,20 @@ void nano::json_handler::representative_count ()
 	if (!ec)
 	{
 		std::size_t count = 0;
-		for (auto & rep_amount : node.ledger.rep_weights.get_rep_amounts ())
+		if (threshold.is_zero ())
 		{
-			if (rep_amount.second < threshold.number ())
+			count = node.ledger.rep_weights.size ();
+		}
+		else
+		{
+			for (auto & rep_amount : node.ledger.rep_weights.get_rep_amounts ())
 			{
-				continue;
+				if (rep_amount.second < threshold.number ())
+				{
+					continue;
+				}
+				++count;
 			}
-			++count;
 		}
 		response_l.put ("count", std::to_string (count));
 	}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3814,9 +3814,19 @@ void nano::json_handler::representatives ()
 
 void nano::json_handler::representative_count ()
 {
+	auto threshold (threshold_optional_impl ());
 	if (!ec)
 	{
-		response_l.put ("count", std::to_string (node.ledger.rep_weights.get_rep_amounts ().size ()));
+		std::size_t count = 0;
+		for (auto & rep_amount : node.ledger.rep_weights.get_rep_amounts ())
+		{
+			if (rep_amount.second < threshold.number ())
+			{
+				continue;
+			}
+			++count;
+		}
+		response_l.put ("count", std::to_string (count));
 	}
 	response_errors ();
 }

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -102,6 +102,7 @@ public:
 	void receive_minimum ();
 	void receive_minimum_set ();
 	void representatives ();
+	void representative_count ();
 	void representatives_online ();
 	void republish ();
 	void search_pending ();

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2740,6 +2740,54 @@ TEST (rpc, representative_count)
 	ASSERT_EQ ("3", response.get<std::string> ("count"));
 }
 
+TEST (rpc, representative_count_threshold)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto & wallet = *system.wallet (0);
+	wallet.insert_adhoc (nano::dev::genesis_key.prv);
+	nano::keypair rep2;
+	nano::keypair rep3;
+	wallet.insert_adhoc (rep2.prv);
+	wallet.insert_adhoc (rep3.prv);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep2.pub, 100 * nano::Knano_ratio);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep3.pub, 200 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep2.pub) == 100 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep3.pub) == 200 * nano::Knano_ratio);
+	wallet.change_sync (rep2.pub, rep2.pub);
+	wallet.change_sync (rep3.pub, rep3.pub);
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "representative_count");
+	request.put ("threshold", (150 * nano::Knano_ratio).convert_to<std::string> ());
+	auto response (wait_response (system, rpc_ctx, request));
+	ASSERT_EQ ("2", response.get<std::string> ("count"));
+}
+
+TEST (rpc, representative_count_bad_threshold)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto & wallet = *system.wallet (0);
+	wallet.insert_adhoc (nano::dev::genesis_key.prv);
+	nano::keypair rep2;
+	nano::keypair rep3;
+	wallet.insert_adhoc (rep2.prv);
+	wallet.insert_adhoc (rep3.prv);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep2.pub, 100 * nano::Knano_ratio);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep3.pub, 200 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep2.pub) == 100 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep3.pub) == 200 * nano::Knano_ratio);
+	wallet.change_sync (rep2.pub, rep2.pub);
+	wallet.change_sync (rep3.pub, rep3.pub);
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "representative_count");
+	request.put ("threshold", "not_a_number");
+	auto response (wait_response (system, rpc_ctx, request));
+	ASSERT_EQ (std::error_code (nano::error_common::bad_threshold).message (), response.get<std::string> ("error"));
+}
+
 // wallet_seed is only available over IPC's unsafe encoding, and when running on test network
 TEST (rpc, wallet_seed)
 {

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -7,6 +7,7 @@
 #include <nano/lib/files.hpp>
 #include <nano/lib/jsonconfig.hpp>
 #include <nano/lib/node_capabilities.hpp>
+#include <nano/lib/ratios.hpp>
 #include <nano/lib/rpcconfig.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/lib/threading.hpp>
@@ -41,6 +42,7 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_cemented.hpp>
+#include <nano/secure/network_params.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/confirmation_height.hpp>
 #include <nano/store/ledger/peer.hpp>
@@ -2655,6 +2657,87 @@ TEST (rpc, representatives)
 	}
 	ASSERT_EQ (1, representatives.size ());
 	ASSERT_EQ (nano::dev::genesis_key.pub, representatives[0]);
+}
+
+TEST (rpc, representatives_threshold)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto & wallet = *system.wallet (0);
+	wallet.insert_adhoc (nano::dev::genesis_key.prv);
+	nano::keypair rep2;
+	nano::keypair rep3;
+	wallet.insert_adhoc (rep2.prv);
+	wallet.insert_adhoc (rep3.prv);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep2.pub, 100 * nano::Knano_ratio);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep3.pub, 200 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep2.pub) == 100 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep3.pub) == 200 * nano::Knano_ratio);
+	wallet.change_sync (rep2.pub, rep2.pub);
+	wallet.change_sync (rep3.pub, rep3.pub);
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "representatives");
+	request.put ("threshold", (150 * nano::Knano_ratio).convert_to<std::string> ());
+	auto response (wait_response (system, rpc_ctx, request));
+	auto & representatives_node (response.get_child ("representatives"));
+	std::vector<nano::account> representatives;
+	for (auto i (representatives_node.begin ()), n (representatives_node.end ()); i != n; ++i)
+	{
+		nano::account account;
+		ASSERT_FALSE (account.decode_account (i->first));
+		representatives.push_back (account);
+	}
+	ASSERT_EQ (2, representatives.size ());
+	ASSERT_NE (std::find (representatives.begin (), representatives.end (), rep3.pub), representatives.end ());
+	ASSERT_EQ (std::find (representatives.begin (), representatives.end (), rep2.pub), representatives.end ());
+}
+
+TEST (rpc, representatives_threshold_bad_threshold)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto & wallet = *system.wallet (0);
+	wallet.insert_adhoc (nano::dev::genesis_key.prv);
+	nano::keypair rep2;
+	nano::keypair rep3;
+	wallet.insert_adhoc (rep2.prv);
+	wallet.insert_adhoc (rep3.prv);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep2.pub, 100 * nano::Knano_ratio);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep3.pub, 200 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep2.pub) == 100 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep3.pub) == 200 * nano::Knano_ratio);
+	wallet.change_sync (rep2.pub, rep2.pub);
+	wallet.change_sync (rep3.pub, rep3.pub);
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "representatives");
+	request.put ("threshold", "not_a_number");
+	auto response (wait_response (system, rpc_ctx, request));
+	ASSERT_EQ (std::error_code (nano::error_common::bad_threshold).message (), response.get<std::string> ("error"));
+}
+
+TEST (rpc, representative_count)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto & wallet = *system.wallet (0);
+	wallet.insert_adhoc (nano::dev::genesis_key.prv);
+	nano::keypair rep2;
+	nano::keypair rep3;
+	wallet.insert_adhoc (rep2.prv);
+	wallet.insert_adhoc (rep3.prv);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep2.pub, 100 * nano::Knano_ratio);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep3.pub, 200 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep2.pub) == 100 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep3.pub) == 200 * nano::Knano_ratio);
+	wallet.change_sync (rep2.pub, rep2.pub);
+	wallet.change_sync (rep3.pub, rep3.pub);
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "representative_count");
+	auto response (wait_response (system, rpc_ctx, request));
+	ASSERT_EQ ("3", response.get<std::string> ("count"));
 }
 
 // wallet_seed is only available over IPC's unsafe encoding, and when running on test network


### PR DESCRIPTION
Fixes #3943 .

Adds an optional `threshold` parameter to the `representatives` RPC,
filtering out representatives with voting weight below the given amount
(raw units, decimal string). Also adds a new `representative_count` RPC
returning the number of representatives with voting weight at or above representative_vote_weight_minimum (default 10 XNO) as a string.

- `nano/node/json_handler.cpp`: threshold filter applied in both the
  simple and sorting branches; new `representative_count` handler;
  removed unused `ordered` map (dead code)
- `nano/node/json_handler.hpp`: declaration for `representative_count`
- `nano/rpc_test/rpc.cpp`: tests for threshold filtering, invalid
  threshold (`nano::error_common::bad_threshold`) and representative_count

Verified locally: build OK, 4 rpc tests pass, clang-format/cmake-format checks pass.