### PR TITLE
Remove dead ipc code

### DIFF
--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -21,7 +21,6 @@
 #include <nano/node/cli.hpp>
 #include <nano/node/daemonconfig.hpp>
 #include <nano/node/inactive_node.hpp>
-#include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/json_handler.hpp>
 #include <nano/node/network.hpp>
 #include <nano/node/node.hpp>
@@ -1365,7 +1364,6 @@ int main (int argc, char * const * argv)
 			nano::inactive_node inactive_node_l (data_path, node_flags);
 
 			nano::node_rpc_config config;
-			nano::ipc::ipc_server server (*inactive_node_l.node, config);
 			auto handler_l (std::make_shared<nano::json_handler> (*inactive_node_l.node, config, command_l.str (), response_handler_l));
 			handler_l->process_request ();
 		}

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -9,7 +9,6 @@
 #include <nano/lib/utility.hpp>
 #include <nano/lib/version.hpp>
 #include <nano/node/cli.hpp>
-#include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/nodeconfig.hpp>
 #include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -647,10 +647,6 @@ void nano::ipc::ipc_server::stop ()
 	{
 		transport->stop ();
 	}
-	if (signals)
-	{
-		signals->cancel ();
-	}
 }
 
 std::optional<std::uint16_t> nano::ipc::ipc_server::listening_tcp_port () const

--- a/nano/node/ipc/ipc_server.hpp
+++ b/nano/node/ipc/ipc_server.hpp
@@ -7,8 +7,6 @@
 #include <nano/node/ipc/ipc_broker.hpp>
 #include <nano/node/node_rpc_config.hpp>
 
-#include <boost/asio/signal_set.hpp>
-
 #include <atomic>
 #include <memory>
 
@@ -41,13 +39,10 @@ namespace ipc
 		nano::logger logger{ "ipc_server" };
 
 	private:
-		void setup_callbacks ();
-
 		std::shared_ptr<nano::ipc::broker> broker;
 		nano::ipc::access access;
 		std::unique_ptr<dsock_file_remover> file_remover;
 		std::vector<std::shared_ptr<nano::ipc::transport>> transports;
-		std::shared_ptr<boost::asio::signal_set> signals;
 	};
 }
 }


### PR DESCRIPTION
Removes IPC code that was never reachable:

- `ipc_server::signals` - a `shared_ptr<signal_set>` that was never assigned, making the `signals->cancel()` branch in `stop()` permanently dead. Drops the member, the branch, and the now-unused `<boost/asio/signal_set.hpp>` include.
- `ipc_server::setup_callbacks()` - declared but never defined or called.
- The `ipc_server` instance in the `--debug_rpc` CLI path - constructed and never used. `json_handler` doesn't take an `ipc_server`.
- The `ipc_server.hpp` include in `nano_rpc/entry.cpp`, which only needs `ipc_rpc_processor`.

No functional change.