### PR TITLE
Reduce sccache cache pressure

### DIFF
--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -39,7 +39,8 @@ jobs:
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_VERSION: linux-sanitizers-${{ matrix.SANITIZER.name }}-${{ matrix.COMPILER }}
+      # LEAK compiles identically to ASAN, so they share namespace.
+      SCCACHE_GHA_VERSION: linux-sanitizers-${{ matrix.SANITIZER.name == 'LEAK' && 'ASAN' || matrix.SANITIZER.name }}-${{ matrix.COMPILER }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout

--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -2,6 +2,10 @@ name: Code Sanitizers
 
 on: [ push, pull_request, workflow_dispatch ]
 
+env:
+  # Only the develop branch populates the cache.
+  SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/develop' && 'READ_WRITE' || 'READ_ONLY' }}
+
 jobs:
   linux_sanitizers:
     name: Linux [${{ matrix.SANITIZER.name }}] [${{ matrix.BACKEND }} | ${{ matrix.COMPILER }}] ${{ matrix.SANITIZER.ignore_errors && ' (Errors Ignored)' || '' }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -20,6 +20,8 @@ jobs:
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_VERSION: macos-${{ matrix.RELEASE }}
+      # Only the develop branch populates the cache.
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/develop' && 'READ_WRITE' || 'READ_ONLY' }}
     runs-on: macos-14
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
@@ -82,6 +84,7 @@ jobs:
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_VERSION: linux-${{ matrix.COMPILER }}-${{ matrix.RELEASE }}
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/develop' && 'READ_WRITE' || 'READ_ONLY' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout


### PR DESCRIPTION
Our GitHub cache usage sits constantly at the 10 GB limit, so entries are evicted as fast as they're written. 
This PR reduces what's written without reducing what CI can read:

- Only `develop` writes to the cache. Every other ref is `READ_ONLY`. Branches and PRs still get cache hits, but from develop branch cache. They no longer evict develop's cache to store their own.
- LEAK shares ASAN's cache namespace.  `ci/build.sh` compiles both with `-DNANO_ASAN=ON`, so the two jobs were storing duplicate cache copies of identical objects.