### PR TITLE
Rate-limit topo bootstrap repair heads

### DIFF
--- a/nano/node/bootstrap/bootstrap_config.cpp
+++ b/nano/node/bootstrap/bootstrap_config.cpp
@@ -64,6 +64,7 @@ nano::error nano::topo_scan_config::deserialize (nano::tomlconfig & toml)
 	toml.get ("max_repair_heads", max_repair_heads);
 	toml.get ("consideration_count", consideration_count);
 	toml.get ("repair_consideration", repair_consideration);
+	toml.get ("repair_rate_limit", repair_rate_limit);
 	toml.get ("candidates", candidates);
 	toml.get ("redundant_skip_threshold", redundant_skip_threshold);
 	toml.get ("redundant_skip_history_size", redundant_skip_history_size);
@@ -86,6 +87,7 @@ nano::error nano::topo_scan_config::serialize (nano::tomlconfig & toml) const
 	toml.put ("max_repair_heads", max_repair_heads, "Maximum number of repair heads; beyond this the per-head band grows instead of the head count.\ntype:uint64");
 	toml.put ("consideration_count", consideration_count, "Number of distinct peers the spearhead samples before advancing the discovery frontier.\ntype:uint64");
 	toml.put ("repair_consideration", repair_consideration, "Number of distinct peers a repair head samples before advancing its band cursor.\ntype:uint64");
+	toml.put ("repair_rate_limit", repair_rate_limit, "Rate limit on topology index requests issued by repair heads, shared across all of them. Repair heads re-scan the already-discovered range indefinitely and every page is verified against the local ledger, so this bounds the background disk load. Use 0 to disable (not recommended).\ntype:uint64");
 	toml.put ("candidates", candidates, "Maximum number of new aggregated entries (the smallest) retained per advance. Topo index requests always use the protocol maximum page size.\ntype:uint64");
 	toml.put ("redundant_skip_threshold", redundant_skip_threshold, "Number of consecutive fully redundant spearhead pages required before fast-forwarding. Use 0 to disable.\ntype:uint64");
 	toml.put ("redundant_skip_history_size", redundant_skip_history_size, "Number of recent spearhead pages considered by the adaptive skip policy. Each page that needed fetching raises the next redundant-page threshold by one. Use 0 for a fixed threshold.\ntype:uint64");

--- a/nano/node/bootstrap/bootstrap_config.hpp
+++ b/nano/node/bootstrap/bootstrap_config.hpp
@@ -52,6 +52,7 @@ public:
 	unsigned max_repair_heads{ 6 }; // Cap on repair heads; beyond it bands grow rather than the head count
 	unsigned consideration_count{ 3 }; // Spearhead: distinct peers sampled before the frontier advances
 	unsigned repair_consideration{ 1 }; // Repair: distinct peers sampled before a band cursor advances
+	std::size_t repair_rate_limit{ 20 }; // Topo index requests per second across all repair heads; every page re-verifies up to max_entries keys against the ledger, so this bounds the sweep's disk load
 	std::size_t candidates{ nano::bootstrap_server::max_topo_entries - 1 }; // Cap on new aggregated entries kept (the smallest) per advance; topo_index responses include the cursor
 	std::size_t redundant_skip_threshold{ 100 }; // Consecutive fully-redundant spearhead pages before fast-forwarding
 	std::size_t redundant_skip_history_size{ 200 }; // Recent spearhead pages remembered; each page that needed fetching raises the next skip threshold by one

--- a/nano/node/bootstrap/topo_strategy.cpp
+++ b/nano/node/bootstrap/topo_strategy.cpp
@@ -39,7 +39,8 @@ topo_strategy::topo_strategy (bootstrap_context & ctx_a) :
 	gaps{ ctx.config.topo_scan, ctx.stats },
 	skip_policy{ ctx.config.topo_scan },
 	spearhead_workers{ 1, nano::thread_role::name::bootstrap_topo_processing },
-	repair_workers{ 1, nano::thread_role::name::bootstrap_topo_processing }
+	repair_workers{ 1, nano::thread_role::name::bootstrap_topo_processing },
+	repair_limiter{ ctx.config.topo_scan.repair_rate_limit }
 {
 	// Retire completed pages straight into the pre-check pipeline
 	scan.sink = [this] (topo_scan::page page) {
@@ -125,11 +126,13 @@ void topo_strategy::scan_one ()
 
 	// Back-pressure each head class on its own pre-check pool (spearhead also on the gap backlog) so a saturated
 	// pool gates only its class; next () never drops a page, which would strand its blocks out of the buffer.
+	// Repair heads are additionally paced by their own rate limiter, and only run at all with the topo index: without
+	// it the pre-check has to probe every entry by hash, and a perpetual sweep in that mode is a random-read storm.
 	std::optional<topo_scan::request> req;
 	ctx.wait ([this, &req] () {
 		topo_scan::head_gates gates{
 			.include_spearhead = gaps.count () < ctx.config.topo_scan.max_gaps && spearhead_workers.queued_tasks () < max_precheck_tasks,
-			.include_repair = repair_workers.queued_tasks () < max_precheck_tasks,
+			.include_repair = ctx.ledger.flags.topo_index && repair_workers.queued_tasks () < max_precheck_tasks && repair_limiter.can_consume (),
 		};
 		req = scan.next (gates);
 		return req.has_value ();
@@ -137,6 +140,12 @@ void topo_strategy::scan_one ()
 	if (!req)
 	{
 		return;
+	}
+
+	// Charge the round now that a repair head has been reserved; the scan thread is the only consumer so the gate above guarantees a token
+	if (req->head != 0)
+	{
+		repair_limiter.try_consume (req->fanout);
 	}
 
 	// Acquire up to `fanout` distinct peers (topo index requests need the capability); the cross-round

--- a/nano/node/bootstrap/topo_strategy.hpp
+++ b/nano/node/bootstrap/topo_strategy.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/lib/interval.hpp>
+#include <nano/lib/rate_limiting.hpp>
 #include <nano/lib/thread_pool.hpp>
 #include <nano/messages/fwd.hpp>
 #include <nano/node/bootstrap/bootstrap_context.hpp>
@@ -80,6 +81,10 @@ private:
 	// Pre-check ledger reads run here, off the message thread
 	nano::thread_pool spearhead_workers;
 	nano::thread_pool repair_workers;
+
+	// Paces repair-head requests: the repair sweep re-verifies the discovered range indefinitely, and each page is a
+	// ledger read, so it must not run at line rate like the spearhead does
+	nano::rate_limiter repair_limiter;
 
 	// Rate-limits the "not enough peers" warning while discovery is starved
 	nano::interval starvation_warning_interval;


### PR DESCRIPTION
## Problem

With topo bootstrap enabled, a synced node ramps to 100% disk read time after a few minutes and stays there (observed on Windows + RocksDB).

Repair heads re-scan the already-discovered topo range indefinitely, and `topo_scan::maybe_advance` zeroes a head's timestamp whenever a page makes progress, so the head re-fires as soon as the reply lands. On a synced node every repair page "makes progress", so the `cooldown` never engages; when a band is exhausted the head is immediately re-armed on the same band. The only limits are the shared `topo_rate_limit` (500 req/s) and the 64-page pre-check queue, so the sweep runs as fast as the pre-check can read the ledger, i.e. it pegs the disk by construction.

If the ledger has no topo index (`--populate_topo_index` never run on an existing ledger), `topo_strategy::precheck` falls back to probing every entry by hash, which turns that sweep into ~1.6k random block reads per page with `fill_cache = false`.

## Changes

- Add `bootstrap.topo_scan.repair_rate_limit` (default 20 req/s, `0` = unlimited) and a dedicated `nano::rate_limiter` in `topo_strategy`. It is applied through `head_gates.include_repair`, so a throttled repair head never stalls the spearhead on the shared scan thread; the spearhead keeps its current pacing.
- Repair heads no longer run at all when `ledger.flags.topo_index` is off. The spearhead still works there (its pages are bounded), but a perpetual sweep needs the sequential topology crawler to be sane.

## Testing

`bootstrap.*`, `bootstrap_topo_scan.*`, `bootstrap_topo_blocks.*`, `toml.*` pass. Not reproduced locally; the fix follows from the code path above and should be verified on the affected Windows/RocksDB setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
