### PR TITLE
Fix representatives count limit off-by-one

### DIFF
--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3787,11 +3787,11 @@ void nano::json_handler::representatives ()
 				{
 					continue;
 				}
-				representatives.put (account.to_account (), amount.convert_to<std::string> ());
-				if (representatives.size () > count)
+				if (representatives.size () >= count)
 				{
 					break;
 				}
+				representatives.put (account.to_account (), amount.convert_to<std::string> ());
 			}
 		}
 		else // Sorting

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -2754,6 +2754,30 @@ TEST (rpc, representatives_threshold_bad_threshold)
 	ASSERT_EQ (std::error_code (nano::error_common::bad_threshold).message (), response.get<std::string> ("error"));
 }
 
+TEST (rpc, representatives_count_limit)
+{
+	nano::test::system system;
+	auto node = add_ipc_enabled_node (system);
+	auto & wallet = *system.wallet (0);
+	wallet.insert_adhoc (nano::dev::genesis_key.prv);
+	nano::keypair rep2;
+	nano::keypair rep3;
+	wallet.insert_adhoc (rep2.prv);
+	wallet.insert_adhoc (rep3.prv);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep2.pub, 100 * nano::Knano_ratio);
+	wallet.send_sync (nano::dev::genesis_key.pub, rep3.pub, 200 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep2.pub) == 100 * nano::Knano_ratio);
+	ASSERT_TIMELY (5s, node->balance (rep3.pub) == 200 * nano::Knano_ratio);
+	wallet.change_sync (rep2.pub, rep2.pub);
+	wallet.change_sync (rep3.pub, rep3.pub);
+	auto const rpc_ctx = add_rpc (system, node);
+	boost::property_tree::ptree request;
+	request.put ("action", "representatives");
+	request.put ("count", "2");
+	auto response (wait_response (system, rpc_ctx, request));
+	ASSERT_EQ (2, response.get_child ("representatives").size ());
+}
+
 TEST (rpc, representative_count)
 {
 	nano::test::system system;


### PR DESCRIPTION
The non-sorting branch of the `representatives` RPC returned one entry more than the requested `count`, because the break check ran after adding the entry to the response. The sorting branch already enforces the limit exactly.

This surfaced during review of #5124 (Copilot flagged it); keeping it out of that PR per review feedback. No change to the sorting path, and the default (no `count`) behavior is unaffected.

Verification: build OK locally, `rpc.representatives_count_limit` added, 7 rpc representatives/count tests pass, clang-format check passes.