### PR TITLE
Fix race in peer_discovery_via_peering_only_node

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -1163,14 +1163,14 @@ TEST (network, peer_discovery_via_peering_only_node)
 	auto node_a = system.make_disconnected_node ();
 	auto node_b = system.make_disconnected_node ();
 
+	ASSERT_EQ (nullptr, node_a->network.find_node_id (node_b->get_node_id ()));
+	ASSERT_EQ (nullptr, node_b->network.find_node_id (node_a->get_node_id ()));
+
 	node_a->network.merge_peer (node_c->network.endpoint ());
 	node_b->network.merge_peer (node_c->network.endpoint ());
 
 	ASSERT_TIMELY (10s, node_a->network.find_node_id (node_c->get_node_id ()));
 	ASSERT_TIMELY (10s, node_b->network.find_node_id (node_c->get_node_id ()));
-
-	ASSERT_EQ (nullptr, node_a->network.find_node_id (node_b->get_node_id ()));
-	ASSERT_EQ (nullptr, node_b->network.find_node_id (node_a->get_node_id ()));
 
 	ASSERT_TIMELY (30s, node_a->network.find_node_id (node_b->get_node_id ()));
 	ASSERT_TIMELY (30s, node_b->network.find_node_id (node_a->get_node_id ()));


### PR DESCRIPTION
The 2 asserts checks that A and B don't know each other, but ran *after* waiting for both to attach to the peering-only node C.

In dev networks `keepalive_period` is 1s, so once A and B are both connected to C, C gossips their endpoints and they reach out to each other almost immediately. The window between `ASSERT_TIMELY (10s, ...find_node_id (node_c...))` returning and the next statement executing can easily exceed that on a loaded machine, causing the assertion to observe an already-established A↔B channel and fail.