### PR TITLE
Validate account_move and epoch_upgrade parameters before acting

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -777,14 +777,18 @@ void nano::json_handler::account_move ()
 						auto account (rpc_l->account_impl (i->second.get<std::string> ("")));
 						accounts.push_back (account);
 					}
-					auto result = wallet->move_accounts (*source_wallet, accounts);
-					if (result)
+					// Validate every account before moving any, the move is not atomic
+					if (!rpc_l->ec)
 					{
-						rpc_l->response_l.put ("moved", result.value () ? "0" : "1");
-					}
-					else
-					{
-						rpc_l->ec = result.error ();
+						auto result = wallet->move_accounts (*source_wallet, accounts);
+						if (result)
+						{
+							rpc_l->response_l.put ("moved", result.value () ? "0" : "1");
+						}
+						else
+						{
+							rpc_l->ec = result.error ();
+						}
 					}
 				}
 				else
@@ -2643,13 +2647,17 @@ void nano::json_handler::epoch_upgrade ()
 		{
 			if (nano::pub_key (prv) == node.ledger.epoch_signer (node.ledger.epoch_link (epoch)))
 			{
-				if (!node.epoch_upgrader.start (prv, epoch, count_limit, threads))
+				// Validate before starting, a rejected count or thread count must not upgrade the ledger
+				if (!ec)
 				{
-					response_l.put ("started", "1");
-				}
-				else
-				{
-					response_l.put ("started", "0");
+					if (!node.epoch_upgrader.start (prv, epoch, count_limit, threads))
+					{
+						response_l.put ("started", "1");
+					}
+					else
+					{
+						response_l.put ("started", "0");
+					}
 				}
 			}
 			else

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -723,6 +723,43 @@ TEST (rpc, account_move)
 	ASSERT_TRUE (source->accounts ().empty ());
 }
 
+/*
+ * An unparseable account in the list rejects the whole request.
+ * The move is not atomic, so validating late would relocate the valid keys and erase them from the source wallet
+ */
+TEST (rpc, account_move_invalid_account)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto wallet_id (node->wallets.items.begin ()->first);
+	auto destination (system.wallet (0));
+	nano::keypair key;
+	auto source_id = nano::random_wallet_id ();
+	auto source (node->wallets.create (source_id));
+	source->insert_adhoc (key.prv);
+
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "account_move");
+	request.put ("wallet", wallet_id.to_string ());
+	request.put ("source", source_id.to_string ());
+	boost::property_tree::ptree keys;
+	boost::property_tree::ptree entry, bad_entry;
+	entry.put ("", key.pub.to_account ());
+	keys.push_back (std::make_pair ("", entry));
+	bad_entry.put ("", "not_an_account");
+	keys.push_back (std::make_pair ("", bad_entry));
+	request.add_child ("accounts", keys);
+	auto response = wait_response (system, rpc_ctx, request);
+
+	auto error = response.get_optional<std::string> ("error");
+	ASSERT_TRUE (error);
+	ASSERT_EQ (std::error_code (nano::error_common::bad_account_number).message (), error.value ());
+	// The valid key must stay where it was
+	ASSERT_TRUE (source->exists (key.pub));
+	ASSERT_FALSE (destination->exists (key.pub));
+}
+
 TEST (rpc, account_move_locked)
 {
 	nano::test::system system;
@@ -6710,6 +6747,32 @@ TEST (rpc, deprecated_account_format)
 	ASSERT_EQ (nano::dev::genesis->hash ().to_string (), frontier);
 	auto deprecated_account_format2 (response2.get_optional<std::string> ("deprecated_account_format"));
 	ASSERT_TRUE (deprecated_account_format2.has_value ());
+}
+
+/*
+ * A count that does not parse rejects the request instead of starting the upgrade.
+ * The response cannot distinguish the two, an error discards the response body either way, so the ledger is the only observable
+ */
+TEST (rpc, epoch_upgrade_invalid_count)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	nano::keypair epoch_signer (nano::dev::genesis_key);
+	auto block_count = node->ledger.block_count ();
+
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "epoch_upgrade");
+	request.put ("epoch", 1);
+	request.put ("key", epoch_signer.prv.to_string ());
+	request.put ("count", "12abc");
+	auto response = wait_response (system, rpc_ctx, request);
+
+	auto error = response.get_optional<std::string> ("error");
+	ASSERT_TRUE (error);
+	ASSERT_EQ (std::error_code (nano::error_common::invalid_count).message (), error.value ());
+	// No epoch block may appear, a started upgrade would produce one for the genesis account
+	ASSERT_NEVER (1s, node->ledger.block_count () != block_count);
 }
 
 TEST (rpc, epoch_upgrade)


### PR DESCRIPTION
Follow-up to #5122. That PR fixed `wallet_change_seed`, which parsed a parameter, ignored the error code the parser had set, and changed the wallet anyway. An audit of every call site of the parsers that can set `ec` — `count_impl`, `count_optional_impl`, `offset_optional_impl`, `threshold_optional_impl`, `work_optional_impl`, `amount_impl`, `account_impl`, `hash_impl` and the difficulty/multiplier/version helpers — found two more handlers with the same defect. Both are state changing.

**`account_move`** parses each entry of `accounts` in a loop and pushes the result unconditionally, then calls `move_accounts` with no error check. A malformed entry leaves a zero account in the vector, and since `wallet_store::move` is not atomic — it moves every key it can fetch and only flags the rest — the valid keys are inserted into the destination wallet and *erased from the source* while the caller receives "Bad account number". Every account is now validated before any is moved.

**`epoch_upgrade`** parses `count` and `threads`, either of which can set `ec`, then reaches `epoch_upgrader.start` unguarded. `count_optional_impl` defaults to `numeric_limits<uint64_t>::max()`, so a count that throws in `stoull` leaves `count_limit` at `UINT64_MAX` and a mistyped parameter starts an unlimited ledger-wide upgrade while the response says "Invalid count". The upgrade is now started only when the parameters are valid.

Both commands are in `rpc_control_impl_set`, so this is operator error rather than a remote attack surface.

The remaining nested parser call sites — `account_remove`, `account_representative_set`, `send`, `receive`, `wallet_add_watch` — already re-check `ec` before acting. The read-only handlers that defer their check (`delegators`, `account_history`, `ledger`, `representatives_online`, `sign`) are harmless: `response_errors` discards `response_l` whenever `ec` is set, so the caller gets a clean error and the only cost is wasted work.

Tests:
- `account_move_invalid_account` sends one valid and one unparseable account and asserts the valid key stays in the source wallet. Against `develop` it fails with `source->exists (key.pub)` false — the key had already been moved.
- `epoch_upgrade_invalid_count` sends a malformed count and asserts the ledger does not grow. The response cannot distinguish the two behaviours, since `response_errors` discards the body when `ec` is set, so the ledger is the only observable. Against `develop` it fails with the block count changing.

Both verified failing on LMDB and RocksDB before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
