### PR TITLE
Run coverage workflow on every push to develop

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,14 +1,14 @@
 name: Coverage Reports
 
 on:
+  push:
+    branches: [develop]
   workflow_dispatch:
     inputs:
       label:
         description: "label to append to run"
-        default: "Scheduled"
+        default: "Manual"
         required: true
-  schedule:
-    - cron: "0 1 * * 0"
 permissions:
   contents: read
 jobs:
@@ -52,7 +52,7 @@ jobs:
         if: ${{ !cancelled() }}
         # Free-form input: never interpolate.
         env:
-          LABEL: ${{ inputs.label || 'Scheduled' }}
+          LABEL: ${{ inputs.label || github.ref_name }}
         run: |
           heading="### Coverage [${{ matrix.BACKEND }}] $LABEL"
           if [[ ! -f coverage/lcov.info ]]; then
@@ -94,7 +94,7 @@ jobs:
           path: tracefiles
       - name: Merge Tracefiles
         env:
-          LABEL: ${{ inputs.label || 'Scheduled' }}
+          LABEL: ${{ inputs.label || github.ref_name }}
         run: |
           mapfile -t tracefiles < <(find tracefiles -name lcov.info 2>/dev/null)
           if [[ ${#tracefiles[@]} -eq 0 ]]; then


### PR DESCRIPTION
## Problem

Coverage only ran on a weekly cron (`0 1 * * 0`) or by manual dispatch, so a regression in coverage was attributable to a week's worth of merges at best, and the reports were stale for most of the week.

## Changes

- Coverage now runs on every push to `develop`, and the weekly `schedule` trigger is dropped — per-commit runs make it redundant
- `workflow_dispatch` is kept so coverage can still be run on demand against any branch; its `label` input now defaults to `Manual` rather than `Scheduled`
- Step summaries label push runs with `github.ref_name` instead of falling back to `Scheduled`, so the heading reads `### Coverage [lmdb] develop`

Note that the coverage job has a 220-minute timeout and no concurrency group, so consecutive merges into `develop` will run overlapping builds. Adding `concurrency` with `cancel-in-progress` would keep only the newest commit's run, at the cost of not having a report for every commit — left out here deliberately, happy to add it if the runner load turns out to be a problem.

## Testing

Workflow-only change, verified by parsing the resulting YAML: the trigger set is `push` (restricted to `develop`) and `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
