### PR TITLE
Encapsulate the open wallets map and test wallet RPC thread safety

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -145,7 +145,7 @@ TEST (node, send_unkeyed)
 	nano::test::system system (1);
 	nano::keypair key2;
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	system.wallet (0)->store.password.value_set (nano::keypair ().prv);
+	system.wallet (0)->lock ();
 	ASSERT_EQ (nullptr, system.wallet (0)->send_action (nano::dev::genesis_key.pub, key2.pub, system.nodes[0]->config.receive_minimum.number ()));
 }
 
@@ -461,10 +461,7 @@ TEST (node, unlock_search)
 	ASSERT_TIMELY (10s, node->balance (nano::dev::genesis_key.pub) != balance);
 	ASSERT_TIMELY (10s, node->active.empty ());
 	system.wallet (0)->insert_adhoc (key2.prv);
-	{
-		nano::lock_guard<std::recursive_mutex> lock{ system.wallet (0)->store.mutex };
-		system.wallet (0)->store.password.value_set (nano::keypair ().prv);
-	}
+	system.wallet (0)->lock ();
 	{
 		ASSERT_FALSE (system.wallet (0)->enter_password (""));
 	}

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -74,7 +74,7 @@ TEST (node, null_account)
 TEST (node, stop)
 {
 	nano::test::system system (1);
-	ASSERT_NE (system.nodes[0]->wallets.items.end (), system.nodes[0]->wallets.items.begin ());
+	ASSERT_NE (0, system.nodes[0]->wallets.wallet_count ());
 	system.stop_node (*system.nodes[0]);
 	ASSERT_TRUE (true);
 }
@@ -111,7 +111,7 @@ TEST (node, block_store_path_failure)
 	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
 	auto node (std::make_shared<nano::node> (system.get_available_port (), path, pool, nano::node_flags{}));
 	system.register_node (node);
-	ASSERT_TRUE (node->wallets.items.empty ());
+	ASSERT_EQ (0, node->wallets.wallet_count ());
 }
 
 TEST (node_DeathTest, readonly_block_store_not_exist)

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -30,7 +30,7 @@ TEST (wallets, open_create)
 	auto & node = *system.nodes[0];
 	node.wallets.stop (); // Stop node wallets to avoid race condition with local wallets sharing same LMDB environment
 	auto wallets = make_wallets (node);
-	ASSERT_EQ (1, wallets.items.size ()); // it starts out with a default wallet
+	ASSERT_EQ (1, wallets.wallet_count ()); // it starts out with a default wallet
 	auto id = nano::random_wallet_id ();
 	ASSERT_EQ (nullptr, wallets.open (id));
 	auto wallet (wallets.create (id));
@@ -46,7 +46,7 @@ TEST (wallets, open_existing)
 	auto id (nano::random_wallet_id ());
 	{
 		auto wallets = make_wallets (node);
-		ASSERT_EQ (1, wallets.items.size ());
+		ASSERT_EQ (1, wallets.wallet_count ());
 		auto wallet (wallets.create (id));
 		ASSERT_NE (nullptr, wallet);
 		ASSERT_EQ (wallet, wallets.open (id));
@@ -61,7 +61,7 @@ TEST (wallets, open_existing)
 	}
 	{
 		auto wallets = make_wallets (node);
-		ASSERT_EQ (2, wallets.items.size ());
+		ASSERT_EQ (2, wallets.wallet_count ());
 		ASSERT_NE (nullptr, wallets.open (id));
 	}
 }
@@ -74,16 +74,16 @@ TEST (wallets, remove)
 	nano::wallet_id one (1);
 	{
 		auto wallets = make_wallets (node);
-		ASSERT_EQ (1, wallets.items.size ());
+		ASSERT_EQ (1, wallets.wallet_count ());
 		auto wallet (wallets.create (one));
 		ASSERT_NE (nullptr, wallet);
-		ASSERT_EQ (2, wallets.items.size ());
+		ASSERT_EQ (2, wallets.wallet_count ());
 		wallets.destroy (one);
-		ASSERT_EQ (1, wallets.items.size ());
+		ASSERT_EQ (1, wallets.wallet_count ());
 	}
 	{
 		auto wallets = make_wallets (node);
-		ASSERT_EQ (1, wallets.items.size ());
+		ASSERT_EQ (1, wallets.wallet_count ());
 	}
 }
 
@@ -131,7 +131,7 @@ TEST (wallets, DISABLED_reload)
 	nano::wallet_id one (1);
 	bool error (false);
 	ASSERT_FALSE (error);
-	ASSERT_EQ (1, node1.wallets.items.size ());
+	ASSERT_EQ (1, node1.wallets.wallet_count ());
 	{
 		nano::lock_guard<nano::mutex> lock_wallet (node1.wallets.mutex);
 		nano::inactive_node node (node1.get_data_path (), nano::inactive_node_flag_defaults ());
@@ -139,7 +139,7 @@ TEST (wallets, DISABLED_reload)
 		ASSERT_NE (wallet, nullptr);
 	}
 	ASSERT_TIMELY (5s, node1.wallets.open (one) != nullptr);
-	ASSERT_EQ (2, node1.wallets.items.size ());
+	ASSERT_EQ (2, node1.wallets.wallet_count ());
 }
 
 TEST (wallets, vote_minimum)
@@ -194,7 +194,7 @@ TEST (wallets, vote_minimum)
 				 .work (*system.work.generate (key2.pub))
 				 .build ();
 	ASSERT_EQ (nano::block_status::progress, node1.process (open2));
-	auto wallet (node1.wallets.items.begin ()->second);
+	auto wallet (system.wallet (0));
 	ASSERT_EQ (0, wallet->reps ().size ());
 	ASSERT_TRUE (wallet->insert_adhoc (nano::dev::genesis_key.prv));
 	ASSERT_TRUE (wallet->insert_adhoc (key1.prv));
@@ -300,7 +300,7 @@ TEST (wallets, rep_scan)
 	config.enable_voting = true;
 	auto & node = *system.add_node (config);
 
-	auto wallet = node.wallets.items.begin ()->second;
+	auto wallet = system.wallet (0);
 
 	// Insert a key that initially has no balance (not a representative)
 	nano::keypair key;
@@ -355,7 +355,7 @@ TEST (wallets, receivable_scan)
 	config.backlog_scan->enable = false;
 	auto & node = *system.add_node (config);
 
-	auto wallet = node.wallets.items.begin ()->second;
+	auto wallet = system.wallet (0);
 	ASSERT_TRUE (wallet->insert_adhoc (nano::dev::genesis_key.prv));
 
 	// Create a send block to self (creates a receivable)

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -137,11 +137,11 @@ public:
 				auto wallet (node->wallets.open (wallet_config.wallet));
 				if (wallet == nullptr)
 				{
-					auto existing (node->wallets.items.begin ());
-					if (existing != node->wallets.items.end ())
+					auto existing (node->wallets.all_wallets ());
+					if (!existing.empty ())
 					{
-						wallet = existing->second;
-						wallet_config.wallet = existing->first;
+						wallet = existing.begin ()->second;
+						wallet_config.wallet = existing.begin ()->first;
 					}
 					else
 					{

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -1489,11 +1489,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 			{
 				auto inactive_node = nano::default_inactive_node (data_path, vm);
 				auto node = inactive_node->node;
-				if (node->wallets.open (wallet_id) != nullptr)
-				{
-					node->wallets.destroy (wallet_id);
-				}
-				else
+				if (!node->wallets.destroy (wallet_id))
 				{
 					std::cerr << "Wallet doesn't exist\n";
 					ec = nano::error_cli::invalid_arguments;

--- a/nano/node/cli.cpp
+++ b/nano/node/cli.cpp
@@ -1423,18 +1423,18 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 			{
 				auto inactive_node = nano::default_inactive_node (data_path, vm);
 				auto node = inactive_node->node;
-				auto existing (inactive_node->node->wallets.items.find (wallet_id));
-				if (existing != inactive_node->node->wallets.items.end ())
+				auto existing (node->wallets.open (wallet_id));
+				if (existing != nullptr)
 				{
-					if (!existing->second->enter_password (password))
+					if (!existing->enter_password (password))
 					{
-						auto seed_result = existing->second->get_seed ();
+						auto seed_result = existing->get_seed ();
 						if (seed_result)
 						{
 							std::cout << boost::str (boost::format ("Seed: %1%\n") % seed_result.value ().to_string ());
-							for (auto const & account : existing->second->accounts ())
+							for (auto const & account : existing->accounts ())
 							{
-								auto key_result = existing->second->fetch_prv (account);
+								auto key_result = existing->fetch_prv (account);
 								debug_assert (key_result);
 								if (key_result)
 								{
@@ -1489,7 +1489,7 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 			{
 				auto inactive_node = nano::default_inactive_node (data_path, vm);
 				auto node = inactive_node->node;
-				if (node->wallets.items.find (wallet_id) != node->wallets.items.end ())
+				if (node->wallets.open (wallet_id) != nullptr)
 				{
 					node->wallets.destroy (wallet_id);
 				}
@@ -1539,17 +1539,17 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 					{
 						auto inactive_node = nano::default_inactive_node (data_path, vm);
 						auto node = inactive_node->node;
-						auto existing (node->wallets.items.find (wallet_id));
-						if (existing != node->wallets.items.end ())
+						auto existing (node->wallets.open (wallet_id));
+						if (existing != nullptr)
 						{
-							bool valid (!existing->second->is_locked ());
+							bool valid (!existing->is_locked ());
 							if (!valid)
 							{
-								valid = !existing->second->enter_password (password);
+								valid = !existing->enter_password (password);
 							}
 							if (valid)
 							{
-								if (existing->second->import (contents.str (), password))
+								if (existing->import (contents.str (), password))
 								{
 									std::cerr << "Unable to import wallet\n";
 									ec = nano::error_cli::invalid_arguments;
@@ -1633,15 +1633,15 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 			nano::wallet_id wallet_id;
 			if (!wallet_id.decode_hex (vm["wallet"].as<std::string> ()))
 			{
-				auto wallet (node->wallets.items.find (wallet_id));
-				if (wallet != node->wallets.items.end ())
+				auto wallet (node->wallets.open (wallet_id));
+				if (wallet != nullptr)
 				{
 					nano::account account_id;
 					if (!account_id.decode_account (vm["account"].as<std::string> ()))
 					{
-						if (wallet->second->exists (account_id))
+						if (wallet->exists (account_id))
 						{
-							wallet->second->remove_account (account_id);
+							wallet->remove_account (account_id);
 						}
 						else
 						{
@@ -1682,10 +1682,10 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 			{
 				auto inactive_node = nano::default_inactive_node (data_path, vm);
 				auto node = inactive_node->node;
-				auto wallet (node->wallets.items.find (wallet_id));
-				if (wallet != node->wallets.items.end ())
+				auto wallet (node->wallets.open (wallet_id));
+				if (wallet != nullptr)
 				{
-					auto representative (wallet->second->get_representative ());
+					auto representative (wallet->get_representative ());
 					std::cout << boost::str (boost::format ("Representative: %1%\n") % representative.to_account ());
 				}
 				else
@@ -1720,10 +1720,10 @@ std::error_code nano::handle_node_options (boost::program_options::variables_map
 					{
 						auto inactive_node = nano::default_inactive_node (data_path, vm);
 						auto node = inactive_node->node;
-						auto wallet (node->wallets.items.find (wallet_id));
-						if (wallet != node->wallets.items.end ())
+						auto wallet (node->wallets.open (wallet_id));
+						if (wallet != nullptr)
 						{
-							wallet->second->set_representative (account);
+							wallet->set_representative (account);
 						}
 						else
 						{

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -4826,12 +4826,9 @@ void nano::json_handler::wallet_destroy ()
 		nano::wallet_id wallet;
 		if (!wallet.decode_hex (wallet_text))
 		{
-			auto existing (rpc_l->node.wallets.open (wallet));
-			if (existing != nullptr)
+			if (rpc_l->node.wallets.destroy (wallet))
 			{
-				rpc_l->node.wallets.destroy (wallet);
-				bool destroyed (rpc_l->node.wallets.open (wallet) == nullptr);
-				rpc_l->response_l.put ("destroyed", destroyed ? "1" : "0");
+				rpc_l->response_l.put ("destroyed", "1");
 			}
 			else
 			{

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -767,10 +767,9 @@ void nano::json_handler::account_move ()
 			nano::wallet_id source;
 			if (!source.decode_hex (source_text))
 			{
-				auto existing (rpc_l->node.wallets.items.find (source));
-				if (existing != rpc_l->node.wallets.items.end ())
+				auto source_wallet (rpc_l->node.wallets.open (source));
+				if (source_wallet != nullptr)
 				{
-					auto source_wallet (existing->second);
 					std::vector<nano::public_key> accounts;
 					for (auto i (accounts_text.begin ()), n (accounts_text.end ()); i != n; ++i)
 					{
@@ -1651,10 +1650,10 @@ void nano::json_handler::block_create ()
 	}
 	if (!ec && wallet != 0 && account != 0)
 	{
-		auto existing = node.wallets.items.find (wallet);
-		if (existing != node.wallets.items.end ())
+		auto existing = node.wallets.open (wallet);
+		if (existing != nullptr)
 		{
-			auto prv_result = existing->second->fetch_prv (account);
+			auto prv_result = existing->fetch_prv (account);
 			if (prv_result)
 			{
 				prv = prv_result.value ();
@@ -4799,8 +4798,7 @@ void nano::json_handler::wallet_create ()
 		{
 			auto wallet_id = random_wallet_id ();
 			auto wallet (rpc_l->node.wallets.create (wallet_id));
-			auto existing (rpc_l->node.wallets.items.find (wallet_id));
-			if (existing != rpc_l->node.wallets.items.end ())
+			if (wallet != nullptr)
 			{
 				rpc_l->response_l.put ("wallet", wallet_id.to_string ());
 			}
@@ -4828,11 +4826,11 @@ void nano::json_handler::wallet_destroy ()
 		nano::wallet_id wallet;
 		if (!wallet.decode_hex (wallet_text))
 		{
-			auto existing (rpc_l->node.wallets.items.find (wallet));
-			if (existing != rpc_l->node.wallets.items.end ())
+			auto existing (rpc_l->node.wallets.open (wallet));
+			if (existing != nullptr)
 			{
 				rpc_l->node.wallets.destroy (wallet);
-				bool destroyed (rpc_l->node.wallets.items.find (wallet) == rpc_l->node.wallets.items.end ());
+				bool destroyed (rpc_l->node.wallets.open (wallet) == nullptr);
 				rpc_l->response_l.put ("destroyed", destroyed ? "1" : "0");
 			}
 			else

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1849,17 +1849,21 @@ void wallets::search_receivable_all ()
 	}
 }
 
-void wallets::destroy (nano::wallet_id const & id_a)
+bool wallets::destroy (nano::wallet_id const & id_a)
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	auto transaction (tx_begin_write ());
 	// action_mutex should be after transactions to prevent deadlocks in deterministic_insert () & insert_adhoc ()
 	nano::lock_guard<nano::mutex> action_lock{ action_mutex };
 	auto existing (items.find (id_a));
-	release_assert (existing != items.end ());
+	if (existing == items.end ())
+	{
+		return false;
+	}
 	auto wallet (existing->second);
 	items.erase (existing);
 	wallet->store.destroy (transaction);
+	return true;
 }
 
 void wallets::reload ()

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -710,10 +710,7 @@ wallet::wallet (nano::store::write_transaction & transaction_a, nano::wallet::wa
 void wallet::enter_initial_password ()
 {
 	nano::raw_key password_l;
-	{
-		nano::lock_guard<std::recursive_mutex> lock{ store.mutex };
-		store.password.value (password_l);
-	}
+	store.password.value (password_l);
 	if (password_l.is_zero ())
 	{
 		auto transaction (wallets.tx_begin_read ());
@@ -2064,8 +2061,6 @@ void wallets::refresh_rep_keys_cache ()
 
 	for (auto const & [id, wallet] : items)
 	{
-		nano::lock_guard<std::recursive_mutex> store_lock{ wallet->store.mutex };
-
 		auto reps_locked = wallet->representatives.lock ();
 		for (auto const & account : *reps_locked)
 		{

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -2177,10 +2177,28 @@ void wallets::receive_confirmed (nano::block_hash const & hash_a, nano::account 
 	}
 }
 
-std::unordered_map<nano::wallet_id, std::shared_ptr<wallet>> wallets::all_wallets ()
+std::unordered_map<nano::wallet_id, std::shared_ptr<wallet>> wallets::all_wallets () const
 {
 	nano::lock_guard<nano::mutex> lock{ mutex };
 	return items;
+}
+
+std::vector<nano::wallet_id> wallets::wallet_ids () const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	std::vector<nano::wallet_id> result;
+	result.reserve (items.size ());
+	for (auto const & [id, wallet] : items)
+	{
+		result.push_back (id);
+	}
+	return result;
+}
+
+std::size_t wallets::wallet_count () const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return items.size ();
 }
 
 void wallets::do_wallet_actions ()

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -2066,18 +2066,15 @@ void wallets::refresh_rep_keys_cache ()
 		{
 			if (wallet->store.exists (wallet_txn, account))
 			{
-				if (wallet->store.valid_password (wallet_txn))
+				// A single fetch reports the locked state too, so the password check and the fetch cannot disagree under a concurrent rekey
+				// A watch-only account can hold representative weight but has no private key to fetch; it cannot vote and is left out of the cache
+				auto prv_result = wallet->store.fetch (wallet_txn, account);
+				if (prv_result)
 				{
-					// A watch-only account can hold representative weight, so a representative here may have no
-					// private key to fetch. Such an account cannot vote and is simply left out of the keys cache.
-					auto prv_result = wallet->store.fetch (wallet_txn, account);
-					if (prv_result)
-					{
-						// Store private key spread across multiple heap allocations via fan to avoid plaintext keys in memory at rest
-						new_cache.emplace_back (account, std::make_unique<nano::fan> (prv_result.value (), config.password_fanout));
-					}
+					// Store private key spread across multiple heap allocations via fan to avoid plaintext keys in memory at rest
+					new_cache.emplace_back (account, std::make_unique<nano::fan> (prv_result.value (), config.password_fanout));
 				}
-				else
+				else if (prv_result.error () == nano::error_common::wallet_locked)
 				{
 					static auto last_log = std::chrono::steady_clock::time_point ();
 					if (last_log < std::chrono::steady_clock::now () - std::chrono::seconds (60))

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -314,7 +314,8 @@ public:
 	std::shared_ptr<wallet> open (nano::wallet_id const &);
 	std::shared_ptr<wallet> create (nano::wallet_id const &);
 	std::shared_ptr<wallet> create_from_json (nano::wallet_id const &, std::string const & json);
-	void destroy (nano::wallet_id const &);
+	// Returns true if the wallet existed and was destroyed
+	bool destroy (nano::wallet_id const &);
 	void reload ();
 	void clear_send_ids ();
 

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -113,6 +113,9 @@ public:
 	nano::fan wallet_key_mem;
 	nano::kdf & kdf;
 	nano::locked<nano::wallet::wallet_handle> handle;
+
+private:
+	// Serializes compound password/wallet-key operations; the fans are individually synchronized already
 	mutable std::recursive_mutex mutex;
 
 private:

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -318,8 +318,12 @@ public:
 	void reload ();
 	void clear_send_ids ();
 
+	// Wallet queries, each returns a consistent snapshot
+	std::unordered_map<nano::wallet_id, std::shared_ptr<wallet>> all_wallets () const;
+	std::vector<nano::wallet_id> wallet_ids () const;
+	std::size_t wallet_count () const;
+
 	// Account lookup
-	std::unordered_map<nano::wallet_id, std::shared_ptr<wallet>> all_wallets ();
 	bool exists (nano::account const &);
 	bool exists_any (nano::account const &, nano::account const &);
 
@@ -362,7 +366,6 @@ public: // Dependencies
 public:
 	std::function<void (bool)> observer;
 
-	std::unordered_map<nano::wallet_id, std::shared_ptr<wallet>> items;
 	std::multimap<nano::uint128_t, std::pair<std::shared_ptr<wallet>, std::function<void (wallet &)>>, std::greater<nano::uint128_t>> actions;
 	nano::locked<std::unordered_map<nano::account, nano::root>> delayed_work;
 
@@ -392,6 +395,9 @@ private:
 	void refresh_rep_keys_cache ();
 
 private:
+	// All open wallets, protected by mutex
+	std::unordered_map<nano::wallet_id, std::shared_ptr<wallet>> items;
+
 	mutable nano::locked<wallet_representatives> representatives;
 	nano::locked<std::vector<std::pair<nano::public_key, std::unique_ptr<nano::fan>>>> rep_keys_cache;
 

--- a/nano/qt/qt.cpp
+++ b/nano/qt/qt.cpp
@@ -1671,12 +1671,9 @@ nano_qt::settings::settings (nano_qt::wallet & wallet_a) :
 		if (!this->wallet.wallet_m->is_locked ())
 		{
 			// lock wallet
-			nano::raw_key empty;
-			empty.clear ();
-			this->wallet.wallet_m->store.password.value_set (empty);
+			this->wallet.wallet_m->lock ();
 			update_locked (true, true);
 			lock_toggle->setText ("Unlock");
-			this->wallet.node.logger.warn (nano::log::type::qt, "Wallet locked");
 			password->setEnabled (1);
 		}
 		else

--- a/nano/rpc_test/CMakeLists.txt
+++ b/nano/rpc_test/CMakeLists.txt
@@ -9,7 +9,8 @@ add_executable(
   enable_control.cpp
   entry.cpp
   receivable.cpp
-  rpc.cpp)
+  rpc.cpp
+  wallet_rpc.cpp)
 
 target_link_libraries(rpc_test test_common)
 

--- a/nano/rpc_test/receivable.cpp
+++ b/nano/rpc_test/receivable.cpp
@@ -411,7 +411,7 @@ TEST (rpc, search_receivable)
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
-	auto wallet (node->wallets.items.begin ()->first.to_string ());
+	auto wallet (node->wallets.wallet_ids ().front ().to_string ());
 	auto latest (node->latest (nano::dev::genesis_key.pub));
 	nano::block_builder builder;
 	auto block = builder

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -162,7 +162,7 @@ TEST (rpc, account_create)
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "account_create");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	auto response0 (wait_response (system, rpc_ctx, request));
 	auto account_text0 (response0.get<std::string> ("account"));
 	nano::account account0;
@@ -211,7 +211,7 @@ TEST (rpc, wallet_contains)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_contains");
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
@@ -226,7 +226,7 @@ TEST (rpc, wallet_doesnt_contain)
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_contains");
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
@@ -270,7 +270,7 @@ TEST (rpc, send)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
 	request.put ("source", nano::dev::genesis_key.pub.to_account ());
@@ -292,7 +292,7 @@ TEST (rpc, send_fail)
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
 	request.put ("source", nano::dev::genesis_key.pub.to_account ());
@@ -309,7 +309,7 @@ TEST (rpc, send_work)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
 	request.put ("source", nano::dev::genesis_key.pub.to_account ());
@@ -337,7 +337,7 @@ TEST (rpc, send_work_disabled)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
 	request.put ("source", nano::dev::genesis_key.pub.to_account ());
@@ -354,7 +354,7 @@ TEST (rpc, send_idempotent)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
 	request.put ("source", nano::dev::genesis_key.pub.to_account ());
@@ -395,7 +395,7 @@ TEST (rpc, send_epoch_2)
 
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "send");
 	request.put ("source", nano::dev::genesis_key.pub.to_account ());
@@ -450,7 +450,7 @@ TEST (rpc, wallet_add)
 	nano::keypair key1;
 	std::string key_text = key1.prv.to_string ();
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_add");
 	request.put ("key", key_text);
@@ -466,7 +466,7 @@ TEST (rpc, wallet_password_valid)
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "password_valid");
 	auto response (wait_response (system, rpc_ctx, request));
@@ -480,7 +480,7 @@ TEST (rpc, wallet_password_change)
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "password_change");
 	request.put ("password", "test");
@@ -508,7 +508,7 @@ TEST (rpc, wallet_password_enter)
 		system.wallet (0)->store.password.value (password_l);
 	}
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "password_enter");
 	request.put ("password", "");
@@ -523,7 +523,7 @@ TEST (rpc, wallet_representative)
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_representative");
 	auto response (wait_response (system, rpc_ctx, request));
@@ -537,13 +537,13 @@ TEST (rpc, wallet_representative_set)
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	nano::keypair key;
 	request.put ("action", "wallet_representative_set");
 	request.put ("representative", key.pub.to_account ());
 	auto response (wait_response (system, rpc_ctx, request));
-	ASSERT_EQ (key.pub, node->wallets.items.begin ()->second->get_representative ());
+	ASSERT_EQ (key.pub, system.wallet (0)->get_representative ());
 }
 
 TEST (rpc, wallet_representative_set_force)
@@ -553,14 +553,14 @@ TEST (rpc, wallet_representative_set_force)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	nano::keypair key;
 	request.put ("action", "wallet_representative_set");
 	request.put ("representative", key.pub.to_account ());
 	request.put ("update_existing_accounts", true);
 	auto response (wait_response (system, rpc_ctx, request));
-	ASSERT_EQ (key.pub, node->wallets.items.begin ()->second->get_representative ());
+	ASSERT_EQ (key.pub, system.wallet (0)->get_representative ());
 	nano::account representative{};
 	while (representative != key.pub)
 	{
@@ -583,7 +583,7 @@ TEST (rpc, account_list)
 	system.wallet (0)->insert_adhoc (key2.prv);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "account_list");
 	auto response (wait_response (system, rpc_ctx, request));
@@ -610,7 +610,7 @@ TEST (rpc, wallet_key_valid)
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_key_valid");
 	auto response (wait_response (system, rpc_ctx, request));
@@ -629,7 +629,7 @@ TEST (rpc, wallet_create)
 	std::string wallet_text (response.get<std::string> ("wallet"));
 	nano::wallet_id wallet_id;
 	ASSERT_FALSE (wallet_id.decode_hex (wallet_text));
-	ASSERT_NE (node->wallets.items.end (), node->wallets.items.find (wallet_id));
+	ASSERT_NE (nullptr, node->wallets.open (wallet_id));
 }
 
 TEST (rpc, wallet_create_seed)
@@ -648,17 +648,17 @@ TEST (rpc, wallet_create_seed)
 	std::string wallet_text (response.get<std::string> ("wallet"));
 	nano::wallet_id wallet_id;
 	ASSERT_FALSE (wallet_id.decode_hex (wallet_text));
-	auto existing (node->wallets.items.find (wallet_id));
-	ASSERT_NE (node->wallets.items.end (), existing);
+	auto existing (node->wallets.open (wallet_id));
+	ASSERT_NE (nullptr, existing);
 	{
-		auto seed0 = existing->second->get_seed ();
+		auto seed0 = existing->get_seed ();
 		ASSERT_TRUE (seed0);
 		ASSERT_EQ (seed, seed0.value ());
 	}
 	auto account_text (response.get<std::string> ("last_restored_account"));
 	nano::account account;
 	ASSERT_FALSE (account.decode_account (account_text));
-	ASSERT_TRUE (existing->second->exists (account));
+	ASSERT_TRUE (existing->exists (account));
 	ASSERT_EQ (pub, account);
 	ASSERT_EQ ("1", response.get<std::string> ("restored_count"));
 }
@@ -671,7 +671,7 @@ TEST (rpc, wallet_export)
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_export");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
 	std::string wallet_json (response.get<std::string> ("json"));
 	// Verify exported JSON is valid by importing it into a new wallet
@@ -687,19 +687,19 @@ TEST (rpc, wallet_destroy)
 	auto node = add_ipc_enabled_node (system);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	auto const rpc_ctx = add_rpc (system, node);
-	auto wallet_id (node->wallets.items.begin ()->first);
+	auto wallet_id (node->wallets.wallet_ids ().front ());
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_destroy");
 	request.put ("wallet", wallet_id.to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
-	ASSERT_EQ (node->wallets.items.end (), node->wallets.items.find (wallet_id));
+	ASSERT_EQ (nullptr, node->wallets.open (wallet_id));
 }
 
 TEST (rpc, account_move)
 {
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
-	auto wallet_id (node->wallets.items.begin ()->first);
+	auto wallet_id (node->wallets.wallet_ids ().front ());
 	auto destination (system.wallet (0));
 	destination->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key;
@@ -727,7 +727,7 @@ TEST (rpc, account_move_locked)
 {
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
-	auto wallet_id (node->wallets.items.begin ()->first);
+	auto wallet_id (node->wallets.wallet_ids ().front ());
 	auto destination (system.wallet (0));
 	nano::keypair key;
 	auto source_id = nano::random_wallet_id ();
@@ -2551,7 +2551,7 @@ TEST (rpc, account_representative_set)
 	boost::property_tree::ptree request;
 	request.put ("account", key2.pub.to_account ());
 	request.put ("representative", key2.pub.to_account ());
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	request.put ("action", "account_representative_set");
 	auto response (wait_response (system, rpc_ctx, request));
 	std::string block_text1 (response.get<std::string> ("block"));
@@ -2578,7 +2578,7 @@ TEST (rpc, account_representative_set_work_disabled)
 	nano::keypair rep;
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
 	request.put ("representative", rep.pub.to_account ());
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	request.put ("action", "account_representative_set");
 	{
 		auto response (wait_response (system, rpc_ctx, request, 10s));
@@ -2604,7 +2604,7 @@ TEST (rpc, account_representative_set_epoch_2_insufficient_work)
 
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "account_representative_set");
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
@@ -2631,7 +2631,7 @@ TEST (rpc, account_remove)
 	auto const rpc_ctx = add_rpc (system0, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "account_remove");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	request.put ("account", key1.to_account ());
 	auto response (wait_response (system0, rpc_ctx, request));
 	ASSERT_FALSE (system0.wallet (0)->exists (key1));
@@ -2667,7 +2667,7 @@ TEST (rpc, wallet_seed)
 	ASSERT_TRUE (seed);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_seed");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
 	{
 		std::string seed_text (response.get<std::string> ("seed"));
@@ -2691,7 +2691,7 @@ TEST (rpc, wallet_change_seed)
 	auto pub (nano::pub_key (prv));
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_change_seed");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	request.put ("seed", seed.to_string ());
 	auto response (wait_response (system0, rpc_ctx, request));
 	{
@@ -2723,7 +2723,7 @@ TEST (rpc, wallet_change_seed_count_rejected)
 	nano::random_pool::generate_block (seed.bytes.data (), seed.bytes.size ());
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_change_seed");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	request.put ("seed", seed.to_string ());
 	// 2^32 truncated to zero and silently restored by ledger scan; the trailing garbage parses as 12 before failing, which restored 12 accounts
 	for (auto const * count : { "4294967296", "12abc" })
@@ -2748,7 +2748,7 @@ TEST (rpc, wallet_frontiers)
 	auto const rpc_ctx = add_rpc (system0, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_frontiers");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	auto response (wait_response (system0, rpc_ctx, request));
 	auto & frontiers_node (response.get_child ("frontiers"));
 	std::vector<nano::account> frontiers;
@@ -3352,7 +3352,7 @@ TEST (rpc, wallet_info)
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_info");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
 	std::string balance_text (response.get<std::string> ("balance"));
 	ASSERT_EQ ("340282366920938463463374607431768211454", balance_text);
@@ -3380,7 +3380,7 @@ TEST (rpc, wallet_balances)
 	auto const rpc_ctx = add_rpc (system0, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_balances");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	auto response (wait_response (system0, rpc_ctx, request));
 	for (auto & balances : response.get_child ("balances"))
 	{
@@ -3456,7 +3456,7 @@ TEST (rpc, wallet_pending)
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_pending");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
 	ASSERT_EQ ("1", response.get<std::string> ("deprecated"));
 	ASSERT_EQ (1, response.get_child ("blocks").size ());
@@ -3482,7 +3482,7 @@ TEST (rpc, wallet_receivable)
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_receivable");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	request.put ("count", "100");
 	auto response (wait_response (system, rpc_ctx, request));
 	ASSERT_EQ (1, response.get_child ("blocks").size ());
@@ -3578,7 +3578,7 @@ TEST (rpc, wallet_receivable_include_active)
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_receivable");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	ASSERT_TRUE (check_block_response_count (system, rpc_ctx, request, 0));
 	request.put ("include_only_confirmed", "false");
 	{
@@ -3630,11 +3630,11 @@ TEST (rpc, work_get)
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "work_get");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
 	auto response (wait_response (system, rpc_ctx, request));
 	std::string work_text (response.get<std::string> ("work"));
-	auto work_result = node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub);
+	auto work_result = system.wallet (0)->get_work (nano::dev::genesis_key.pub);
 	ASSERT_TRUE (work_result);
 	ASSERT_EQ (nano::to_string_hex (work_result.value ()), work_text);
 }
@@ -3648,14 +3648,14 @@ TEST (rpc, wallet_work_get)
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_work_get");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
 	for (auto & works : response.get_child ("works"))
 	{
 		std::string account_text (works.first);
 		ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), account_text);
 		std::string work_text (works.second.get<std::string> (""));
-		auto work_result = node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub);
+		auto work_result = system.wallet (0)->get_work (nano::dev::genesis_key.pub);
 		ASSERT_TRUE (work_result);
 		ASSERT_EQ (nano::to_string_hex (work_result.value ()), work_text);
 	}
@@ -3670,13 +3670,13 @@ TEST (rpc, work_set)
 	uint64_t work0 (100);
 	boost::property_tree::ptree request;
 	request.put ("action", "work_set");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
 	request.put ("work", nano::to_string_hex (work0));
 	auto response (wait_response (system, rpc_ctx, request));
 	std::string success (response.get<std::string> ("success"));
 	ASSERT_TRUE (success.empty ());
-	auto work1_result = node->wallets.items.begin ()->second->get_work (nano::dev::genesis_key.pub);
+	auto work1_result = system.wallet (0)->get_work (nano::dev::genesis_key.pub);
 	ASSERT_TRUE (work1_result);
 	ASSERT_EQ (work1_result.value (), work0);
 }
@@ -3743,7 +3743,7 @@ TEST (rpc, wallet_republish)
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_republish");
-	request.put ("wallet", node1->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node1->wallets.wallet_ids ().front ().to_string ());
 	request.put ("count", 1);
 	auto response (wait_response (system, rpc_ctx, request));
 	auto & blocks_node (response.get_child ("blocks"));
@@ -4488,7 +4488,7 @@ TEST (rpc, json_block_input)
 	boost::property_tree::ptree request;
 	request.put ("action", "sign");
 	request.put ("json_block", "true");
-	std::string wallet = node1->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node1->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("account", key.pub.to_account ());
 	boost::property_tree::ptree json;
@@ -5119,7 +5119,7 @@ TEST (rpc, accounts_create)
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "accounts_create");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	request.put ("count", "8");
 	auto response (wait_response (system, rpc_ctx, request));
 	auto & accounts (response.get_child ("accounts"));
@@ -5146,7 +5146,7 @@ TEST (rpc, accounts_create_locked)
 
 	boost::property_tree::ptree request;
 	request.put ("action", "accounts_create");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	request.put ("count", "8");
 	auto response = wait_response (system, rpc_ctx, request);
 
@@ -5187,7 +5187,7 @@ TEST (rpc, block_create)
 	boost::property_tree::ptree request;
 	request.put ("action", "block_create");
 	request.put ("type", "send");
-	request.put ("wallet", node1->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node1->wallets.wallet_ids ().front ().to_string ());
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
 	request.put ("previous", latest.to_string ());
 	request.put ("amount", "340282366920938463463374607431768211355");
@@ -5257,7 +5257,7 @@ TEST (rpc, block_create)
 	boost::property_tree::ptree request2;
 	request2.put ("action", "block_create");
 	request2.put ("type", "receive");
-	request2.put ("wallet", node1->wallets.items.begin ()->first.to_string ());
+	request2.put ("wallet", node1->wallets.wallet_ids ().front ().to_string ());
 	request2.put ("account", key.pub.to_account ());
 	request2.put ("source", send2->hash ().to_string ());
 	request2.put ("previous", change->hash ().to_string ());
@@ -5284,7 +5284,7 @@ TEST (rpc, block_create_state)
 	boost::property_tree::ptree request;
 	request.put ("action", "block_create");
 	request.put ("type", "state");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	request.put ("account", nano::dev::genesis_key.pub.to_account ());
 	request.put ("previous", nano::dev::genesis->hash ().to_string ());
 	request.put ("representative", nano::dev::genesis_key.pub.to_account ());
@@ -5367,7 +5367,7 @@ TEST (rpc, block_create_state_request_work)
 		boost::property_tree::ptree request;
 		request.put ("action", "block_create");
 		request.put ("type", "state");
-		request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+		request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 		request.put ("account", nano::dev::genesis_key.pub.to_account ());
 		request.put ("representative", nano::dev::genesis_key.pub.to_account ());
 		request.put ("balance", (nano::dev::constants.genesis_amount - nano::Knano_ratio).convert_to<std::string> ());
@@ -5558,7 +5558,7 @@ TEST (rpc, wallet_lock)
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	ASSERT_FALSE (system.wallet (0)->is_locked ());
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_lock");
@@ -5574,7 +5574,7 @@ TEST (rpc, wallet_locked)
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_locked");
 	auto response (wait_response (system, rpc_ctx, request));
@@ -5628,7 +5628,7 @@ TEST (rpc, wallet_ledger)
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_ledger");
-	request.put ("wallet", node1->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node1->wallets.wallet_ids ().front ().to_string ());
 	request.put ("sorting", "1");
 	request.put ("count", "1");
 	auto response (wait_response (system, rpc_ctx, request));
@@ -5679,7 +5679,7 @@ TEST (rpc, wallet_add_watch)
 	auto node = add_ipc_enabled_node (system);
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
-	std::string wallet = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("action", "wallet_add_watch");
 	boost::property_tree::ptree entry;
@@ -6212,7 +6212,7 @@ TEST (rpc, wallet_history)
 	auto const rpc_ctx = add_rpc (system, node);
 	boost::property_tree::ptree request;
 	request.put ("action", "wallet_history");
-	request.put ("wallet", node->wallets.items.begin ()->first.to_string ());
+	request.put ("wallet", node->wallets.wallet_ids ().front ().to_string ());
 	auto response (wait_response (system, rpc_ctx, request));
 	std::vector<std::tuple<std::string, std::string, std::string, std::string, std::string, std::string>> history_l;
 	auto & history_node (response.get_child ("history"));
@@ -6302,7 +6302,7 @@ TEST (rpc, sign_block)
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request;
 	request.put ("action", "sign");
-	std::string wallet = node1->wallets.items.begin ()->first.to_string ();
+	std::string wallet = node1->wallets.wallet_ids ().front ().to_string ();
 	request.put ("wallet", wallet);
 	request.put ("account", key.pub.to_account ());
 	std::string json;
@@ -7042,7 +7042,7 @@ TEST (rpc, receive)
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto wallet = system.wallet (0);
-	std::string wallet_text = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet_text = node->wallets.wallet_ids ().front ().to_string ();
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key1;
 	wallet->insert_adhoc (key1.prv);
@@ -7082,7 +7082,7 @@ TEST (rpc, receive_unopened)
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
 	auto wallet = system.wallet (0);
-	std::string wallet_text = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet_text = node->wallets.wallet_ids ().front ().to_string ();
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	// Test receiving for unopened account
 	nano::keypair key1;
@@ -7139,7 +7139,7 @@ TEST (rpc, receive_work_disabled)
 	config.work_threads = 0;
 	auto node = add_ipc_enabled_node (system, config);
 	auto wallet = system.wallet (1);
-	std::string wallet_text = node->wallets.items.begin ()->first.to_string ();
+	std::string wallet_text = node->wallets.wallet_ids ().front ().to_string ();
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key1;
 	ASSERT_TRUE (worker_node.work_generation_enabled ());
@@ -7173,7 +7173,7 @@ TEST (rpc, receive_pruned)
 	auto node2 = add_ipc_enabled_node (system, node_config, node_flags);
 	auto wallet1 = system.wallet (0);
 	auto wallet2 = system.wallet (1);
-	std::string wallet_text = node2->wallets.items.begin ()->first.to_string ();
+	std::string wallet_text = node2->wallets.wallet_ids ().front ().to_string ();
 	wallet1->insert_adhoc (nano::dev::genesis_key.prv);
 	nano::keypair key1;
 	wallet2->insert_adhoc (key1.prv);

--- a/nano/rpc_test/rpc_context.cpp
+++ b/nano/rpc_test/rpc_context.cpp
@@ -34,6 +34,30 @@ boost::property_tree::ptree nano::test::wait_response (nano::test::system & syst
 	return response_json;
 }
 
+void nano::test::wait_responses_impl (nano::test::system & system, rpc_context const & rpc_ctx, std::vector<boost::property_tree::ptree> & requests, std::chrono::duration<double, std::nano> const & time, std::vector<boost::property_tree::ptree> & responses)
+{
+	// Start every request before waiting so they are in flight simultaneously
+	std::vector<std::unique_ptr<test_response>> in_flight;
+	in_flight.reserve (requests.size ());
+	for (auto & request : requests)
+	{
+		in_flight.push_back (std::make_unique<test_response> (request, rpc_ctx.rpc->listening_port (), *system.io_ctx));
+	}
+	ASSERT_TIMELY (time, std::all_of (in_flight.begin (), in_flight.end (), [] (auto const & response) { return response->status != 0; }));
+	for (auto const & response : in_flight)
+	{
+		ASSERT_EQ (200, response->status);
+		responses.push_back (response->json);
+	}
+}
+
+std::vector<boost::property_tree::ptree> nano::test::wait_responses (nano::test::system & system, rpc_context const & rpc_ctx, std::vector<boost::property_tree::ptree> & requests, std::chrono::duration<double, std::nano> const & time)
+{
+	std::vector<boost::property_tree::ptree> responses;
+	wait_responses_impl (system, rpc_ctx, requests, time, responses);
+	return responses;
+}
+
 bool nano::test::check_block_response_count (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, uint64_t size_count)
 {
 	auto response (wait_response (system, rpc_ctx, request));
@@ -46,6 +70,10 @@ nano::test::rpc_context nano::test::add_rpc (nano::test::system & system, std::s
 	auto node_rpc_config (std::make_unique<nano::node_rpc_config> ());
 	auto ipc_server (std::make_shared<nano::ipc::ipc_server> (*node_a, *node_rpc_config));
 	nano::rpc_config rpc_config (node_a->network_params.network, system.get_available_port (), options.enable_control);
+	if (options.num_ipc_connections)
+	{
+		rpc_config.rpc_process.num_ipc_connections = *options.num_ipc_connections;
+	}
 	const auto ipc_tcp_port = ipc_server->listening_tcp_port ();
 	debug_assert (ipc_tcp_port.has_value ());
 	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (system.io_ctx, rpc_config, ipc_tcp_port.value ()));

--- a/nano/rpc_test/rpc_context.hpp
+++ b/nano/rpc_test/rpc_context.hpp
@@ -2,6 +2,9 @@
 
 #include <boost/property_tree/ptree.hpp>
 
+#include <optional>
+#include <vector>
+
 namespace nano
 {
 class ipc_rpc_processor;
@@ -34,12 +37,20 @@ namespace test
 
 	boost::property_tree::ptree wait_response (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time = 5s);
 
+	void wait_responses_impl (nano::test::system & system, rpc_context const & rpc_ctx, std::vector<boost::property_tree::ptree> & requests, std::chrono::duration<double, std::nano> const & time, std::vector<boost::property_tree::ptree> & responses);
+
+	// Sends all requests at once and waits for every response, returned in request order.
+	// Concurrent processing requires the server to be started with more than one IPC connection, see rpc_options::num_ipc_connections
+	std::vector<boost::property_tree::ptree> wait_responses (nano::test::system & system, rpc_context const & rpc_ctx, std::vector<boost::property_tree::ptree> & requests, std::chrono::duration<double, std::nano> const & time = 5s);
+
 	bool check_block_response_count (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, uint64_t size_count);
 
 	// Configuration for the RPC server started by add_rpc
 	struct rpc_options
 	{
 		bool enable_control{ true };
+		// Overrides the RPC → IPC connection count; the dev network default of 1 processes requests one at a time
+		std::optional<unsigned> num_ipc_connections{};
 	};
 
 	rpc_context add_rpc (nano::test::system &, std::shared_ptr<nano::node> const &, rpc_options const & options = {});

--- a/nano/rpc_test/wallet_rpc.cpp
+++ b/nano/rpc_test/wallet_rpc.cpp
@@ -1,0 +1,242 @@
+#include <nano/node/ipc/ipc_server.hpp>
+#include <nano/node/wallet.hpp>
+#include <nano/rpc/rpc_request_processor.hpp>
+#include <nano/rpc_test/common.hpp>
+#include <nano/rpc_test/rpc_context.hpp>
+#include <nano/secure/common.hpp>
+#include <nano/test_common/system.hpp>
+#include <nano/test_common/testutil.hpp>
+
+#include <gtest/gtest.h>
+
+#include <unordered_set>
+
+using namespace nano::test;
+using namespace std::chrono_literals;
+
+/*
+ * Concurrency tests for wallet RPC handlers. Batches of requests are processed simultaneously,
+ * so under TSAN these tests double as data race detectors for the wallet container.
+ */
+
+namespace
+{
+// Enough RPC → IPC connections for a whole batch of requests to be in flight at once
+constexpr unsigned ipc_connections{ 8 };
+
+boost::property_tree::ptree wallet_create_request ()
+{
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_create");
+	return request;
+}
+
+boost::property_tree::ptree wallet_destroy_request (nano::wallet_id const & wallet)
+{
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_destroy");
+	request.put ("wallet", wallet.to_string ());
+	return request;
+}
+
+boost::property_tree::ptree wallet_export_request (nano::wallet_id const & wallet)
+{
+	boost::property_tree::ptree request;
+	request.put ("action", "wallet_export");
+	request.put ("wallet", wallet.to_string ());
+	return request;
+}
+
+boost::property_tree::ptree account_list_request (nano::wallet_id const & wallet)
+{
+	boost::property_tree::ptree request;
+	request.put ("action", "account_list");
+	request.put ("wallet", wallet.to_string ());
+	return request;
+}
+
+boost::property_tree::ptree account_move_request (nano::wallet_id const & wallet, nano::wallet_id const & source, nano::account const & account)
+{
+	boost::property_tree::ptree request;
+	request.put ("action", "account_move");
+	request.put ("wallet", wallet.to_string ());
+	request.put ("source", source.to_string ());
+	boost::property_tree::ptree accounts;
+	boost::property_tree::ptree entry;
+	entry.put ("", account.to_account ());
+	accounts.push_back (std::make_pair ("", entry));
+	request.add_child ("accounts", accounts);
+	return request;
+}
+}
+
+// Concurrent wallet_create requests must each create a distinct wallet
+TEST (rpc, wallet_concurrent_create)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto const rpc_ctx = add_rpc (system, node, { .num_ipc_connections = ipc_connections });
+	auto const initial_count = node->wallets.wallet_count ();
+
+	std::vector<boost::property_tree::ptree> requests (8, wallet_create_request ());
+	auto responses = wait_responses (system, rpc_ctx, requests);
+	ASSERT_EQ (requests.size (), responses.size ());
+
+	std::unordered_set<nano::wallet_id> ids;
+	for (auto const & response : responses)
+	{
+		auto wallet_text (response.get_optional<std::string> ("wallet"));
+		ASSERT_TRUE (wallet_text) << "unexpected response: " << response.get<std::string> ("error", "<none>");
+		nano::wallet_id id;
+		ASSERT_FALSE (id.decode_hex (*wallet_text));
+		ASSERT_NE (nullptr, node->wallets.open (id));
+		ids.insert (id);
+	}
+	ASSERT_EQ (requests.size (), ids.size ());
+	ASSERT_EQ (initial_count + requests.size (), node->wallets.wallet_count ());
+}
+
+// Concurrent wallet_destroy requests for distinct wallets must all succeed
+TEST (rpc, wallet_concurrent_destroy)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto const rpc_ctx = add_rpc (system, node, { .num_ipc_connections = ipc_connections });
+	auto const initial_count = node->wallets.wallet_count ();
+
+	std::vector<boost::property_tree::ptree> requests;
+	for (auto i = 0; i < 8; ++i)
+	{
+		auto id (nano::random_wallet_id ());
+		ASSERT_NE (nullptr, node->wallets.create (id));
+		requests.push_back (wallet_destroy_request (id));
+	}
+	auto responses = wait_responses (system, rpc_ctx, requests);
+	ASSERT_EQ (requests.size (), responses.size ());
+
+	for (auto const & response : responses)
+	{
+		ASSERT_EQ ("1", response.get<std::string> ("destroyed", ""));
+	}
+	ASSERT_EQ (initial_count, node->wallets.wallet_count ());
+}
+
+// Concurrent wallet_destroy requests for the same wallet: exactly one wins, the rest report wallet not found
+TEST (rpc, wallet_concurrent_destroy_same)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto const rpc_ctx = add_rpc (system, node, { .num_ipc_connections = ipc_connections });
+	auto const initial_count = node->wallets.wallet_count ();
+
+	// Repeated rounds give the destroy requests more chances to interleave
+	for (auto round = 0; round < 10; ++round)
+	{
+		auto id (nano::random_wallet_id ());
+		ASSERT_NE (nullptr, node->wallets.create (id));
+
+		std::vector<boost::property_tree::ptree> requests (8, wallet_destroy_request (id));
+		auto responses = wait_responses (system, rpc_ctx, requests);
+		ASSERT_EQ (requests.size (), responses.size ());
+
+		std::size_t destroyed{ 0 };
+		for (auto const & response : responses)
+		{
+			if (response.get<std::string> ("destroyed", "") == "1")
+			{
+				++destroyed;
+			}
+			else
+			{
+				ASSERT_EQ ("Wallet not found", response.get<std::string> ("error", ""));
+			}
+		}
+		ASSERT_EQ (1, destroyed);
+		ASSERT_EQ (nullptr, node->wallets.open (id));
+	}
+	ASSERT_EQ (initial_count, node->wallets.wallet_count ());
+}
+
+// Hammers wallet creation, destruction and reads concurrently; the wallet set must stay consistent throughout
+TEST (rpc, wallet_concurrent_create_destroy_read)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto const rpc_ctx = add_rpc (system, node, { .num_ipc_connections = ipc_connections });
+
+	// Stable wallet targeted by the read requests while other wallets churn
+	auto stable_id (nano::random_wallet_id ());
+	auto stable_wallet = node->wallets.create (stable_id);
+	ASSERT_NE (nullptr, stable_wallet);
+	ASSERT_TRUE (stable_wallet->insert_adhoc (nano::dev::genesis_key.prv, false));
+
+	auto const initial_count = node->wallets.wallet_count ();
+	auto const rounds = 5;
+
+	std::vector<nano::wallet_id> previous_round;
+	for (auto round = 0; round < rounds; ++round)
+	{
+		// A fresh wallet whose only account is moved into the stable wallet mid-batch
+		nano::keypair key;
+		auto source_id (nano::random_wallet_id ());
+		auto source_wallet = node->wallets.create (source_id);
+		ASSERT_NE (nullptr, source_wallet);
+		ASSERT_TRUE (source_wallet->insert_adhoc (key.prv, false));
+
+		std::vector<boost::property_tree::ptree> requests;
+		requests.push_back (wallet_create_request ());
+		requests.push_back (wallet_create_request ());
+		// Destroy every wallet that the previous round left behind
+		for (auto const & id : previous_round)
+		{
+			requests.push_back (wallet_destroy_request (id));
+		}
+		requests.push_back (account_move_request (stable_id, source_id, key.pub));
+		requests.push_back (wallet_export_request (stable_id));
+		requests.push_back (account_list_request (stable_id));
+		requests.push_back (wallet_export_request (nano::random_wallet_id ()));
+
+		auto responses = wait_responses (system, rpc_ctx, requests, 10s);
+		ASSERT_EQ (requests.size (), responses.size ());
+
+		std::vector<nano::wallet_id> created;
+		for (std::size_t i = 0; i < 2; ++i)
+		{
+			auto wallet_text (responses[i].get_optional<std::string> ("wallet"));
+			ASSERT_TRUE (wallet_text) << "unexpected response: " << responses[i].get<std::string> ("error", "<none>");
+			nano::wallet_id id;
+			ASSERT_FALSE (id.decode_hex (*wallet_text));
+			created.push_back (id);
+		}
+		for (std::size_t i = 0; i < previous_round.size (); ++i)
+		{
+			ASSERT_EQ ("1", responses[2 + i].get<std::string> ("destroyed", ""));
+		}
+		auto const moved_index = 2 + previous_round.size ();
+		ASSERT_EQ ("1", responses[moved_index].get<std::string> ("moved", ""));
+		ASSERT_TRUE (stable_wallet->exists (key.pub));
+		ASSERT_FALSE (responses[moved_index + 1].get<std::string> ("json", "").empty ());
+		auto accounts_node = responses[moved_index + 2].get_child_optional ("accounts");
+		ASSERT_TRUE (accounts_node);
+		bool genesis_present{ false };
+		for (auto const & entry : *accounts_node)
+		{
+			genesis_present |= entry.second.get<std::string> ("") == nano::dev::genesis_key.pub.to_account ();
+		}
+		ASSERT_TRUE (genesis_present);
+		ASSERT_EQ ("Wallet not found", responses[moved_index + 3].get<std::string> ("error", ""));
+
+		// The drained source wallet is destroyed together with the created wallets next round
+		created.push_back (source_id);
+		previous_round = created;
+	}
+
+	// Destroy the wallets left over from the final round
+	for (auto const & id : previous_round)
+	{
+		ASSERT_TRUE (node->wallets.destroy (id));
+	}
+	ASSERT_EQ (initial_count, node->wallets.wallet_count ());
+	// The stable wallet holds the genesis account plus one moved account per round
+	ASSERT_EQ (1 + rounds, stable_wallet->accounts ().size ());
+}

--- a/nano/slow_test/node.cpp
+++ b/nano/slow_test/node.cpp
@@ -2113,7 +2113,7 @@ TEST (system, block_sequence)
 	flags.disable_max_peers_per_ip = true;
 	flags.disable_ongoing_bootstrap = true;
 	auto root = system.add_node (config, flags);
-	auto wallet = root->wallets.items.begin ()->second;
+	auto wallet = system.wallet (0);
 	wallet->insert_adhoc (nano::dev::genesis_key.prv);
 	for (auto rep : reps)
 	{
@@ -2125,7 +2125,7 @@ TEST (system, block_sequence)
 			config.peering_port = system.get_available_port ();
 			system.add_node (config, flags);
 		}
-		std::cerr << rep.pub.to_account () << ' ' << pr->wallets.items.begin ()->second->exists (rep.pub) << pr->weight (rep.pub) << ' ' << '\n';
+		std::cerr << rep.pub.to_account () << ' ' << pr->wallets.all_wallets ().begin ()->second->exists (rep.pub) << pr->weight (rep.pub) << ' ' << '\n';
 	}
 	while (std::any_of (system.nodes.begin (), system.nodes.end (), [] (std::shared_ptr<nano::node> const & node) {
 		// std::cerr << node->rep_crawler.representative_count () << ' ';

--- a/nano/test_common/system.cpp
+++ b/nano/test_common/system.cpp
@@ -277,10 +277,9 @@ void nano::test::system::ledger_initialization_set (std::deque<nano::keypair> co
 std::shared_ptr<nano::wallet::wallet> nano::test::system::wallet (size_t index_a)
 {
 	debug_assert (nodes.size () > index_a);
-	auto size (nodes[index_a]->wallets.items.size ());
-	(void)size;
-	debug_assert (size == 1);
-	return nodes[index_a]->wallets.items.begin ()->second;
+	auto wallets (nodes[index_a]->wallets.all_wallets ());
+	debug_assert (wallets.size () == 1);
+	return wallets.begin ()->second;
 }
 
 uint64_t nano::test::system::work_generate_limited (nano::block_hash const & root_a, uint64_t min_a, uint64_t max_a)
@@ -605,7 +604,7 @@ void nano::test::system::generate_change_unknown (nano::node & node_a, std::vect
 
 void nano::test::system::generate_send_new (nano::node & node_a, std::vector<nano::account> & accounts_a)
 {
-	debug_assert (node_a.wallets.items.size () == 1);
+	debug_assert (node_a.wallets.wallet_count () == 1);
 	nano::uint128_t amount;
 	nano::account source;
 	{
@@ -615,7 +614,7 @@ void nano::test::system::generate_send_new (nano::node & node_a, std::vector<nan
 	}
 	if (!amount.is_zero ())
 	{
-		auto pub_result = node_a.wallets.items.begin ()->second->deterministic_insert ();
+		auto pub_result = node_a.wallets.all_wallets ().begin ()->second->deterministic_insert ();
 		debug_assert (pub_result);
 		accounts_a.push_back (pub_result.value ());
 		auto hash = wallet (0)->send_sync (source, pub_result.value (), amount);


### PR DESCRIPTION
## Problem

`wallets::items` was a public member guarded by `wallets::mutex` only by convention. Several RPC handlers (`account_move`, `block_create`, `wallet_create`, `wallet_destroy`), the CLI and the Qt wallet launcher accessed the map without holding the mutex, racing against `reload()` on the receivable scan thread and against concurrent wallet RPCs. A concurrent rehash during an unlocked `find` is undefined behavior.

Additionally, `wallets::destroy` asserted that the wallet exists, so two concurrent `wallet_destroy` requests for the same wallet could crash the node: both passed the handler's existence pre-check before either performed the destroy.

## Changes

- `wallets::items` is now private; outside access goes through `open()` or the snapshot queries `all_wallets()`, `wallet_ids()` and `wallet_count()`
- All unlocked call sites (RPC handlers, CLI, Qt wallet launcher, tests) migrated to the synchronized accessors
- `wallets::destroy` returns whether a wallet was destroyed instead of asserting on a missing one; the `wallet_destroy` RPC and CLI now perform a single atomic destroy instead of check-then-destroy
- New test primitive `wait_responses` sends a whole batch of RPC requests at once and collects every response, plus an `rpc_options::num_ipc_connections` override — the dev network default of 1 RPC → IPC connection processes requests one at a time, which would make concurrent tests meaningless
- New test suite `rpc.wallet_concurrent_*` covering parallel wallet creation, destruction of distinct wallets, racing destroys of the same wallet (exactly one wins) and a mixed create/destroy/read/account_move hammer

## Testing

- Full wallet and RPC test suites pass with both LMDB and RocksDB backends
- The new tests run under the existing TSAN/ASAN CI matrices, where concurrent request processing makes them effective data race detectors
- The harness was validated against a temporarily reintroduced version of the destroy race: with the request batch processed concurrently, the old assertion is reliably triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)