### PR TITLE
Fetch submodules in parallel

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -11,6 +11,9 @@ on:
 
 env:
   artifact: 1
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: submodule.fetchJobs
+  GIT_CONFIG_VALUE_0: 8
 
 jobs:
   prepare_build:

--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -5,6 +5,9 @@ on: [ push, pull_request, workflow_dispatch ]
 env:
   # Only the develop branch populates the cache.
   SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/develop' && 'READ_WRITE' || 'READ_ONLY' }}
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: submodule.fetchJobs
+  GIT_CONFIG_VALUE_0: 8
 
 jobs:
   linux_sanitizers:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,10 @@ on:
     - cron: "0 1 * * 0"
 permissions:
   contents: read
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: submodule.fetchJobs
+  GIT_CONFIG_VALUE_0: 8
 jobs:
   coverage_test:
     name: Coverage Test [${{ matrix.BACKEND }}]

--- a/.github/workflows/flamegraphs.yml
+++ b/.github/workflows/flamegraphs.yml
@@ -2,6 +2,11 @@ name: Code Flamegraphs
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: submodule.fetchJobs
+  GIT_CONFIG_VALUE_0: 8
+
 jobs:
   linux_flamegraphs:
     name: Linux [${{ matrix.TEST_NAME }}]

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,6 +2,11 @@ name: Unit Tests
 
 on: [push, pull_request]
 
+env:
+  GIT_CONFIG_COUNT: 1
+  GIT_CONFIG_KEY_0: submodule.fetchJobs
+  GIT_CONFIG_VALUE_0: 8
+
 jobs:
   macos_test:
     name: macOS [${{ matrix.BACKEND }}]


### PR DESCRIPTION
Submodule checkout takes a lot of time during CI runs.
14 submodules plus Boost's 180 submodules are currently fetched serially by each job.

This PR sets `submodule.fetchJobs=8` in the five workflows so `actions/checkout` fetches them concurrently. The work is network-bound, so 8 parallel fetches is fine on 4-core runners.

From my testing `actions/checkout` time is reduced by up to 61 percent

| Job | Before | After | Change |
| --- | ---: | ---: | ---: |
| Linux [rocksdb / gcc] | 6m37s | 2m44s | -61% |
| Linux [lmdb / clang] | 6m37s | 3m53s | -41% |
| Linux [lmdb / gcc] | 5m08s | 3m47s | -27% |
| Linux [rocksdb / clang] | 4m09s | 3m34s | -14% |
| Docker [rocksdb] | 7m01s | 2m48s | -58% |
| Docker [build] | 7m10s | 3m45s | -48% |
| Docker [lmdb] | 5m53s | 2m42s | -54% |
| Windows [lmdb] | 6m37s | 4m22s | -34% |
| Windows [rocksdb] | 8m22s | 4m21s | -48% |
| macOS [lmdb] | 9m36s | 5m16s | -45% |
| macOS [rocksdb] | 6m27s | 6m38s | +3% |
| **Mean** | 6m42s | 3m58s | -41% |