### PR TITLE
Disable core dumps for expected death tests in CI

### DIFF
--- a/ci/tests/common.sh
+++ b/ci/tests/common.sh
@@ -14,3 +14,7 @@ get_exec_extension() {
             ;;
     esac
 }
+
+get_test_executable() {
+    echo "./${1}$(get_exec_extension)"
+}

--- a/ci/tests/run-core-tests.sh
+++ b/ci/tests/run-core-tests.sh
@@ -1,4 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
-$(dirname "$BASH_SOURCE")/run-tests.sh core_test
+script_dir=$(dirname "$BASH_SOURCE")
+
+if [ -z "${COREDUMP_DIR-}" ]; then
+    exec "${script_dir}/run-tests.sh" core_test
+fi
+
+# Match ordinary and typed death-test suites using Google Test's naming convention.
+death_test_filter='*DeathTest.*:*DeathTest/*.*'
+status=0
+
+# Expected child crashes must not fill the runner's disk with core dumps.
+(
+    unset COREDUMP_DIR
+    ulimit -S -c 0 || exit
+    "${script_dir}/run-tests.sh" core_test --gtest_filter="${death_test_filter}"
+) || status=$?
+
+"${script_dir}/run-tests.sh" core_test --gtest_filter="-${death_test_filter}" || status=$?
+
+exit "${status}"

--- a/ci/tests/run-core-tests.sh
+++ b/ci/tests/run-core-tests.sh
@@ -1,22 +1,35 @@
 #!/bin/bash
 set -euo pipefail
 
-script_dir=$(dirname "$BASH_SOURCE")
+script_dir=$(dirname "${BASH_SOURCE[0]}")
+source "${script_dir}/common.sh"
 
+# Without dump collection there is nothing to opt out of, so run the suite in one go.
 if [ -z "${COREDUMP_DIR-}" ]; then
     exec "${script_dir}/run-tests.sh" core_test
 fi
 
-# Match ordinary and typed death-test suites using Google Test's naming convention.
+# Suites suffixed `DeathTest` crash child processes on purpose, and every crash writes a
+# multi-gigabyte dump - enough to fill the runner's disk before the rest of the suite
+# starts. Run them in a separate pass with core dumps turned off.
+# The pattern covers plain suites (`foo_DeathTest.bar`) and the typed/parameterized
+# instantiations gtest names `foo_DeathTest/0.bar`.
 death_test_filter='*DeathTest.*:*DeathTest/*.*'
+
+# Guard the naming convention: if it ever drifts, the death tests would silently fall
+# into the dump-collecting pass and fill the disk again with nothing reporting it.
+listed=$("$(get_test_executable core_test)" --gtest_list_tests --gtest_filter="${death_test_filter}")
+case "${listed}" in
+    *DeathTest*) ;;
+    *)
+        echo "::error::No test suites matched '${death_test_filter}'"
+        exit 1
+        ;;
+esac
+
 status=0
 
-# Expected child crashes must not fill the runner's disk with core dumps.
-(
-    unset COREDUMP_DIR
-    ulimit -S -c 0 || exit
-    "${script_dir}/run-tests.sh" core_test --gtest_filter="${death_test_filter}"
-) || status=$?
+NANO_DISABLE_CORE_DUMPS=1 "${script_dir}/run-tests.sh" core_test --gtest_filter="${death_test_filter}" || status=$?
 
 "${script_dir}/run-tests.sh" core_test --gtest_filter="-${death_test_filter}" || status=$?
 

--- a/ci/tests/run-tests.sh
+++ b/ci/tests/run-tests.sh
@@ -11,14 +11,16 @@ fi
 
 echo "Running tests for target: ${target}"
 
-# Enable core dumps for this process
-if [ -n "${COREDUMP_DIR-}" ]; then
+# Enable core dumps for this process, unless the caller expects crashes
+if [ -n "${NANO_DISABLE_CORE_DUMPS-}" ]; then
+    ulimit -c 0
+elif [ -n "${COREDUMP_DIR-}" ]; then
     ulimit -c unlimited
 fi
 
 # Run the test
 shift
-executable=./${target}$(get_exec_extension)
+executable=$(get_test_executable "${target}")
 "${executable}" "$@"
 status=$?
 


### PR DESCRIPTION
Expected death-test crashes currently generate core dumps when CI enables dump collection. In the [macOS/RocksDB CI failure](https://github.com/nanocurrency/nano-node/actions/runs/34227154932/job/102063965502?pr=5162), these dumps accumulated to 34.7 GB and the runner reported only 36 MB free before the first ordinary core test crashed.

Run ordinary and typed death-test suites in a separate process with core dumps disabled, then run the remaining core tests with dump collection enabled. Both phases run even if one fails, and failures from either phase are preserved. Without dump collection enabled, the runner continues to use a single invocation.

Validation:

- All nine death tests pass with both LMDB and RocksDB.
- A shell harness verified core limits, ordinary/typed suite selection, and failure propagation with dump collection enabled and disabled.
- Shell syntax and diff whitespace checks pass.

🤖 Generated with [Codex](https://openai.com/codex/)
