### PR TITLE
Ledger-bloat mitigation: state commitment, proofs, retention, cold-pending sweep, storage-weighted PoW

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -71,6 +71,7 @@ add_executable(
   peer_container.cpp
   rep_weight_store.cpp
   scheduler_buckets.cpp
+  state_commitment.cpp
   stats.cpp
   signal_manager.cpp
   socket.cpp

--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(
   rep_weight_store.cpp
   scheduler_buckets.cpp
   state_commitment.cpp
+  storage_weighted_work.cpp
   stats.cpp
   signal_manager.cpp
   socket.cpp

--- a/nano/core_test/state_commitment.cpp
+++ b/nano/core_test/state_commitment.cpp
@@ -149,3 +149,41 @@ TEST (state_commitment, pending_proof_roundtrip)
 	ASSERT_TRUE (proof->pending_claim.has_value ());
 	ASSERT_EQ (destination.pub, proof->pending_claim->account);
 }
+
+// The retention planner classifies droppable vs kept blocks for a per-account window,
+// proves every retained account against the checkpoint root, and quantifies reclaim.
+TEST (state_commitment, retention_plan)
+{
+	auto ctx = nano::test::ledger_single_chain (16); // 16 blocks on genesis account
+	auto & ledger = ctx.ledger ();
+	{
+		auto write = ledger.tx_begin_write ();
+		ledger.cement (write, ctx.blocks ().back ()->hash ());
+	}
+	auto transaction = ledger.tx_begin_read ();
+	auto commitment = nano::compute_state_commitment (ledger, transaction);
+
+	// Genesis account cemented frontier height = 1 (genesis) + 16 built blocks.
+	uint64_t const total_height = ledger.cemented.account_height (transaction, nano::dev::genesis_key.pub);
+	ASSERT_EQ (17, total_height);
+
+	auto plan = nano::plan_capped_retention (ledger, transaction, 5, 0);
+	// Checkpoint anchors to the same root the commitment computes.
+	ASSERT_EQ (commitment.root, plan.checkpoint.root);
+	ASSERT_EQ (1, plan.checkpoint.account_count);
+	// Keep the top 5, drop the rest; kept + droppable accounts for the whole chain.
+	ASSERT_EQ (5, plan.kept_blocks);
+	ASSERT_EQ (total_height - 5, plan.droppable_blocks);
+	ASSERT_EQ (total_height, plan.kept_blocks + plan.droppable_blocks);
+	ASSERT_GT (plan.reclaimable_bytes, 0);
+	// Every retained account frontier proves against the checkpoint root.
+	ASSERT_EQ (1, plan.accounts_checked);
+	ASSERT_EQ (1, plan.accounts_proven);
+	ASSERT_TRUE (plan.all_proven);
+
+	// A window taller than the chain drops nothing.
+	auto plan_full = nano::plan_capped_retention (ledger, transaction, 1000, 0);
+	ASSERT_EQ (0, plan_full.droppable_blocks);
+	ASSERT_EQ (total_height, plan_full.kept_blocks);
+	ASSERT_EQ (0, plan_full.reclaimable_bytes);
+}

--- a/nano/core_test/state_commitment.cpp
+++ b/nano/core_test/state_commitment.cpp
@@ -1,0 +1,87 @@
+#include <nano/lib/blockbuilders.hpp>
+#include <nano/lib/blocks.hpp>
+#include <nano/lib/work.hpp>
+#include <nano/secure/ledger.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
+#include <nano/secure/state_commitment.hpp>
+#include <nano/store/ledger/pending.hpp>
+#include <nano/store/ledger_store.hpp>
+#include <nano/test_common/ledger_context.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+// A fresh ledger holds only the cemented genesis account and no pending entries.
+TEST (state_commitment, genesis_only)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto transaction = ledger.tx_begin_read ();
+	auto commitment = nano::compute_state_commitment (ledger, transaction);
+	ASSERT_EQ (1, commitment.account_count);
+	ASSERT_EQ (0, commitment.pending_count);
+	ASSERT_FALSE (commitment.root.is_zero ());
+}
+
+// The commitment is a pure function of state: recomputing yields byte-identical roots.
+TEST (state_commitment, deterministic)
+{
+	auto ctx = nano::test::ledger_send_receive ();
+	auto & ledger = ctx.ledger ();
+	{
+		auto write = ledger.tx_begin_write ();
+		for (auto const & block : ctx.blocks ())
+		{
+			ledger.cement (write, block->hash ());
+		}
+	}
+	auto transaction = ledger.tx_begin_read ();
+	auto first = nano::compute_state_commitment (ledger, transaction);
+	auto second = nano::compute_state_commitment (ledger, transaction);
+	ASSERT_EQ (first.root, second.root);
+	ASSERT_EQ (first.accounts_root, second.accounts_root);
+	ASSERT_EQ (first.pending_root, second.pending_root);
+	// Send + receive on genesis leaves no live pending entry.
+	ASSERT_EQ (1, first.account_count);
+	ASSERT_EQ (0, first.pending_count);
+}
+
+// A dust send to a never-opened account adds exactly one permanent pending entry;
+// the commitment must reflect it: pending_count rises and the root changes.
+TEST (state_commitment, dust_pending_changes_root)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+
+	nano::block_hash baseline_root;
+	{
+		auto transaction = ledger.tx_begin_read ();
+		baseline_root = nano::compute_state_commitment (ledger, transaction).root;
+	}
+
+	nano::keypair destination;
+	nano::block_builder builder;
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	auto dust = builder.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - 1)
+				.link (destination.pub) // 32 arbitrary bytes: the abuse vector
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.build ();
+
+	{
+		auto write = ledger.tx_begin_write ();
+		ASSERT_EQ (nano::block_status::progress, ledger.process (write, dust));
+		ledger.cement (write, dust->hash ());
+	}
+
+	auto transaction = ledger.tx_begin_read ();
+	auto after = nano::compute_state_commitment (ledger, transaction);
+	ASSERT_EQ (1, after.pending_count);
+	ASSERT_NE (baseline_root, after.root);
+	ASSERT_FALSE (after.pending_root.is_zero ());
+}

--- a/nano/core_test/state_commitment.cpp
+++ b/nano/core_test/state_commitment.cpp
@@ -1,8 +1,10 @@
 #include <nano/lib/blockbuilders.hpp>
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/work.hpp>
+#include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_cemented.hpp>
+#include <nano/secure/pending_info.hpp>
 #include <nano/secure/state_commitment.hpp>
 #include <nano/store/ledger/pending.hpp>
 #include <nano/store/ledger_store.hpp>
@@ -84,4 +86,66 @@ TEST (state_commitment, dust_pending_changes_root)
 	ASSERT_EQ (1, after.pending_count);
 	ASSERT_NE (baseline_root, after.root);
 	ASSERT_FALSE (after.pending_root.is_zero ());
+}
+
+// An account proof reconstructs the commitment root and verifies; tampering fails.
+TEST (state_commitment, account_proof_roundtrip)
+{
+	auto ctx = nano::test::ledger_send_receive ();
+	auto & ledger = ctx.ledger ();
+	{
+		auto write = ledger.tx_begin_write ();
+		for (auto const & block : ctx.blocks ())
+		{
+			ledger.cement (write, block->hash ());
+		}
+	}
+	auto transaction = ledger.tx_begin_read ();
+	auto commitment = nano::compute_state_commitment (ledger, transaction);
+	auto proof = nano::generate_account_proof (ledger, transaction, nano::dev::genesis_key.pub);
+	ASSERT_TRUE (proof.has_value ());
+	// The proof reconstructs the exact same root the commitment produced.
+	ASSERT_EQ (commitment.root, proof->root);
+	ASSERT_TRUE (nano::verify_state_proof (proof.value ()));
+
+	// Tampering with the claimed balance must break verification.
+	auto tampered = proof.value ();
+	tampered.account_claim->balance = tampered.account_claim->balance.number () + 1;
+	ASSERT_FALSE (nano::verify_state_proof (tampered));
+
+	// A non-existent account yields no proof.
+	nano::keypair absent;
+	ASSERT_FALSE (nano::generate_account_proof (ledger, transaction, absent.pub).has_value ());
+}
+
+// A pending proof over the dust receivable reconstructs the root and verifies.
+TEST (state_commitment, pending_proof_roundtrip)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	nano::keypair destination;
+	nano::block_builder builder;
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	auto dust = builder.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - 1)
+				.link (destination.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.build ();
+	{
+		auto write = ledger.tx_begin_write ();
+		ASSERT_EQ (nano::block_status::progress, ledger.process (write, dust));
+		ledger.cement (write, dust->hash ());
+	}
+	auto transaction = ledger.tx_begin_read ();
+	auto commitment = nano::compute_state_commitment (ledger, transaction);
+	auto proof = nano::generate_pending_proof (ledger, transaction, nano::pending_key{ destination.pub, dust->hash () });
+	ASSERT_TRUE (proof.has_value ());
+	ASSERT_EQ (commitment.root, proof->root);
+	ASSERT_TRUE (nano::verify_state_proof (proof.value ()));
+	ASSERT_TRUE (proof->pending_claim.has_value ());
+	ASSERT_EQ (destination.pub, proof->pending_claim->account);
 }

--- a/nano/core_test/state_commitment.cpp
+++ b/nano/core_test/state_commitment.cpp
@@ -187,3 +187,87 @@ TEST (state_commitment, retention_plan)
 	ASSERT_EQ (total_height, plan_full.kept_blocks);
 	ASSERT_EQ (0, plan_full.reclaimable_bytes);
 }
+
+namespace
+{
+// Helper: an empty ledger plus a single cemented 1-raw dust send to a fresh account,
+// which leaves exactly one permanent pending entry. Returns the pending key.
+std::shared_ptr<nano::block> make_dust (nano::ledger & ledger, nano::keypair const & destination)
+{
+	nano::block_builder builder;
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	auto dust = builder.state ()
+				.account (nano::dev::genesis_key.pub)
+				.previous (nano::dev::genesis->hash ())
+				.representative (nano::dev::genesis_key.pub)
+				.balance (nano::dev::constants.genesis_amount - 1)
+				.link (destination.pub)
+				.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				.work (*pool.generate (nano::dev::genesis->hash ()))
+				.build ();
+	auto write = ledger.tx_begin_write ();
+	EXPECT_EQ (nano::block_status::progress, ledger.process (write, dust));
+	ledger.cement (write, dust->hash ());
+	return dust;
+}
+}
+
+// An aged, sub-threshold pending entry is classified cold, stays committed under
+// cold_root, and remains claimable via a cold-pending proof.
+TEST (state_commitment, pending_sweep_cold)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	nano::keypair destination;
+	auto dust = make_dust (ledger, destination);
+	nano::pending_key key{ destination.pub, dust->hash () };
+
+	auto transaction = ledger.tx_begin_read ();
+	uint64_t const far_future = std::numeric_limits<uint64_t>::max () / 2;
+
+	// Aged (reference in the far future) and sub-threshold (amount 1 <= threshold 1) => cold.
+	auto plan = nano::plan_pending_sweep (ledger, transaction, far_future, 0, nano::amount{ 1 }, 0);
+	ASSERT_EQ (1, plan.cold_count);
+	ASSERT_EQ (0, plan.hot_count);
+	ASSERT_FALSE (plan.cold_root.is_zero ());
+	ASSERT_GT (plan.reclaimable_pending_bytes, 0);
+	ASSERT_EQ (1, plan.cold_checked);
+	ASSERT_EQ (1, plan.cold_proven);
+	ASSERT_TRUE (plan.all_proven);
+
+	// The receiver can still claim: a cold proof verifies against cold_root.
+	auto proof = nano::generate_cold_pending_proof (ledger, transaction, far_future, 0, nano::amount{ 1 }, key);
+	ASSERT_TRUE (proof.has_value ());
+	ASSERT_EQ (plan.cold_root, proof->cold_root);
+	ASSERT_TRUE (nano::verify_cold_pending_proof (proof.value ()));
+
+	// Tampering with the claimed amount breaks the cold proof.
+	auto tampered = proof.value ();
+	tampered.claim.amount = tampered.claim.amount.number () + 1;
+	ASSERT_FALSE (nano::verify_cold_pending_proof (tampered));
+}
+
+// A pending entry that is not sub-threshold, or not aged, stays hot (never swept).
+TEST (state_commitment, pending_sweep_hot)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	nano::keypair destination;
+	auto dust = make_dust (ledger, destination);
+	auto transaction = ledger.tx_begin_read ();
+	uint64_t const far_future = std::numeric_limits<uint64_t>::max () / 2;
+
+	// Threshold 0: the 1-raw amount is above it, so not dust -> hot.
+	auto by_amount = nano::plan_pending_sweep (ledger, transaction, far_future, 0, nano::amount{ 0 }, 0);
+	ASSERT_EQ (0, by_amount.cold_count);
+	ASSERT_EQ (1, by_amount.hot_count);
+
+	// Reference time 0: nothing is old enough -> hot.
+	auto by_age = nano::plan_pending_sweep (ledger, transaction, 0, 1, nano::amount{ 1 }, 0);
+	ASSERT_EQ (0, by_age.cold_count);
+	ASSERT_EQ (1, by_age.hot_count);
+
+	// A never-cold entry yields no cold proof.
+	nano::pending_key key{ destination.pub, dust->hash () };
+	ASSERT_FALSE (nano::generate_cold_pending_proof (ledger, transaction, 0, 1, nano::amount{ 1 }, key).has_value ());
+}

--- a/nano/core_test/storage_weighted_work.cpp
+++ b/nano/core_test/storage_weighted_work.cpp
@@ -1,0 +1,88 @@
+#include <nano/lib/blockbuilders.hpp>
+#include <nano/lib/blocks.hpp>
+#include <nano/lib/numbers.hpp>
+#include <nano/lib/work.hpp>
+#include <nano/secure/common.hpp>
+#include <nano/secure/ledger.hpp>
+#include <nano/secure/ledger_set_any.hpp>
+#include <nano/secure/storage_weighted_work.hpp>
+#include <nano/test_common/ledger_context.hpp>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+namespace
+{
+std::shared_ptr<nano::block> send_to (nano::account const & destination)
+{
+	nano::block_builder builder;
+	nano::work_pool pool{ nano::dev::network_params.network, std::numeric_limits<unsigned>::max () };
+	return builder.state ()
+	.account (nano::dev::genesis_key.pub)
+	.previous (nano::dev::genesis->hash ())
+	.representative (nano::dev::genesis_key.pub)
+	.balance (nano::dev::constants.genesis_amount - 1)
+	.link (destination)
+	.sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+	.work (*pool.generate (nano::dev::genesis->hash ()))
+	.build ();
+}
+}
+
+// A send to a not-yet-opened account is storage-weighted: its required work is the base
+// requirement scaled by the multiplier, and at multiplier 1 it collapses to the base.
+TEST (storage_weighted_work, new_account_is_weighted)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	nano::keypair fresh;
+	auto block = send_to (fresh.pub);
+	auto transaction = ledger.tx_begin_read ();
+
+	ASSERT_TRUE (nano::block_adds_new_account (ledger, transaction, *block));
+
+	uint64_t const base = ledger.work.threshold_base (block->work_version ());
+	auto weighted = nano::evaluate_storage_weighted_work (ledger, transaction, *block, 8.0);
+	ASSERT_TRUE (weighted.creates_new_account);
+	ASSERT_EQ (base, weighted.base_threshold);
+	ASSERT_EQ (nano::difficulty::from_multiplier (8.0, base), weighted.required_threshold);
+	ASSERT_GT (weighted.required_threshold, weighted.base_threshold);
+
+	// Multiplier 1 must not raise the requirement, and the block's own work satisfies it.
+	auto unweighted = nano::evaluate_storage_weighted_work (ledger, transaction, *block, 1.0);
+	ASSERT_EQ (base, unweighted.required_threshold);
+	ASSERT_TRUE (unweighted.satisfies);
+}
+
+// A send to an already-opened account carries no storage weight, whatever the multiplier.
+TEST (storage_weighted_work, existing_account_not_weighted)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	// Genesis account already exists in the ledger.
+	auto block = send_to (nano::dev::genesis_key.pub);
+	auto transaction = ledger.tx_begin_read ();
+
+	ASSERT_FALSE (nano::block_adds_new_account (ledger, transaction, *block));
+
+	auto weighted = nano::evaluate_storage_weighted_work (ledger, transaction, *block, 8.0);
+	ASSERT_FALSE (weighted.creates_new_account);
+	ASSERT_EQ (weighted.base_threshold, weighted.required_threshold);
+	ASSERT_DOUBLE_EQ (1.0, weighted.weight_multiplier);
+	ASSERT_TRUE (weighted.satisfies);
+}
+
+// A multiplier below 1 can never lower the base requirement.
+TEST (storage_weighted_work, multiplier_floor)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	nano::keypair fresh;
+	auto block = send_to (fresh.pub);
+	auto transaction = ledger.tx_begin_read ();
+
+	auto result = nano::evaluate_storage_weighted_work (ledger, transaction, *block, 0.25);
+	ASSERT_EQ (result.base_threshold, result.required_threshold);
+	ASSERT_DOUBLE_EQ (1.0, result.weight_multiplier);
+}

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -36,6 +36,7 @@
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_cemented.hpp>
 #include <nano/secure/state_commitment.hpp>
+#include <nano/secure/storage_weighted_work.hpp>
 #include <nano/secure/transaction.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/block.hpp>
@@ -52,6 +53,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <vector>
 
 namespace
@@ -1806,6 +1808,53 @@ void nano::json_handler::state_pending_sweep ()
 		rpc_l->response_l.put ("cold_checked", std::to_string (plan.cold_checked));
 		rpc_l->response_l.put ("cold_proven", std::to_string (plan.cold_proven));
 		rpc_l->response_l.put ("all_proven", plan.all_proven ? "true" : "false");
+		rpc_l->response_errors ();
+	}));
+}
+
+void nano::json_handler::work_storage_weight ()
+{
+	// Advisory (Block 5): evaluate a block against the storage-weighted PoW requirement.
+	// A state send to a not-yet-opened account must carry `multiplier`x the base work.
+	auto hash (hash_impl ());
+	double multiplier = 8.0; // default: state-creating sends must work 8x harder
+	auto multiplier_text (request.get_optional<std::string> ("multiplier"));
+	if (!ec && multiplier_text.has_value ())
+	{
+		try
+		{
+			multiplier = std::stod (multiplier_text.value ());
+		}
+		catch (...)
+		{
+			ec = nano::error_rpc::bad_multiplier_format;
+		}
+		if (!ec && (multiplier < 1.0 || !std::isfinite (multiplier)))
+		{
+			ec = nano::error_rpc::bad_multiplier_format;
+		}
+	}
+	if (ec)
+	{
+		response_errors ();
+		return;
+	}
+	node.workers.post (create_worker_task ([hash, multiplier] (std::shared_ptr<nano::json_handler> const & rpc_l) {
+		auto transaction (rpc_l->node.ledger.tx_begin_read ());
+		auto block (rpc_l->node.ledger.any.block_get (transaction, hash));
+		if (block == nullptr)
+		{
+			rpc_l->ec = nano::error_blocks::not_found;
+			rpc_l->response_errors ();
+			return;
+		}
+		auto result (nano::evaluate_storage_weighted_work (rpc_l->node.ledger, transaction, *block, multiplier));
+		rpc_l->response_l.put ("creates_new_account", result.creates_new_account ? "true" : "false");
+		rpc_l->response_l.put ("weight_multiplier", nano::to_string (result.weight_multiplier));
+		rpc_l->response_l.put ("base_threshold", nano::to_string_hex (result.base_threshold));
+		rpc_l->response_l.put ("required_threshold", nano::to_string_hex (result.required_threshold));
+		rpc_l->response_l.put ("achieved_difficulty", nano::to_string_hex (result.achieved_difficulty));
+		rpc_l->response_l.put ("satisfies", result.satisfies ? "true" : "false");
 		rpc_l->response_errors ();
 	}));
 }
@@ -5818,6 +5867,7 @@ ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ()
 	no_arg_funcs.emplace ("state_checkpoint", &nano::json_handler::state_checkpoint);
 	no_arg_funcs.emplace ("state_retention_plan", &nano::json_handler::state_retention_plan);
 	no_arg_funcs.emplace ("state_pending_sweep", &nano::json_handler::state_pending_sweep);
+	no_arg_funcs.emplace ("work_storage_weight", &nano::json_handler::work_storage_weight);
 	no_arg_funcs.emplace ("block_create", &nano::json_handler::block_create);
 	no_arg_funcs.emplace ("block_hash", &nano::json_handler::block_hash);
 	no_arg_funcs.emplace ("bootstrap", &nano::json_handler::bootstrap);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1755,6 +1755,61 @@ void nano::json_handler::state_retention_plan ()
 	}));
 }
 
+void nano::json_handler::state_pending_sweep ()
+{
+	// Plan the cold-pending sweep (Block 4): identify aged, sub-threshold pending entries
+	// that can be offloaded to the committed cold subtree, quantify reclaimable bytes, and
+	// prove each offloaded entry stays claimable against cold_root. Read-only, no deletion.
+	auto age_text (request.get_optional<std::string> ("age"));
+	auto threshold_text (request.get_optional<std::string> ("threshold"));
+	auto reference_text (request.get_optional<std::string> ("reference_timestamp"));
+	auto count_text (request.get_optional<std::string> ("count"));
+
+	uint64_t min_age_seconds = 30 * 24 * 60 * 60; // default 30 days
+	nano::amount amount_threshold{ 1 }; // default: 1 raw (the dust vector)
+	uint64_t reference_timestamp = nano::seconds_since_epoch ();
+	uint64_t max_prove = 128;
+
+	if (age_text.has_value () && decode_unsigned (age_text.value (), min_age_seconds))
+	{
+		ec = nano::error_common::invalid_count;
+	}
+	if (!ec && threshold_text.has_value () && amount_threshold.decode_dec (threshold_text.value ()))
+	{
+		ec = nano::error_common::bad_threshold;
+	}
+	if (!ec && reference_text.has_value () && decode_unsigned (reference_text.value (), reference_timestamp))
+	{
+		ec = nano::error_common::invalid_count;
+	}
+	if (!ec && count_text.has_value () && decode_unsigned (count_text.value (), max_prove))
+	{
+		ec = nano::error_common::invalid_count;
+	}
+	if (ec)
+	{
+		response_errors ();
+		return;
+	}
+
+	node.workers.post (create_worker_task ([min_age_seconds, amount_threshold, reference_timestamp, max_prove] (std::shared_ptr<nano::json_handler> const & rpc_l) {
+		auto transaction (rpc_l->node.ledger.tx_begin_read ());
+		auto plan (nano::plan_pending_sweep (rpc_l->node.ledger, transaction, reference_timestamp, min_age_seconds, amount_threshold, max_prove));
+		rpc_l->response_l.put ("root", plan.checkpoint.root.to_string ());
+		rpc_l->response_l.put ("reference_timestamp", std::to_string (plan.reference_timestamp));
+		rpc_l->response_l.put ("min_age_seconds", std::to_string (plan.min_age_seconds));
+		rpc_l->response_l.put ("amount_threshold", plan.amount_threshold.number ().convert_to<std::string> ());
+		rpc_l->response_l.put ("hot_count", std::to_string (plan.hot_count));
+		rpc_l->response_l.put ("cold_count", std::to_string (plan.cold_count));
+		rpc_l->response_l.put ("cold_root", plan.cold_root.to_string ());
+		rpc_l->response_l.put ("reclaimable_pending_bytes", std::to_string (plan.reclaimable_pending_bytes));
+		rpc_l->response_l.put ("cold_checked", std::to_string (plan.cold_checked));
+		rpc_l->response_l.put ("cold_proven", std::to_string (plan.cold_proven));
+		rpc_l->response_l.put ("all_proven", plan.all_proven ? "true" : "false");
+		rpc_l->response_errors ();
+	}));
+}
+
 void nano::json_handler::block_create ()
 {
 	std::string type (request.get<std::string> ("type"));
@@ -5762,6 +5817,7 @@ ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ()
 	no_arg_funcs.emplace ("state_proof", &nano::json_handler::state_proof);
 	no_arg_funcs.emplace ("state_checkpoint", &nano::json_handler::state_checkpoint);
 	no_arg_funcs.emplace ("state_retention_plan", &nano::json_handler::state_retention_plan);
+	no_arg_funcs.emplace ("state_pending_sweep", &nano::json_handler::state_pending_sweep);
 	no_arg_funcs.emplace ("block_create", &nano::json_handler::block_create);
 	no_arg_funcs.emplace ("block_hash", &nano::json_handler::block_hash);
 	no_arg_funcs.emplace ("bootstrap", &nano::json_handler::bootstrap);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -35,6 +35,7 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_cemented.hpp>
+#include <nano/secure/state_commitment.hpp>
 #include <nano/secure/transaction.hpp>
 #include <nano/store/ledger/account.hpp>
 #include <nano/store/ledger/block.hpp>
@@ -1590,6 +1591,23 @@ void nano::json_handler::block_count ()
 		response_l.put ("pruned", std::to_string (node.ledger.pruned_count ()));
 	}
 	response_errors ();
+}
+
+void nano::json_handler::state_commitment ()
+{
+	// Read-only measurement (Block 1): compute the deterministic Merkle commitment
+	// over cemented state. Runs on the worker pool since it walks the whole cemented
+	// account frontier and pending set.
+	node.workers.post (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
+		auto transaction (rpc_l->node.ledger.tx_begin_read ());
+		auto commitment (nano::compute_state_commitment (rpc_l->node.ledger, transaction));
+		rpc_l->response_l.put ("root", commitment.root.to_string ());
+		rpc_l->response_l.put ("accounts_root", commitment.accounts_root.to_string ());
+		rpc_l->response_l.put ("pending_root", commitment.pending_root.to_string ());
+		rpc_l->response_l.put ("account_count", std::to_string (commitment.account_count));
+		rpc_l->response_l.put ("pending_count", std::to_string (commitment.pending_count));
+		rpc_l->response_errors ();
+	}));
 }
 
 void nano::json_handler::block_create ()
@@ -5595,6 +5613,7 @@ ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ()
 	no_arg_funcs.emplace ("blocks_info", &nano::json_handler::blocks_info);
 	no_arg_funcs.emplace ("block_account", &nano::json_handler::block_account);
 	no_arg_funcs.emplace ("block_count", &nano::json_handler::block_count);
+	no_arg_funcs.emplace ("state_commitment", &nano::json_handler::state_commitment);
 	no_arg_funcs.emplace ("block_create", &nano::json_handler::block_create);
 	no_arg_funcs.emplace ("block_hash", &nano::json_handler::block_hash);
 	no_arg_funcs.emplace ("bootstrap", &nano::json_handler::bootstrap);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1702,6 +1702,59 @@ void nano::json_handler::state_proof ()
 	}));
 }
 
+void nano::json_handler::state_checkpoint ()
+{
+	// Capture the current cemented commitment as a checkpoint anchor (Block 3).
+	node.workers.post (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
+		auto transaction (rpc_l->node.ledger.tx_begin_read ());
+		auto checkpoint (nano::capture_state_checkpoint (rpc_l->node.ledger, transaction));
+		rpc_l->response_l.put ("cemented_height", std::to_string (checkpoint.cemented_height));
+		rpc_l->response_l.put ("root", checkpoint.root.to_string ());
+		rpc_l->response_l.put ("account_count", std::to_string (checkpoint.account_count));
+		rpc_l->response_l.put ("pending_count", std::to_string (checkpoint.pending_count));
+		rpc_l->response_errors ();
+	}));
+}
+
+void nano::json_handler::state_retention_plan ()
+{
+	// Plan capped retention (Block 3): report the safe-to-drop set, reclaimable bytes,
+	// and a frontier-proof safety check against the checkpoint root. Read-only.
+	auto window_text (request.get_optional<std::string> ("window"));
+	auto count_text (request.get_optional<std::string> ("count"));
+	uint64_t window = 128;
+	uint64_t max_prove = 128;
+	if (window_text.has_value () && decode_unsigned (window_text.value (), window))
+	{
+		ec = nano::error_common::invalid_count;
+	}
+	if (!ec && count_text.has_value () && decode_unsigned (count_text.value (), max_prove))
+	{
+		ec = nano::error_common::invalid_count;
+	}
+	if (ec)
+	{
+		response_errors ();
+		return;
+	}
+	node.workers.post (create_worker_task ([window, max_prove] (std::shared_ptr<nano::json_handler> const & rpc_l) {
+		auto transaction (rpc_l->node.ledger.tx_begin_read ());
+		auto plan (nano::plan_capped_retention (rpc_l->node.ledger, transaction, window, max_prove));
+		rpc_l->response_l.put ("root", plan.checkpoint.root.to_string ());
+		rpc_l->response_l.put ("cemented_height", std::to_string (plan.checkpoint.cemented_height));
+		rpc_l->response_l.put ("account_count", std::to_string (plan.checkpoint.account_count));
+		rpc_l->response_l.put ("history_window", std::to_string (plan.history_window));
+		rpc_l->response_l.put ("kept_blocks", std::to_string (plan.kept_blocks));
+		rpc_l->response_l.put ("droppable_blocks", std::to_string (plan.droppable_blocks));
+		rpc_l->response_l.put ("retained_pending", std::to_string (plan.retained_pending));
+		rpc_l->response_l.put ("reclaimable_bytes", std::to_string (plan.reclaimable_bytes));
+		rpc_l->response_l.put ("accounts_checked", std::to_string (plan.accounts_checked));
+		rpc_l->response_l.put ("accounts_proven", std::to_string (plan.accounts_proven));
+		rpc_l->response_l.put ("all_proven", plan.all_proven ? "true" : "false");
+		rpc_l->response_errors ();
+	}));
+}
+
 void nano::json_handler::block_create ()
 {
 	std::string type (request.get<std::string> ("type"));
@@ -5707,6 +5760,8 @@ ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ()
 	no_arg_funcs.emplace ("block_count", &nano::json_handler::block_count);
 	no_arg_funcs.emplace ("state_commitment", &nano::json_handler::state_commitment);
 	no_arg_funcs.emplace ("state_proof", &nano::json_handler::state_proof);
+	no_arg_funcs.emplace ("state_checkpoint", &nano::json_handler::state_checkpoint);
+	no_arg_funcs.emplace ("state_retention_plan", &nano::json_handler::state_retention_plan);
 	no_arg_funcs.emplace ("block_create", &nano::json_handler::block_create);
 	no_arg_funcs.emplace ("block_hash", &nano::json_handler::block_hash);
 	no_arg_funcs.emplace ("bootstrap", &nano::json_handler::bootstrap);

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -1610,6 +1610,98 @@ void nano::json_handler::state_commitment ()
 	}));
 }
 
+void nano::json_handler::state_proof ()
+{
+	// Build a succinct inclusion proof (Block 2) against the state commitment root.
+	// With just "account", proves that account's cemented frontier + balance.
+	// With "account" + "hash", proves the pending entry (account, send hash).
+	node.workers.post (create_worker_task ([] (std::shared_ptr<nano::json_handler> const & rpc_l) {
+		auto account (rpc_l->account_impl ());
+		auto hash_text (rpc_l->request.get_optional<std::string> ("hash"));
+		if (rpc_l->ec)
+		{
+			rpc_l->response_errors ();
+			return;
+		}
+		auto transaction (rpc_l->node.ledger.tx_begin_read ());
+		std::optional<nano::state_proof> proof;
+		if (hash_text.has_value ())
+		{
+			nano::block_hash hash{ 0 };
+			if (hash.decode_hex (hash_text.value ()))
+			{
+				rpc_l->ec = nano::error_blocks::invalid_block_hash;
+				rpc_l->response_errors ();
+				return;
+			}
+			proof = nano::generate_pending_proof (rpc_l->node.ledger, transaction, nano::pending_key{ account, hash });
+		}
+		else
+		{
+			proof = nano::generate_account_proof (rpc_l->node.ledger, transaction, account);
+		}
+		if (!proof.has_value ())
+		{
+			rpc_l->ec = nano::error_common::account_not_found;
+			rpc_l->response_errors ();
+			return;
+		}
+
+		auto const & p = proof.value ();
+		if (p.account_claim.has_value ())
+		{
+			auto const & c = p.account_claim.value ();
+			boost::property_tree::ptree claim;
+			claim.put ("type", "account");
+			claim.put ("account", c.account.to_account ());
+			claim.put ("frontier", c.frontier.to_string ());
+			claim.put ("balance", c.balance.number ().convert_to<std::string> ());
+			claim.put ("height", std::to_string (c.height));
+			rpc_l->response_l.add_child ("claim", claim);
+		}
+		else
+		{
+			auto const & c = p.pending_claim.value ();
+			boost::property_tree::ptree claim;
+			claim.put ("type", "pending");
+			claim.put ("account", c.account.to_account ());
+			claim.put ("hash", c.hash.to_string ());
+			claim.put ("source", c.source.to_account ());
+			claim.put ("amount", c.amount.number ().convert_to<std::string> ());
+			claim.put ("epoch", std::to_string (static_cast<unsigned> (c.epoch)));
+			rpc_l->response_l.add_child ("claim", claim);
+		}
+
+		boost::property_tree::ptree path;
+		for (auto const & step : p.path)
+		{
+			boost::property_tree::ptree node;
+			node.put ("hash", step.hash.to_string ());
+			node.put ("sibling_on_right", step.sibling_on_right ? "true" : "false");
+			path.push_back (std::make_pair ("", node));
+		}
+		rpc_l->response_l.add_child ("path", path);
+
+		boost::property_tree::ptree peaks;
+		for (auto const & peak : p.peaks)
+		{
+			boost::property_tree::ptree entry;
+			entry.put ("", peak.to_string ());
+			peaks.push_back (std::make_pair ("", entry));
+		}
+		rpc_l->response_l.add_child ("peaks", peaks);
+
+		rpc_l->response_l.put ("peak_index", std::to_string (p.peak_index));
+		rpc_l->response_l.put ("other_root", p.other_root.to_string ());
+		rpc_l->response_l.put ("account_count", std::to_string (p.account_count));
+		rpc_l->response_l.put ("pending_count", std::to_string (p.pending_count));
+		rpc_l->response_l.put ("root", p.root.to_string ());
+		// Self-check so a caller can trust the node computed a consistent proof.
+		rpc_l->response_l.put ("verified", nano::verify_state_proof (p) ? "true" : "false");
+		rpc_l->response_errors ();
+	}));
+}
+
 void nano::json_handler::block_create ()
 {
 	std::string type (request.get<std::string> ("type"));
@@ -5614,6 +5706,7 @@ ipc_json_handler_no_arg_func_map create_ipc_json_handler_no_arg_func_map ()
 	no_arg_funcs.emplace ("block_account", &nano::json_handler::block_account);
 	no_arg_funcs.emplace ("block_count", &nano::json_handler::block_count);
 	no_arg_funcs.emplace ("state_commitment", &nano::json_handler::state_commitment);
+	no_arg_funcs.emplace ("state_proof", &nano::json_handler::state_proof);
 	no_arg_funcs.emplace ("block_create", &nano::json_handler::block_create);
 	no_arg_funcs.emplace ("block_hash", &nano::json_handler::block_hash);
 	no_arg_funcs.emplace ("bootstrap", &nano::json_handler::bootstrap);

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -61,6 +61,7 @@ public:
 	void block_account ();
 	void block_count ();
 	void state_commitment ();
+	void state_proof ();
 	void block_create ();
 	void block_hash ();
 	void bootstrap ();

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -62,6 +62,8 @@ public:
 	void block_count ();
 	void state_commitment ();
 	void state_proof ();
+	void state_checkpoint ();
+	void state_retention_plan ();
 	void block_create ();
 	void block_hash ();
 	void bootstrap ();

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -65,6 +65,7 @@ public:
 	void state_checkpoint ();
 	void state_retention_plan ();
 	void state_pending_sweep ();
+	void work_storage_weight ();
 	void block_create ();
 	void block_hash ();
 	void bootstrap ();

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -60,6 +60,7 @@ public:
 	void blocks_info ();
 	void block_account ();
 	void block_count ();
+	void state_commitment ();
 	void block_create ();
 	void block_hash ();
 	void bootstrap ();

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -64,6 +64,7 @@ public:
 	void state_proof ();
 	void state_checkpoint ();
 	void state_retention_plan ();
+	void state_pending_sweep ();
 	void block_create ();
 	void block_hash ();
 	void bootstrap ();

--- a/nano/secure/CMakeLists.txt
+++ b/nano/secure/CMakeLists.txt
@@ -42,6 +42,8 @@ add_library(
   rep_weights.cpp
   state_commitment.hpp
   state_commitment.cpp
+  storage_weighted_work.hpp
+  storage_weighted_work.cpp
   transaction.hpp
   voting_policy.hpp
   voting_policy.cpp)

--- a/nano/secure/CMakeLists.txt
+++ b/nano/secure/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(
   receivable_iterator_impl.hpp
   rep_weights.hpp
   rep_weights.cpp
+  state_commitment.hpp
+  state_commitment.cpp
   transaction.hpp
   voting_policy.hpp
   voting_policy.cpp)

--- a/nano/secure/state_commitment.cpp
+++ b/nano/secure/state_commitment.cpp
@@ -272,6 +272,28 @@ void build_mmr_proof (std::vector<nano::block_hash> const & leaves, uint64_t tar
 	}
 	peak_index = mountains.size () - 1 - target_desc_index;
 }
+
+// Reconstruct the MMR root from a leaf and its inclusion path/peaks. Returns nullopt if
+// the leaf does not climb to the claimed peak. Shared by the overall-root verifier and
+// the cold-subtree verifier so the two can never diverge.
+std::optional<nano::block_hash> reconstruct_mmr_root (nano::block_hash const & leaf, std::vector<nano::state_proof_step> const & path, std::vector<nano::block_hash> const & peaks, uint64_t peak_index)
+{
+	nano::block_hash node = leaf;
+	for (auto const & step : path)
+	{
+		node = step.sibling_on_right ? hash_internal_node (node, step.hash) : hash_internal_node (step.hash, node);
+	}
+	if (peak_index >= peaks.size () || !(peaks[peak_index] == node))
+	{
+		return std::nullopt;
+	}
+	std::optional<nano::block_hash> accumulator;
+	for (auto const & peak : peaks)
+	{
+		accumulator = accumulator.has_value () ? hash_internal_node (peak, accumulator.value ()) : peak;
+	}
+	return accumulator.has_value () ? accumulator.value () : empty_root ();
+}
 }
 
 nano::state_commitment_result nano::compute_state_commitment (nano::ledger const & ledger, nano::secure::transaction const & transaction)
@@ -378,27 +400,15 @@ bool nano::verify_state_proof (nano::state_proof const & proof)
 		leaf = pending_leaf (key, info);
 	}
 
-	// Climb to the mountain peak.
-	nano::block_hash node = leaf;
-	for (auto const & step : proof.path)
-	{
-		node = step.sibling_on_right ? hash_internal_node (node, step.hash) : hash_internal_node (step.hash, node);
-	}
-	if (proof.peak_index >= proof.peaks.size () || !(proof.peaks[proof.peak_index] == node))
+	// Climb to the mountain peak and rebag the peaks into the sub-tree root.
+	auto sub = reconstruct_mmr_root (leaf, proof.path, proof.peaks, proof.peak_index);
+	if (!sub.has_value ())
 	{
 		return false;
 	}
 
-	// Rebag the peaks exactly as mmr_root does.
-	std::optional<nano::block_hash> accumulator;
-	for (auto const & peak : proof.peaks)
-	{
-		accumulator = accumulator.has_value () ? hash_internal_node (peak, accumulator.value ()) : peak;
-	}
-	nano::block_hash const sub = accumulator.has_value () ? accumulator.value () : empty_root ();
-
-	nano::block_hash const accounts_root = is_account ? sub : proof.other_root;
-	nano::block_hash const pending_root = is_account ? proof.other_root : sub;
+	nano::block_hash const accounts_root = is_account ? sub.value () : proof.other_root;
+	nano::block_hash const pending_root = is_account ? proof.other_root : sub.value ();
 	return overall_root (accounts_root, pending_root, proof.account_count, proof.pending_count) == proof.root;
 }
 
@@ -463,4 +473,136 @@ nano::capped_retention_plan nano::plan_capped_retention (nano::ledger const & le
 	}
 	plan.all_proven = plan.accounts_proven == plan.accounts_checked;
 	return plan;
+}
+
+namespace
+{
+// Classify the cemented pending set into cold (aged AND sub-threshold) vs hot. Returns
+// the cold entries' keys and leaves in canonical order, plus the hot count. A pending
+// entry whose send block is unavailable (pruned) is conservatively kept hot, since its
+// age cannot be read.
+struct cold_classification final
+{
+	std::vector<nano::pending_key> cold_keys;
+	std::vector<nano::block_hash> cold_leaves;
+	uint64_t hot_count{ 0 };
+};
+
+cold_classification classify_cold (nano::ledger const & ledger, nano::secure::transaction const & transaction, uint64_t reference_timestamp, uint64_t min_age_seconds, nano::amount const & amount_threshold)
+{
+	cold_classification out;
+	for (auto i = ledger.store.pending.begin (transaction), n = ledger.store.pending.end (transaction); i != n; ++i)
+	{
+		nano::pending_key const & key = i->first;
+		nano::pending_info const & info = i->second;
+		if (!ledger.cemented.block_exists_or_pruned (transaction, key.hash))
+		{
+			continue;
+		}
+		bool cold = false;
+		if (info.amount.number () <= amount_threshold.number ())
+		{
+			auto block = ledger.cemented.block_get (transaction, key.hash);
+			if (block != nullptr && block->has_sideband ())
+			{
+				uint64_t const timestamp = block->sideband ().timestamp;
+				// Guard against clock skew / future timestamps: only age forward.
+				if (reference_timestamp > timestamp && (reference_timestamp - timestamp) >= min_age_seconds)
+				{
+					cold = true;
+				}
+			}
+		}
+		if (cold)
+		{
+			out.cold_keys.push_back (key);
+			out.cold_leaves.push_back (pending_leaf (key, info));
+		}
+		else
+		{
+			++out.hot_count;
+		}
+	}
+	return out;
+}
+}
+
+nano::pending_sweep_plan nano::plan_pending_sweep (nano::ledger const & ledger, nano::secure::transaction const & transaction, uint64_t reference_timestamp, uint64_t min_age_seconds, nano::amount const & amount_threshold, uint64_t max_to_prove)
+{
+	nano::pending_sweep_plan plan;
+	plan.checkpoint = nano::capture_state_checkpoint (ledger, transaction);
+	plan.reference_timestamp = reference_timestamp;
+	plan.min_age_seconds = min_age_seconds;
+	plan.amount_threshold = amount_threshold;
+
+	auto classified = classify_cold (ledger, transaction, reference_timestamp, min_age_seconds, amount_threshold);
+	plan.hot_count = classified.hot_count;
+	plan.cold_count = classified.cold_leaves.size ();
+	plan.cold_root = mmr_root (classified.cold_leaves);
+
+	// Approximate on-disk cost of one pending record: key (account + hash) + info
+	// (source + amount + epoch). Index / page overhead is not modelled.
+	uint64_t const approx_pending_bytes = 64 + 49;
+	plan.reclaimable_pending_bytes = plan.cold_count * approx_pending_bytes;
+
+	// Safety gate: each cold entry must remain claimable, i.e. provable against cold_root.
+	for (uint64_t idx = 0; idx < classified.cold_leaves.size (); ++idx)
+	{
+		if (max_to_prove != 0 && plan.cold_checked >= max_to_prove)
+		{
+			break;
+		}
+		std::vector<nano::state_proof_step> path;
+		std::vector<nano::block_hash> peaks;
+		uint64_t peak_index = 0;
+		build_mmr_proof (classified.cold_leaves, idx, path, peaks, peak_index);
+		++plan.cold_checked;
+		auto reconstructed = reconstruct_mmr_root (classified.cold_leaves[idx], path, peaks, peak_index);
+		if (reconstructed.has_value () && reconstructed.value () == plan.cold_root)
+		{
+			++plan.cold_proven;
+		}
+	}
+	plan.all_proven = plan.cold_proven == plan.cold_checked;
+	return plan;
+}
+
+std::optional<nano::cold_pending_proof> nano::generate_cold_pending_proof (nano::ledger const & ledger, nano::secure::transaction const & transaction, uint64_t reference_timestamp, uint64_t min_age_seconds, nano::amount const & amount_threshold, nano::pending_key const & key)
+{
+	auto classified = classify_cold (ledger, transaction, reference_timestamp, min_age_seconds, amount_threshold);
+	uint64_t target = 0;
+	bool found = false;
+	for (uint64_t i = 0; i < classified.cold_keys.size (); ++i)
+	{
+		if (classified.cold_keys[i].account == key.account && classified.cold_keys[i].hash == key.hash)
+		{
+			target = i;
+			found = true;
+			break;
+		}
+	}
+	if (!found)
+	{
+		return std::nullopt;
+	}
+	auto info = ledger.store.pending.get (transaction, key);
+	if (!info.has_value ())
+	{
+		return std::nullopt;
+	}
+
+	nano::cold_pending_proof proof;
+	proof.claim = nano::state_proof_pending_claim{ key.account, key.hash, info->source, info->amount, info->epoch };
+	build_mmr_proof (classified.cold_leaves, target, proof.path, proof.peaks, proof.peak_index);
+	proof.cold_root = mmr_root (classified.cold_leaves);
+	return proof;
+}
+
+bool nano::verify_cold_pending_proof (nano::cold_pending_proof const & proof)
+{
+	nano::pending_key key{ proof.claim.account, proof.claim.hash };
+	nano::pending_info info{ proof.claim.source, proof.claim.amount, proof.claim.epoch };
+	nano::block_hash const leaf = pending_leaf (key, info);
+	auto reconstructed = reconstruct_mmr_root (leaf, proof.path, proof.peaks, proof.peak_index);
+	return reconstructed.has_value () && reconstructed.value () == proof.cold_root;
 }

--- a/nano/secure/state_commitment.cpp
+++ b/nano/secure/state_commitment.cpp
@@ -1,0 +1,237 @@
+#include <nano/crypto/blake2/blake2.h>
+#include <nano/secure/account_info.hpp>
+#include <nano/secure/common.hpp>
+#include <nano/secure/ledger.hpp>
+#include <nano/secure/ledger_set_cemented.hpp>
+#include <nano/secure/pending_info.hpp>
+#include <nano/secure/state_commitment.hpp>
+#include <nano/secure/transaction.hpp>
+#include <nano/store/ledger/account.hpp>
+#include <nano/store/ledger/confirmation_height.hpp>
+#include <nano/store/ledger/pending.hpp>
+#include <nano/store/ledger_store.hpp>
+
+#include <array>
+#include <cstring>
+#include <vector>
+
+namespace
+{
+// Domain-separation tags. Leaf and node prefixes differ so that no internal node
+// hash can ever collide with a leaf hash (second-preimage resistance for the tree).
+constexpr uint8_t leaf_prefix = 0x00;
+constexpr uint8_t node_prefix = 0x01;
+
+// Minimal blake2b-256 hashing helper mirroring nano::block::generate_hash.
+class hasher final
+{
+public:
+	hasher ()
+	{
+		auto status = blake2b_init (&state, sizeof (nano::block_hash::bytes));
+		debug_assert (status == 0);
+		(void)status;
+	}
+	void update (uint8_t const * data, size_t size)
+	{
+		auto status = blake2b_update (&state, data, size);
+		debug_assert (status == 0);
+		(void)status;
+	}
+	void update (uint8_t byte)
+	{
+		update (&byte, 1);
+	}
+	template <typename T>
+	void update_union (T const & value)
+	{
+		update (value.bytes.data (), value.bytes.size ());
+	}
+	void update_u64 (uint64_t value)
+	{
+		// Fixed little-endian encoding so the digest is platform-independent.
+		std::array<uint8_t, 8> buffer;
+		for (auto i = 0; i < 8; ++i)
+		{
+			buffer[i] = static_cast<uint8_t> (value >> (8 * i));
+		}
+		update (buffer.data (), buffer.size ());
+	}
+	nano::block_hash finalize ()
+	{
+		nano::block_hash result;
+		auto status = blake2b_final (&state, result.bytes.data (), sizeof (result.bytes));
+		debug_assert (status == 0);
+		(void)status;
+		return result;
+	}
+
+private:
+	blake2b_state state;
+};
+
+nano::block_hash hash_internal_node (nano::block_hash const & left, nano::block_hash const & right)
+{
+	hasher h;
+	h.update (node_prefix);
+	h.update_union (left);
+	h.update_union (right);
+	return h.finalize ();
+}
+
+/*
+ * Streaming Merkle Mountain Range accumulator. Leaves are folded in one at a time
+ * in canonical order; only the current peaks (at most log2(n) of them) are held in
+ * memory. bag() collapses the peaks into a single root deterministically, folding
+ * from the smallest peak up into the largest so that a fixed leaf sequence always
+ * yields the same root.
+ */
+class merkle_mountain_range final
+{
+public:
+	void add_leaf (nano::block_hash const & leaf)
+	{
+		nano::block_hash carry = leaf;
+		size_t height = 0;
+		while (height < peaks.size () && peaks[height].has_value ())
+		{
+			carry = hash_internal_node (peaks[height].value (), carry);
+			peaks[height].reset ();
+			++height;
+		}
+		if (height == peaks.size ())
+		{
+			peaks.emplace_back (carry);
+		}
+		else
+		{
+			peaks[height] = carry;
+		}
+		++leaf_count;
+	}
+
+	uint64_t count () const
+	{
+		return leaf_count;
+	}
+
+	// Deterministic root over all leaves added so far. Empty accumulator hashes to
+	// a fixed sentinel (node hash of the empty peak set) so callers get a stable value.
+	nano::block_hash bag () const
+	{
+		std::optional<nano::block_hash> accumulator;
+		for (auto const & peak : peaks)
+		{
+			if (!peak.has_value ())
+			{
+				continue;
+			}
+			if (!accumulator.has_value ())
+			{
+				accumulator = peak.value ();
+			}
+			else
+			{
+				accumulator = hash_internal_node (peak.value (), accumulator.value ());
+			}
+		}
+		if (!accumulator.has_value ())
+		{
+			// No leaves: return a fixed, domain-separated empty root.
+			hasher h;
+			h.update (node_prefix);
+			nano::block_hash zero{ 0 };
+			h.update_union (zero);
+			h.update_union (zero);
+			return h.finalize ();
+		}
+		return accumulator.value ();
+	}
+
+private:
+	std::vector<std::optional<nano::block_hash>> peaks;
+	uint64_t leaf_count{ 0 };
+};
+
+nano::block_hash account_leaf (nano::account const & account, nano::block_hash const & frontier, nano::amount const & balance, uint64_t height)
+{
+	hasher h;
+	h.update (leaf_prefix);
+	static constexpr std::array<uint8_t, 4> tag{ 'a', 'c', 'c', 't' };
+	h.update (tag.data (), tag.size ());
+	h.update_union (account);
+	h.update_union (frontier);
+	h.update_union (balance);
+	h.update_u64 (height);
+	return h.finalize ();
+}
+
+nano::block_hash pending_leaf (nano::pending_key const & key, nano::pending_info const & info)
+{
+	hasher h;
+	h.update (leaf_prefix);
+	static constexpr std::array<uint8_t, 4> tag{ 'p', 'e', 'n', 'd' };
+	h.update (tag.data (), tag.size ());
+	h.update_union (key.account);
+	h.update_union (key.hash);
+	h.update_union (info.source);
+	h.update_union (info.amount);
+	h.update (static_cast<uint8_t> (info.epoch));
+	return h.finalize ();
+}
+}
+
+nano::state_commitment_result nano::compute_state_commitment (nano::ledger const & ledger, nano::secure::transaction const & transaction)
+{
+	nano::state_commitment_result result;
+
+	// Accounts: iterate the cemented frontier table in key order. Each account
+	// contributes its cemented frontier hash, balance and height.
+	merkle_mountain_range accounts_mmr;
+	for (auto i = ledger.store.confirmation_height.begin (transaction), n = ledger.store.confirmation_height.end (transaction); i != n; ++i)
+	{
+		nano::account const & account = i->first;
+		nano::confirmation_height_info const & info = i->second;
+		if (info.height == 0)
+		{
+			continue;
+		}
+		auto balance = ledger.cemented.block_balance (transaction, info.frontier);
+		if (!balance.has_value ())
+		{
+			// Frontier block not resolvable (e.g. pruned): skip rather than commit to a guess.
+			continue;
+		}
+		accounts_mmr.add_leaf (account_leaf (account, info.frontier, balance.value (), info.height));
+	}
+	result.accounts_root = accounts_mmr.bag ();
+	result.account_count = accounts_mmr.count ();
+
+	// Pending: iterate the pending table in key order, including only entries whose
+	// send block has been cemented, so the commitment reflects cemented state only.
+	merkle_mountain_range pending_mmr;
+	for (auto i = ledger.store.pending.begin (transaction), n = ledger.store.pending.end (transaction); i != n; ++i)
+	{
+		nano::pending_key const & key = i->first;
+		nano::pending_info const & info = i->second;
+		if (!ledger.cemented.block_exists_or_pruned (transaction, key.hash))
+		{
+			continue;
+		}
+		pending_mmr.add_leaf (pending_leaf (key, info));
+	}
+	result.pending_root = pending_mmr.bag ();
+	result.pending_count = pending_mmr.count ();
+
+	// Overall root binds both sub-roots plus their counts under a versioned tag.
+	hasher h;
+	static constexpr std::array<uint8_t, 25> tag{ 'n', 'a', 'n', 'o', '-', 's', 't', 'a', 't', 'e', '-', 'c', 'o', 'm', 'm', 'i', 't', 'm', 'e', 'n', 't', '-', 'v', '1', '\0' };
+	h.update (tag.data (), tag.size ());
+	h.update_union (result.accounts_root);
+	h.update_union (result.pending_root);
+	h.update_u64 (result.account_count);
+	h.update_u64 (result.pending_count);
+	result.root = h.finalize ();
+
+	return result;
+}

--- a/nano/secure/state_commitment.cpp
+++ b/nano/secure/state_commitment.cpp
@@ -1,4 +1,7 @@
 #include <nano/crypto/blake2/blake2.h>
+#include <nano/lib/block_sideband.hpp>
+#include <nano/lib/block_type.hpp>
+#include <nano/lib/blocks.hpp>
 #include <nano/secure/account_info.hpp>
 #include <nano/secure/common.hpp>
 #include <nano/secure/ledger.hpp>
@@ -397,4 +400,67 @@ bool nano::verify_state_proof (nano::state_proof const & proof)
 	nano::block_hash const accounts_root = is_account ? sub : proof.other_root;
 	nano::block_hash const pending_root = is_account ? proof.other_root : sub;
 	return overall_root (accounts_root, pending_root, proof.account_count, proof.pending_count) == proof.root;
+}
+
+nano::state_checkpoint nano::capture_state_checkpoint (nano::ledger const & ledger, nano::secure::transaction const & transaction)
+{
+	auto commitment = nano::compute_state_commitment (ledger, transaction);
+	nano::state_checkpoint checkpoint;
+	checkpoint.cemented_height = ledger.cemented_count ();
+	checkpoint.root = commitment.root;
+	checkpoint.account_count = commitment.account_count;
+	checkpoint.pending_count = commitment.pending_count;
+	return checkpoint;
+}
+
+nano::capped_retention_plan nano::plan_capped_retention (nano::ledger const & ledger, nano::secure::transaction const & transaction, uint64_t history_window, uint64_t max_accounts_to_prove)
+{
+	nano::capped_retention_plan plan;
+	plan.checkpoint = nano::capture_state_checkpoint (ledger, transaction);
+	plan.history_window = history_window;
+	plan.retained_pending = plan.checkpoint.pending_count;
+
+	// Approximate on-disk cost of one cemented state block: the serialized block plus
+	// its sideband. This is an estimate for reporting reclaimable storage, not an exact
+	// per-record figure (index / page overhead is not modelled).
+	uint64_t const approx_stored_block_bytes = nano::state_block::size + nano::block_sideband::size (nano::block_type::state);
+
+	// Classify cemented blocks per account: keep the top `history_window` (frontier
+	// included), drop the rest. Content below the window stays committed under the root.
+	for (auto i = ledger.store.confirmation_height.begin (transaction), n = ledger.store.confirmation_height.end (transaction); i != n; ++i)
+	{
+		nano::confirmation_height_info const & info = i->second;
+		uint64_t const height = info.height;
+		if (height == 0)
+		{
+			continue;
+		}
+		uint64_t const kept = history_window == 0 ? height : std::min (height, history_window);
+		plan.kept_blocks += kept;
+		plan.droppable_blocks += height - kept;
+	}
+	plan.reclaimable_bytes = plan.droppable_blocks * approx_stored_block_bytes;
+
+	// Safety gate: every retained account frontier must remain provable against the
+	// checkpoint root. Prove up to `max_accounts_to_prove` accounts (0 = all).
+	for (auto i = ledger.store.confirmation_height.begin (transaction), n = ledger.store.confirmation_height.end (transaction); i != n; ++i)
+	{
+		if (max_accounts_to_prove != 0 && plan.accounts_checked >= max_accounts_to_prove)
+		{
+			break;
+		}
+		nano::account const & account = i->first;
+		if (i->second.height == 0)
+		{
+			continue;
+		}
+		auto proof = nano::generate_account_proof (ledger, transaction, account);
+		++plan.accounts_checked;
+		if (proof.has_value () && proof->root == plan.checkpoint.root && nano::verify_state_proof (proof.value ()))
+		{
+			++plan.accounts_proven;
+		}
+	}
+	plan.all_proven = plan.accounts_proven == plan.accounts_checked;
+	return plan;
 }

--- a/nano/secure/state_commitment.cpp
+++ b/nano/secure/state_commitment.cpp
@@ -11,8 +11,11 @@
 #include <nano/store/ledger/pending.hpp>
 #include <nano/store/ledger_store.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstring>
+#include <iterator>
+#include <optional>
 #include <vector>
 
 namespace
@@ -79,79 +82,16 @@ nano::block_hash hash_internal_node (nano::block_hash const & left, nano::block_
 	return h.finalize ();
 }
 
-/*
- * Streaming Merkle Mountain Range accumulator. Leaves are folded in one at a time
- * in canonical order; only the current peaks (at most log2(n) of them) are held in
- * memory. bag() collapses the peaks into a single root deterministically, folding
- * from the smallest peak up into the largest so that a fixed leaf sequence always
- * yields the same root.
- */
-class merkle_mountain_range final
+// Fixed empty-tree value (domain-separated node hash of two zero hashes).
+nano::block_hash empty_root ()
 {
-public:
-	void add_leaf (nano::block_hash const & leaf)
-	{
-		nano::block_hash carry = leaf;
-		size_t height = 0;
-		while (height < peaks.size () && peaks[height].has_value ())
-		{
-			carry = hash_internal_node (peaks[height].value (), carry);
-			peaks[height].reset ();
-			++height;
-		}
-		if (height == peaks.size ())
-		{
-			peaks.emplace_back (carry);
-		}
-		else
-		{
-			peaks[height] = carry;
-		}
-		++leaf_count;
-	}
-
-	uint64_t count () const
-	{
-		return leaf_count;
-	}
-
-	// Deterministic root over all leaves added so far. Empty accumulator hashes to
-	// a fixed sentinel (node hash of the empty peak set) so callers get a stable value.
-	nano::block_hash bag () const
-	{
-		std::optional<nano::block_hash> accumulator;
-		for (auto const & peak : peaks)
-		{
-			if (!peak.has_value ())
-			{
-				continue;
-			}
-			if (!accumulator.has_value ())
-			{
-				accumulator = peak.value ();
-			}
-			else
-			{
-				accumulator = hash_internal_node (peak.value (), accumulator.value ());
-			}
-		}
-		if (!accumulator.has_value ())
-		{
-			// No leaves: return a fixed, domain-separated empty root.
-			hasher h;
-			h.update (node_prefix);
-			nano::block_hash zero{ 0 };
-			h.update_union (zero);
-			h.update_union (zero);
-			return h.finalize ();
-		}
-		return accumulator.value ();
-	}
-
-private:
-	std::vector<std::optional<nano::block_hash>> peaks;
-	uint64_t leaf_count{ 0 };
-};
+	hasher h;
+	h.update (node_prefix);
+	nano::block_hash zero{ 0 };
+	h.update_union (zero);
+	h.update_union (zero);
+	return h.finalize ();
+}
 
 nano::block_hash account_leaf (nano::account const & account, nano::block_hash const & frontier, nano::amount const & balance, uint64_t height)
 {
@@ -179,15 +119,70 @@ nano::block_hash pending_leaf (nano::pending_key const & key, nano::pending_info
 	h.update (static_cast<uint8_t> (info.epoch));
 	return h.finalize ();
 }
+
+// Merkle Mountain Range root over an ordered leaf list. bag() folds the peaks from
+// the smallest (height 0) upward, each peak on the left of the running accumulator,
+// exactly as the streaming accumulator does, so a fixed leaf sequence yields a fixed
+// root. This is the single source of truth for sub-tree roots.
+nano::block_hash mmr_root (std::vector<nano::block_hash> const & leaves)
+{
+	std::vector<std::optional<nano::block_hash>> peaks;
+	for (auto const & leaf : leaves)
+	{
+		nano::block_hash carry = leaf;
+		size_t height = 0;
+		while (height < peaks.size () && peaks[height].has_value ())
+		{
+			carry = hash_internal_node (peaks[height].value (), carry);
+			peaks[height].reset ();
+			++height;
+		}
+		if (height == peaks.size ())
+		{
+			peaks.emplace_back (carry);
+		}
+		else
+		{
+			peaks[height] = carry;
+		}
+	}
+	std::optional<nano::block_hash> accumulator;
+	for (auto const & peak : peaks)
+	{
+		if (!peak.has_value ())
+		{
+			continue;
+		}
+		accumulator = accumulator.has_value () ? hash_internal_node (peak.value (), accumulator.value ()) : peak.value ();
+	}
+	return accumulator.has_value () ? accumulator.value () : empty_root ();
 }
 
-nano::state_commitment_result nano::compute_state_commitment (nano::ledger const & ledger, nano::secure::transaction const & transaction)
+// Overall root binding both sub-roots plus their counts under a versioned tag.
+nano::block_hash overall_root (nano::block_hash const & accounts_root, nano::block_hash const & pending_root, uint64_t account_count, uint64_t pending_count)
 {
-	nano::state_commitment_result result;
+	hasher h;
+	static constexpr std::array<uint8_t, 25> tag{ 'n', 'a', 'n', 'o', '-', 's', 't', 'a', 't', 'e', '-', 'c', 'o', 'm', 'm', 'i', 't', 'm', 'e', 'n', 't', '-', 'v', '1', '\0' };
+	h.update (tag.data (), tag.size ());
+	h.update_union (accounts_root);
+	h.update_union (pending_root);
+	h.update_u64 (account_count);
+	h.update_u64 (pending_count);
+	return h.finalize ();
+}
 
-	// Accounts: iterate the cemented frontier table in key order. Each account
-	// contributes its cemented frontier hash, balance and height.
-	merkle_mountain_range accounts_mmr;
+// The ordered cemented leaves plus their keys, so callers can find a target index.
+struct collected_leaves final
+{
+	std::vector<nano::account> account_keys;
+	std::vector<nano::block_hash> account_leaves;
+	std::vector<nano::pending_key> pending_keys;
+	std::vector<nano::block_hash> pending_leaves;
+};
+
+collected_leaves collect (nano::ledger const & ledger, nano::secure::transaction const & transaction)
+{
+	collected_leaves out;
 	for (auto i = ledger.store.confirmation_height.begin (transaction), n = ledger.store.confirmation_height.end (transaction); i != n; ++i)
 	{
 		nano::account const & account = i->first;
@@ -199,17 +194,11 @@ nano::state_commitment_result nano::compute_state_commitment (nano::ledger const
 		auto balance = ledger.cemented.block_balance (transaction, info.frontier);
 		if (!balance.has_value ())
 		{
-			// Frontier block not resolvable (e.g. pruned): skip rather than commit to a guess.
 			continue;
 		}
-		accounts_mmr.add_leaf (account_leaf (account, info.frontier, balance.value (), info.height));
+		out.account_keys.push_back (account);
+		out.account_leaves.push_back (account_leaf (account, info.frontier, balance.value (), info.height));
 	}
-	result.accounts_root = accounts_mmr.bag ();
-	result.account_count = accounts_mmr.count ();
-
-	// Pending: iterate the pending table in key order, including only entries whose
-	// send block has been cemented, so the commitment reflects cemented state only.
-	merkle_mountain_range pending_mmr;
 	for (auto i = ledger.store.pending.begin (transaction), n = ledger.store.pending.end (transaction); i != n; ++i)
 	{
 		nano::pending_key const & key = i->first;
@@ -218,20 +207,194 @@ nano::state_commitment_result nano::compute_state_commitment (nano::ledger const
 		{
 			continue;
 		}
-		pending_mmr.add_leaf (pending_leaf (key, info));
+		out.pending_keys.push_back (key);
+		out.pending_leaves.push_back (pending_leaf (key, info));
 	}
-	result.pending_root = pending_mmr.bag ();
-	result.pending_count = pending_mmr.count ();
+	return out;
+}
 
-	// Overall root binds both sub-roots plus their counts under a versioned tag.
-	hasher h;
-	static constexpr std::array<uint8_t, 25> tag{ 'n', 'a', 'n', 'o', '-', 's', 't', 'a', 't', 'e', '-', 'c', 'o', 'm', 'm', 'i', 't', 'm', 'e', 'n', 't', '-', 'v', '1', '\0' };
-	h.update (tag.data (), tag.size ());
-	h.update_union (result.accounts_root);
-	h.update_union (result.pending_root);
-	h.update_u64 (result.account_count);
-	h.update_u64 (result.pending_count);
-	result.root = h.finalize ();
+// Build the MMR inclusion path + peaks for leaf `target` within an ordered list.
+// `peaks` are returned in ascending-height (bag consumption) order; `peak_index` is
+// the position in that list of the mountain the target belongs to.
+void build_mmr_proof (std::vector<nano::block_hash> const & leaves, uint64_t target, std::vector<nano::state_proof_step> & path, std::vector<nano::block_hash> & peaks, uint64_t & peak_index)
+{
+	uint64_t n = leaves.size ();
+	// Perfect subtrees (mountains), largest height first, covering earliest leaves.
+	struct mountain
+	{
+		uint64_t start;
+		uint64_t size;
+	};
+	std::vector<mountain> mountains;
+	uint64_t cursor = 0;
+	for (int height = 62; height >= 0; --height)
+	{
+		uint64_t const bit = uint64_t{ 1 } << height;
+		if (n & bit)
+		{
+			mountains.push_back ({ cursor, bit });
+			cursor += bit;
+		}
+	}
+	peaks.assign (mountains.size (), nano::block_hash{ 0 });
+	size_t target_desc_index = 0;
+	for (size_t m = 0; m < mountains.size (); ++m)
+	{
+		auto const & mount = mountains[m];
+		bool const holds = target >= mount.start && target < mount.start + mount.size;
+		std::vector<nano::block_hash> level (leaves.begin () + mount.start, leaves.begin () + mount.start + mount.size);
+		uint64_t pos = holds ? target - mount.start : 0;
+		while (level.size () > 1)
+		{
+			if (holds)
+			{
+				uint64_t const sibling = pos ^ 1;
+				path.push_back ({ level[sibling], sibling == pos + 1 });
+			}
+			std::vector<nano::block_hash> next (level.size () / 2);
+			for (size_t j = 0; j < next.size (); ++j)
+			{
+				next[j] = hash_internal_node (level[2 * j], level[2 * j + 1]);
+			}
+			level = std::move (next);
+			pos /= 2;
+		}
+		// bag() consumes peaks ascending-height => reverse of the descending mountain order.
+		size_t const ascending = mountains.size () - 1 - m;
+		peaks[ascending] = level[0];
+		if (holds)
+		{
+			target_desc_index = m;
+		}
+	}
+	peak_index = mountains.size () - 1 - target_desc_index;
+}
+}
 
+nano::state_commitment_result nano::compute_state_commitment (nano::ledger const & ledger, nano::secure::transaction const & transaction)
+{
+	auto leaves = collect (ledger, transaction);
+	nano::state_commitment_result result;
+	result.account_count = leaves.account_leaves.size ();
+	result.pending_count = leaves.pending_leaves.size ();
+	result.accounts_root = mmr_root (leaves.account_leaves);
+	result.pending_root = mmr_root (leaves.pending_leaves);
+	result.root = overall_root (result.accounts_root, result.pending_root, result.account_count, result.pending_count);
 	return result;
+}
+
+std::optional<nano::state_proof> nano::generate_account_proof (nano::ledger const & ledger, nano::secure::transaction const & transaction, nano::account const & account)
+{
+	auto leaves = collect (ledger, transaction);
+	auto it = std::find (leaves.account_keys.begin (), leaves.account_keys.end (), account);
+	if (it == leaves.account_keys.end ())
+	{
+		return std::nullopt;
+	}
+	uint64_t const target = static_cast<uint64_t> (std::distance (leaves.account_keys.begin (), it));
+
+	// Recover the claim fields from the cemented frontier for the target account.
+	auto ch = ledger.store.confirmation_height.get (transaction, account);
+	if (!ch.has_value () || ch->height == 0)
+	{
+		return std::nullopt;
+	}
+	auto balance = ledger.cemented.block_balance (transaction, ch->frontier);
+	if (!balance.has_value ())
+	{
+		return std::nullopt;
+	}
+
+	nano::state_proof proof;
+	proof.account_claim = nano::state_proof_account_claim{ account, ch->frontier, balance.value (), ch->height };
+	build_mmr_proof (leaves.account_leaves, target, proof.path, proof.peaks, proof.peak_index);
+	proof.other_root = mmr_root (leaves.pending_leaves);
+	proof.account_count = leaves.account_leaves.size ();
+	proof.pending_count = leaves.pending_leaves.size ();
+	auto accounts_root = mmr_root (leaves.account_leaves);
+	proof.root = overall_root (accounts_root, proof.other_root, proof.account_count, proof.pending_count);
+	return proof;
+}
+
+std::optional<nano::state_proof> nano::generate_pending_proof (nano::ledger const & ledger, nano::secure::transaction const & transaction, nano::pending_key const & key)
+{
+	auto leaves = collect (ledger, transaction);
+	uint64_t target = 0;
+	bool found = false;
+	for (uint64_t i = 0; i < leaves.pending_keys.size (); ++i)
+	{
+		if (leaves.pending_keys[i].account == key.account && leaves.pending_keys[i].hash == key.hash)
+		{
+			target = i;
+			found = true;
+			break;
+		}
+	}
+	if (!found)
+	{
+		return std::nullopt;
+	}
+	auto info = ledger.store.pending.get (transaction, key);
+	if (!info.has_value ())
+	{
+		return std::nullopt;
+	}
+
+	nano::state_proof proof;
+	proof.pending_claim = nano::state_proof_pending_claim{ key.account, key.hash, info->source, info->amount, info->epoch };
+	build_mmr_proof (leaves.pending_leaves, target, proof.path, proof.peaks, proof.peak_index);
+	proof.other_root = mmr_root (leaves.account_leaves);
+	proof.account_count = leaves.account_leaves.size ();
+	proof.pending_count = leaves.pending_leaves.size ();
+	auto pending_root = mmr_root (leaves.pending_leaves);
+	proof.root = overall_root (proof.other_root, pending_root, proof.account_count, proof.pending_count);
+	return proof;
+}
+
+bool nano::verify_state_proof (nano::state_proof const & proof)
+{
+	// Exactly one claim must be present.
+	if (proof.account_claim.has_value () == proof.pending_claim.has_value ())
+	{
+		return false;
+	}
+	bool const is_account = proof.account_claim.has_value ();
+
+	// Recompute the leaf from the claim, binding the claim to the proof.
+	nano::block_hash leaf;
+	if (is_account)
+	{
+		auto const & c = proof.account_claim.value ();
+		leaf = account_leaf (c.account, c.frontier, c.balance, c.height);
+	}
+	else
+	{
+		auto const & c = proof.pending_claim.value ();
+		nano::pending_key key{ c.account, c.hash };
+		nano::pending_info info{ c.source, c.amount, c.epoch };
+		leaf = pending_leaf (key, info);
+	}
+
+	// Climb to the mountain peak.
+	nano::block_hash node = leaf;
+	for (auto const & step : proof.path)
+	{
+		node = step.sibling_on_right ? hash_internal_node (node, step.hash) : hash_internal_node (step.hash, node);
+	}
+	if (proof.peak_index >= proof.peaks.size () || !(proof.peaks[proof.peak_index] == node))
+	{
+		return false;
+	}
+
+	// Rebag the peaks exactly as mmr_root does.
+	std::optional<nano::block_hash> accumulator;
+	for (auto const & peak : proof.peaks)
+	{
+		accumulator = accumulator.has_value () ? hash_internal_node (peak, accumulator.value ()) : peak;
+	}
+	nano::block_hash const sub = accumulator.has_value () ? accumulator.value () : empty_root ();
+
+	nano::block_hash const accounts_root = is_account ? sub : proof.other_root;
+	nano::block_hash const pending_root = is_account ? proof.other_root : sub;
+	return overall_root (accounts_root, pending_root, proof.account_count, proof.pending_count) == proof.root;
 }

--- a/nano/secure/state_commitment.hpp
+++ b/nano/secure/state_commitment.hpp
@@ -1,12 +1,16 @@
 #pragma once
 
+#include <nano/lib/epoch.hpp>
 #include <nano/lib/numbers.hpp>
 
 #include <cstdint>
+#include <optional>
+#include <vector>
 
 namespace nano
 {
 class ledger;
+class pending_key;
 namespace secure
 {
 	class transaction;
@@ -48,4 +52,73 @@ struct state_commitment_result final
  * Intended to be invoked off the hot path (e.g. via the state_commitment RPC).
  */
 nano::state_commitment_result compute_state_commitment (nano::ledger const &, nano::secure::transaction const &);
+
+/*
+ * Block 2 of the ledger-bloat mitigation work: a succinct inclusion proof against
+ * the commitment root produced by compute_state_commitment(). A holder of only the
+ * trusted root (a light / storage-capped node) can verify that a specific account
+ * frontier+balance, or a specific pending entry, is part of cemented state - without
+ * holding the ledger. Verification is a PURE function of the proof and touches no
+ * store, so it can run anywhere.
+ */
+
+// One authentication step from a leaf up to its Merkle Mountain Range peak.
+struct state_proof_step final
+{
+	nano::block_hash hash{ 0 };
+	// True if `hash` is the right-hand sibling (so the running value is on the left).
+	bool sibling_on_right{ false };
+};
+
+// The account-frontier claim an account proof attests to.
+struct state_proof_account_claim final
+{
+	nano::account account{};
+	nano::block_hash frontier{ 0 };
+	nano::amount balance{ 0 };
+	uint64_t height{ 0 };
+};
+
+// The pending-entry claim a pending proof attests to.
+struct state_proof_pending_claim final
+{
+	nano::account account{}; // receiving (destination) account
+	nano::block_hash hash{ 0 }; // send block hash
+	nano::account source{};
+	nano::amount amount{ 0 };
+	nano::epoch epoch{ nano::epoch::epoch_0 };
+};
+
+struct state_proof final
+{
+	// Exactly one of these is populated; it identifies the sub-tree and the claim.
+	std::optional<state_proof_account_claim> account_claim;
+	std::optional<state_proof_pending_claim> pending_claim;
+
+	// Authentication path from the claimed leaf up to its mountain peak.
+	std::vector<state_proof_step> path;
+	// All mountain peaks in ascending-height (bag consumption) order.
+	std::vector<nano::block_hash> peaks;
+	// Index into `peaks` of the peak this claim's mountain reaches.
+	uint64_t peak_index{ 0 };
+
+	// Root of the OTHER sub-tree (pending_root for an account proof, and vice versa),
+	// needed to rebuild the overall root.
+	nano::block_hash other_root{ 0 };
+	uint64_t account_count{ 0 };
+	uint64_t pending_count{ 0 };
+
+	// The overall commitment root this proof reconstructs to.
+	nano::block_hash root{ 0 };
+};
+
+// Build an inclusion proof for `account`'s cemented frontier. Returns nullopt if the
+// account is not in the cemented frontier (or its frontier block is unresolvable).
+std::optional<nano::state_proof> generate_account_proof (nano::ledger const &, nano::secure::transaction const &, nano::account const &);
+
+// Build an inclusion proof for a cemented pending entry keyed by (account, send hash).
+std::optional<nano::state_proof> generate_pending_proof (nano::ledger const &, nano::secure::transaction const &, nano::pending_key const &);
+
+// Verify a proof reconstructs its stated root from its claim. Pure; no store access.
+bool verify_state_proof (nano::state_proof const &);
 }

--- a/nano/secure/state_commitment.hpp
+++ b/nano/secure/state_commitment.hpp
@@ -167,4 +167,53 @@ struct capped_retention_plan final
 // Proving is O(accounts_checked * total accounts), so callers off a bound it for large
 // ledgers; accounts_checked vs checkpoint.account_count reports any sampling.
 nano::capped_retention_plan plan_capped_retention (nano::ledger const &, nano::secure::transaction const &, uint64_t history_window, uint64_t max_accounts_to_prove);
+
+/*
+ * Block 4 of the ledger-bloat mitigation work: the cold-pending sweep. The pending
+ * table is the un-prunable dust residue - a send to a never-opened account mints a
+ * receivable that lives forever on every node. We do NOT expire or return it (that
+ * would break the irreversible-send guarantee and is unsound without a global clock).
+ * Instead we identify AGED, SUB-THRESHOLD pending entries and move them out of the hot
+ * working set into a committed COLD subtree. A cold entry is never lost: its membership
+ * stays committed under `cold_root`, and its receiver can still claim it at any time by
+ * presenting an inclusion proof. This layer classifies and proves; it deletes nothing.
+ */
+
+// A pending entry qualifies as cold when it is at least `min_age_seconds` old (by the
+// send block's timestamp vs a caller-supplied reference time) AND its amount is at or
+// below `amount_threshold` (dust). The caller supplies the reference time so the library
+// stays deterministic and testable.
+struct pending_sweep_plan final
+{
+	nano::state_checkpoint checkpoint;
+	uint64_t reference_timestamp{ 0 };
+	uint64_t min_age_seconds{ 0 };
+	nano::amount amount_threshold{ 0 };
+
+	uint64_t hot_count{ 0 }; // pending entries a node keeps resident
+	uint64_t cold_count{ 0 }; // aged sub-threshold entries offloadable to the cold subtree
+	nano::block_hash cold_root{ 0 }; // MMR root committing exactly the cold entries
+	uint64_t reclaimable_pending_bytes{ 0 }; // cold_count * approximate pending record size
+
+	uint64_t cold_checked{ 0 }; // cold entries whose claimability proof was verified
+	uint64_t cold_proven{ 0 }; // of those, how many verified against cold_root
+	bool all_proven{ false };
+};
+
+nano::pending_sweep_plan plan_pending_sweep (nano::ledger const &, nano::secure::transaction const &, uint64_t reference_timestamp, uint64_t min_age_seconds, nano::amount const & amount_threshold, uint64_t max_to_prove);
+
+// A standalone proof that a cold pending entry is committed under `cold_root`, so its
+// receiver can claim it after it has been offloaded from the hot table. Verification is
+// pure (no store access).
+struct cold_pending_proof final
+{
+	nano::state_proof_pending_claim claim;
+	std::vector<nano::state_proof_step> path;
+	std::vector<nano::block_hash> peaks;
+	uint64_t peak_index{ 0 };
+	nano::block_hash cold_root{ 0 };
+};
+
+std::optional<nano::cold_pending_proof> generate_cold_pending_proof (nano::ledger const &, nano::secure::transaction const &, uint64_t reference_timestamp, uint64_t min_age_seconds, nano::amount const & amount_threshold, nano::pending_key const &);
+bool verify_cold_pending_proof (nano::cold_pending_proof const &);
 }

--- a/nano/secure/state_commitment.hpp
+++ b/nano/secure/state_commitment.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+
+#include <cstdint>
+
+namespace nano
+{
+class ledger;
+namespace secure
+{
+	class transaction;
+}
+
+/*
+ * Block 1 of the ledger-bloat mitigation work: a deterministic Merkle commitment
+ * over the cemented ledger state. This is a read-only measurement primitive - it
+ * does not change consensus, block validation, or storage. Its purpose is to prove
+ * that a single canonical root can be derived from the cemented account frontier and
+ * the cemented pending set, so that later blocks (proof service, storage-capped nodes)
+ * can let a node discard history / cold-store dust while still proving any account's
+ * balance against this root.
+ *
+ * The root is a PURE FUNCTION of cemented state: two honest nodes that have cemented
+ * the same set of blocks must produce byte-identical roots regardless of sync order.
+ */
+struct state_commitment_result final
+{
+	// Overall canonical root binding both sub-roots and their counts.
+	nano::block_hash root{ 0 };
+	// Merkle root over the cemented account frontier leaves.
+	nano::block_hash accounts_root{ 0 };
+	// Merkle root over the cemented pending (receivable) leaves.
+	nano::block_hash pending_root{ 0 };
+	// Number of cemented accounts folded into accounts_root.
+	uint64_t account_count{ 0 };
+	// Number of cemented pending entries folded into pending_root.
+	uint64_t pending_count{ 0 };
+};
+
+/*
+ * Walk the cemented account frontier (confirmation_height table) and the cemented
+ * pending set (pending table, restricted to entries whose send block is cemented),
+ * hashing each into a leaf and folding the leaves - in canonical store key order -
+ * into a Merkle Mountain Range accumulator. Returns the resulting roots and counts.
+ *
+ * Cost is O(cemented accounts + cemented pending) store reads and O(log n) memory.
+ * Intended to be invoked off the hot path (e.g. via the state_commitment RPC).
+ */
+nano::state_commitment_result compute_state_commitment (nano::ledger const &, nano::secure::transaction const &);
+}

--- a/nano/secure/state_commitment.hpp
+++ b/nano/secure/state_commitment.hpp
@@ -121,4 +121,50 @@ std::optional<nano::state_proof> generate_pending_proof (nano::ledger const &, n
 
 // Verify a proof reconstructs its stated root from its claim. Pure; no store access.
 bool verify_state_proof (nano::state_proof const &);
+
+/*
+ * Block 3 of the ledger-bloat mitigation work: the retention planner. A storage-capped
+ * node keeps, per account, only its cemented frontier plus a bounded window of recent
+ * history, and discards everything cemented below that - the discarded content stays
+ * committed under the checkpoint root and can be re-fetched with a proof if ever needed.
+ *
+ * This layer computes the SAFE-TO-DROP set and proves it is safe (every retained account
+ * still verifies against the checkpoint root) and quantifies the reclaimable storage. It
+ * does NOT delete anything - destructive pruning + on-demand backfill is a follow-on that
+ * builds on this planner as its safety gate.
+ */
+
+// An anchor a storage-capped node (and light clients) prove against: the commitment root
+// at a given cemented height, with the leaf counts it binds.
+struct state_checkpoint final
+{
+	uint64_t cemented_height{ 0 }; // ledger.cemented_count() at capture time
+	nano::block_hash root{ 0 };
+	uint64_t account_count{ 0 };
+	uint64_t pending_count{ 0 };
+};
+
+// Capture the current cemented commitment as a checkpoint.
+nano::state_checkpoint capture_state_checkpoint (nano::ledger const &, nano::secure::transaction const &);
+
+// The result of planning capped retention against a freshly captured checkpoint.
+struct capped_retention_plan final
+{
+	nano::state_checkpoint checkpoint;
+	uint64_t history_window{ 0 }; // blocks kept per account, counting the frontier
+	uint64_t kept_blocks{ 0 }; // blocks a capped node would retain (frontier + window)
+	uint64_t droppable_blocks{ 0 }; // cemented blocks below the window, safe to drop
+	uint64_t retained_pending{ 0 }; // cemented pending entries (kept until Block 4)
+	uint64_t reclaimable_bytes{ 0 }; // droppable_blocks * approximate stored block size
+	uint64_t accounts_checked{ 0 }; // accounts whose frontier proof was verified
+	uint64_t accounts_proven{ 0 }; // of those, how many verified against checkpoint.root
+	bool all_proven{ false }; // accounts_proven == accounts_checked (no failures)
+};
+
+// Plan capped retention: classify cemented blocks as kept vs droppable for the given
+// per-account history window, quantify reclaimable bytes, and verify frontier proofs for
+// up to `max_accounts_to_prove` accounts against the checkpoint root (0 = prove all).
+// Proving is O(accounts_checked * total accounts), so callers off a bound it for large
+// ledgers; accounts_checked vs checkpoint.account_count reports any sampling.
+nano::capped_retention_plan plan_capped_retention (nano::ledger const &, nano::secure::transaction const &, uint64_t history_window, uint64_t max_accounts_to_prove);
 }

--- a/nano/secure/storage_weighted_work.cpp
+++ b/nano/secure/storage_weighted_work.cpp
@@ -1,0 +1,47 @@
+#include <nano/lib/blocks.hpp>
+#include <nano/lib/constants.hpp>
+#include <nano/lib/numbers.hpp>
+#include <nano/secure/ledger.hpp>
+#include <nano/secure/ledger_set_any.hpp>
+#include <nano/secure/storage_weighted_work.hpp>
+#include <nano/secure/transaction.hpp>
+
+#include <algorithm>
+
+bool nano::block_adds_new_account (nano::ledger const & ledger, nano::secure::transaction const & transaction, nano::block const & block)
+{
+	if (!block.is_send ())
+	{
+		return false;
+	}
+	// A state send carries the destination in its link; a legacy send in destination().
+	nano::account destination = block.link_field ().has_value () ? block.link_field ().value ().as_account () : block.destination ();
+	// New footprint iff the destination account is not yet opened in the ledger. A dust
+	// send to a never-opened account satisfies this on every block (the account never
+	// opens), so each such send pays the elevated cost.
+	return !ledger.any.account_exists (transaction, destination);
+}
+
+nano::storage_weighted_work_result nano::evaluate_storage_weighted_work (nano::ledger const & ledger, nano::secure::transaction const & transaction, nano::block const & block, double new_account_multiplier)
+{
+	nano::storage_weighted_work_result result;
+	// Never below 1.0: the storage weight only ever raises the requirement.
+	double const multiplier = std::max (1.0, new_account_multiplier);
+
+	result.base_threshold = ledger.work.threshold_base (block.work_version ());
+	result.achieved_difficulty = ledger.work.difficulty (block);
+	result.creates_new_account = nano::block_adds_new_account (ledger, transaction, block);
+
+	if (result.creates_new_account)
+	{
+		result.weight_multiplier = multiplier;
+		result.required_threshold = nano::difficulty::from_multiplier (multiplier, result.base_threshold);
+	}
+	else
+	{
+		result.weight_multiplier = 1.0;
+		result.required_threshold = result.base_threshold;
+	}
+	result.satisfies = result.achieved_difficulty >= result.required_threshold;
+	return result;
+}

--- a/nano/secure/storage_weighted_work.hpp
+++ b/nano/secure/storage_weighted_work.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <nano/lib/numbers.hpp>
+
+#include <cstdint>
+
+namespace nano
+{
+class block;
+class ledger;
+namespace secure
+{
+	class transaction;
+}
+
+/*
+ * Block 5 of the ledger-bloat mitigation work: the storage-weighted proof-of-work
+ * throttle. Proof-of-work today is a one-time issuance cost uncorrelated with the
+ * PERMANENT storage a block imposes, so minting dust is nearly free. This prices the
+ * mass-dust vector in CPU (never a monetary fee, so the feeless model is preserved):
+ * a state send whose destination account is not yet opened creates new permanent
+ * ledger footprint (a fresh account / receivable that may never be received), so it is
+ * required to carry more work than a send to an already-existing account.
+ *
+ * Legitimate first-contact onboarding pays the higher cost once per real new account -
+ * rare and acceptable - while an attacker fanning dust out to fabricated destinations
+ * pays it on every block. An attacker can dodge by pre-opening the destinations they
+ * control, but that itself costs an open + receive per destination, which is the
+ * self-limiting cost the throttle is meant to impose.
+ *
+ * This is an ADVISORY policy calculator: it computes the storage-weighted requirement
+ * and whether a block meets it. It does not change consensus work validation, which
+ * would require network-wide activation.
+ */
+
+// True if the block adds a brand-new account to permanent state: a send whose
+// destination account is not yet opened in the ledger.
+bool block_adds_new_account (nano::ledger const &, nano::secure::transaction const &, nano::block const &);
+
+struct storage_weighted_work_result final
+{
+	bool creates_new_account{ false }; // whether the storage weight applies
+	double weight_multiplier{ 1.0 }; // multiplier applied to the base requirement
+	uint64_t base_threshold{ 0 }; // normal work requirement for this block
+	uint64_t required_threshold{ 0 }; // storage-weighted requirement (>= base_threshold)
+	uint64_t achieved_difficulty{ 0 }; // difficulty of the block's current work
+	bool satisfies{ false }; // achieved_difficulty >= required_threshold
+};
+
+// Evaluate a block against the storage-weighted requirement. `new_account_multiplier`
+// (>= 1.0) is how much harder a state-creating send must work. Advisory / measurement.
+nano::storage_weighted_work_result evaluate_storage_weighted_work (nano::ledger const &, nano::secure::transaction const &, nano::block const &, double new_account_multiplier);
+}


### PR DESCRIPTION
## Summary

A read-only foundation for bounding ledger growth from dust / receivable spam, in five layers. Each is measurement / planning / advisory only — **no consensus, validation, or storage behavior changes, and no destructive deletion** — but together they are the machinery a storage-capped node and a work-throttle would build on.

### Motivation

A node can create unbounded permanent state by sending 1-raw "dust" to fabricated destination accounts: each send writes 32 arbitrary bytes into its own chain (`link`) and mints a permanent pending entry that is never received. Existing mechanisms don't bound this — pruning is opt-in, keeps every account head block, and cannot remove pending entries; balance-bucketed prioritization governs confirmation order, not retention; PoW is a one-time cost uncorrelated with lifetime storage.

## The five layers

1. **State commitment** (`compute_state_commitment`) — folds the cemented account frontier and cemented pending set, in canonical store key order, into a Merkle Mountain Range: a canonical root plus per-subtree roots and counts. Pure function of cemented state (byte-identical across honest nodes); domain-separated leaf/node hashes; little-endian integers.

2. **Inclusion proofs** (`generate_account_proof` / `generate_pending_proof` / `verify_state_proof`) — succinct MMR proofs against the root; verification is a pure function with no store access, so a light client can run it. A generated proof reconstructs byte-identically the commitment root.

3. **Capped-retention planner** (`capture_state_checkpoint` / `plan_capped_retention`) — classifies cemented blocks as kept vs droppable for a per-account history window, quantifies reclaimable bytes, and proves each retained account frontier against the checkpoint root. Safety invariant: the commitment leaf set is account **frontiers + pending only**, never pre-frontier history, so dropping history leaves the root unchanged.

4. **Cold-pending sweep** (`plan_pending_sweep` / `generate_cold_pending_proof` / `verify_cold_pending_proof`) — partitions the cemented pending set into hot vs **cold** (aged AND sub-threshold), commits the cold set under `cold_root`, and proves each cold entry stays claimable. Cold entries are never expired or returned, preserving the irreversible-send guarantee; a claimant presents a store-free proof to receive. Pruned (age-unreadable) entries stay hot; timestamps only age forward.

5. **Storage-weighted PoW** (`block_adds_new_account` / `evaluate_storage_weighted_work`) — a state send to a not-yet-opened account creates new permanent footprint, so its required work is scaled by a multiplier (floored at 1.0). Prices the mass-dust vector in CPU without any fee. Advisory policy calculator; consensus validation is unchanged.

## Interface (RPCs)

- `state_commitment` → root + sub-roots + counts
- `state_proof` (`account`, or `account`+`hash`) → claim, path, peaks, roots, `verified`
- `state_checkpoint` → `{ cemented_height, root, counts }`
- `state_retention_plan` (`window`, `count`) → kept/droppable blocks, `reclaimable_bytes`, per-account proof safety
- `state_pending_sweep` (`age`, `threshold`, `reference_timestamp`, `count`) → hot/cold counts, `cold_root`, `reclaimable_pending_bytes`, cold-proof safety
- `work_storage_weight` (`hash`, `multiplier`) → base/required threshold, achieved difficulty, `creates_new_account`, `satisfies`

## Changes

- `nano/secure/state_commitment.{hpp,cpp}` — commitment, MMR, proofs + pure verify, checkpoint + retention planner, pending sweep + cold proofs (shared leaf/hash/MMR/reconstruct helpers)
- `nano/secure/storage_weighted_work.{hpp,cpp}` — new-account detection + storage-weighted work policy
- `nano/node/json_handler` — the six RPCs above
- `nano/core_test/state_commitment.cpp`, `nano/core_test/storage_weighted_work.cpp` — tests for all five layers

## Testing

`core_test` covers all five layers, including tamper rejection on both proof types, hot/cold classification negatives, the retention safety invariant, and the work-weighting branches. The MMR fold, domain-separated hashing, canonical ordering, proof generation/verification, retention arithmetic + invariant, and cold classification + cold-proof verification were additionally validated standalone against the tree's blake2b reference implementation across every mountain shape (n = 1…4999).

🤖 Generated with [Claude Code](https://claude.com/claude-code)