### PR TITLE
Fix vote generator busy-spin when a replacement hits a full bucket

### DIFF
--- a/nano/core_test/vote_generator.cpp
+++ b/nano/core_test/vote_generator.cpp
@@ -234,24 +234,61 @@ TEST (vote_generator_index, replacement_when_bucket_full)
 	ASSERT_TRUE (index.push (root1, hash_a, 0));
 	ASSERT_TRUE (index.push (root2, hash_b, 0));
 
-	// Replace root1: dedup updates to hash_c, but queue.push fails (bucket full with stale + valid entries)
+	// Replacement of root1 is rejected while the bucket is full
+	ASSERT_FALSE (index.push (root1, hash_c, 0));
+	ASSERT_EQ (index.size (), 2);
+	ASSERT_FALSE (index.empty ());
+
+	// The old hash remains the active mapping, so pushing it again is a duplicate
+	ASSERT_FALSE (index.push (root1, hash_a, 0));
+
+	// Both original entries remain valid and extractable
+	auto batch = index.next_batch (10);
+	ASSERT_EQ (batch.size (), 2);
+	ASSERT_EQ (batch[0].first, root1);
+	ASSERT_EQ (batch[0].second, hash_a);
+	ASSERT_EQ (batch[1].first, root2);
+	ASSERT_EQ (batch[1].second, hash_b);
+
+	// No orphaned dedup entries: size and emptiness agree with the drained queue
+	ASSERT_EQ (index.size (), 0);
+	ASSERT_TRUE (index.empty ());
+	ASSERT_TRUE (index.next_batch (10).empty ());
+}
+
+TEST (vote_generator_index, replacement_retry_after_drain)
+{
+	nano::vote_generator_index index{ 2 }; // max 2 per bucket
+
+	auto root1 = nano::qualified_root{ nano::root{ 1 }, nano::block_hash{ 1 } };
+	auto root2 = nano::qualified_root{ nano::root{ 2 }, nano::block_hash{ 2 } };
+	auto hash_a = nano::block_hash{ 10 };
+	auto hash_b = nano::block_hash{ 20 };
+	auto hash_c = nano::block_hash{ 30 };
+
+	// Fill bucket 0 with root2 in front so draining frees space while root1 stays queued
+	ASSERT_TRUE (index.push (root2, hash_b, 0));
+	ASSERT_TRUE (index.push (root1, hash_a, 0));
+
+	// Replacement rejected while the bucket is full
 	ASSERT_FALSE (index.push (root1, hash_c, 0));
 
-	// Dedup was updated despite push failure: root1 now maps to hash_c
-	// Queue still has: root1/hash_a(stale), root2/hash_b(valid)
-	ASSERT_EQ (index.size (), 2);
-
-	// Extract: root1/hash_a is stale (dedup says hash_c) → skipped; root2/hash_b → valid
-	auto batch = index.next_batch (10);
+	// Drain one entry to free space, root1/hash_a stays queued
+	auto batch = index.next_batch (1);
 	ASSERT_EQ (batch.size (), 1);
 	ASSERT_EQ (batch[0].first, root2);
-	ASSERT_EQ (batch[0].second, hash_b);
 
-	// root1 is a zombie: exists in dedup but not in queue
+	// Retrying the replacement now succeeds and the old entry becomes stale
+	ASSERT_TRUE (index.push (root1, hash_c, 0));
 	ASSERT_EQ (index.size (), 1);
-	ASSERT_FALSE (index.empty ());
-	auto empty_batch = index.next_batch (10);
-	ASSERT_TRUE (empty_batch.empty ());
+
+	// Only the replacement is extracted, the stale hash_a entry is skipped
+	auto rest = index.next_batch (10);
+	ASSERT_EQ (rest.size (), 1);
+	ASSERT_EQ (rest[0].first, root1);
+	ASSERT_EQ (rest[0].second, hash_c);
+	ASSERT_TRUE (index.empty ());
+	ASSERT_EQ (index.size (), 0);
 }
 
 /*

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -570,10 +570,12 @@ bool nano::vote_generator_index::push (nano::qualified_root const & root, nano::
 		}
 		else
 		{
-			// Different hash for same root
-			// Update dedup (old becomes stale)
-			existing->second = hash;
+			// Different hash for same root, replace only once the queue accepts the new entry (old becomes stale)
 			bool added = queue.push ({ root, hash }, { bucket });
+			if (added)
+			{
+				existing->second = hash;
+			}
 			return added;
 		}
 	}
@@ -591,6 +593,8 @@ bool nano::vote_generator_index::push (nano::qualified_root const & root, nano::
 
 auto nano::vote_generator_index::next_batch (size_t count) -> std::deque<entry>
 {
+	debug_assert (dedup.size () <= queue.size ()); // Every dedup entry must have a matching queue entry
+
 	queue.periodic_update ();
 
 	std::deque<entry> result;
@@ -618,5 +622,5 @@ size_t nano::vote_generator_index::size () const
 
 bool nano::vote_generator_index::empty () const
 {
-	return dedup.empty ();
+	return queue.empty ();
 }

--- a/nano/node/vote_generator.hpp
+++ b/nano/node/vote_generator.hpp
@@ -59,7 +59,9 @@ public:
 	/// Remove and return up to `count` valid entries (stale entries from replacements are skipped)
 	std::deque<entry> next_batch (size_t count);
 
+	/// Number of pending roots
 	size_t size () const;
+	/// True when the underlying queue holds no entries, stale or valid
 	bool empty () const;
 
 private:


### PR DESCRIPTION
Fixes #5129

## Problem

`vote_generator_index::push` updated its `dedup` map before checking whether the underlying `fair_queue` accepted the entry. When a replacement (different hash for the same root) hit a full bucket, `dedup` ended up naming a hash that was never enqueued. The still-queued old entry was later skipped as stale without erasing the map entry, orphaning it permanently.

Since `size()`/`empty()` reported on `dedup` while `next_batch()` drains the queue, a single orphan made the `vote_generator_verifier` wait predicate permanently true with nothing to pop — the voting threads busy-spin at 100% CPU while hammering the shared mutex, and the affected root is silenced for vote generation (visible as a climbing `vote_generator::overfill` counter).

## Fix

- Update `dedup` only once the queue has accepted the replacement. On rejection the old hash remains the active mapping and its queued entry stays consumable, so a full bucket now load-sheds the winner change (the old winner keeps being voted until rebroadcast retries succeed) instead of wedging the verifier. This matches how full buckets already treat new roots.
- `empty()` is now backed by the queue rather than `dedup`, so any future divergence degrades into a blocked thread instead of a spin.
- `next_batch()` asserts the invariant that every `dedup` entry has a matching queue entry.

## Tests

- `vote_generator_index.replacement_when_bucket_full` previously pinned the broken intermediate state as characterization; it now guards the fixed behavior (old mapping stays active and extractable, no orphaned entries after draining).
- New `vote_generator_index.replacement_retry_after_drain` covers recovery: a rejected replacement succeeds when retried after the bucket drains, with the stale entry skipped on extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)