### PR TITLE
Stop the rebroadcaster before testing queue deduplication

### DIFF
--- a/nano/core_test/block_rebroadcaster.cpp
+++ b/nano/core_test/block_rebroadcaster.cpp
@@ -213,6 +213,9 @@ TEST (block_rebroadcaster, duplicate_block)
 	nano::test::system system;
 	auto & node = *system.add_node ();
 
+	// Deduplication covers only blocks waiting in the queue, so stop the processing thread to keep the first push queued
+	node.block_rebroadcaster.stop ();
+
 	// Create a block
 	nano::keypair key;
 	auto send = nano::state_block_builder ()


### PR DESCRIPTION
The `block_rebroadcaster.duplicate_block` test is flaky under parallel test load. `push` deduplicates only against blocks currently waiting in the queue, and since the test node has no peers, `network::check_capacity` short-circuits to success — the processing thread is free to consume the first block immediately. When that consumption lands between the two pushes, the second push is legitimately accepted again and the test fails.

Queue-scoped deduplication is intentional: repeated rebroadcasts are throttled separately by the cooldown index at broadcast time, and the `cooldown` test relies on a drained block being pushable again within the cooldown window. This change makes the test match that contract by stopping the processing thread first, so the first push stays queued and the duplicate check is deterministic regardless of scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)