### PR TITLE
Bugfix: Code sanitizers are only running LMDB

### DIFF
--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       COMPILER: ${{ matrix.COMPILER }}
-      BACKEND: ${{ matrix.BACKEND }}
+      NANO_BACKEND: ${{ matrix.BACKEND }}
       SANITIZER: ${{ matrix.SANITIZER.name }}
       IGNORE_ERRORS: ${{ matrix.SANITIZER.ignore_errors }}
       TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}
@@ -100,7 +100,7 @@ jobs:
     runs-on: macos-14
     env:
       COMPILER: ${{ matrix.COMPILER }}
-      BACKEND: ${{ matrix.BACKEND }}
+      NANO_BACKEND: ${{ matrix.BACKEND }}
       SANITIZER: ${{ matrix.SANITIZER.name }}
       IGNORE_ERRORS: ${{ matrix.SANITIZER.ignore_errors }}
       TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}

--- a/.github/workflows/flamegraphs.yml
+++ b/.github/workflows/flamegraphs.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       TEST_NAME: ${{ matrix.TEST_NAME }}
-      BACKEND: lmdb
+      NANO_BACKEND: lmdb
       COMPILER: gcc
       TEST_USE_ROCKSDB: "0"
       DEADLINE_SCALE_FACTOR: "1"


### PR DESCRIPTION
Code sanitizers are only running LMDB because the variable name for setting the database backend is wrong. This means that lmdb is running twice, while Rocksdb never runs
The Flamegraph flow also uses the wrong variable name when it tries to set the backend to LMDB . However, LMDB is the default anyway so it doesn't cause a problem. Variable name has been updated to the correct one to avoid future confusion