### PR TITLE
Return outbound actions from election tick

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(
   difficulty.cpp
   distributed_work.cpp
   election.cpp
+  election_pacing.cpp
   election_scheduler.cpp
   priority_scheduler.cpp
   enums.cpp

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -1,7 +1,6 @@
 #include <nano/lib/blockbuilders.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/jsonconfig.hpp>
-#include <nano/node/active_elections.hpp>
 #include <nano/node/block_rebroadcaster.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
@@ -14,6 +13,29 @@
 #include <gtest/gtest.h>
 
 using namespace std::chrono_literals;
+
+namespace
+{
+std::shared_ptr<nano::block> test_block (nano::test::system & system)
+{
+	nano::block_builder builder;
+	auto send = builder
+				.send ()
+				.previous (nano::dev::genesis->hash ())
+				.destination (nano::keypair ().pub)
+				.balance (nano::dev::constants.genesis_amount - 100)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*system.work.generate (nano::dev::genesis->hash ()))
+				.build ();
+	send->sideband_set ({});
+	return send;
+}
+
+nano::election_snapshot test_snapshot (std::shared_ptr<nano::block> const & winner, std::unordered_map<nano::account, nano::vote_info> votes = {}, bool quorum = false)
+{
+	return { winner->qualified_root (), winner, quorum, std::move (votes) };
+}
+}
 
 TEST (confirmation_solicitor, batches)
 {
@@ -38,34 +60,20 @@ TEST (confirmation_solicitor, batches)
 	ASSERT_EQ (channel1, representatives.front ().channel);
 	ASSERT_EQ (nano::dev::genesis_key.pub, representatives.front ().account);
 	ASSERT_TIMELY_EQ (3s, node2.network.size (), 1);
-	nano::block_builder builder;
-	auto send = builder
-				.send ()
-				.previous (nano::dev::genesis->hash ())
-				.destination (nano::keypair ().pub)
-				.balance (nano::dev::constants.genesis_amount - 100)
-				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*system.work.generate (nano::dev::genesis->hash ()))
-				.build ();
-	send->sideband_set ({});
+	auto send = test_block (system);
 	for (size_t i (0); i < nano::network::confirm_req_hashes_max; ++i)
 	{
-		auto election (std::make_shared<nano::election> (node2, send, nano::election_behavior::priority));
-		ASSERT_FALSE (solicitor.add (*election));
+		ASSERT_TRUE (solicitor.add (test_snapshot (send)));
 	}
-	// Reached the maximum amount of requests for the channel
-	auto election (std::make_shared<nano::election> (node2, send, nano::election_behavior::priority));
 	// Broadcasting should be immediate
 	ASSERT_EQ (0, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
-	ASSERT_FALSE (solicitor.broadcast (*election));
+	ASSERT_TRUE (solicitor.broadcast (test_snapshot (send)));
 	// One publish through directed broadcasting (random flooding moved to block_rebroadcaster)
 	ASSERT_EQ (1, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
 	solicitor.flush ();
 	ASSERT_EQ (1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
 }
 
-namespace nano
-{
 TEST (confirmation_solicitor, different_hash)
 {
 	nano::test::system system;
@@ -89,22 +97,14 @@ TEST (confirmation_solicitor, different_hash)
 	ASSERT_EQ (channel1, representatives.front ().channel);
 	ASSERT_EQ (nano::dev::genesis_key.pub, representatives.front ().account);
 	ASSERT_TIMELY_EQ (3s, node2.network.size (), 1);
-	nano::block_builder builder;
-	auto send = builder
-				.send ()
-				.previous (nano::dev::genesis->hash ())
-				.destination (nano::keypair ().pub)
-				.balance (nano::dev::constants.genesis_amount - 100)
-				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*system.work.generate (nano::dev::genesis->hash ()))
-				.build ();
-	send->sideband_set ({});
-	auto election (std::make_shared<nano::election> (node2, send, nano::election_behavior::priority));
-	// Add a vote for something else, not the winner
-	election->last_votes[representative.account] = { std::chrono::steady_clock::now (), 1, 1 };
+	auto send = test_block (system);
+	// The representative voted for something else, not the winner
+	std::unordered_map<nano::account, nano::vote_info> votes;
+	votes[representative.account] = { std::chrono::steady_clock::now (), 1, 1 };
+	auto snapshot = test_snapshot (send, votes);
 	// Ensure the request and broadcast goes through
-	ASSERT_FALSE (solicitor.add (*election));
-	ASSERT_FALSE (solicitor.broadcast (*election));
+	ASSERT_TRUE (solicitor.add (snapshot));
+	ASSERT_TRUE (solicitor.broadcast (snapshot));
 	// One publish through directed broadcasting (random flooding moved to block_rebroadcaster)
 	ASSERT_EQ (1, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::out));
 	solicitor.flush ();
@@ -133,36 +133,25 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	ASSERT_EQ (max_representatives + 1, representatives.size ());
 	solicitor.prepare (representatives);
 	ASSERT_TIMELY_EQ (3s, node2.network.size (), 1);
-	nano::block_builder builder;
-	auto send = builder
-				.send ()
-				.previous (nano::dev::genesis->hash ())
-				.destination (nano::keypair ().pub)
-				.balance (nano::dev::constants.genesis_amount - 100)
-				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
-				.work (*system.work.generate (nano::dev::genesis->hash ()))
-				.build ();
-	send->sideband_set ({});
-	auto election (std::make_shared<nano::election> (node2, send, nano::election_behavior::priority));
-	// Add a vote for something else, not the winner
+	auto send = test_block (system);
+	// Every representative voted for something else, not the winner
+	std::unordered_map<nano::account, nano::vote_info> votes;
 	for (auto const & rep : representatives)
 	{
-		election->set_last_vote (rep.account, { std::chrono::steady_clock::now (), 1, 1 });
+		votes[rep.account] = { std::chrono::steady_clock::now (), 1, 1 };
 	}
-	ASSERT_FALSE (solicitor.add (*election));
-	ASSERT_FALSE (solicitor.broadcast (*election));
+	ASSERT_TRUE (solicitor.add (test_snapshot (send, votes)));
+	ASSERT_TRUE (solicitor.broadcast (test_snapshot (send, votes)));
 	solicitor.flush ();
 	// All requests went through, the last one would normally not go through due to the cap but a vote for a different hash does not count towards the cap
 	ASSERT_TIMELY_EQ (6s, max_representatives + 1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
 
 	solicitor.prepare (representatives);
-	auto election2 (std::make_shared<nano::election> (node2, send, nano::election_behavior::priority));
-	ASSERT_FALSE (solicitor.add (*election2));
-	ASSERT_FALSE (solicitor.broadcast (*election2));
+	ASSERT_TRUE (solicitor.add (test_snapshot (send)));
+	ASSERT_TRUE (solicitor.broadcast (test_snapshot (send)));
 
 	solicitor.flush ();
 
 	// All requests but one went through, due to the cap
 	ASSERT_EQ (2 * max_representatives + 1, node2.stats.count (nano::stat::type::message, nano::stat::detail::confirm_req, nano::stat::dir::out));
-}
 }

--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -28,6 +28,35 @@ TEST (election, construction)
 	node, nano::dev::genesis, nano::election_behavior::priority, 0, [] (auto const &) {}, [] (auto const &) {}, [] (auto const &) {});
 }
 
+// Ticking an active election broadcasts a vote for the current winner via the vote generator
+TEST (election, tick_broadcast_vote)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv); // Local representative that can vote
+	auto election = std::make_shared<nano::election> (node, nano::dev::genesis, nano::election_behavior::priority, 42);
+	ASSERT_TRUE (election->transition_active ());
+	auto const now = std::chrono::steady_clock::now ();
+	election->tick (now);
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::broadcast_vote_normal));
+	// Vote broadcasts are paced, an immediate second tick does not vote again
+	election->tick (now);
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::broadcast_vote_normal));
+}
+
+// A confirmed election broadcasts a final vote
+TEST (election, broadcast_vote_final)
+{
+	nano::test::system system (1);
+	auto & node = *system.nodes[0];
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv); // Local representative that can vote
+	auto election = std::make_shared<nano::election> (node, nano::dev::genesis, nano::election_behavior::priority, 42);
+	ASSERT_TRUE (election->transition_active ());
+	election->force_confirm ();
+	election->broadcast_vote ();
+	ASSERT_EQ (1, node.stats.count (nano::stat::type::election, nano::stat::detail::broadcast_vote_final));
+}
+
 TEST (election, behavior)
 {
 	nano::test::system system (1);

--- a/nano/core_test/election_pacing.cpp
+++ b/nano/core_test/election_pacing.cpp
@@ -1,0 +1,133 @@
+#include <nano/node/election_behavior.hpp>
+#include <nano/node/election_pacing.hpp>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+auto const base_latency = 100ms;
+auto const vote_interval = 500ms;
+auto const block_interval = 1000ms;
+
+nano::election_pacing make_pacing ()
+{
+	return nano::election_pacing{ {
+	.base_latency = base_latency,
+	.vote_interval = vote_interval,
+	.block_interval = block_interval,
+	} };
+}
+
+// Start well past the clock epoch so interval arithmetic behaves like on a running system
+std::chrono::steady_clock::time_point start_time ()
+{
+	return std::chrono::steady_clock::time_point{} + 1h;
+}
+}
+
+TEST (election_pacing, vote_due_initially)
+{
+	auto pacing = make_pacing ();
+	ASSERT_TRUE (pacing.due_vote (start_time ()));
+}
+
+TEST (election_pacing, vote_interval)
+{
+	auto pacing = make_pacing ();
+	auto now = start_time ();
+
+	pacing.vote_sent (now);
+	ASSERT_FALSE (pacing.due_vote (now));
+	ASSERT_FALSE (pacing.due_vote (now + vote_interval / 2));
+	ASSERT_TRUE (pacing.due_vote (now + vote_interval));
+	ASSERT_TRUE (pacing.due_vote (now + vote_interval * 2));
+}
+
+TEST (election_pacing, vote_reset)
+{
+	auto pacing = make_pacing ();
+	auto now = start_time ();
+
+	pacing.vote_sent (now);
+	ASSERT_FALSE (pacing.due_vote (now));
+
+	pacing.reset_vote ();
+	ASSERT_TRUE (pacing.due_vote (now));
+}
+
+TEST (election_pacing, block_due_initially)
+{
+	auto pacing = make_pacing ();
+	ASSERT_TRUE (pacing.due_block (nano::block_hash{ 1 }, start_time ()));
+	ASSERT_TRUE (pacing.is_first_block ());
+}
+
+TEST (election_pacing, block_interval)
+{
+	auto pacing = make_pacing ();
+	auto now = start_time ();
+
+	nano::block_hash winner{ 1 };
+	pacing.block_sent (winner, now);
+	ASSERT_FALSE (pacing.is_first_block ());
+	ASSERT_FALSE (pacing.due_block (winner, now));
+	ASSERT_FALSE (pacing.due_block (winner, now + block_interval / 2));
+	ASSERT_TRUE (pacing.due_block (winner, now + block_interval * 2));
+}
+
+TEST (election_pacing, block_winner_change)
+{
+	auto pacing = make_pacing ();
+	auto now = start_time ();
+
+	nano::block_hash winner1{ 1 };
+	nano::block_hash winner2{ 2 };
+
+	pacing.block_sent (winner1, now);
+	ASSERT_FALSE (pacing.due_block (winner1, now));
+	// A different winner is due immediately, regardless of the interval
+	ASSERT_TRUE (pacing.due_block (winner2, now));
+
+	pacing.block_sent (winner2, now);
+	ASSERT_FALSE (pacing.due_block (winner2, now));
+	ASSERT_TRUE (pacing.due_block (winner1, now));
+}
+
+TEST (election_pacing, request_due_initially)
+{
+	auto pacing = make_pacing ();
+	ASSERT_TRUE (pacing.due_request (nano::election_behavior::priority, start_time ()));
+}
+
+TEST (election_pacing, request_interval)
+{
+	auto pacing = make_pacing ();
+	auto now = start_time ();
+
+	auto interval = pacing.request_interval (nano::election_behavior::priority);
+	pacing.request_sent (now);
+	ASSERT_FALSE (pacing.due_request (nano::election_behavior::priority, now));
+	ASSERT_FALSE (pacing.due_request (nano::election_behavior::priority, now + interval / 2));
+	ASSERT_TRUE (pacing.due_request (nano::election_behavior::priority, now + interval * 2));
+}
+
+TEST (election_pacing, request_interval_by_behavior)
+{
+	auto pacing = make_pacing ();
+
+	ASSERT_EQ (base_latency * 5, pacing.request_interval (nano::election_behavior::manual));
+	ASSERT_EQ (base_latency * 5, pacing.request_interval (nano::election_behavior::priority));
+	ASSERT_EQ (base_latency * 5, pacing.request_interval (nano::election_behavior::hinted));
+	ASSERT_EQ (base_latency * 2, pacing.request_interval (nano::election_behavior::optimistic));
+
+	// Optimistic elections request less frequently, verify the behavior-dependent due time
+	auto now = start_time ();
+	pacing.request_sent (now);
+	auto between = now + base_latency * 3;
+	ASSERT_TRUE (pacing.due_request (nano::election_behavior::optimistic, between));
+	ASSERT_FALSE (pacing.due_request (nano::election_behavior::priority, between));
+}

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -91,6 +91,8 @@ add_library(
   election.cpp
   election_behavior.hpp
   election_insertion_result.hpp
+  election_pacing.hpp
+  election_pacing.cpp
   election_status.hpp
   endpoint.cpp
   endpoint.hpp

--- a/nano/node/active_elections.cpp
+++ b/nano/node/active_elections.cpp
@@ -5,6 +5,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/node/active_elections.hpp>
+#include <nano/node/block_rebroadcaster.hpp>
 #include <nano/node/cementing_set.hpp>
 #include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
@@ -526,8 +527,23 @@ void nano::active_elections::tick_elections (nano::unique_lock<nano::mutex> & lo
 
 	for (auto const & election : election_list)
 	{
-		bool tick_result = election->tick (solicitor);
-		if (tick_result)
+		auto const actions = election->tick (now);
+
+		if (auto const & snapshot = actions.snapshot)
+		{
+			if (actions.broadcast && solicitor.broadcast (*snapshot))
+			{
+				election->broadcast_sent (snapshot->winner->hash ());
+
+				// Random flood for block propagation
+				node.block_rebroadcaster.push (snapshot->winner);
+			}
+			if (actions.request && solicitor.add (*snapshot))
+			{
+				election->request_sent ();
+			}
+		}
+		if (actions.cleanup)
 		{
 			erase (election->qualified_root);
 		}

--- a/nano/node/confirmation_solicitor.cpp
+++ b/nano/node/confirmation_solicitor.cpp
@@ -29,54 +29,53 @@ void nano::confirmation_solicitor::prepare (std::vector<nano::representative> co
 	prepared = true;
 }
 
-bool nano::confirmation_solicitor::broadcast (nano::election const & election_a)
+bool nano::confirmation_solicitor::broadcast (nano::election_snapshot const & election_a)
 {
 	debug_assert (prepared);
-	bool error (true);
-	if (rebroadcasted++ < max_block_broadcasts)
+	if (rebroadcasted++ >= max_block_broadcasts)
 	{
-		auto const & hash (election_a.status.winner->hash ());
-		nano::messages::publish winner{ config.network_params.network, election_a.status.winner };
-		unsigned count = 0;
-		// Directed broadcasting to principal representatives
-		for (auto i (representatives_broadcasts.begin ()), n (representatives_broadcasts.end ()); i != n && count < max_election_broadcasts; ++i)
-		{
-			auto existing (election_a.last_votes.find (i->account));
-			bool const exists (existing != election_a.last_votes.end ());
-			bool const different (exists && existing->second.hash != hash);
-			if (!exists || different)
-			{
-				i->channel->send (winner, nano::transport::traffic_type::block_broadcast);
-				count += different ? 0 : 1;
-			}
-		}
-		error = false;
+		return false;
 	}
-	return error;
+	auto const & hash (election_a.winner->hash ());
+	nano::messages::publish winner{ config.network_params.network, election_a.winner };
+	unsigned count = 0;
+	// Directed broadcasting to principal representatives
+	for (auto i (representatives_broadcasts.begin ()), n (representatives_broadcasts.end ()); i != n && count < max_election_broadcasts; ++i)
+	{
+		auto existing (election_a.votes.find (i->account));
+		bool const exists (existing != election_a.votes.end ());
+		bool const different (exists && existing->second.hash != hash);
+		if (!exists || different)
+		{
+			i->channel->send (winner, nano::transport::traffic_type::block_broadcast);
+			count += different ? 0 : 1;
+		}
+	}
+	return true;
 }
 
-bool nano::confirmation_solicitor::add (nano::election const & election_a)
+bool nano::confirmation_solicitor::add (nano::election_snapshot const & election_a)
 {
 	debug_assert (prepared);
-	bool error (true);
+	bool added (false);
 	unsigned count = 0;
-	auto const & hash (election_a.status.winner->hash ());
+	auto const & hash (election_a.winner->hash ());
 	for (auto i (representatives_requests.begin ()); i != representatives_requests.end () && count < max_election_requests;)
 	{
 		bool full_queue (false);
 		auto rep (*i);
-		auto existing (election_a.last_votes.find (rep.account));
-		bool const exists (existing != election_a.last_votes.end ());
-		bool const is_final (exists && (!election_a.is_quorum.load () || existing->second.timestamp == std::numeric_limits<uint64_t>::max ()));
+		auto existing (election_a.votes.find (rep.account));
+		bool const exists (existing != election_a.votes.end ());
+		bool const is_final (exists && (!election_a.quorum || existing->second.timestamp == std::numeric_limits<uint64_t>::max ()));
 		bool const different (exists && existing->second.hash != hash);
 		if (!exists || !is_final || different)
 		{
 			if (!rep.channel->max (nano::transport::traffic_type::confirmation_requests))
 			{
 				auto & request_queue (requests[rep.channel]);
-				request_queue.emplace_back (election_a.status.winner->hash (), election_a.status.winner->root ());
+				request_queue.emplace_back (hash, election_a.qualified_root.root ());
 				count += different ? 0 : 1;
-				error = false;
+				added = true;
 			}
 			else
 			{
@@ -85,7 +84,7 @@ bool nano::confirmation_solicitor::add (nano::election const & election_a)
 		}
 		i = !full_queue ? i + 1 : representatives_requests.erase (i);
 	}
-	return error;
+	return added;
 }
 
 void nano::confirmation_solicitor::flush ()

--- a/nano/node/confirmation_solicitor.hpp
+++ b/nano/node/confirmation_solicitor.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <nano/node/election.hpp>
+#include <nano/node/fwd.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/repcrawler.hpp>
 
@@ -7,9 +9,6 @@
 
 namespace nano
 {
-class election;
-class node;
-class node_config;
 /** This class accepts elections that need further votes before they can be confirmed and bundles them in to single confirm_req packets */
 class confirmation_solicitor final
 {
@@ -17,10 +16,10 @@ public:
 	confirmation_solicitor (nano::network &, nano::node_config const &);
 	/** Prepare object for batching election confirmation requests*/
 	void prepare (std::vector<nano::representative> const &);
-	/** Broadcast the winner of an election if the broadcast limit has not been reached. Returns false if the broadcast was performed */
-	bool broadcast (nano::election const &);
-	/** Add an election that needs to be confirmed. Returns false if successfully added */
-	bool add (nano::election const &);
+	/** Broadcast the winner of an election if the broadcast limit has not been reached. Returns true if the broadcast was performed */
+	bool broadcast (nano::election_snapshot const &);
+	/** Add an election that needs to be confirmed. Returns true if any confirmation request was queued */
+	bool add (nano::election_snapshot const &);
 	/** Dispatch bundled requests to each channel*/
 	void flush ();
 	/** Global maximum amount of block broadcasts */

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -206,11 +206,12 @@ bool nano::election::transition_priority ()
 		return false;
 	}
 
+	auto const previous_behavior = behavior_m;
 	behavior_m = nano::election_behavior::priority;
 	pacing.reset_vote (); // Allow new outgoing votes immediately
 
 	node.logger.debug (nano::log::type::election, "Transitioned election behavior to priority from {} for root: {} (duration: {}ms)",
-	to_string (behavior_m),
+	to_string (previous_behavior),
 	qualified_root,
 	duration ().count ());
 

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -35,6 +35,11 @@ nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> cons
 	vote_action (std::move (vote_action_a)),
 	update_action (std::move (update_action_a)),
 	node (node_a),
+	pacing ({
+	.base_latency = base_latency (),
+	.vote_interval = node_a.config.network_params.network.vote_broadcast_interval,
+	.block_interval = node_a.config.network_params.network.block_broadcast_interval,
+	}),
 	behavior_m (election_behavior_a),
 	status (block_a),
 	height (block_a->sideband ().height),
@@ -176,30 +181,15 @@ bool nano::election::state_change (nano::election_state expected_a, nano::electi
 	return result;
 }
 
-std::chrono::milliseconds nano::election::confirm_req_time () const
-{
-	switch (behavior_m)
-	{
-		case election_behavior::manual:
-		case election_behavior::priority:
-		case election_behavior::hinted:
-			return base_latency () * 5;
-		case election_behavior::optimistic:
-			return base_latency () * 2;
-	}
-	debug_assert (false);
-	return {};
-}
-
 void nano::election::send_confirm_req (nano::confirmation_solicitor & solicitor_a)
 {
 	debug_assert (!mutex.try_lock ());
 
-	if (confirm_req_time () < (std::chrono::steady_clock::now () - last_req))
+	if (pacing.due_request (behavior_m, std::chrono::steady_clock::now ()))
 	{
 		if (!solicitor_a.add (*this))
 		{
-			last_req = std::chrono::steady_clock::now ();
+			pacing.request_sent (std::chrono::steady_clock::now ());
 			++confirmation_request_count;
 
 			node.stats.inc (nano::stat::type::election, nano::stat::detail::confirmation_request);
@@ -225,7 +215,7 @@ bool nano::election::transition_priority ()
 	}
 
 	behavior_m = nano::election_behavior::priority;
-	last_vote = std::chrono::steady_clock::time_point{}; // allow new outgoing votes immediately
+	pacing.reset_vote (); // Allow new outgoing votes immediately
 
 	node.logger.debug (nano::log::type::election, "Transitioned election behavior to priority from {} for root: {} (duration: {}ms)",
 	to_string (behavior_m),
@@ -272,35 +262,18 @@ bool nano::election::failed () const
 	return state_m == nano::election_state::expired_unconfirmed;
 }
 
-bool nano::election::broadcast_block_predicate () const
-{
-	debug_assert (!mutex.try_lock ());
-
-	// Broadcast the block if enough time has passed since the last broadcast (or it's the first broadcast)
-	if (last_block + node.config.network_params.network.block_broadcast_interval < std::chrono::steady_clock::now ())
-	{
-		return true;
-	}
-	// Or the current election winner has changed
-	if (status.winner->hash () != last_block_hash)
-	{
-		return true;
-	}
-	return false;
-}
-
 void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a)
 {
 	debug_assert (!mutex.try_lock ());
 
-	if (broadcast_block_predicate ())
+	if (pacing.due_block (status.winner->hash (), std::chrono::steady_clock::now ()))
 	{
 		if (!solicitor_a.broadcast (*this))
 		{
-			last_block = std::chrono::steady_clock::now ();
-			last_block_hash = status.winner->hash ();
+			bool const initial = pacing.is_first_block ();
+			pacing.block_sent (status.winner->hash (), std::chrono::steady_clock::now ());
 
-			node.stats.inc (nano::stat::type::election, last_block_hash.is_zero () ? nano::stat::detail::broadcast_block_initial : nano::stat::detail::broadcast_block_repeat);
+			node.stats.inc (nano::stat::type::election, initial ? nano::stat::detail::broadcast_block_initial : nano::stat::detail::broadcast_block_repeat);
 
 			node.logger.debug (nano::log::type::election, "Broadcasted current winner: {} for root: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms)",
 			status.winner->hash (),
@@ -699,11 +672,12 @@ void nano::election::broadcast_vote_locked (nano::unique_lock<nano::mutex> & loc
 {
 	debug_assert (lock.owns_lock ());
 
-	if (std::chrono::steady_clock::now () < last_vote + node.config.network_params.network.vote_broadcast_interval)
+	auto const now = std::chrono::steady_clock::now ();
+	if (!pacing.due_vote (now))
 	{
 		return;
 	}
-	last_vote = std::chrono::steady_clock::now ();
+	pacing.vote_sent (now);
 
 	if (node.config.enable_voting && node.wallets.reps ().voting > 0)
 	{

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -468,7 +468,7 @@ void nano::election::confirm_if_quorum (nano::unique_lock<nano::mutex> & lock_a)
 	}
 	if (have_quorum (tally_l))
 	{
-		if (!is_quorum.exchange (true) && node.config.enable_voting && node.wallets.reps ().voting > 0)
+		if (!is_quorum.exchange (true) && node.is_voting ())
 		{
 			++vote_broadcast_count;
 			node.vote_generator.vote_final (qualified_root, status.winner->hash (), bucket);
@@ -671,16 +671,15 @@ void nano::election::broadcast_vote_locked (std::chrono::steady_clock::time_poin
 {
 	debug_assert (!mutex.try_lock ());
 
+	if (!node.is_voting ())
+	{
+		return;
+	}
 	if (!pacing.due_vote (now))
 	{
 		return;
 	}
 	pacing.vote_sent (now);
-
-	if (!node.config.enable_voting || node.wallets.reps ().voting == 0)
-	{
-		return;
-	}
 
 	// Broadcast a final vote if reached quorum or already confirmed
 	bool const is_final = confirmed_locked () || have_quorum (tally_impl ());
@@ -701,7 +700,7 @@ void nano::election::broadcast_vote_locked (std::chrono::steady_clock::time_poin
 void nano::election::remove_votes (nano::block_hash const & hash_a)
 {
 	debug_assert (!mutex.try_lock ());
-	if (node.config.enable_voting && node.wallets.reps ().voting > 0)
+	if (node.is_voting ())
 	{
 		// Remove votes from election
 		auto list_generated_votes (node.history.votes (root, hash_a));

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -4,9 +4,7 @@
 #include <nano/lib/vote.hpp>
 #include <nano/node/active_elections.hpp>
 #include <nano/node/block_processor.hpp>
-#include <nano/node/block_rebroadcaster.hpp>
 #include <nano/node/cementing_set.hpp>
-#include <nano/node/confirmation_solicitor.hpp>
 #include <nano/node/election.hpp>
 #include <nano/node/local_vote_history.hpp>
 #include <nano/node/network.hpp>
@@ -181,28 +179,22 @@ bool nano::election::state_change (nano::election_state expected_a, nano::electi
 	return result;
 }
 
-void nano::election::send_confirm_req (nano::confirmation_solicitor & solicitor_a)
+void nano::election::request_sent ()
 {
-	debug_assert (!mutex.try_lock ());
+	nano::lock_guard<nano::mutex> guard{ mutex };
 
-	if (pacing.due_request (behavior_m, std::chrono::steady_clock::now ()))
-	{
-		if (solicitor_a.add (snapshot_locked ()))
-		{
-			pacing.request_sent (std::chrono::steady_clock::now ());
-			++confirmation_request_count;
+	pacing.request_sent (std::chrono::steady_clock::now ());
+	++confirmation_request_count;
 
-			node.stats.inc (nano::stat::type::election, nano::stat::detail::confirmation_request);
-			node.logger.debug (nano::log::type::election, "Sent confirmation request for root: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms, confirmation requests: {})",
-			qualified_root,
-			to_string (behavior_m),
-			to_string (state_m),
-			status.voter_count,
-			status.block_count,
-			duration ().count (),
-			confirmation_request_count.load ());
-		}
-	}
+	node.stats.inc (nano::stat::type::election, nano::stat::detail::confirmation_request);
+	node.logger.debug (nano::log::type::election, "Sent confirmation request for root: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms, confirmation requests: {})",
+	qualified_root,
+	to_string (behavior_m),
+	to_string (state_m),
+	status.voter_count,
+	status.block_count,
+	duration ().count (),
+	confirmation_request_count.load ());
 }
 
 bool nano::election::transition_priority ()
@@ -262,38 +254,23 @@ bool nano::election::failed () const
 	return state_m == nano::election_state::expired_unconfirmed;
 }
 
-void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a)
+void nano::election::broadcast_sent (nano::block_hash const & winner)
 {
-	debug_assert (!mutex.try_lock ());
+	nano::lock_guard<nano::mutex> guard{ mutex };
 
-	if (pacing.due_block (status.winner->hash (), std::chrono::steady_clock::now ()))
-	{
-		if (solicitor_a.broadcast (snapshot_locked ()))
-		{
-			bool const initial = pacing.is_first_block ();
-			pacing.block_sent (status.winner->hash (), std::chrono::steady_clock::now ());
+	bool const initial = pacing.is_first_block ();
+	pacing.block_sent (winner, std::chrono::steady_clock::now ());
 
-			node.stats.inc (nano::stat::type::election, initial ? nano::stat::detail::broadcast_block_initial : nano::stat::detail::broadcast_block_repeat);
+	node.stats.inc (nano::stat::type::election, initial ? nano::stat::detail::broadcast_block_initial : nano::stat::detail::broadcast_block_repeat);
 
-			node.logger.debug (nano::log::type::election, "Broadcasted current winner: {} for root: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms)",
-			status.winner->hash (),
-			qualified_root,
-			to_string (behavior_m),
-			to_string (state_m),
-			status.voter_count,
-			status.block_count,
-			duration ().count ());
-
-			// Random flood for block propagation
-			node.block_rebroadcaster.push (status.winner);
-		}
-	}
-}
-
-void nano::election::broadcast_vote ()
-{
-	nano::unique_lock<nano::mutex> lock{ mutex };
-	broadcast_vote_locked (lock);
+	node.logger.debug (nano::log::type::election, "Broadcasted current winner: {} for root: {} (behavior: {}, state: {}, voters: {}, blocks: {}, duration: {}ms)",
+	winner,
+	qualified_root,
+	to_string (behavior_m),
+	to_string (state_m),
+	status.voter_count,
+	status.block_count,
+	duration ().count ());
 }
 
 nano::vote_info nano::election::get_last_vote (nano::account const & account)
@@ -314,26 +291,34 @@ nano::election_status nano::election::get_status () const
 	return status;
 }
 
-bool nano::election::tick (nano::confirmation_solicitor & solicitor)
+nano::election_actions nano::election::tick (std::chrono::steady_clock::time_point now)
 {
 	nano::unique_lock<nano::mutex> lock{ mutex };
-	bool result = false;
+	nano::election_actions actions;
 	switch (state_m)
 	{
 		case nano::election_state::passive:
-			if (base_latency () * passive_duration_factor < std::chrono::steady_clock::now () - state_start)
+			if (base_latency () * passive_duration_factor < now - state_start)
 			{
 				state_change (nano::election_state::passive, nano::election_state::active);
 			}
 			break;
 		case nano::election_state::active:
-			broadcast_vote_locked (lock);
-			broadcast_block (solicitor);
-			send_confirm_req (solicitor);
+			broadcast_vote_locked (now);
+			actions.broadcast = pacing.due_block (status.winner->hash (), now);
+			actions.request = pacing.due_request (behavior_m, now);
+			if (actions.broadcast || actions.request)
+			{
+				actions.snapshot = snapshot_locked ();
+			}
 			break;
 		case nano::election_state::confirmed:
-			result = true; // Return true to indicate this election should be cleaned up
-			broadcast_block (solicitor); // Ensure election winner is broadcasted
+			actions.cleanup = true; // Election is done and should be cleaned up
+			if (pacing.due_block (status.winner->hash (), now))
+			{
+				actions.broadcast = true; // Ensure election winner is broadcasted
+				actions.snapshot = snapshot_locked ();
+			}
 			state_change (nano::election_state::confirmed, nano::election_state::expired_confirmed);
 			break;
 		case nano::election_state::expired_unconfirmed:
@@ -341,10 +326,11 @@ bool nano::election::tick (nano::confirmation_solicitor & solicitor)
 			debug_assert (false);
 			break;
 		case nano::election_state::cancelled:
-			return true; // Clean up cancelled elections immediately
+			actions.cleanup = true; // Clean up cancelled elections immediately
+			return actions;
 	}
 
-	if (!confirmed_locked () && time_to_live () < std::chrono::steady_clock::now () - election_start)
+	if (!confirmed_locked () && time_to_live () < now - election_start)
 	{
 		// It is possible the election confirmed while acquiring the mutex
 		// state_change returning true would indicate it
@@ -355,12 +341,12 @@ bool nano::election::tick (nano::confirmation_solicitor & solicitor)
 			nano::log::arg{ "qualified_root", qualified_root },
 			nano::log::arg{ "status", current_status_locked () });
 
-			result = true; // Return true to indicate this election should be cleaned up
+			actions.cleanup = true; // Election expired and should be cleaned up
 			status.type = nano::election_status_type::stopped;
 		}
 	}
 
-	return result;
+	return actions;
 }
 
 std::chrono::milliseconds nano::election::time_to_live () const
@@ -674,45 +660,41 @@ std::chrono::milliseconds nano::election::duration () const
 	return std::chrono::duration_cast<std::chrono::milliseconds> (std::chrono::steady_clock::now () - election_start);
 }
 
-void nano::election::broadcast_vote_locked (nano::unique_lock<nano::mutex> & lock)
+void nano::election::broadcast_vote ()
 {
-	debug_assert (lock.owns_lock ());
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	broadcast_vote_locked (std::chrono::steady_clock::now ());
+}
 
-	auto const now = std::chrono::steady_clock::now ();
+void nano::election::broadcast_vote_locked (std::chrono::steady_clock::time_point now)
+{
+	debug_assert (!mutex.try_lock ());
+
 	if (!pacing.due_vote (now))
 	{
 		return;
 	}
 	pacing.vote_sent (now);
 
-	if (node.config.enable_voting && node.wallets.reps ().voting > 0)
+	if (!node.config.enable_voting || node.wallets.reps ().voting == 0)
 	{
-		node.stats.inc (nano::stat::type::election, nano::stat::detail::broadcast_vote);
-		++vote_broadcast_count;
-
-		if (confirmed_locked () || have_quorum (tally_impl ()))
-		{
-			node.stats.inc (nano::stat::type::election, nano::stat::detail::broadcast_vote_final);
-			node.logger.trace (nano::log::type::election, nano::log::detail::broadcast_vote,
-			nano::log::arg{ "id", id },
-			nano::log::arg{ "qualified_root", qualified_root },
-			nano::log::arg{ "winner", status.winner },
-			nano::log::arg{ "type", "final" });
-
-			node.vote_generator.vote_final (qualified_root, status.winner->hash (), bucket);
-		}
-		else
-		{
-			node.stats.inc (nano::stat::type::election, nano::stat::detail::broadcast_vote_normal);
-			node.logger.trace (nano::log::type::election, nano::log::detail::broadcast_vote,
-			nano::log::arg{ "id", id },
-			nano::log::arg{ "qualified_root", qualified_root },
-			nano::log::arg{ "winner", status.winner },
-			nano::log::arg{ "type", "normal" });
-
-			node.vote_generator.vote_normal (qualified_root, status.winner->hash (), bucket);
-		}
+		return;
 	}
+
+	// Broadcast a final vote if reached quorum or already confirmed
+	bool const is_final = confirmed_locked () || have_quorum (tally_impl ());
+
+	node.stats.inc (nano::stat::type::election, nano::stat::detail::broadcast_vote);
+	node.stats.inc (nano::stat::type::election, is_final ? nano::stat::detail::broadcast_vote_final : nano::stat::detail::broadcast_vote_normal);
+	++vote_broadcast_count;
+
+	node.logger.trace (nano::log::type::election, nano::log::detail::broadcast_vote,
+	nano::log::arg{ "id", id },
+	nano::log::arg{ "qualified_root", qualified_root },
+	nano::log::arg{ "winner", status.winner },
+	nano::log::arg{ "type", is_final ? "final" : "normal" });
+
+	node.vote_generator.vote (qualified_root, status.winner->hash (), bucket, is_final ? nano::vote_type::final : nano::vote_type::normal);
 }
 
 void nano::election::remove_votes (nano::block_hash const & hash_a)

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -187,7 +187,7 @@ void nano::election::send_confirm_req (nano::confirmation_solicitor & solicitor_
 
 	if (pacing.due_request (behavior_m, std::chrono::steady_clock::now ()))
 	{
-		if (!solicitor_a.add (*this))
+		if (solicitor_a.add (snapshot_locked ()))
 		{
 			pacing.request_sent (std::chrono::steady_clock::now ());
 			++confirmation_request_count;
@@ -268,7 +268,7 @@ void nano::election::broadcast_block (nano::confirmation_solicitor & solicitor_a
 
 	if (pacing.due_block (status.winner->hash (), std::chrono::steady_clock::now ()))
 	{
-		if (!solicitor_a.broadcast (*this))
+		if (solicitor_a.broadcast (snapshot_locked ()))
 		{
 			bool const initial = pacing.is_first_block ();
 			pacing.block_sent (status.winner->hash (), std::chrono::steady_clock::now ());
@@ -637,6 +637,12 @@ bool nano::election::publish (std::shared_ptr<nano::block> const & block_a)
 	3) given block in already in election & election contains less than 10 blocks (replacing block content with new)
 	*/
 	return result;
+}
+
+nano::election_snapshot nano::election::snapshot_locked () const
+{
+	debug_assert (!mutex.try_lock ());
+	return { qualified_root, status.winner, is_quorum.load (), last_votes };
 }
 
 nano::election_extended_status nano::election::current_status () const

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -5,6 +5,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/numbers_templ.hpp>
 #include <nano/lib/stats_enums.hpp>
+#include <nano/node/election_pacing.hpp>
 #include <nano/node/election_status.hpp>
 #include <nano/node/vote_with_weight_info.hpp>
 #include <nano/secure/common.hpp>
@@ -81,13 +82,6 @@ private: // State management
 
 	std::chrono::steady_clock::time_point state_start{ std::chrono::steady_clock::now () };
 
-	// These are modified while not holding the mutex from transition_time only
-	std::chrono::steady_clock::time_point last_block{};
-	nano::block_hash last_block_hash{ 0 };
-	std::chrono::steady_clock::time_point last_req{};
-	/** The last time vote for this election was generated */
-	std::chrono::steady_clock::time_point last_vote{};
-
 	bool valid_change (nano::election_state, nano::election_state) const;
 	bool state_change (nano::election_state, nano::election_state);
 
@@ -158,6 +152,10 @@ public: // Interface
 private: // Dependencies
 	nano::node & node;
 
+private:
+	// Paces outbound votes, winner block broadcasts and confirmation requests
+	nano::election_pacing pacing;
+
 public: // Information
 	uint64_t const height;
 	nano::root const root;
@@ -183,7 +181,6 @@ private:
 	nano::election_extended_status current_status_locked () const;
 	// lock_a does not own the mutex on return
 	void confirm_once (nano::unique_lock<nano::mutex> & lock_a);
-	bool broadcast_block_predicate () const;
 	void broadcast_block (nano::confirmation_solicitor &);
 	void send_confirm_req (nano::confirmation_solicitor &);
 	/**
@@ -199,10 +196,6 @@ private:
 	 * Calculates minimum time delay between subsequent votes when processing non-final votes
 	 */
 	std::chrono::seconds cooldown_time (nano::uint128_t weight) const;
-	/**
-	 * Calculates time delay between broadcasting confirmation requests
-	 */
-	std::chrono::milliseconds confirm_req_time () const;
 
 private:
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> last_blocks;

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -39,6 +39,15 @@ public:
 // map of vote weight per block, ordered greater first
 using tally_t = std::map<nano::uint128_t, std::shared_ptr<nano::block>, std::greater<nano::uint128_t>>;
 
+/** Point-in-time view of election state needed to solicit votes and broadcast the winner */
+struct election_snapshot final
+{
+	nano::qualified_root qualified_root;
+	std::shared_ptr<nano::block> winner;
+	bool quorum; // Vote quorum was reached, only final votes are of interest
+	std::unordered_map<nano::account, nano::vote_info> votes;
+};
+
 struct election_extended_status final
 {
 	nano::election_status status;
@@ -177,6 +186,7 @@ public: // Information
 
 private:
 	nano::tally_t tally_impl () const;
+	nano::election_snapshot snapshot_locked () const;
 	bool confirmed_locked () const;
 	nano::election_extended_status current_status_locked () const;
 	// lock_a does not own the mutex on return
@@ -216,13 +226,10 @@ private: // Constants
 	static std::size_t constexpr max_blocks{ 10 };
 
 	friend class active_elections;
-	friend class confirmation_solicitor;
 
 public: // Only used in tests
 	void force_confirm ();
 
-	friend class confirmation_solicitor_different_hash_Test;
-	friend class confirmation_solicitor_bypass_max_requests_cap_Test;
 	friend class votes_add_existing_Test;
 	friend class votes_add_old_Test;
 };

--- a/nano/node/election.hpp
+++ b/nano/node/election.hpp
@@ -7,6 +7,7 @@
 #include <nano/lib/stats_enums.hpp>
 #include <nano/node/election_pacing.hpp>
 #include <nano/node/election_status.hpp>
+#include <nano/node/fwd.hpp>
 #include <nano/node/vote_with_weight_info.hpp>
 #include <nano/secure/common.hpp>
 
@@ -14,20 +15,12 @@
 #include <chrono>
 #include <map>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
 namespace nano
 {
-class block;
-class channel;
-class confirmation_solicitor;
-enum class election_behavior;
-class inactive_cache_information;
-class node;
-enum class vote_code;
-enum class vote_source;
-
 class vote_info final
 {
 public:
@@ -46,6 +39,19 @@ struct election_snapshot final
 	std::shared_ptr<nano::block> winner;
 	bool quorum; // Vote quorum was reached, only final votes are of interest
 	std::unordered_map<nano::account, nano::vote_info> votes;
+};
+
+/** Outbound actions requested by an election when ticked, performed by the active elections loop */
+struct election_actions final
+{
+	// Snapshot of the election state, present whenever a broadcast or request is due
+	std::optional<nano::election_snapshot> snapshot;
+	// Broadcast the current winner block
+	bool broadcast{ false };
+	// Solicit votes from representatives
+	bool request{ false };
+	// Election is finished and should be erased from the active set
+	bool cleanup{ false };
 };
 
 struct election_extended_status final
@@ -86,7 +92,6 @@ private:
 
 private: // State management
 	static unsigned constexpr passive_duration_factor = 5;
-	static unsigned constexpr active_request_count_min = 2;
 	nano::election_state state_m{ election_state::passive };
 
 	std::chrono::steady_clock::time_point state_start{ std::chrono::steady_clock::now () };
@@ -95,8 +100,16 @@ private: // State management
 	bool state_change (nano::election_state, nano::election_state);
 
 public: // State transitions
-	// Returns true if the election should be cleaned up
-	bool tick (nano::confirmation_solicitor &);
+	// Advance the election state machine and return the outbound actions that are due
+	nano::election_actions tick (std::chrono::steady_clock::time_point now);
+
+	// Broadcast a vote for the current winner via the vote generator, if one is due
+	void broadcast_vote ();
+
+	// Record a successful confirmation request round
+	void request_sent ();
+	// Record a successful broadcast of the given winner block
+	void broadcast_sent (nano::block_hash const & winner);
 
 	bool transition_active ();
 	bool transition_priority ();
@@ -139,11 +152,6 @@ public: // Interface
 	void confirm_if_quorum (nano::unique_lock<nano::mutex> &);
 	void try_confirm (nano::block_hash const & hash);
 
-	/**
-	 * Broadcasts vote for the current winner of this election
-	 * Checks if sufficient amount of time (`vote_generation_interval`) passed since the last vote generation
-	 */
-	void broadcast_vote ();
 	nano::vote_info get_last_vote (nano::account const & account);
 	void set_last_vote (nano::account const & account, nano::vote_info vote_info);
 	nano::election_status get_status () const;
@@ -191,13 +199,8 @@ private:
 	nano::election_extended_status current_status_locked () const;
 	// lock_a does not own the mutex on return
 	void confirm_once (nano::unique_lock<nano::mutex> & lock_a);
-	void broadcast_block (nano::confirmation_solicitor &);
-	void send_confirm_req (nano::confirmation_solicitor &);
-	/**
-	 * Broadcast vote for current election winner. Generates final vote if reached quorum or already confirmed
-	 * Requires mutex lock
-	 */
-	void broadcast_vote_locked (nano::unique_lock<nano::mutex> & lock);
+	// Broadcast a vote for the current winner if due, final if reached quorum or already confirmed
+	void broadcast_vote_locked (std::chrono::steady_clock::time_point now);
 	void remove_votes (nano::block_hash const &);
 	void remove_block (nano::block_hash const &);
 	bool replace_by_weight (nano::unique_lock<nano::mutex> & lock_a, nano::block_hash const &);
@@ -224,8 +227,6 @@ public: // Logging
 
 private: // Constants
 	static std::size_t constexpr max_blocks{ 10 };
-
-	friend class active_elections;
 
 public: // Only used in tests
 	void force_confirm ();

--- a/nano/node/election_pacing.cpp
+++ b/nano/node/election_pacing.cpp
@@ -1,0 +1,72 @@
+#include <nano/lib/assert.hpp>
+#include <nano/node/election_behavior.hpp>
+#include <nano/node/election_pacing.hpp>
+
+nano::election_pacing::election_pacing (nano::election_pacing_params params_a) :
+	params{ params_a }
+{
+}
+
+bool nano::election_pacing::due_vote (std::chrono::steady_clock::time_point now) const
+{
+	return !last_vote || now >= *last_vote + params.vote_interval;
+}
+
+void nano::election_pacing::vote_sent (std::chrono::steady_clock::time_point now)
+{
+	last_vote = now;
+}
+
+void nano::election_pacing::reset_vote ()
+{
+	last_vote.reset ();
+}
+
+bool nano::election_pacing::due_block (nano::block_hash const & winner, std::chrono::steady_clock::time_point now) const
+{
+	if (!last_block || *last_block + params.block_interval < now)
+	{
+		return true;
+	}
+	if (winner != last_block_hash)
+	{
+		return true;
+	}
+	return false;
+}
+
+void nano::election_pacing::block_sent (nano::block_hash const & winner, std::chrono::steady_clock::time_point now)
+{
+	last_block = now;
+	last_block_hash = winner;
+}
+
+bool nano::election_pacing::is_first_block () const
+{
+	return !last_block.has_value ();
+}
+
+bool nano::election_pacing::due_request (nano::election_behavior behavior, std::chrono::steady_clock::time_point now) const
+{
+	return !last_request || request_interval (behavior) < now - *last_request;
+}
+
+void nano::election_pacing::request_sent (std::chrono::steady_clock::time_point now)
+{
+	last_request = now;
+}
+
+std::chrono::milliseconds nano::election_pacing::request_interval (nano::election_behavior behavior) const
+{
+	switch (behavior)
+	{
+		case nano::election_behavior::manual:
+		case nano::election_behavior::priority:
+		case nano::election_behavior::hinted:
+			return params.base_latency * 5;
+		case nano::election_behavior::optimistic:
+			return params.base_latency * 2;
+	}
+	debug_assert (false);
+	return {};
+}

--- a/nano/node/election_pacing.hpp
+++ b/nano/node/election_pacing.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+#include <nano/node/fwd.hpp>
+
+#include <chrono>
+#include <optional>
+
+namespace nano
+{
+struct election_pacing_params
+{
+	std::chrono::milliseconds base_latency;
+	std::chrono::milliseconds vote_interval;
+	std::chrono::milliseconds block_interval;
+};
+
+/**
+ * Paces outbound election activity: vote broadcasts, winner block broadcasts and confirmation requests.
+ * Pure logic with injected time, guarded externally by the owning election's mutex.
+ */
+class election_pacing final
+{
+public:
+	explicit election_pacing (nano::election_pacing_params params);
+
+	// Vote broadcast is due when the vote interval elapsed since the last one (or none was sent yet)
+	bool due_vote (std::chrono::steady_clock::time_point now) const;
+	void vote_sent (std::chrono::steady_clock::time_point now);
+	// Allow the next vote broadcast immediately
+	void reset_vote ();
+
+	// Winner block broadcast is due when the block interval elapsed or the winner changed
+	bool due_block (nano::block_hash const & winner, std::chrono::steady_clock::time_point now) const;
+	void block_sent (nano::block_hash const & winner, std::chrono::steady_clock::time_point now);
+	// True until the first block broadcast is recorded
+	bool is_first_block () const;
+
+	// Confirmation request is due when the behavior-dependent request interval elapsed
+	bool due_request (nano::election_behavior, std::chrono::steady_clock::time_point now) const;
+	void request_sent (std::chrono::steady_clock::time_point now);
+
+	// Time between confirmation requests for the given election behavior
+	std::chrono::milliseconds request_interval (nano::election_behavior) const;
+
+private:
+	nano::election_pacing_params const params;
+
+	std::optional<std::chrono::steady_clock::time_point> last_vote;
+	std::optional<std::chrono::steady_clock::time_point> last_block;
+	std::optional<std::chrono::steady_clock::time_point> last_request;
+	nano::block_hash last_block_hash{ 0 };
+};
+}

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -30,6 +30,7 @@ class cementing_set;
 class cementing_set_config;
 class distributed_work_factory;
 class election;
+class election_pacing;
 class election_status;
 class epoch_upgrader;
 class fork_cache;

--- a/nano/node/message_processor.cpp
+++ b/nano/node/message_processor.cpp
@@ -220,8 +220,7 @@ public:
 	void confirm_req (nano::messages::confirm_req const & message) override
 	{
 		// Don't load nodes with disabled voting
-		// TODO: This check should be cached somewhere
-		if (node.config.enable_voting && node.wallets.reps ().voting > 0)
+		if (node.is_voting ())
 		{
 			if (!message.roots_hashes.empty ())
 			{

--- a/nano/node/node.cpp
+++ b/nano/node/node.cpp
@@ -848,6 +848,11 @@ bool nano::node::online () const
 	return rep_crawler.total_weight () > online_reps.delta ();
 }
 
+bool nano::node::is_voting () const
+{
+	return config.enable_voting && wallets.have_voting_reps ();
+}
+
 bool nano::node::warmed_up () const
 {
 	return std::chrono::steady_clock::now () - startup_time >= warmup_time;

--- a/nano/node/node.hpp
+++ b/nano/node/node.hpp
@@ -67,6 +67,9 @@ public:
 
 	bool online () const;
 
+	// Whether this node generates its own votes: voting enabled in config and wallets hold a voting-capable representative
+	bool is_voting () const;
+
 	nano::bootstrap_weights get_bootstrap_weights () const;
 
 	// Attempts to bootstrap block. This is the best effort, there is no guarantee that the block will be bootstrapped.

--- a/nano/node/wallet.cpp
+++ b/nano/node/wallet.cpp
@@ -1962,6 +1962,11 @@ wallet_representatives wallets::reps () const
 	return *representatives.lock ();
 }
 
+bool wallets::have_voting_reps () const
+{
+	return have_voting_reps_m.load (std::memory_order_relaxed);
+}
+
 auto wallets::signer () -> signer_t
 {
 	return [this] (auto const & callback) { foreach_representative (callback); };
@@ -1971,7 +1976,9 @@ bool wallets::check_rep (nano::account const & account)
 {
 	auto half_principal_weight = node.minimum_principal_weight () / 2;
 	auto representatives_locked = representatives.lock ();
-	return check_rep_impl (*representatives_locked, account, half_principal_weight);
+	auto result = check_rep_impl (*representatives_locked, account, half_principal_weight);
+	have_voting_reps_m.store (representatives_locked->voting > 0, std::memory_order_relaxed);
+	return result;
 }
 
 bool wallets::check_rep_impl (wallet_representatives & reps, nano::account const & account, nano::uint128_t const & half_principal_weight)
@@ -2028,6 +2035,8 @@ void wallets::refresh_rep_index ()
 		}
 		wallet->representatives.lock ()->swap (new_representatives);
 	}
+
+	have_voting_reps_m.store (reps_locked->voting > 0, std::memory_order_relaxed);
 }
 
 void wallets::foreach_representative (std::function<void (nano::public_key const & pub, nano::raw_key const & prv)> const & action)

--- a/nano/node/wallet.hpp
+++ b/nano/node/wallet.hpp
@@ -15,6 +15,7 @@
 #include <nano/wallet/wallet_value.hpp>
 #include <nano/wallet/wallets_backend.hpp>
 
+#include <atomic>
 #include <mutex>
 #include <optional>
 #include <thread>
@@ -337,6 +338,8 @@ public:
 	bool check_rep (nano::account const &);
 	void refresh_reps ();
 	wallet_representatives reps () const;
+	// Cached check whether any local wallet representative has voting weight
+	bool have_voting_reps () const;
 
 	/// Returns a signer that iterates over all representatives in the wallet
 	using signer_t = std::function<void (std::function<void (nano::public_key const &, nano::raw_key const &)> const &)>;
@@ -393,6 +396,7 @@ private:
 
 private:
 	mutable nano::locked<wallet_representatives> representatives;
+	std::atomic<bool> have_voting_reps_m{ false }; // True if any local representative has voting weight
 	nano::locked<std::vector<std::pair<nano::public_key, std::unique_ptr<nano::fan>>>> rep_keys_cache;
 
 	friend class wallet;


### PR DESCRIPTION
This PR restructures how elections perform outbound network activity (vote broadcasts, winner block broadcasts, confirmation requests): decisions stay inside the election, while batched execution moves to the active elections loop.

## Changes

- **Extract election broadcast pacing into `election_pacing`**: pure pacing logic (vote/block/request intervals) with injected time, guarded by the owning election's mutex, covered by unit tests.
- **Decouple `confirmation_solicitor` from election internals**: the solicitor now consumes a plain `election_snapshot` (root, winner, quorum flag, votes) instead of reaching into `nano::election` via friend access.
- **Return outbound actions from election tick instead of performing them**: `election::tick` returns `election_actions` — a state snapshot plus `broadcast`/`request`/`cleanup` flags — executed by `active_elections::tick_elections`. The solicitor is per-round batch state (prepared rep list, global broadcast budget, per-channel request queues), so its actions can only be executed above individual elections; this also removes channel sends performed while holding the election mutex. Pacing commits (`broadcast_sent`/`request_sent`) happen only on successful solicitor handoff, so elections retry next round when caps are hit, same as before. Vote broadcasts intentionally stay inside the election: the vote generator is already an asynchronous sink, so all vote paths (tick, insert, quorum) call it directly and the tick loop remains the single executor of solicitor actions.
- **Fix transition_priority log to report the previous behavior**
- **Add cached `node::is_voting` check**: avoids locking the wallet representatives mutex on hot paths (message processing, vote decisions).

## Behavior notes

- `broadcast_block_initial`/`broadcast_block_repeat` stats now report correctly (previously "initial" could never trigger since the hash was checked after being assigned).
- Winner broadcasts record the hash that was actually sent; a winner change since the snapshot triggers an immediate rebroadcast on the next tick.

## Testing

- New `election_pacing` unit tests
- New election tick / vote broadcast tests
- `confirmation_solicitor` tests simplified to construct snapshots directly instead of fake elections

🤖 Generated with [Claude Code](https://claude.com/claude-code)
