### PR TITLE
Fix vote generator CI races

### DIFF
--- a/nano/core_test/vote_generator.cpp
+++ b/nano/core_test/vote_generator.cpp
@@ -1,7 +1,9 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/ratios.hpp>
 #include <nano/lib/vote.hpp>
+#include <nano/node/backlog_scan.hpp>
 #include <nano/node/node_observers.hpp>
+#include <nano/node/nodeconfig.hpp>
 #include <nano/node/vote_generator.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/secure/voting_policy.hpp>
@@ -677,7 +679,9 @@ TEST (vote_generator_broadcaster, check_capacity_backpressure)
 TEST (vote_generator, basic_broadcast)
 {
 	nano::test::system system;
-	auto & node = *system.add_node ();
+	auto config = system.default_config ();
+	config.backlog_scan->enable = false; // Keep setup from starting elections and recording final votes
+	auto & node = *system.add_node (config);
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 
 	auto blocks = nano::test::setup_chain (system, node, 1);

--- a/nano/core_test/vote_generator.cpp
+++ b/nano/core_test/vote_generator.cpp
@@ -6,7 +6,9 @@
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/vote_generator.hpp>
 #include <nano/node/wallet.hpp>
+#include <nano/secure/ledger.hpp>
 #include <nano/secure/voting_policy.hpp>
+#include <nano/store/ledger/final_vote.hpp>
 #include <nano/test_common/chains.hpp>
 #include <nano/test_common/random.hpp>
 #include <nano/test_common/system.hpp>
@@ -14,6 +16,7 @@
 
 #include <gtest/gtest.h>
 
+#include <map>
 #include <set>
 
 using namespace std::chrono_literals;
@@ -760,6 +763,60 @@ TEST (vote_generator, multiple_representatives)
 	ASSERT_TRUE (signers.count (rep1.pub));
 	ASSERT_TRUE (signers.count (rep2.pub));
 	ASSERT_TRUE (signers.count (rep3.pub));
+}
+
+// Final vote records must be visible in a fresh ledger snapshot when their votes are observed
+TEST (vote_generator, final_vote_record_visible_at_broadcast)
+{
+	int constexpr block_count = 1024;
+	nano::test::system system;
+	auto config = system.default_config ();
+	config.backlog_scan->enable = false;
+	config.vote_generator->batch_size = block_count; // Allow broadcasting while a large batch is still being published
+	config.vote_generator->delay = 1ms;
+	nano::node_flags flags;
+	flags.disable_rep_crawler = true; // Final replies for cemented blocks do not require vote records
+	auto & node = *system.add_node (config, flags);
+	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
+
+	auto blocks = nano::test::setup_chain (system, node, block_count);
+	ASSERT_TRUE (node.ledger.store.final_vote.empty (node.ledger.tx_begin_read ()));
+
+	std::map<nano::block_hash, nano::qualified_root> roots;
+	for (auto const & block : blocks)
+	{
+		roots.emplace (block->hash (), block->qualified_root ());
+	}
+
+	nano::shared_locked<std::map<nano::block_hash, std::optional<nano::block_hash>>> records;
+	node.observers.vote.add ([&node, roots, records] (std::shared_ptr<nano::vote> const & vote, std::shared_ptr<nano::transport::channel> const &, nano::vote_source, nano::vote_code) {
+		if (vote->is_final ())
+		{
+			// Capture visibility at observation time without waiting for the record to appear
+			auto transaction = node.ledger.tx_begin_read ();
+			for (auto const & hash : vote->hashes)
+			{
+				if (auto it = roots.find (hash); it != roots.end ())
+				{
+					auto record = node.ledger.store.final_vote.get (transaction, it->second);
+					records->emplace (hash, record);
+				}
+			}
+		}
+	});
+
+	for (auto const & block : blocks)
+	{
+		node.vote_generator.vote_final (block->qualified_root (), block->hash (), 0);
+	}
+	ASSERT_TIMELY_EQ (5s, records->size (), blocks.size ());
+
+	auto locked = records.lock ();
+	for (auto const & [hash, record] : locked.get ())
+	{
+		ASSERT_TRUE (record) << "Missing final vote record for " << hash.to_string ();
+		ASSERT_EQ (hash, *record);
+	}
 }
 
 // Normal vote for a root with an existing final vote record is upgraded and routed to final broadcaster

--- a/nano/node/vote_generator.cpp
+++ b/nano/node/vote_generator.cpp
@@ -152,6 +152,9 @@ void nano::vote_generator::process_final (std::deque<vote_generator_verifier::en
 		}
 	}
 
+	// Commit final vote records before publishing permits
+	transaction.commit ();
+
 	for (auto const & permit : verified)
 	{
 		debug_assert (permit.type () == nano::vote_type::final);


### PR DESCRIPTION
Final votes could be observed before `process_final()` committed their ledger records. A normal vote requested immediately afterward could miss the record and remain normal, causing `vote_generator.normal_upgraded_to_final` to fail. Commit the final-vote transaction before publishing permits to the broadcaster.

Disable backlog scanning in `vote_generator.basic_broadcast` so setup cannot start elections between processing and cementing the block and unexpectedly create a final-vote record.

Add `final_vote_record_visible_at_broadcast` to check a fresh ledger snapshot immediately when final votes are observed for 1,024 previously unvoted roots. Disable representative crawling in this test because replies for cemented blocks do not require stored vote records. Regression detection depends on thread scheduling.

Validation:

- All 74 related voting tests passed on both LMDB and RocksDB in Debug and coverage builds (`vote_generator*.*:vote_broadcast_index.*:voting_policy*.*:vote_replier.*`).
- The new regression test passed 20 repetitions per backend with the fix. Temporarily removing the early commit caused missing-record failures in 1/5 LMDB runs and 5/5 RocksDB runs. The commit was restored before final validation.
- Formatting and whitespace checks passed. Coverage was reviewed; existing dispatch, rejection, backpressure, configuration and defensive gaps remain. LLVM continues to report existing profile-mismatch warnings.

🤖 Generated with OpenAI Codex
