### PR TITLE
Fixed inverted debug assert

### DIFF
--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1904,7 +1904,7 @@ void wallets::reload ()
 	}
 	for (auto & i : deleted_items)
 	{
-		debug_assert (items.find (i) == items.end ());
+		debug_assert (items.find (i) != items.end ());
 		items.erase (i);
 	}
 }


### PR DESCRIPTION
The debug_assert is currently inverted. The code populates deleted_items and then asserts that the items are not there.
This fails when run in debug build, but release mode is unaffected
It's probably a very rare edge case, but a bug nonetheless