### PR TITLE
Fix out-of-range channel access in peer_history_restart

### DIFF
--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -2707,13 +2707,13 @@ TEST (node, peer_history_restart)
 			store.peer.put (transaction, endpoint_key, 37);
 		}
 		node2->start ();
-		ASSERT_TIMELY (10s, !node2->network.empty ());
-		// Confirm that the peers match with the endpoints we are expecting
-		auto list (node2->network.list (2));
-		ASSERT_EQ (node1->network.endpoint (), list[0]->get_remote_endpoint ());
+		// Confirm that the node connected to the peer loaded from the cache
+		ASSERT_TIMELY (10s, node2->network.find_channel (node1->network.endpoint ()));
 		ASSERT_EQ (1, node2->network.size ());
 		system.stop_node (*node2);
 	}
+	// The restarted node reuses the same node id, so wait for node1 to purge the stale channel, otherwise the reconnect is rejected as a duplicate
+	ASSERT_TIMELY (10s, node1->network.empty ());
 	// Restart node
 	{
 		nano::node_flags node_flags;
@@ -2730,10 +2730,8 @@ TEST (node, peer_history_restart)
 			ASSERT_EQ (store.peer.count (transaction), 1);
 			ASSERT_TRUE (store.peer.exists (transaction, endpoint_key));
 		}
-		ASSERT_TIMELY (10s, !node3->network.empty ());
-		// Confirm that the peers match with the endpoints we are expecting
-		auto list (node3->network.list (2));
-		ASSERT_EQ (node1->network.endpoint (), list[0]->get_remote_endpoint ());
+		// Confirm that the node reconnected to the peer loaded from the cache
+		ASSERT_TIMELY (10s, node3->network.find_channel (node1->network.endpoint ()));
 		ASSERT_EQ (1, node3->network.size ());
 		system.stop_node (*node3);
 	}


### PR DESCRIPTION
`node.peer_history_restart` aborted on the Windows CI runner with `deque subscript out of range`, raised by `list[0]` in the restart block.

The restarted node reopens the same data directory, so it loads the same node id as the node that was just stopped. node1 still holds that node's channel until its next cleanup tick, so it rejects the reconnect as a duplicate node id and closes the socket. The restarted node has already inserted its own channel by then, which means the test was asserting against a channel that was already dead and had merely not been purged yet — the restart phase never verified a live connection at all. When the purge erased that channel between the `empty ()` check and the `list (2)` call, `list` came back empty and `list[0]` ran off the end.

The two reads are the defect: `network::list` takes the lock, copies, and releases it, so nothing holds the channel set still across the `empty ()` check and the subsequent index. This reproduces only where the two land far enough apart to straddle a cleanup tick, which is why it has surfaced on Windows and not on the other runners.

This change waits for the stale channel to be dropped before restarting, so the reconnect is accepted and the test exercises a real reconnect, and replaces the `empty ()` plus `list[0]` pair with a single `find_channel` predicate — the same idiom already used with `find_node_id` in the `network` and `tcp_server` tests. Verified with debug logging that both nodes now accept the channel on reconnect, where previously node1 logged `Rejected duplicate channel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
