### PR TITLE
Bugfix: Back-pressure on own frontier processing pool

### DIFF
--- a/nano/node/bootstrap/frontier_strategy.cpp
+++ b/nano/node/bootstrap/frontier_strategy.cpp
@@ -58,7 +58,7 @@ void frontier_strategy::run_one ()
 		return !ctx.accounts.priority_half_full ();
 	});
 	ctx.wait ([this] () {
-		return ctx.workers.queued_tasks () < ctx.config.frontier_scan.max_pending;
+		return workers.queued_tasks () < ctx.config.frontier_scan.max_pending;
 	});
 	auto channel = ctx.wait_channel (strategy::frontier);
 	if (!channel)


### PR DESCRIPTION
The frontier scan loop is gated on `ctx.workers` instead of the strategy's own processing pool. It was watching a queue it never writes to. Restores the intent of #5106, reverted by a rebase conflict in "Add per-strategy bootstrap rate limits".

I have tested bootstrapping with this fix, and observed higher average BPS