### PR TITLE
Bugfix: RocksDB block cache bypassed after first table scan

### DIFF
--- a/nano/store/rocksdb/backend_rocksdb.cpp
+++ b/nano/store/rocksdb/backend_rocksdb.cpp
@@ -362,7 +362,9 @@ bool backend_rocksdb::exists (nano::store::transaction const & txn, nano::store:
 		}
 		else if constexpr (std::is_same_v<V, ::rocksdb::ReadOptions *>)
 		{
-			return db->Get (*ptr, table_to_column_family (table), key_slice, &slice);
+			::rocksdb::ReadOptions options = *ptr;
+			options.fill_cache = false;
+			return db->Get (options, table_to_column_family (table), key_slice, &slice);
 		}
 		else
 		{

--- a/nano/store/rocksdb/iterator.cpp
+++ b/nano/store/rocksdb/iterator.cpp
@@ -68,8 +68,9 @@ auto iterator::make_iterator (::rocksdb::DB * db, std::variant<::rocksdb::Transa
 		}
 		else if constexpr (std::is_same_v<V, ::rocksdb::ReadOptions *>)
 		{
-			ptr->fill_cache = false;
-			return db->NewIterator (*ptr, table);
+			::rocksdb::ReadOptions ropts = *ptr;
+			ropts.fill_cache = false;
+			return db->NewIterator (ropts, table);
 		}
 		else
 		{


### PR DESCRIPTION
Each read transaction holds a shared RocksDB ReadOptions object. When creating an iterator, we set fill_cache = false directly on it so scans don't pollute the block cache but the change sticks for the transaction's lifetime. 
After the first iterator, all later get calls on the same transaction also skip the block cache, so data that should be cached isn't.