### PR TITLE
CI: Cache Windows builds

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -152,6 +152,15 @@ jobs:
       BUILD_TYPE: ${{ matrix.RELEASE && 'RelWithDebInfo' || 'Debug' }}
       TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}
       DEADLINE_SCALE_FACTOR: ${{ matrix.BACKEND == 'rocksdb' && '2' || '1' }}
+      # VS generator ignores compiler launchers; use Ninja to cache.
+      CMAKE_GENERATOR: Ninja
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
+      SCCACHE_GHA_ENABLED: "true"
+      # Backends compile identically; share a namespace.
+      SCCACHE_GHA_VERSION: windows-${{ matrix.RELEASE }}
+      SCCACHE_IDLE_TIMEOUT: "0"
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/develop' && 'READ_WRITE' || 'READ_ONLY' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
@@ -162,10 +171,21 @@ jobs:
       - name: Prepare
         run: ci/prepare/windows/prepare.ps1
 
+      # Ninja needs cl.exe on PATH.
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Build Tests
         id: build
         run: ci/build-tests.sh
         shell: bash
+
+      - name: Build cache stats
+        if: always()
+        run: sccache --show-stats
 
       - name: Setup Core Dumps
         if: steps.build.outcome == 'success' && (success() || failure())

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,22 @@ if(MSVC)
   add_definitions(/MP)
   add_definitions(
     -D_SILENCE_STDEXT_ARR_ITERS_DEPRECATION_WARNING) # Suppress iterator warning
+
+  # RocksDB's generic ASM language would otherwise claim .asm ahead of MASM,
+  # breaking Boost.Context. Nothing here needs .asm as generic ASM.
+  set(CMAKE_ASM_SOURCE_FILE_EXTENSIONS s;S)
+
+  # /Zi shares one PDB across a target's TUs, which compiler caches can't
+  # handle. /Z7 embeds debug info per object file instead.
+  if(CMAKE_C_COMPILER_LAUNCHER OR CMAKE_CXX_COMPILER_LAUNCHER)
+    message(STATUS "Compiler launcher in use - embedding MSVC debug info (/Z7)")
+    foreach(flags_var
+            CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG
+            CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+      string(REPLACE "/ZI" "/Z7" ${flags_var} "${${flags_var}}")
+      string(REPLACE "/Zi" "/Z7" ${flags_var} "${${flags_var}}")
+    endforeach()
+  endif()
 endif()
 
 set(CPACK_PACKAGE_VENDOR "Nano Currency")
@@ -519,6 +535,9 @@ else()
       1
       CACHE BOOL "" FORCE)
 endif()
+# Runs inside RocksDB's scope to drop MSVC flags that defeat compiler caching
+set(CMAKE_PROJECT_rocksdb_INCLUDE
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/RocksDBMsvcCache.cmake)
 add_subdirectory(submodules/rocksdb EXCLUDE_FROM_ALL)
 
 # cpptoml

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -77,17 +77,6 @@ number_of_processors() {
     esac
 }
 
-parallel_build_flag() {
-    case "$(uname -s)" in
-        CYGWIN*|MINGW32*|MSYS*|MINGW*)
-            echo "-- -m"
-            ;;
-        *)
-            echo "--parallel $(number_of_processors)"
-            ;;
-    esac
-}
-
-cmake --build ${PWD} ${BUILD_TARGET} $(parallel_build_flag)
+cmake --build ${PWD} ${BUILD_TARGET} --parallel $(number_of_processors)
 
 popd

--- a/ci/prepare/windows/prepare.ps1
+++ b/ci/prepare/windows/prepare.ps1
@@ -2,3 +2,4 @@ $ErrorActionPreference = "Stop"
 
 & "$PSScriptRoot\disable-defender.ps1"
 & "$PSScriptRoot\install-qt.ps1"
+& "$PSScriptRoot\remove-git-link.ps1"

--- a/ci/prepare/windows/remove-git-link.ps1
+++ b/ci/prepare/windows/remove-git-link.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = "Continue"
+
+# Git's link.exe shadows the MSVC linker when bash puts /usr/bin first on PATH.
+$gitLink = "C:\Program Files\Git\usr\bin\link.exe"
+if (Test-Path $gitLink) {
+    Remove-Item $gitLink -Force
+}

--- a/ci/prepare/windows/remove-git-link.ps1
+++ b/ci/prepare/windows/remove-git-link.ps1
@@ -1,7 +1,8 @@
-$ErrorActionPreference = "Continue"
+$ErrorActionPreference = "Stop"
 
 # Git's link.exe shadows the MSVC linker when bash puts /usr/bin first on PATH.
 $gitLink = "C:\Program Files\Git\usr\bin\link.exe"
 if (Test-Path $gitLink) {
-    Remove-Item $gitLink -Force
+    Write-Host "Removing Git link.exe to avoid shadowing MSVC linker: $gitLink"
+    Remove-Item $gitLink -Force -ErrorAction Stop
 }

--- a/cmake/Modules/RocksDBMsvcCache.cmake
+++ b/cmake/Modules/RocksDBMsvcCache.cmake
@@ -1,0 +1,29 @@
+# Included via CMAKE_PROJECT_rocksdb_INCLUDE. RocksDB hardcodes /Zi and
+# /d2Zi+ for MSVC, which defeat compiler caching (shared PDB, and sccache
+# rejects /d2Zi+ outright). Strip them once RocksDB has set its flags; /Z7
+# elsewhere still gives it embedded debug info.
+
+if(NOT MSVC)
+  return()
+endif()
+
+if(NOT CMAKE_C_COMPILER_LAUNCHER AND NOT CMAKE_CXX_COMPILER_LAUNCHER)
+  return()
+endif()
+
+# DEFER requires CMake 3.19; older just stays uncached.
+if(CMAKE_VERSION VERSION_LESS 3.19)
+  message(
+    STATUS "RocksDB: CMake < 3.19, leaving MSVC debug flags uncacheable")
+  return()
+endif()
+
+function(nano_strip_rocksdb_uncacheable_flags)
+  foreach(flags_var CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+    string(REPLACE "/d2Zi+" "" ${flags_var} "${${flags_var}}")
+    string(REPLACE "/Zi" "" ${flags_var} "${${flags_var}}")
+    set(${flags_var} "${${flags_var}}" PARENT_SCOPE)
+  endforeach()
+endfunction()
+
+cmake_language(DEFER CALL nano_strip_rocksdb_uncacheable_flags)


### PR DESCRIPTION
Enables sccache for Windows CI builds, matching the caching already in place for Linux and macOS. The default MSVC generator ignores compiler launchers, so this switches Windows to Ninja and fixes what that switch broke along the way:

- RocksDB's generic ASM language was claiming .asm ahead of MASM, breaking Boost.Context — pinned CMAKE_ASM_SOURCE_FILE_EXTENSIONS before RocksDB enables the language.
- RocksDB hardcodes /Zi and /d2Zi+, which defeat compiler caching (shared PDB; sccache rejects /d2Zi+ outright). A new cmake/Modules/RocksDBMsvcCache.cmake, hooked in via CMAKE_PROJECT_rocksdb_INCLUDE, strips those after RocksDB sets its own flags; the rest of the project switches /Zi//ZI → /Z7 when a compiler launcher is active.
- Git's link.exe was shadowing the MSVC linker once bash put /usr/bin first on PATH — removed during prepare.

Tested on my own fork with warmed cache:: Windows lmdb (https://github.com/RickiNano/nano-node/actions/runs/32287902103) and Windows rocksdb (https://github.com/RickiNano/nano-node/actions/runs/32287902103) both went green with a 97%+ cache hit rate, and build times dropped ~30% or approximately 20 minutes.