### PR TITLE
Use public wallet_ids accessor in account_move_invalid_account test

### DIFF
--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -733,7 +733,7 @@ TEST (rpc, account_move_invalid_account)
 {
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
-	auto wallet_id (node->wallets.items.begin ()->first);
+	auto wallet_id (node->wallets.wallet_ids ().front ());
 	auto destination (system.wallet (0));
 	nano::keypair key;
 	auto source_id = nano::random_wallet_id ();


### PR DESCRIPTION
Fixes the build break introduced in #5127: the `rpc.account_move_invalid_account` test still accessed the now-private `wallets.items` map directly. Replaced with the public `wallet_ids ()` accessor, matching the pattern used by the other RPC tests.

Verified the test passes with both LMDB and RocksDB backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
