### PR TITLE
Test final tally across a winner switch

### DIFF
--- a/nano/core_test/election.cpp
+++ b/nano/core_test/election.cpp
@@ -195,6 +195,76 @@ TEST (election, sealed_round_frozen)
 	ASSERT_EQ (nano::dev::constants.genesis_amount, election->get_status ().tally.number ());
 }
 
+// The reported final tally follows the winner across a fork switch: final votes behind the displaced block are neither carried over to the new winner nor pooled into its final tally once it confirms
+TEST (election, final_tally_follows_winner_switch)
+{
+	nano::test::system system;
+	nano::node_config node_config = system.default_config ();
+	node_config.online_weight_minimum = nano::dev::constants.genesis_amount;
+	node_config.backlog_scan->enable = false;
+	auto & node = *system.add_node (node_config);
+
+	// Split the weight so that only genesis can reach the quorum of two thirds: a minor rep holds a tenth of the supply and genesis keeps the rest
+	auto const minor = nano::test::setup_rep (system, node, nano::dev::constants.genesis_amount / 10);
+	auto const genesis_weight = node.ledger.weight (nano::dev::genesis_key.pub);
+	ASSERT_LT (node.ledger.weight (minor.pub), node.online_reps.delta ());
+	ASSERT_GE (genesis_weight, node.online_reps.delta ());
+
+	// Fork the minor rep's chain so that reprocessing the winning fork never moves genesis weight; send1 enters the ledger, send2 only the election
+	auto const latest = node.latest (minor.pub);
+	auto const balance = node.balance (minor.pub);
+	nano::state_block_builder builder;
+	auto send1 = builder.make_block ()
+				 .account (minor.pub)
+				 .previous (latest)
+				 .representative (minor.pub)
+				 .balance (balance - 1)
+				 .link (nano::keypair{}.pub)
+				 .sign (minor.prv, minor.pub)
+				 .work (*system.work.generate (latest))
+				 .build ();
+	auto send2 = builder.make_block ()
+				 .account (minor.pub)
+				 .previous (latest)
+				 .representative (minor.pub)
+				 .balance (balance - 1)
+				 .link (nano::keypair{}.pub)
+				 .sign (minor.prv, minor.pub)
+				 .work (*system.work.generate (latest))
+				 .build ();
+	ASSERT_NE (send1->hash (), send2->hash ());
+	ASSERT_TRUE (nano::test::process (node, { send1 }));
+	auto const minor_weight = node.ledger.weight (minor.pub);
+
+	auto election = std::make_shared<nano::election> (node, send1, nano::election_behavior::priority, 42);
+	ASSERT_TRUE (election->publish (send2));
+	ASSERT_EQ (2, election->blocks ().size ());
+
+	// The minor rep commits to send1 with a final vote: send1 stays the winner with that final weight behind it, short of final quorum
+	ASSERT_EQ (nano::vote_code::vote, election->vote (minor.pub, nano::vote::timestamp_final, send1->hash (), nano::vote_source::live));
+	auto status = election->get_status ();
+	ASSERT_EQ (send1->hash (), status.winner->hash ());
+	ASSERT_EQ (minor_weight, status.tally.number ());
+	ASSERT_EQ (minor_weight, status.final_tally.number ());
+	ASSERT_FALSE (election->confirmed ());
+
+	// A normal vote from genesis moves the winner to send2, which has no final votes: the final tally must not keep the minor rep's weight
+	ASSERT_EQ (nano::vote_code::vote, election->vote (nano::dev::genesis_key.pub, nano::vote::timestamp_min, send2->hash (), nano::vote_source::live));
+	status = election->get_status ();
+	ASSERT_EQ (send2->hash (), status.winner->hash ());
+	ASSERT_EQ (genesis_weight, status.tally.number ());
+	ASSERT_EQ (0, status.final_tally.number ());
+	ASSERT_FALSE (election->confirmed ());
+
+	// Genesis finalizes send2: the election confirms on genesis weight alone and the frozen record reports only that, not the minor rep's final vote for send1
+	ASSERT_EQ (nano::vote_code::vote, election->vote (nano::dev::genesis_key.pub, nano::vote::timestamp_final, send2->hash (), nano::vote_source::live));
+	ASSERT_TRUE (election->confirmed ());
+	status = election->get_status ();
+	ASSERT_EQ (send2->hash (), status.winner->hash ());
+	ASSERT_EQ (genesis_weight, status.tally.number ());
+	ASSERT_EQ (genesis_weight, status.final_tally.number ());
+}
+
 // Only a confirmed election keeps voting after sealing, a cancelled one must not vote
 TEST (election, sealed_no_broadcast_vote)
 {

--- a/nano/core_test/election_ballot.cpp
+++ b/nano/core_test/election_ballot.cpp
@@ -1040,7 +1040,7 @@ TEST (election_ballot, evaluate_final_weight_resets_on_winner_switch)
 	auto round3 = ballot.evaluate (10);
 	ASSERT_EQ (fork, round3.winner);
 	ASSERT_EQ (5, round3.final_winner_weight);
-	ASSERT_FALSE (round3.final_quorum); // 5 alone is below the threshold, 5 + 7 would not be
+	ASSERT_FALSE (round3.final_quorum); // 5 alone is below the threshold, while 5 + 7 would reach it
 
 	// Only the fork's own final weight reaching the threshold confirms it
 	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (reps.rep (6), nano::vote::timestamp_final, fork->hash (), 0s, epoch));

--- a/nano/core_test/election_ballot.cpp
+++ b/nano/core_test/election_ballot.cpp
@@ -1009,6 +1009,84 @@ TEST (election_ballot, evaluate_final_weight_follows_winner)
 }
 
 /*
+ * The final weight is re-read for whichever block holds the winner slot after each evaluation, it is never carried over from a previous winner.
+ * When the winner moves to a fork without final votes the final weight must drop to zero rather than keep the old winner's total, and final votes the new winner then collects must not be pooled with the old winner's: a stale or pooled value would misreport confirmation progress and, at the threshold, confirm a block its finalizing reps never voted for.
+ */
+TEST (election_ballot, evaluate_final_weight_resets_on_winner_switch)
+{
+	test_reps reps;
+	auto initial = create_block ();
+	auto fork = create_block ();
+	nano::election_ballot ballot{ initial, reps.query () };
+	ASSERT_EQ (nano::election_ballot::insert_outcome::inserted, ballot.insert (fork).outcome);
+
+	// 7 final weight backs the initial winner, short of the threshold of 10
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (reps.rep (7), nano::vote::timestamp_final, initial->hash (), 0s, epoch));
+	auto round1 = ballot.evaluate (10);
+	ASSERT_EQ (initial, round1.winner);
+	ASSERT_EQ (7, round1.final_winner_weight);
+	ASSERT_FALSE (round1.final_quorum);
+
+	// 20 normal weight moves the winner to the fork, which has no final votes of its own
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (reps.rep (20), nano::vote::timestamp_min, fork->hash (), 0s, epoch));
+	auto round2 = ballot.evaluate (10);
+	ASSERT_EQ (fork, round2.winner);
+	ASSERT_EQ (20, round2.winner_weight);
+	ASSERT_EQ (0, round2.final_winner_weight); // Not the 7 left behind on the initial block
+	ASSERT_FALSE (round2.final_quorum);
+
+	// Final weight the fork collects is counted on its own, not pooled with the 7 behind the initial block
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (reps.rep (5), nano::vote::timestamp_final, fork->hash (), 0s, epoch));
+	auto round3 = ballot.evaluate (10);
+	ASSERT_EQ (fork, round3.winner);
+	ASSERT_EQ (5, round3.final_winner_weight);
+	ASSERT_FALSE (round3.final_quorum); // 5 alone is below the threshold, 5 + 7 would not be
+
+	// Only the fork's own final weight reaching the threshold confirms it
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (reps.rep (6), nano::vote::timestamp_final, fork->hash (), 0s, epoch));
+	auto round4 = ballot.evaluate (10);
+	ASSERT_EQ (fork, round4.winner);
+	ASSERT_EQ (11, round4.final_winner_weight);
+	ASSERT_TRUE (round4.final_quorum);
+}
+
+/*
+ * Final quorum is a property of the current winner and is re-derived on every evaluation, so a winner switch revokes it until the new winner earns it with final votes of its own, and restores it if the old winner regains the slot with its retained final votes.
+ * Election confirmation is gated on this flag: were it to survive a switch, an election could confirm the new winner on the strength of final votes cast for the block it displaced.
+ */
+TEST (election_ballot, evaluate_final_quorum_follows_winner_switch)
+{
+	test_reps reps;
+	auto initial = create_block ();
+	auto fork = create_block ();
+	nano::election_ballot ballot{ initial, reps.query () };
+	ASSERT_EQ (nano::election_ballot::insert_outcome::inserted, ballot.insert (fork).outcome);
+
+	// 12 final weight gives the initial block final quorum at a threshold of 10
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (reps.rep (12), nano::vote::timestamp_final, initial->hash (), 0s, epoch));
+	auto round1 = ballot.evaluate (10);
+	ASSERT_EQ (initial, round1.winner);
+	ASSERT_EQ (12, round1.final_winner_weight);
+	ASSERT_TRUE (round1.final_quorum);
+
+	// 20 normal weight moves the winner to the fork; final quorum stays with the displaced block, not with the slot
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (reps.rep (20), nano::vote::timestamp_min, fork->hash (), 0s, epoch));
+	auto round2 = ballot.evaluate (10);
+	ASSERT_EQ (fork, round2.winner);
+	ASSERT_EQ (20, round2.winner_weight);
+	ASSERT_EQ (0, round2.final_winner_weight);
+	ASSERT_FALSE (round2.final_quorum);
+
+	// 10 more normal weight brings the initial block to 22 and the winner slot back with it, so its retained final votes count again
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (reps.rep (10), nano::vote::timestamp_min, initial->hash (), 0s, epoch));
+	auto round3 = ballot.evaluate (10);
+	ASSERT_EQ (initial, round3.winner);
+	ASSERT_EQ (22, round3.winner_weight);
+	ASSERT_EQ (12, round3.final_winner_weight);
+	ASSERT_TRUE (round3.final_quorum);
+}
+
+/*
  * The tally query is a pure report: it shows the current standings without advancing the winner.
  * Only evaluate may move the winner, so status displays and RPC endpoints can inspect the tally freely without side effects on consensus state.
  */


### PR DESCRIPTION
Adds test coverage pinning how the election ballot reports final-vote weight and final quorum when the winning fork changes. Tests only, no production code changes.

## What is pinned

`election_ballot::evaluate ()` derives `winner_weight`, `final_winner_weight` and `final_quorum` from the recorded votes on every call, always for whichever block currently holds the winner slot, and carries nothing between rounds. A winner switch therefore re-derives all three.

The suite did not cover a switch. `election_ballot.evaluate_final_weight_follows_winner` places final votes on a losing fork, where the winner never moves, so these paths were unexercised.

## Tests

- `election_ballot.evaluate_final_weight_resets_on_winner_switch`: the final weight drops to zero when the winner moves to a fork with no final votes, and final votes the new winner subsequently collects are counted on their own rather than pooled with the displaced fork's.
- `election_ballot.evaluate_final_quorum_follows_winner_switch`: `final_quorum` is revoked by a winner switch and restored when the original winner regains the slot with its retained final votes.
- `election.final_tally_follows_winner_switch`: end to end on a node, the reported final tally follows the winner across a fork switch, and the record frozen at confirmation carries only the final weight cast for the confirmed block.

Each test was checked against deliberately broken variants of `evaluate ()`, one carrying the previous winner's final weight across a switch and one pooling final weight across all forks, and fails under both.

## Notes on the election test

The fork sits on a minor representative's chain rather than on genesis, so the rollback and reprocess triggered by the winner switch can never move genesis weight and the asserted tallies are deterministic. `online_weight_minimum` is set to the full genesis amount so the minor representative is below quorum and genesis alone is above it; the `ASSERT_LT`/`ASSERT_GE` pair pins that arrangement so the test fails loudly rather than vacuously if the quorum constant changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

