### PR TITLE
Cache submodules for faster checkout

### DIFF
--- a/.github/actions/checkout-submodules/action.yml
+++ b/.github/actions/checkout-submodules/action.yml
@@ -3,14 +3,14 @@ description: "Initialize submodules, restoring them from cache when possible"
 runs:
   using: "composite"
   steps:
-    # The gitlink SHAs recorded in the tree fully determine the recursive
-    # submodule state, so they make a precise cache key. .gitmodules is
-    # included to catch url/path changes that leave the SHAs untouched.
+    # Gitlink SHAs fully determine the recursive submodule state, so they
+    # make a precise cache key. .gitmodules catches url/path changes that
+    # leave the SHAs untouched.
     - name: Submodule cache key
       id: key
       shell: bash
       run: |
-        hash=$({ git ls-tree HEAD submodules/; cat .gitmodules; } | git hash-object --stdin)
+        hash=$({ git ls-tree -r HEAD | grep '^160000 '; cat .gitmodules; } | git hash-object --stdin)
         echo "hash=$hash" >> "$GITHUB_OUTPUT"
 
     - name: Restore submodules

--- a/.github/actions/checkout-submodules/action.yml
+++ b/.github/actions/checkout-submodules/action.yml
@@ -1,0 +1,38 @@
+name: "checkout-submodules"
+description: "Initialize submodules, restoring them from cache when possible"
+runs:
+  using: "composite"
+  steps:
+    # The gitlink SHAs recorded in the tree fully determine the recursive
+    # submodule state, so they make a precise cache key. .gitmodules is
+    # included to catch url/path changes that leave the SHAs untouched.
+    - name: Submodule cache key
+      id: key
+      shell: bash
+      run: |
+        hash=$({ git ls-tree HEAD submodules/; cat .gitmodules; } | git hash-object --stdin)
+        echo "hash=$hash" >> "$GITHUB_OUTPUT"
+
+    - name: Restore submodules
+      uses: actions/cache@v4
+      with:
+        path: |
+          submodules
+          .git/modules
+        key: submodules-${{ runner.os }}-${{ steps.key.outputs.hash }}
+        # An outdated cache is still worth restoring: the update below only
+        # has to fetch whichever submodules actually moved.
+        restore-keys: |
+          submodules-${{ runner.os }}-
+
+    # Always run, so a missing, partial or outdated cache is repaired rather
+    # than trusted. On an exact hit this is a local no-op.
+    #
+    # A restored cache carries its own remote urls in .git/modules, which
+    # `update` fetches from, so sync them back from .gitmodules first. --force
+    # discards any modifications a previous job left in a cached worktree.
+    - name: Update submodules
+      shell: bash
+      run: |
+        git submodule sync --recursive
+        git submodule update --init --force --recursive --depth=1 --jobs 8

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -53,9 +53,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: "recursive"
           ref: ${{ needs.prepare_build.outputs.ci_tag }}
           repository: ${{ github.repository }}
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Prepare
         run: ci/prepare/macos/prepare.sh
@@ -90,9 +92,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: "recursive"
           ref: ${{ needs.prepare_build.outputs.ci_tag }}
           repository: ${{ github.repository }}
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Prepare
         run: sudo -E ci/prepare/linux/prepare.sh
@@ -133,9 +137,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: "recursive"
           ref: ${{ needs.prepare_build.outputs.ci_tag }}
           repository: ${{ github.repository }}
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk-space
@@ -173,9 +179,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: "recursive"
           ref: ${{ needs.prepare_build.outputs.ci_tag }}
           repository: ${{ github.repository }}
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Prepare
         run: ci/prepare/windows/prepare.ps1

--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -48,8 +48,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Prepare
         run: sudo -E ci/prepare/linux/prepare.sh
@@ -115,8 +116,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Prepare
         run: ci/prepare/macos/prepare.sh

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,8 +33,8 @@ jobs:
     timeout-minutes: 220
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
       - name: Fetch Deps
         run: |
           sudo apt-get update -qq

--- a/.github/workflows/flamegraphs.yml
+++ b/.github/workflows/flamegraphs.yml
@@ -28,8 +28,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Prepare
         run: sudo -E ci/prepare/linux/prepare.sh

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -32,8 +32,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Prepare
         run: ci/prepare/macos/prepare.sh
@@ -94,8 +95,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Prepare
         run: sudo -E ci/prepare/linux/prepare.sh
@@ -154,8 +156,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Prepare
         run: ci/prepare/windows/prepare.ps1
@@ -197,8 +200,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk-space
@@ -226,8 +230,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: "recursive"
+
+      - name: Checkout Submodules
+        uses: ./.github/actions/checkout-submodules
 
       - name: Free Disk Space
         uses: ./.github/actions/free-disk-space


### PR DESCRIPTION
Adds a checkout-submodules action that caches submodules/ and .git/modules, keyed on the gitlink SHAs (git ls-tree HEAD submodules/) and .gitmodules. Replaces actions/checkout's submodules.

On a cache hit, only submodules that actually changed get fetched; everything else restores from cache. 
`git submodule sync && update --init --force --recursive` always runs afterward to repair partial/stale/missing caches.