### PR TITLE
Fix cleanup after failed RocksDB opens

### DIFF
--- a/nano/core_test/backend.cpp
+++ b/nano/core_test/backend.cpp
@@ -1,3 +1,4 @@
+#include <nano/lib/config.hpp>
 #include <nano/lib/files.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/secure/network_params.hpp>
@@ -1620,4 +1621,47 @@ TEST (backend, copy_to_optional_tables)
 		ASSERT_TRUE (destination->success (destination->get (read_tx, nano::store::table::pending, nano::store::db_val{ make_key (1) }, result)));
 		ASSERT_EQ (make_value (42), result.convert_to<nano::uint256_union> ());
 	}
+}
+
+/*
+ * RocksDB-specific tests
+ */
+
+// A failed database open must remain safe to destroy during exception unwinding
+TEST (backend, rocksdb_open_failure_cleanup)
+{
+	if (nano::default_database_backend () != nano::database_backend::rocksdb)
+	{
+		GTEST_SKIP ();
+	}
+
+	auto const path = nano::unique_path ();
+	ASSERT_TRUE (std::filesystem::create_directories (path / "rocksdb" / "LOCK"));
+
+	EXPECT_THROW (
+	{
+		auto backend = nano::test::make_backend (path);
+		backend->open (test_schema, nano::store::open_mode::read_write);
+	},
+	std::runtime_error);
+}
+
+// Once the open error is removed, the same backend must support creation and reopening
+TEST (backend, rocksdb_open_failure_retry)
+{
+	if (nano::default_database_backend () != nano::database_backend::rocksdb)
+	{
+		GTEST_SKIP ();
+	}
+
+	auto const path = nano::unique_path ();
+	auto const lock_path = path / "rocksdb" / "LOCK";
+	ASSERT_TRUE (std::filesystem::create_directories (lock_path));
+	auto backend = nano::test::make_backend (path);
+	EXPECT_THROW (backend->open (test_schema, nano::store::open_mode::read_write), std::runtime_error);
+
+	ASSERT_TRUE (std::filesystem::remove (lock_path));
+	ASSERT_NO_THROW (backend->create (test_schema, 1));
+	ASSERT_NO_THROW (backend->open (test_schema, nano::store::open_mode::read_write));
+	EXPECT_EQ (1, backend->get_meta ().version);
 }

--- a/nano/store/rocksdb/backend_rocksdb.cpp
+++ b/nano/store/rocksdb/backend_rocksdb.cpp
@@ -167,27 +167,20 @@ void backend_rocksdb::open_db (std::filesystem::path const & path, nano::store::
 {
 	::rocksdb::Status s;
 
+	::rocksdb::DB * db_l{ nullptr };
+	::rocksdb::TransactionDB * transaction_db_l{ nullptr };
 	std::vector<::rocksdb::ColumnFamilyHandle *> handles_l;
 	if (mode == nano::store::open_mode::read_only)
 	{
-		::rocksdb::DB * db_l;
 		s = ::rocksdb::DB::OpenForReadOnly (options, path.string (), column_families, &handles_l, &db_l);
-		db.reset (db_l);
 	}
 	else
 	{
-		::rocksdb::TransactionDB * transaction_db_l;
 		s = ::rocksdb::TransactionDB::Open (options, ::rocksdb::TransactionDBOptions{}, path.string (), column_families, &handles_l, &transaction_db_l);
-		db.reset (transaction_db_l);
-		transaction_db = transaction_db_l;
+		db_l = transaction_db_l;
 	}
 
-	handles.resize (handles_l.size ());
-	for (size_t i = 0; i < handles_l.size (); ++i)
-	{
-		handles[i].reset (handles_l[i]);
-	}
-
+	// A failed open can leave output pointers untouched or column family handles already deleted
 	if (!s.ok ())
 	{
 		if (is_not_found (s))
@@ -195,6 +188,14 @@ void backend_rocksdb::open_db (std::filesystem::path const & path, nano::store::
 			throw nano::error (nano::error_backend::db_not_found);
 		}
 		throw std::runtime_error ("Failed to open RocksDB database: " + s.ToString ());
+	}
+
+	db.reset (db_l);
+	transaction_db = transaction_db_l;
+	handles.resize (handles_l.size ());
+	for (size_t i = 0; i < handles_l.size (); ++i)
+	{
+		handles[i].reset (handles_l[i]);
 	}
 }
 


### PR DESCRIPTION
A failed RocksDB open can leave the backend owning an invalid pointer and crash during exception unwinding or a later retry. Initialize output pointers and check the open status before adopting database or column-family handles: `TransactionDB::Open()` can leave its output untouched on failure, and failed initialization can already have freed the returned handles.

The RocksDB-specific regressions are grouped at the end of `backend.cpp`. They make RocksDB's `LOCK` path a directory to force an open error without filling a disk:

- `backend.rocksdb_open_failure_cleanup` reproduced SIGSEGV before the fix and now verifies safe exception unwinding.
- `backend.rocksdb_open_failure_retry` verifies creation and reopening on the same backend once the obstruction is removed.

Validation:

- Backend, block-store, and the affected election test pass on both LMDB and RocksDB, with expected backend-specific skips.
- The coverage check exercises all eight branches of `open_db`. Broader backend gaps remain in configuration, backup/compaction, statistics, table variants, and flush/error paths.
- C++ formatting and diff whitespace checks pass.

The CI death-test core-dump policy is addressed separately in [#5163](https://github.com/nanocurrency/nano-node/pull/5163).

🤖 Generated with [Codex](https://openai.com/codex/)
