### PR TITLE
Test that a node reports its own representative as online

### DIFF
--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -5927,6 +5927,28 @@ TEST (rpc, online_reps)
 	ASSERT_EQ (representatives3.size (), 1);
 }
 
+// A node hosting a representative should report it as online in its own `representatives_online` output, even while completely idle
+TEST (rpc, representatives_online_local)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	ASSERT_TRUE (node->online_reps.list ().empty ());
+
+	// Make this node a representative for the genesis account
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+
+	// The local representative is observed through the loopback rep crawler query, no block activity involved
+	ASSERT_TIMELY_EQ (10s, node->online_reps.list ().size (), 1);
+
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "representatives_online");
+	auto response (wait_response (system, rpc_ctx, request));
+	auto representatives (response.get_child ("representatives"));
+	ASSERT_EQ (1, representatives.size ());
+	ASSERT_EQ (nano::dev::genesis_key.pub.to_account (), representatives.begin ()->second.get<std::string> (""));
+}
+
 TEST (rpc, confirmation_history)
 {
 	nano::test::system system;


### PR DESCRIPTION
Adds an RPC test covering the scenario reported in #3046: a node hosting its own representative did not list that representative in its own `representatives_online` output unless it happened to be actively voting on an election.

The test starts a single node, inserts the genesis key into that node's own wallet, and asserts the representative appears in that same node's `representatives_online` response — with no block activity whatsoever. The absence of activity is the point: the original report described the representative appearing only briefly after making a transaction.

For a fully idle node the only path that can satisfy the assertion is the loopback rep crawler query in `rep_crawler::run`, answered by `vote_replier` with a final vote for a cemented block and registered through `online_reps::observe`.

Existing tests cover this at the component level (`online_reps.observe_local`, `rep_crawler.rep_local`); this adds the missing end-to-end assertion that the RPC actually surfaces it.

Verified to pass against both LMDB and RocksDB backends, and to fail by timeout on both when the loopback rep crawler query is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
