### PR TITLE
Fixed missing cache hit reports

### DIFF
--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -44,6 +44,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       # LEAK compiles identically to ASAN, so they share namespace.
       SCCACHE_GHA_VERSION: linux-sanitizers-${{ matrix.SANITIZER.name == 'LEAK' && 'ASAN' || matrix.SANITIZER.name }}-${{ matrix.COMPILER }}
+      SCCACHE_IDLE_TIMEOUT: "0"
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
@@ -111,6 +112,7 @@ jobs:
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_VERSION: macos-sanitizers-${{ matrix.SANITIZER.name }}-${{ matrix.COMPILER }}
+      SCCACHE_IDLE_TIMEOUT: "0"
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -27,6 +27,7 @@ jobs:
       SCCACHE_GHA_VERSION: macos-${{ matrix.RELEASE }}
       # Only the develop branch populates the cache.
       SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/develop' && 'READ_WRITE' || 'READ_ONLY' }}
+      SCCACHE_IDLE_TIMEOUT: "0"
     runs-on: macos-14
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
@@ -90,6 +91,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_VERSION: linux-${{ matrix.COMPILER }}-${{ matrix.RELEASE }}
       SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/develop' && 'READ_WRITE' || 'READ_ONLY' }}
+      SCCACHE_IDLE_TIMEOUT: "0"
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout


### PR DESCRIPTION
Sccache is intermittently reporting 0% cache hits because the server timed out mid-job. Setting the idle timeout to "0" on the sanitizer and unit test jobs fixes this.