### PR TITLE
Read rep weights for a tally as a single consistent snapshot

### DIFF
--- a/nano/core_test/election_ballot.cpp
+++ b/nano/core_test/election_ballot.cpp
@@ -10,7 +10,9 @@
 
 #include <algorithm>
 #include <chrono>
+#include <span>
 #include <unordered_map>
+#include <vector>
 
 using namespace std::chrono_literals;
 
@@ -19,15 +21,28 @@ namespace
 std::chrono::steady_clock::time_point constexpr epoch{};
 
 // Representative weights for one test, injected into the ballot as its weight query
+// Records every query so tests can check that a tally reads all its reps with a single call
 struct test_reps
 {
-	std::unordered_map<nano::account, nano::uint128_t> weights;
+	nano::rep_weight_map weights;
+	size_t queries{ 0 }; // Number of weight queries made so far
+	std::vector<nano::account> last_query; // Reps requested by the latest query
 
+	// Reps without a registered weight are left out of the result, exercising the ballot's missing-rep handling
 	nano::election_ballot::weight_fn query ()
 	{
-		return [this] (nano::account const & rep) {
-			auto existing = weights.find (rep);
-			return existing != weights.end () ? existing->second : nano::uint128_t{ 0 };
+		return [this] (std::span<nano::account const> reps) {
+			++queries;
+			last_query.assign (reps.begin (), reps.end ());
+			nano::rep_weight_map result;
+			for (auto const & rep : reps)
+			{
+				if (auto existing = weights.find (rep); existing != weights.end ())
+				{
+					result[rep] = existing->second;
+				}
+			}
+			return result;
 		};
 	}
 
@@ -1067,6 +1082,142 @@ TEST (election_ballot, votes_with_weight_ordering)
 	ASSERT_EQ (std::max (rep_medium, rep_equal1), votes[2].representative);
 	ASSERT_EQ (rep_small, votes[3].representative);
 	ASSERT_EQ (initial->hash (), votes[0].hash);
+}
+
+/*
+ * Every tally reads the weights of all voting reps with exactly one weight query, so a tally is one consistent snapshot of the rep weights.
+ * Vote recording and insertion into a ballot with room do not consult weights at all; only a full ballot's eviction decision needs a tally.
+ */
+TEST (election_ballot, weight_query_single_call_per_tally)
+{
+	test_reps reps;
+	auto blocks = create_blocks_hash_ordered (2);
+	auto initial = blocks[0];
+	auto fork = blocks[1];
+	nano::election_ballot ballot{ initial, reps.query (), 1 };
+
+	auto rep1 = reps.rep (1);
+	auto rep2 = reps.rep (2);
+	auto rep3 = reps.rep (3);
+
+	// Recording votes never queries weights
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (rep1, nano::vote::timestamp_min, initial->hash (), 0s, epoch));
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (rep2, nano::vote::timestamp_min, fork->hash (), 0s, epoch));
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (rep3, nano::vote::timestamp_min, fork->hash (), 0s, epoch));
+	ASSERT_EQ (0, reps.queries);
+
+	// One evaluation is one query naming every voting rep exactly once
+	auto round = ballot.evaluate (100);
+	ASSERT_EQ (1, reps.queries);
+	ASSERT_EQ (3, reps.last_query.size ());
+	std::vector<nano::account> expected{ rep1, rep2, rep3 };
+	std::sort (expected.begin (), expected.end ());
+	std::sort (reps.last_query.begin (), reps.last_query.end ());
+	ASSERT_EQ (expected, reps.last_query);
+	ASSERT_EQ (1, round.winner_weight);
+
+	// The other tally entry points behave the same
+	ASSERT_EQ (1, ballot.tally ().size ());
+	ASSERT_EQ (2, reps.queries);
+	ASSERT_EQ (3, ballot.votes_with_weight ().size ());
+	ASSERT_EQ (3, reps.queries);
+
+	// A full ballot tallies once to pick the eviction candidate and compare the incoming block against it
+	ASSERT_EQ (nano::election_ballot::insert_outcome::rejected, ballot.insert (fork).outcome);
+	ASSERT_EQ (4, reps.queries);
+
+	// Inserting into a ballot with room does not tally
+	nano::election_ballot roomy{ initial, reps.query () };
+	reps.queries = 0;
+	ASSERT_EQ (nano::election_ballot::insert_outcome::inserted, roomy.insert (fork).outcome);
+	ASSERT_EQ (0, reps.queries);
+}
+
+/*
+ * A tally is a snapshot: weights read for one tally all come from the same query, so a concurrent weight change is seen fully or not at all.
+ * The query below moves the whole weight from one rep to another after every call, simulating a change of representative racing with the tally.
+ * Whichever side of the change a tally lands on, the total weight it sees is the same, whereas reading each rep separately could count the moved weight twice or not at all.
+ */
+TEST (election_ballot, weight_query_snapshot)
+{
+	nano::keypair rep_source;
+	nano::keypair rep_destination;
+	nano::uint128_t const amount{ 100 };
+
+	bool moved{ false };
+	size_t queries{ 0 };
+	auto query = [&] (std::span<nano::account const> reps) {
+		++queries;
+		nano::rep_weight_map result;
+		result[rep_source.pub] = moved ? 0 : amount;
+		result[rep_destination.pub] = moved ? amount : 0;
+		moved = !moved;
+		return result;
+	};
+
+	auto blocks = create_blocks_hash_ordered (2);
+	auto initial = blocks[0];
+	auto fork = blocks[1];
+	nano::election_ballot ballot{ initial, query };
+	ASSERT_EQ (nano::election_ballot::insert_outcome::inserted, ballot.insert (fork).outcome);
+
+	// The two reps back different forks, so a mixed read would show up as a change in the total or in the winner margin
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (rep_source.pub, nano::vote::timestamp_min, initial->hash (), 0s, epoch));
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (rep_destination.pub, nano::vote::timestamp_min, fork->hash (), 0s, epoch));
+
+	// Every tally sees the whole weight exactly once, on one side of the move or the other, and the backed fork alternates with it
+	for (size_t i = 0; i < 4; ++i)
+	{
+		auto tally = ballot.tally ();
+		ASSERT_EQ (2, tally.size ());
+		ASSERT_EQ (amount, tally.begin ()->first.weight);
+		ASSERT_EQ (0, std::next (tally.begin ())->first.weight);
+		auto const expected_hash = i % 2 == 0 ? initial->hash () : fork->hash ();
+		ASSERT_EQ (expected_hash, tally.begin ()->first.hash);
+	}
+
+	// The quorum margin reflects one side of the move, never both: the leading fork has the full weight and its rival none
+	auto round = ballot.evaluate (amount);
+	ASSERT_EQ (initial->hash (), round.winner->hash ());
+	ASSERT_EQ (amount, round.winner_weight);
+	ASSERT_TRUE (round.quorum);
+
+	// A per-rep read would have taken two queries per tally; the ballot issued exactly one per tally and one for the evaluation
+	ASSERT_EQ (5, queries);
+}
+
+/*
+ * A rep missing from the weight query result counts as zero weight, the same as a rep the ledger does not know.
+ * Its vote is still recorded and still anchors replay and cooldown checks; it just carries no tally weight.
+ */
+TEST (election_ballot, weight_query_missing_rep_is_zero)
+{
+	test_reps reps;
+	auto initial = create_block ();
+	nano::election_ballot ballot{ initial, reps.query () };
+
+	nano::keypair unknown;
+	auto known = reps.rep (5);
+
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (unknown.pub, nano::vote::timestamp_min, initial->hash (), 0s, epoch));
+	ASSERT_EQ (nano::election_ballot::vote_result::accepted, ballot.vote (known, nano::vote::timestamp_min, initial->hash (), 0s, epoch));
+
+	// The unknown rep was asked for but not answered, and contributes nothing
+	auto round = ballot.evaluate (0);
+	ASSERT_EQ (2, reps.last_query.size ());
+	ASSERT_EQ (5, round.winner_weight);
+	ASSERT_EQ (5, total_weight (ballot));
+
+	auto votes = ballot.votes_with_weight ();
+	ASSERT_EQ (2, votes.size ());
+	ASSERT_EQ (known, votes[0].representative);
+	ASSERT_EQ (5, votes[0].weight);
+	ASSERT_EQ (unknown.pub, votes[1].representative);
+	ASSERT_EQ (0, votes[1].weight);
+
+	// The vote is recorded despite carrying no weight
+	ASSERT_TRUE (ballot.find_vote (unknown.pub));
+	ASSERT_EQ (nano::election_ballot::vote_result::replay, ballot.vote (unknown.pub, nano::vote::timestamp_min, initial->hash (), 0s, epoch));
 }
 
 /*

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -32,6 +32,7 @@
 #include <nano/store/ledger/version.hpp>
 #include <nano/store/lmdb/backend_lmdb.hpp>
 #include <nano/store/rocksdb/backend_rocksdb.hpp>
+#include <nano/test_common/hooked_backend.hpp>
 #include <nano/test_common/ledger_context.hpp>
 #include <nano/test_common/make_store.hpp>
 #include <nano/test_common/system.hpp>
@@ -751,7 +752,7 @@ TEST (ledger, weights_snapshot)
 	nano::block_builder builder;
 	std::deque<std::shared_ptr<nano::block>> changes;
 	nano::block_hash previous = nano::dev::genesis->hash ();
-	for (size_t i = 0; i < 200; ++i)
+	for (size_t i = 0; i < 100; ++i)
 	{
 		auto const & rep = i % 2 == 0 ? rep1 : rep2;
 		auto change = builder.state ()
@@ -779,11 +780,18 @@ TEST (ledger, weights_snapshot)
 	std::atomic<bool> processed{ true };
 	std::atomic<size_t> reads{ 0 };
 	std::atomic<size_t> inconsistent{ 0 };
-	std::latch first_read{ 1 };
+
+	// Each update is followed by at least one snapshot before the next, so the reader keeps pace with the writer and cannot miss the run
+	auto await_read = [&] {
+		auto const target = reads.load () + 1;
+		while (reads.load () < target)
+		{
+			std::this_thread::yield ();
+		}
+	};
 
 	// The write transaction is opened on the writer thread, as the store requires
 	std::thread writer ([&] {
-		first_read.wait (); // Hold the writer until the reader has taken its first snapshot, so the run cannot end unobserved
 		auto transaction = ledger.tx_begin_write ();
 		for (auto const & change : changes)
 		{
@@ -792,24 +800,20 @@ TEST (ledger, weights_snapshot)
 				processed = false;
 				break;
 			}
+			await_read ();
 		}
 		done = true;
 	});
 
 	std::thread reader ([&] {
-		auto read = [&] {
+		while (!done)
+		{
 			auto weights = ledger.weights (reps);
 			++reads;
 			if (weights.at (rep1.pub) + weights.at (rep2.pub) != nano::dev::constants.genesis_amount)
 			{
 				++inconsistent;
 			}
-		};
-		read ();
-		first_read.count_down ();
-		while (!done)
-		{
-			read ();
 		}
 	});
 
@@ -818,7 +822,7 @@ TEST (ledger, weights_snapshot)
 
 	ASSERT_TRUE (processed);
 	ASSERT_EQ (0, inconsistent.load ());
-	ASSERT_GT (reads.load (), 0);
+	ASSERT_GE (reads.load (), changes.size ());
 
 	// The last change leaves the whole balance with the second rep
 	ASSERT_EQ (0, ledger.weight (rep1.pub));
@@ -836,7 +840,7 @@ TEST (ledger, weights_snapshot_send_change)
 	auto & ledger = ctx.ledger ();
 	auto & pool = ctx.pool ();
 	nano::keypair rep1, rep2, destination;
-	size_t const count = 200;
+	size_t const count = 100;
 
 	// Block j sends one raw and delegates the rest to rep1 when j is odd and to rep2 when j is even
 	nano::block_builder builder;
@@ -872,25 +876,35 @@ TEST (ledger, weights_snapshot_send_change)
 	std::atomic<bool> rolled_back{ false };
 	std::atomic<size_t> reads{ 0 };
 	std::atomic<size_t> inconsistent{ 0 };
-	std::latch first_read{ 1 };
+
+	// Each update is followed by at least one snapshot before the next, so the reader keeps pace with the writer and cannot miss the run
+	auto await_read = [&] {
+		auto const target = reads.load () + 1;
+		while (reads.load () < target)
+		{
+			std::this_thread::yield ();
+		}
+	};
 
 	// The remaining blocks are applied to the end and then rolled back to the first block, all on the writer's transaction
 	std::thread writer ([&] {
-		first_read.wait (); // Hold the writer until the reader has taken its first snapshot, so the run cannot end unobserved
 		auto transaction = ledger.tx_begin_write ();
 		for (auto it = std::next (blocks.begin ()); it != blocks.end () && processed; ++it)
 		{
 			processed = ledger.process (transaction, *it) == nano::block_status::progress;
+			await_read ();
 		}
 		if (processed)
 		{
 			rolled_back = !ledger.rollback (transaction, blocks[1]->hash ());
+			await_read ();
 		}
 		done = true;
 	});
 
 	std::thread reader ([&] {
-		auto read = [&] {
+		while (!done)
+		{
 			auto weights = ledger.weights (reps);
 			++reads;
 			auto const held = weights.at (rep1.pub) + weights.at (rep2.pub);
@@ -900,12 +914,6 @@ TEST (ledger, weights_snapshot_send_change)
 			{
 				++inconsistent;
 			}
-		};
-		read ();
-		first_read.count_down ();
-		while (!done)
-		{
-			read ();
 		}
 	});
 
@@ -915,7 +923,7 @@ TEST (ledger, weights_snapshot_send_change)
 	ASSERT_TRUE (processed);
 	ASSERT_TRUE (rolled_back);
 	ASSERT_EQ (0, inconsistent.load ());
-	ASSERT_GT (reads.load (), 0);
+	ASSERT_GE (reads.load (), count);
 
 	// Only the first block remains, and the totals are back where they started
 	ASSERT_EQ (nano::dev::constants.genesis_amount - 1, ledger.weight (rep1.pub));
@@ -923,6 +931,78 @@ TEST (ledger, weights_snapshot_send_change)
 	ASSERT_EQ (committed_before, ledger.rep_weights.get_weight_committed ());
 	ASSERT_EQ (unused_before, ledger.rep_weights.get_weight_unused ());
 	ledger.rep_weights.verify_consistency (0);
+}
+
+/*
+ * Deterministic counterpart of the send and change snapshot test: the store is hooked so that every table access while a block is processed or rolled back also batch-reads both reps, as a reader interleaving at exactly that point would.
+ * The chain and the invariant are the same, so at every access exactly one rep must hold the balance and it must be the rep chosen by the last applied block.
+ */
+TEST (ledger, weights_snapshot_mid_update)
+{
+	auto hooked = nano::test::make_hooked_store ();
+	nano::logger logger;
+	nano::stats stats{ logger };
+	nano::ledger ledger (*hooked.store, nano::dev::network_params, stats, logger);
+	nano::work_pool pool{ nano::dev::network_params.network, 1 };
+	nano::keypair rep1, rep2, destination;
+	size_t const count = 20;
+
+	// Block j sends one raw and delegates the rest to rep1 when j is odd and to rep2 when j is even
+	nano::block_builder builder;
+	std::deque<std::shared_ptr<nano::block>> blocks;
+	nano::block_hash previous = nano::dev::genesis->hash ();
+	for (size_t j = 1; j <= count; ++j)
+	{
+		auto const & rep = j % 2 == 1 ? rep1 : rep2;
+		auto block = builder.state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (previous)
+					 .representative (rep.pub)
+					 .balance (nano::dev::constants.genesis_amount - j)
+					 .link (destination.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*pool.generate (previous))
+					 .build ();
+		previous = block->hash ();
+		blocks.push_back (block);
+	}
+
+	// The first block brings the balance under one of the two reps, from here on exactly one of them holds all of it
+	{
+		auto transaction = ledger.tx_begin_write ();
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, blocks.front ()));
+	}
+
+	std::vector<nano::account> const reps{ rep1.pub, rep2.pub };
+	size_t observations{ 0 };
+	size_t inconsistent{ 0 };
+	hooked.backend.before_access = [&] (nano::store::table) {
+		auto weights = ledger.weights (reps);
+		++observations;
+		auto const held = weights.at (rep1.pub) + weights.at (rep2.pub);
+		auto const applied = nano::dev::constants.genesis_amount - held;
+		auto const & holder = applied % 2 == 1 ? rep1.pub : rep2.pub;
+		if (applied < 1 || applied > count || weights.at (holder) != held)
+		{
+			++inconsistent;
+		}
+	};
+
+	{
+		auto transaction = ledger.tx_begin_write ();
+		for (auto it = std::next (blocks.begin ()); it != blocks.end (); ++it)
+		{
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, *it));
+		}
+		ASSERT_FALSE (ledger.rollback (transaction, blocks[1]->hash ()));
+	}
+	hooked.backend.before_access = nullptr;
+
+	// Every block and every rollback reads and writes both reps in the store, and every access saw a whole state
+	ASSERT_GE (observations, 8 * (count - 1));
+	ASSERT_EQ (0, inconsistent);
+	ASSERT_EQ (nano::dev::constants.genesis_amount - 1, ledger.weight (rep1.pub));
+	ASSERT_EQ (0, ledger.weight (rep2.pub));
 }
 
 /*
@@ -1604,37 +1684,42 @@ TEST (ledger, rep_weights_batch_snapshot)
 		rep_weights.add (txn, rep2, 50);
 	}
 
+	size_t const rounds{ 100 };
 	std::atomic<bool> done{ false };
 	std::atomic<size_t> reads{ 0 };
 	std::atomic<size_t> inconsistent{ 0 };
-	std::latch first_read{ 1 };
+
+	// Each update is followed by at least one snapshot before the next, so the reader keeps pace with the writer and cannot miss the run
+	auto await_read = [&] {
+		auto const target = reads.load () + 1;
+		while (reads.load () < target)
+		{
+			std::this_thread::yield ();
+		}
+	};
 
 	// The write transaction is opened on the writer thread, as the store requires
 	std::thread writer ([&] {
-		first_read.wait (); // Hold the writer until the reader has taken its first snapshot, so the run cannot end unobserved
 		auto txn{ store->tx_begin_write () };
-		for (size_t i = 0; i < 2000; ++i)
+		for (size_t i = 0; i < rounds; ++i)
 		{
 			rep_weights.move (txn, rep1, rep2, amount);
+			await_read ();
 			rep_weights.move (txn, rep2, rep1, amount);
+			await_read ();
 		}
 		done = true;
 	});
 
 	std::thread reader ([&] {
-		auto read = [&] {
+		while (!done)
+		{
 			auto weights = rep_weights.get (reps);
 			++reads;
 			if (weights.at (rep1) + weights.at (rep2) != total)
 			{
 				++inconsistent;
 			}
-		};
-		read ();
-		first_read.count_down ();
-		while (!done)
-		{
-			read ();
 		}
 	});
 
@@ -1642,7 +1727,7 @@ TEST (ledger, rep_weights_batch_snapshot)
 	reader.join ();
 
 	ASSERT_EQ (0, inconsistent.load ());
-	ASSERT_GT (reads.load (), 0);
+	ASSERT_GE (reads.load (), 2 * rounds);
 	ASSERT_EQ (100, rep_weights.get (rep1));
 	ASSERT_EQ (50, rep_weights.get (rep2));
 }
@@ -1671,37 +1756,42 @@ TEST (ledger, rep_weights_move_add_sub_snapshot)
 		return (weight1 == 100 && weight2 == 50) || (weight1 == 0 && weight2 == 170);
 	};
 
+	size_t const rounds{ 100 };
 	std::atomic<bool> done{ false };
 	std::atomic<size_t> reads{ 0 };
 	std::atomic<size_t> inconsistent{ 0 };
-	std::latch first_read{ 1 };
+
+	// Each update is followed by at least one snapshot before the next, so the reader keeps pace with the writer and cannot miss the run
+	auto await_read = [&] {
+		auto const target = reads.load () + 1;
+		while (reads.load () < target)
+		{
+			std::this_thread::yield ();
+		}
+	};
 
 	// The write transaction is opened on the writer thread, as the store requires
 	std::thread writer ([&] {
-		first_read.wait (); // Hold the writer until the reader has taken its first snapshot, so the run cannot end unobserved
 		auto txn{ store->tx_begin_write () };
-		for (size_t i = 0; i < 2000; ++i)
+		for (size_t i = 0; i < rounds; ++i)
 		{
 			rep_weights.move_add_sub (txn, rep1, 100, rep2, 120);
+			await_read ();
 			rep_weights.move_add_sub (txn, rep2, 120, rep1, 100);
+			await_read ();
 		}
 		done = true;
 	});
 
 	std::thread reader ([&] {
-		auto read = [&] {
+		while (!done)
+		{
 			auto weights = rep_weights.get (reps);
 			++reads;
 			if (!legitimate (weights.at (rep1), weights.at (rep2)))
 			{
 				++inconsistent;
 			}
-		};
-		read ();
-		first_read.count_down ();
-		while (!done)
-		{
-			read ();
 		}
 	});
 
@@ -1709,9 +1799,58 @@ TEST (ledger, rep_weights_move_add_sub_snapshot)
 	reader.join ();
 
 	ASSERT_EQ (0, inconsistent.load ());
-	ASSERT_GT (reads.load (), 0);
+	ASSERT_GE (reads.load (), 2 * rounds);
 	ASSERT_EQ (100, rep_weights.get (rep1));
 	ASSERT_EQ (50, rep_weights.get (rep2));
+}
+
+/*
+ * Deterministic counterpart of the snapshot test above: the store is hooked so that every access to the rep weights table during an update also batch-reads the cache, as a reader interleaving at exactly that point would.
+ * Those accesses all happen before the cache lock is taken, so each read must show the state before the update or the state after it, never anything in between.
+ * The former implementation applied an unequal update as a move followed by a separate add or sub, and the store accesses of the second step ran with the cache half updated.
+ */
+TEST (ledger, rep_weights_move_add_sub_mid_update)
+{
+	auto hooked = nano::test::make_hooked_store ();
+	auto & store = *hooked.store;
+	nano::rep_weights rep_weights{ store.rep_weight };
+	nano::account const rep1{ 1 };
+	nano::account const rep2{ 2 };
+	std::vector<nano::account> const reps{ rep1, rep2 };
+	auto txn{ store.tx_begin_write () };
+	rep_weights.add (txn, rep1, 100);
+	rep_weights.add (txn, rep2, 50);
+
+	// The same two legitimate states as in the snapshot test
+	auto legitimate = [] (nano::uint128_t const & weight1, nano::uint128_t const & weight2) {
+		return (weight1 == 100 && weight2 == 50) || (weight1 == 0 && weight2 == 170);
+	};
+
+	size_t observations{ 0 };
+	size_t inconsistent{ 0 };
+	hooked.backend.before_access = [&] (nano::store::table table) {
+		if (table == nano::store::table::rep_weights)
+		{
+			auto weights = rep_weights.get (reps);
+			++observations;
+			if (!legitimate (weights.at (rep1), weights.at (rep2)))
+			{
+				++inconsistent;
+			}
+		}
+	};
+
+	rep_weights.move_add_sub (txn, rep1, 100, rep2, 120);
+	ASSERT_EQ (0, rep_weights.get (rep1));
+	ASSERT_EQ (170, rep_weights.get (rep2));
+	rep_weights.move_add_sub (txn, rep2, 120, rep1, 100);
+	ASSERT_EQ (100, rep_weights.get (rep1));
+	ASSERT_EQ (50, rep_weights.get (rep2));
+	hooked.backend.before_access = nullptr;
+
+	// Each update reads and writes both reps in the store, and every one of those accesses saw a whole state
+	ASSERT_GE (observations, 8);
+	ASSERT_EQ (0, inconsistent);
 }
 
 TEST (ledger, representation)

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -40,7 +40,11 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <latch>
 #include <limits>
+#include <thread>
+#include <vector>
 
 using namespace std::chrono_literals;
 
@@ -520,6 +524,306 @@ TEST (ledger, weight)
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (nano::dev::genesis_key.pub));
 }
 
+/*
+ * The batch read answers every requested representative from the same source as the single read.
+ * With the bootstrap height reached it reads the cache: delegated weights come back exactly, unknown reps and the zero account come back as zero.
+ * Before that it reads the preconfigured bootstrap weights and ignores the cache entirely, and it switches back to the cache once the height is reached.
+ */
+TEST (ledger, weights)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::keypair key1, key2, rep1, rep2, unknown;
+	nano::uint128_t const amount1{ 1000 };
+	nano::uint128_t const amount2{ 500 };
+
+	// Delegate part of the genesis balance to two representatives
+	nano::block_builder builder;
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - amount1)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto open1 = builder.state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (rep1.pub)
+				 .balance (amount1)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	auto send2 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - amount1 - amount2)
+				 .link (key2.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	auto open2 = builder.state ()
+				 .account (key2.pub)
+				 .previous (0)
+				 .representative (rep2.pub)
+				 .balance (amount2)
+				 .link (send2->hash ())
+				 .sign (key2.prv, key2.pub)
+				 .work (*pool.generate (key2.pub))
+				 .build ();
+	{
+		auto transaction = ledger.tx_begin_write ();
+		for (auto const & block : { send1, open1, send2, open2 })
+		{
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, block));
+		}
+	}
+
+	std::vector<nano::account> const reps{ nano::dev::genesis_key.pub, rep1.pub, rep2.pub, unknown.pub, 0 };
+
+	// Cached weights agree with the single read and with the database for every requested rep
+	ASSERT_TRUE (ledger.bootstrap_height_reached ());
+	{
+		auto weights = ledger.weights (reps);
+		ASSERT_EQ (reps.size (), weights.size ());
+		ASSERT_EQ (nano::dev::constants.genesis_amount - amount1 - amount2, weights.at (nano::dev::genesis_key.pub));
+		ASSERT_EQ (amount1, weights.at (rep1.pub));
+		ASSERT_EQ (amount2, weights.at (rep2.pub));
+		ASSERT_EQ (0, weights.at (unknown.pub));
+		ASSERT_EQ (0, weights.at (0));
+
+		auto transaction = ledger.tx_begin_read ();
+		for (auto const & rep : reps)
+		{
+			ASSERT_EQ (ledger.weight (rep), weights.at (rep));
+			ASSERT_EQ (ledger.weight_exact (transaction, rep), weights.at (rep));
+		}
+	}
+
+	// Duplicates collapse, an empty request yields an empty result
+	ASSERT_EQ (1, ledger.weights (std::vector<nano::account>{ rep1.pub, rep1.pub }).size ());
+	ASSERT_TRUE (ledger.weights (std::vector<nano::account>{}).empty ());
+
+	// Bootstrap weights replace the cache entirely: a preconfigured rep is answered from the table even where the ledger disagrees, and a rep known only to the ledger reads zero
+	nano::keypair rep_bootstrap;
+	ledger.bootstrap_weights.max_blocks = ledger.block_count () + 1;
+	ledger.bootstrap_weights.representatives[rep1.pub] = 42;
+	ledger.bootstrap_weights.representatives[rep_bootstrap.pub] = 7;
+	ASSERT_FALSE (ledger.bootstrap_height_reached ());
+	{
+		std::vector<nano::account> const bootstrap_reps{ nano::dev::genesis_key.pub, rep1.pub, rep2.pub, rep_bootstrap.pub, unknown.pub };
+		auto weights = ledger.weights (bootstrap_reps);
+		ASSERT_EQ (bootstrap_reps.size (), weights.size ());
+		ASSERT_EQ (0, weights.at (nano::dev::genesis_key.pub));
+		ASSERT_EQ (42, weights.at (rep1.pub));
+		ASSERT_EQ (0, weights.at (rep2.pub));
+		ASSERT_EQ (7, weights.at (rep_bootstrap.pub));
+		ASSERT_EQ (0, weights.at (unknown.pub));
+		for (auto const & rep : bootstrap_reps)
+		{
+			ASSERT_EQ (ledger.weight (rep), weights.at (rep));
+		}
+
+		// The exact database weights are untouched by the bootstrap table
+		auto transaction = ledger.tx_begin_read ();
+		ASSERT_EQ (amount1, ledger.weight_exact (transaction, rep1.pub));
+		ASSERT_EQ (amount2, ledger.weight_exact (transaction, rep2.pub));
+		ASSERT_EQ (0, ledger.weight_exact (transaction, rep_bootstrap.pub));
+	}
+
+	// Reaching the bootstrap height switches the batch read back to the cache
+	auto send3 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send2->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - amount1 - amount2 - 1)
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send2->hash ()))
+				 .build ();
+	{
+		auto transaction = ledger.tx_begin_write ();
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, send3));
+	}
+	ASSERT_TRUE (ledger.bootstrap_height_reached ());
+	{
+		auto weights = ledger.weights (reps);
+		ASSERT_EQ (nano::dev::constants.genesis_amount - amount1 - amount2 - 1, weights.at (nano::dev::genesis_key.pub));
+		ASSERT_EQ (amount1, weights.at (rep1.pub));
+		ASSERT_EQ (amount2, weights.at (rep2.pub));
+		ASSERT_EQ (0, weights.at (unknown.pub));
+	}
+}
+
+/*
+ * The cache minimum applies to the batch read exactly as to the single read: a representative below it reads zero from the cache while the database still holds its exact weight.
+ */
+TEST (ledger, weights_min_rep_weight)
+{
+	nano::uint128_t const min_weight{ 100 };
+	auto ctx = nano::test::ledger_empty ({ .min_rep_weight = min_weight });
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::keypair key1, key2, rep_below, rep_at;
+
+	// One representative lands just below the minimum, the other exactly on it
+	nano::block_builder builder;
+	auto send1 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (nano::dev::genesis->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - (min_weight - 1))
+				 .link (key1.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto open1 = builder.state ()
+				 .account (key1.pub)
+				 .previous (0)
+				 .representative (rep_below.pub)
+				 .balance (min_weight - 1)
+				 .link (send1->hash ())
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	auto send2 = builder.state ()
+				 .account (nano::dev::genesis_key.pub)
+				 .previous (send1->hash ())
+				 .representative (nano::dev::genesis_key.pub)
+				 .balance (nano::dev::constants.genesis_amount - (min_weight - 1) - min_weight)
+				 .link (key2.pub)
+				 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	auto open2 = builder.state ()
+				 .account (key2.pub)
+				 .previous (0)
+				 .representative (rep_at.pub)
+				 .balance (min_weight)
+				 .link (send2->hash ())
+				 .sign (key2.prv, key2.pub)
+				 .work (*pool.generate (key2.pub))
+				 .build ();
+	{
+		auto transaction = ledger.tx_begin_write ();
+		for (auto const & block : { send1, open1, send2, open2 })
+		{
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, block));
+		}
+	}
+
+	std::vector<nano::account> const reps{ nano::dev::genesis_key.pub, rep_below.pub, rep_at.pub };
+	auto weights = ledger.weights (reps);
+	ASSERT_EQ (reps.size (), weights.size ());
+	ASSERT_EQ (0, weights.at (rep_below.pub));
+	ASSERT_EQ (min_weight, weights.at (rep_at.pub));
+	ASSERT_EQ (nano::dev::constants.genesis_amount - (min_weight - 1) - min_weight, weights.at (nano::dev::genesis_key.pub));
+	for (auto const & rep : reps)
+	{
+		ASSERT_EQ (ledger.weight (rep), weights.at (rep));
+	}
+
+	// The database keeps the exact weight of the rep the cache drops
+	auto transaction = ledger.tx_begin_read ();
+	ASSERT_EQ (min_weight - 1, ledger.weight_exact (transaction, rep_below.pub));
+	ASSERT_EQ (min_weight, ledger.weight_exact (transaction, rep_at.pub));
+}
+
+/*
+ * A representative change moves the account's whole balance from one rep to the other in a single ledger step, and the batch read never observes it half way.
+ * The genesis account flips its representative back and forth while a reader keeps batch-reading both reps; the two weights must always add up to the genesis balance.
+ * Two single reads could see the old rep before the move and the new rep after it, counting the balance twice or not at all.
+ */
+TEST (ledger, weights_snapshot)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::keypair rep1, rep2;
+
+	// Change blocks alternating the genesis representative between the two reps, prepared up front so the writer runs back to back
+	nano::block_builder builder;
+	std::deque<std::shared_ptr<nano::block>> changes;
+	nano::block_hash previous = nano::dev::genesis->hash ();
+	for (size_t i = 0; i < 200; ++i)
+	{
+		auto const & rep = i % 2 == 0 ? rep1 : rep2;
+		auto change = builder.state ()
+					  .account (nano::dev::genesis_key.pub)
+					  .previous (previous)
+					  .representative (rep.pub)
+					  .balance (nano::dev::constants.genesis_amount)
+					  .link (0)
+					  .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					  .work (*pool.generate (previous))
+					  .build ();
+		previous = change->hash ();
+		changes.push_back (change);
+	}
+
+	// The first change brings the whole balance under one of the two reps, so from here on their weights always sum to it
+	{
+		auto transaction = ledger.tx_begin_write ();
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, changes.front ()));
+	}
+	changes.pop_front ();
+
+	std::vector<nano::account> const reps{ rep1.pub, rep2.pub };
+	std::atomic<bool> done{ false };
+	std::atomic<bool> processed{ true };
+	std::atomic<size_t> reads{ 0 };
+	std::atomic<size_t> inconsistent{ 0 };
+	std::latch first_read{ 1 };
+
+	// The write transaction is opened on the writer thread, as the store requires
+	std::thread writer ([&] {
+		first_read.wait (); // Hold the writer until the reader has taken its first snapshot, so the run cannot end unobserved
+		auto transaction = ledger.tx_begin_write ();
+		for (auto const & change : changes)
+		{
+			if (ledger.process (transaction, change) != nano::block_status::progress)
+			{
+				processed = false;
+				break;
+			}
+		}
+		done = true;
+	});
+
+	std::thread reader ([&] {
+		auto read = [&] {
+			auto weights = ledger.weights (reps);
+			++reads;
+			if (weights.at (rep1.pub) + weights.at (rep2.pub) != nano::dev::constants.genesis_amount)
+			{
+				++inconsistent;
+			}
+		};
+		read ();
+		first_read.count_down ();
+		while (!done)
+		{
+			read ();
+		}
+	});
+
+	writer.join ();
+	reader.join ();
+
+	ASSERT_TRUE (processed);
+	ASSERT_EQ (0, inconsistent.load ());
+	ASSERT_GT (reads.load (), 0);
+
+	// The last change leaves the whole balance with the second rep
+	ASSERT_EQ (0, ledger.weight (rep1.pub));
+	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (rep2.pub));
+}
+
 TEST (ledger, representative_change)
 {
 	auto ctx = nano::test::ledger_empty ();
@@ -751,6 +1055,105 @@ TEST (ledger, rep_cache_min_weight)
 	rep_weights.sub (txn, 1, 5);
 	ASSERT_EQ (0, rep_weights.size ());
 	ASSERT_EQ (1, store->rep_weight.count (txn));
+}
+
+/*
+ * The batch read answers every requested rep, mirroring the single read: unknown reps, the zero account and reps below the cache minimum all come back as zero.
+ */
+TEST (ledger, rep_weights_batch)
+{
+	auto store{ nano::test::make_store () };
+	nano::uint128_t min_weight{ 10 };
+	nano::rep_weights rep_weights{ store->rep_weight, min_weight };
+	auto txn{ store->tx_begin_write () };
+
+	rep_weights.add (txn, 1, 100);
+	rep_weights.add (txn, 2, 200);
+	rep_weights.add (txn, 3, 9); // Below the cache minimum
+
+	std::vector<nano::account> reps{ 1, 2, 3, 4, 0 };
+	auto weights = rep_weights.get (reps);
+	ASSERT_EQ (5, weights.size ());
+	ASSERT_EQ (100, weights.at (1));
+	ASSERT_EQ (200, weights.at (2));
+	ASSERT_EQ (0, weights.at (3));
+	ASSERT_EQ (0, weights.at (4));
+	ASSERT_EQ (0, weights.at (0));
+
+	// Every entry matches the single read
+	for (auto const & rep : reps)
+	{
+		ASSERT_EQ (rep_weights.get (rep), weights.at (rep));
+	}
+
+	// Duplicates collapse, an empty request yields an empty result
+	std::vector<nano::account> duplicates{ 1, 1 };
+	ASSERT_EQ (1, rep_weights.get (duplicates).size ());
+	ASSERT_TRUE (rep_weights.get (std::vector<nano::account>{}).empty ());
+}
+
+/*
+ * A batch read is one consistent snapshot: a move between two reps, which updates both under one lock, is either fully visible or not at all.
+ * A writer shuffles weight back and forth between two reps while a reader keeps reading both; the sum must never drift.
+ * Reading the reps one at a time could observe the source before the move and the destination after it, double counting the moved amount or losing it.
+ */
+TEST (ledger, rep_weights_batch_snapshot)
+{
+	auto store{ nano::test::make_store () };
+	nano::rep_weights rep_weights{ store->rep_weight };
+	nano::account const rep1{ 1 };
+	nano::account const rep2{ 2 };
+	nano::uint128_t const total{ 150 };
+	nano::uint128_t const amount{ 50 };
+	std::vector<nano::account> const reps{ rep1, rep2 };
+
+	{
+		auto txn{ store->tx_begin_write () };
+		rep_weights.add (txn, rep1, 100);
+		rep_weights.add (txn, rep2, 50);
+	}
+
+	std::atomic<bool> done{ false };
+	std::atomic<size_t> reads{ 0 };
+	std::atomic<size_t> inconsistent{ 0 };
+	std::latch first_read{ 1 };
+
+	// The write transaction is opened on the writer thread, as the store requires
+	std::thread writer ([&] {
+		first_read.wait (); // Hold the writer until the reader has taken its first snapshot, so the run cannot end unobserved
+		auto txn{ store->tx_begin_write () };
+		for (size_t i = 0; i < 2000; ++i)
+		{
+			rep_weights.move (txn, rep1, rep2, amount);
+			rep_weights.move (txn, rep2, rep1, amount);
+		}
+		done = true;
+	});
+
+	std::thread reader ([&] {
+		auto read = [&] {
+			auto weights = rep_weights.get (reps);
+			++reads;
+			if (weights.at (rep1) + weights.at (rep2) != total)
+			{
+				++inconsistent;
+			}
+		};
+		read ();
+		first_read.count_down ();
+		while (!done)
+		{
+			read ();
+		}
+	});
+
+	writer.join ();
+	reader.join ();
+
+	ASSERT_EQ (0, inconsistent.load ());
+	ASSERT_GT (reads.load (), 0);
+	ASSERT_EQ (100, rep_weights.get (rep1));
+	ASSERT_EQ (50, rep_weights.get (rep2));
 }
 
 TEST (ledger, representation)

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -43,6 +43,7 @@
 #include <atomic>
 #include <latch>
 #include <limits>
+#include <map>
 #include <thread>
 #include <vector>
 
@@ -924,6 +925,231 @@ TEST (ledger, weights_snapshot_send_change)
 	ledger.rep_weights.verify_consistency (0);
 }
 
+/*
+ * Every block type feeds the same few rep weight operations, so this drives all of them through the ledger against a model of who holds what.
+ * The model records each account's representative and balance; after every block and every rollback the cache and the store must show the weights it implies,
+ * the committed total must equal the sum of balances, the unused total must have grown by exactly what became pending, and a ledger rebuilt from the store must agree with the live one.
+ * The chain covers legacy send, open, receive and change, state send, open, receive with a rep change, send with a rep change and a plain rep change,
+ * an epoch upgrade, an epoch open and a receive into it, whose previous representative is the zero account.
+ */
+TEST (ledger, weights_all_block_types)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & store = ctx.store ();
+	auto & pool = ctx.pool ();
+	nano::block_builder builder;
+	nano::keypair key1, key2, key3, rep1, rep2, rep3, rep4;
+	auto const & genesis = nano::dev::genesis_key;
+	auto const total = nano::dev::constants.genesis_amount;
+	auto const unit = nano::Knano_ratio;
+	std::vector<nano::account> const reps{ genesis.pub, rep1.pub, rep2.pub, rep3.pub, rep4.pub };
+
+	// Who holds what: each account's balance sits with its representative
+	struct holding
+	{
+		nano::account representative;
+		nano::uint128_t balance;
+	};
+	using model_t = std::map<nano::account, holding>;
+	model_t model{ { genesis.pub, { genesis.pub, total } } };
+	auto const unused_initial = ledger.rep_weights.get_weight_unused ();
+
+	auto check = [&] (nano::ledger const & ledger_l, nano::secure::transaction const & transaction) {
+		nano::rep_weight_map expected;
+		nano::uint128_t balances{ 0 };
+		for (auto const & [account, held] : model)
+		{
+			expected[held.representative] += held.balance;
+			balances += held.balance;
+		}
+		auto const weights = ledger_l.weights (reps);
+		for (auto const & rep : reps)
+		{
+			ASSERT_EQ (expected[rep], weights.at (rep));
+			ASSERT_EQ (expected[rep], ledger_l.weight_exact (transaction, rep));
+		}
+		// Whatever no account holds is pending, and pending weight is unused
+		ASSERT_EQ (balances, ledger_l.rep_weights.get_weight_committed ());
+		ASSERT_EQ (unused_initial + (total - balances), ledger_l.rep_weights.get_weight_unused ());
+		ledger_l.rep_weights.verify_consistency (0);
+	};
+
+	auto send1 = builder.send ()
+				 .previous (nano::dev::genesis->hash ())
+				 .destination (key1.pub)
+				 .balance (total - unit)
+				 .sign (genesis.prv, genesis.pub)
+				 .work (*pool.generate (nano::dev::genesis->hash ()))
+				 .build ();
+	auto open1 = builder.open ()
+				 .source (send1->hash ())
+				 .representative (rep1.pub)
+				 .account (key1.pub)
+				 .sign (key1.prv, key1.pub)
+				 .work (*pool.generate (key1.pub))
+				 .build ();
+	auto send2 = builder.send ()
+				 .previous (send1->hash ())
+				 .destination (key1.pub)
+				 .balance (total - 3 * unit)
+				 .sign (genesis.prv, genesis.pub)
+				 .work (*pool.generate (send1->hash ()))
+				 .build ();
+	auto receive1 = builder.receive ()
+					.previous (open1->hash ())
+					.source (send2->hash ())
+					.sign (key1.prv, key1.pub)
+					.work (*pool.generate (open1->hash ()))
+					.build ();
+	auto change1 = builder.change ()
+				   .previous (receive1->hash ())
+				   .representative (rep2.pub)
+				   .sign (key1.prv, key1.pub)
+				   .work (*pool.generate (receive1->hash ()))
+				   .build ();
+	auto send3 = builder.state ()
+				 .account (genesis.pub)
+				 .previous (send2->hash ())
+				 .representative (genesis.pub)
+				 .balance (total - 7 * unit)
+				 .link (key2.pub)
+				 .sign (genesis.prv, genesis.pub)
+				 .work (*pool.generate (send2->hash ()))
+				 .build ();
+	auto open2 = builder.state ()
+				 .account (key2.pub)
+				 .previous (0)
+				 .representative (rep3.pub)
+				 .balance (4 * unit)
+				 .link (send3->hash ())
+				 .sign (key2.prv, key2.pub)
+				 .work (*pool.generate (key2.pub))
+				 .build ();
+	auto send4 = builder.state ()
+				 .account (genesis.pub)
+				 .previous (send3->hash ())
+				 .representative (genesis.pub)
+				 .balance (total - 12 * unit)
+				 .link (key2.pub)
+				 .sign (genesis.prv, genesis.pub)
+				 .work (*pool.generate (send3->hash ()))
+				 .build ();
+	auto receive2 = builder.state () // Receive and change representative at once
+					.account (key2.pub)
+					.previous (open2->hash ())
+					.representative (rep4.pub)
+					.balance (9 * unit)
+					.link (send4->hash ())
+					.sign (key2.prv, key2.pub)
+					.work (*pool.generate (open2->hash ()))
+					.build ();
+	auto send5 = builder.state () // Send and change representative at once
+				 .account (key2.pub)
+				 .previous (receive2->hash ())
+				 .representative (rep3.pub)
+				 .balance (3 * unit)
+				 .link (key3.pub)
+				 .sign (key2.prv, key2.pub)
+				 .work (*pool.generate (receive2->hash ()))
+				 .build ();
+	auto change2 = builder.state ()
+				   .account (key2.pub)
+				   .previous (send5->hash ())
+				   .representative (rep4.pub)
+				   .balance (3 * unit)
+				   .link (0)
+				   .sign (key2.prv, key2.pub)
+				   .work (*pool.generate (send5->hash ()))
+				   .build ();
+	auto epoch1 = builder.state ()
+				  .account (key2.pub)
+				  .previous (change2->hash ())
+				  .representative (rep4.pub)
+				  .balance (3 * unit)
+				  .link (ledger.epoch_link (nano::epoch::epoch_1))
+				  .sign (genesis.prv, genesis.pub)
+				  .work (*pool.generate (change2->hash ()))
+				  .build ();
+	auto epoch_open = builder.state ()
+					  .account (key3.pub)
+					  .previous (0)
+					  .representative (0)
+					  .balance (0)
+					  .link (ledger.epoch_link (nano::epoch::epoch_1))
+					  .sign (genesis.prv, genesis.pub)
+					  .work (*pool.generate (key3.pub))
+					  .build ();
+	auto receive3 = builder.state () // The previous representative is the zero account of the epoch open
+					.account (key3.pub)
+					.previous (epoch_open->hash ())
+					.representative (rep1.pub)
+					.balance (6 * unit)
+					.link (send5->hash ())
+					.sign (key3.prv, key3.pub)
+					.work (*pool.generate (epoch_open->hash ()))
+					.build ();
+
+	// Each block with the holding it leaves its account in
+	struct step
+	{
+		std::shared_ptr<nano::block> block;
+		nano::account account;
+		holding after;
+	};
+	std::vector<step> const steps{
+		{ send1, genesis.pub, { genesis.pub, total - unit } },
+		{ open1, key1.pub, { rep1.pub, unit } },
+		{ send2, genesis.pub, { genesis.pub, total - 3 * unit } },
+		{ receive1, key1.pub, { rep1.pub, 3 * unit } },
+		{ change1, key1.pub, { rep2.pub, 3 * unit } },
+		{ send3, genesis.pub, { genesis.pub, total - 7 * unit } },
+		{ open2, key2.pub, { rep3.pub, 4 * unit } },
+		{ send4, genesis.pub, { genesis.pub, total - 12 * unit } },
+		{ receive2, key2.pub, { rep4.pub, 9 * unit } },
+		{ send5, key2.pub, { rep3.pub, 3 * unit } },
+		{ change2, key2.pub, { rep4.pub, 3 * unit } },
+		{ epoch1, key2.pub, { rep4.pub, 3 * unit } },
+		{ epoch_open, key3.pub, { 0, 0 } },
+		{ receive3, key3.pub, { rep1.pub, 6 * unit } },
+	};
+
+	// The model after each step, so a rollback can be checked against the state before the block
+	std::vector<model_t> snapshots{ model };
+	{
+		auto transaction = ledger.tx_begin_write ();
+		check (ledger, transaction);
+		for (size_t i = 0; i < steps.size (); ++i)
+		{
+			SCOPED_TRACE ("block " + std::to_string (i + 1));
+			ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, steps[i].block));
+			model[steps[i].account] = steps[i].after;
+			snapshots.push_back (model);
+			check (ledger, transaction);
+		}
+	}
+	{
+		SCOPED_TRACE ("reload after processing");
+		nano::ledger reloaded (store, nano::dev::network_params, ctx.stats (), ctx.logger ());
+		check (reloaded, reloaded.tx_begin_read ());
+	}
+	{
+		auto transaction = ledger.tx_begin_write ();
+		for (size_t i = steps.size (); i > 0; --i)
+		{
+			SCOPED_TRACE ("rollback of block " + std::to_string (i));
+			ASSERT_FALSE (ledger.rollback (transaction, steps[i - 1].block->hash ()));
+			model = snapshots[i - 1];
+			check (ledger, transaction);
+		}
+	}
+	{
+		SCOPED_TRACE ("reload after rollback");
+		nano::ledger reloaded (store, nano::dev::network_params, ctx.stats (), ctx.logger ());
+		check (reloaded, reloaded.tx_begin_read ());
+	}
+}
+
 TEST (ledger, representative_change)
 {
 	auto ctx = nano::test::ledger_empty ();
@@ -1112,6 +1338,37 @@ TEST (ledger, rep_weights_put)
 	// The store is not written
 	auto txn{ store->tx_begin_read () };
 	ASSERT_EQ (0, store->rep_weight.count (txn));
+}
+
+/*
+ * append_from folds a cache built from one slice of the store table into another, which is how the cache is assembled in parallel at startup: weights are summed per rep and both totals are carried over.
+ */
+TEST (ledger, rep_weights_append_from)
+{
+	auto store{ nano::test::make_store () };
+	nano::rep_weights target{ store->rep_weight };
+	nano::rep_weights slice{ store->rep_weight };
+	nano::account const rep1{ 1 };
+	nano::account const rep2{ 2 };
+
+	target.put (rep1, 100);
+	target.put_unused (5);
+	slice.put (rep1, 50);
+	slice.put (rep2, 200);
+	slice.put_unused (7);
+
+	target.append_from (slice);
+	ASSERT_EQ (150, target.get (rep1));
+	ASSERT_EQ (200, target.get (rep2));
+	ASSERT_EQ (2, target.size ());
+	ASSERT_EQ (350, target.get_weight_committed ());
+	ASSERT_EQ (12, target.get_weight_unused ());
+
+	// The appended cache is left as it was
+	ASSERT_EQ (50, slice.get (rep1));
+	ASSERT_EQ (200, slice.get (rep2));
+	ASSERT_EQ (250, slice.get_weight_committed ());
+	ASSERT_EQ (7, slice.get_weight_unused ());
 }
 
 /*

--- a/nano/core_test/ledger.cpp
+++ b/nano/core_test/ledger.cpp
@@ -824,6 +824,106 @@ TEST (ledger, weights_snapshot)
 	ASSERT_EQ (nano::dev::constants.genesis_amount, ledger.weight (rep2.pub));
 }
 
+/*
+ * A block that switches representative and sends in one step takes the old balance from one rep and gives the new balance to the other, and the batch read never observes it half applied.
+ * The genesis account alternates its representative while sending one raw per block, then the chain is rolled back to its first block, so the update runs in both directions under a reader.
+ * Every observed state must be the exact state after some block: the weight held says how many blocks are applied, and the rep chosen by the last of them must hold all of it.
+ */
+TEST (ledger, weights_snapshot_send_change)
+{
+	auto ctx = nano::test::ledger_empty ();
+	auto & ledger = ctx.ledger ();
+	auto & pool = ctx.pool ();
+	nano::keypair rep1, rep2, destination;
+	size_t const count = 200;
+
+	// Block j sends one raw and delegates the rest to rep1 when j is odd and to rep2 when j is even
+	nano::block_builder builder;
+	std::deque<std::shared_ptr<nano::block>> blocks;
+	nano::block_hash previous = nano::dev::genesis->hash ();
+	for (size_t j = 1; j <= count; ++j)
+	{
+		auto const & rep = j % 2 == 1 ? rep1 : rep2;
+		auto block = builder.state ()
+					 .account (nano::dev::genesis_key.pub)
+					 .previous (previous)
+					 .representative (rep.pub)
+					 .balance (nano::dev::constants.genesis_amount - j)
+					 .link (destination.pub)
+					 .sign (nano::dev::genesis_key.prv, nano::dev::genesis_key.pub)
+					 .work (*pool.generate (previous))
+					 .build ();
+		previous = block->hash ();
+		blocks.push_back (block);
+	}
+
+	// The first block brings the balance under one of the two reps, from here on exactly one of them holds all of it
+	{
+		auto transaction = ledger.tx_begin_write ();
+		ASSERT_EQ (nano::block_status::progress, ledger.process (transaction, blocks.front ()));
+	}
+	auto const committed_before = ledger.rep_weights.get_weight_committed ();
+	auto const unused_before = ledger.rep_weights.get_weight_unused ();
+
+	std::vector<nano::account> const reps{ rep1.pub, rep2.pub };
+	std::atomic<bool> done{ false };
+	std::atomic<bool> processed{ true };
+	std::atomic<bool> rolled_back{ false };
+	std::atomic<size_t> reads{ 0 };
+	std::atomic<size_t> inconsistent{ 0 };
+	std::latch first_read{ 1 };
+
+	// The remaining blocks are applied to the end and then rolled back to the first block, all on the writer's transaction
+	std::thread writer ([&] {
+		first_read.wait (); // Hold the writer until the reader has taken its first snapshot, so the run cannot end unobserved
+		auto transaction = ledger.tx_begin_write ();
+		for (auto it = std::next (blocks.begin ()); it != blocks.end () && processed; ++it)
+		{
+			processed = ledger.process (transaction, *it) == nano::block_status::progress;
+		}
+		if (processed)
+		{
+			rolled_back = !ledger.rollback (transaction, blocks[1]->hash ());
+		}
+		done = true;
+	});
+
+	std::thread reader ([&] {
+		auto read = [&] {
+			auto weights = ledger.weights (reps);
+			++reads;
+			auto const held = weights.at (rep1.pub) + weights.at (rep2.pub);
+			auto const applied = nano::dev::constants.genesis_amount - held;
+			auto const & holder = applied % 2 == 1 ? rep1.pub : rep2.pub;
+			if (applied < 1 || applied > count || weights.at (holder) != held)
+			{
+				++inconsistent;
+			}
+		};
+		read ();
+		first_read.count_down ();
+		while (!done)
+		{
+			read ();
+		}
+	});
+
+	writer.join ();
+	reader.join ();
+
+	ASSERT_TRUE (processed);
+	ASSERT_TRUE (rolled_back);
+	ASSERT_EQ (0, inconsistent.load ());
+	ASSERT_GT (reads.load (), 0);
+
+	// Only the first block remains, and the totals are back where they started
+	ASSERT_EQ (nano::dev::constants.genesis_amount - 1, ledger.weight (rep1.pub));
+	ASSERT_EQ (0, ledger.weight (rep2.pub));
+	ASSERT_EQ (committed_before, ledger.rep_weights.get_weight_committed ());
+	ASSERT_EQ (unused_before, ledger.rep_weights.get_weight_unused ());
+	ledger.rep_weights.verify_consistency (0);
+}
+
 TEST (ledger, representative_change)
 {
 	auto ctx = nano::test::ledger_empty ();
@@ -991,70 +1091,204 @@ TEST (ledger, open_fork)
 	ASSERT_EQ (nano::block_status::fork, ledger.process (transaction, block3));
 }
 
-TEST (ledger, representation_changes)
+/*
+ * put loads a weight straight into the cache without touching the store, which is how the cache is filled from the database table at startup, and a later put for the same rep overwrites the earlier value.
+ */
+TEST (ledger, rep_weights_put)
 {
 	auto store{ nano::test::make_store () };
-	nano::keypair key1;
 	nano::rep_weights rep_weights{ store->rep_weight };
-	ASSERT_EQ (0, rep_weights.get (key1.pub));
-	rep_weights.put (key1.pub, 1);
-	ASSERT_EQ (1, rep_weights.get (key1.pub));
-	rep_weights.put (key1.pub, 2);
-	ASSERT_EQ (2, rep_weights.get (key1.pub));
+	nano::account const rep{ 1 };
+	ASSERT_EQ (0, rep_weights.get (rep));
+
+	rep_weights.put (rep, 1);
+	ASSERT_EQ (1, rep_weights.get (rep));
+	ASSERT_EQ (1, rep_weights.size ());
+
+	rep_weights.put (rep, 2);
+	ASSERT_EQ (2, rep_weights.get (rep));
+	ASSERT_EQ (1, rep_weights.size ());
+
+	// The store is not written
+	auto txn{ store->tx_begin_read () };
+	ASSERT_EQ (0, store->rep_weight.count (txn));
 }
 
-TEST (ledger, delete_rep_weight_of_zero)
+/*
+ * A rep whose weight drops to zero is removed from both the cache and the store, whether it gets there through sub or through move_add_sub, and a rep receiving weight for the first time is created in both.
+ * An update carrying no weight, as an account without balance changing its representative produces, leaves both untouched.
+ */
+TEST (ledger, rep_weights_zero_weight)
 {
 	auto store{ nano::test::make_store () };
 	nano::rep_weights rep_weights{ store->rep_weight };
+	nano::account const rep1{ 1 };
+	nano::account const rep2{ 2 };
+	nano::account const rep3{ 3 };
 	auto txn{ store->tx_begin_write () };
-	rep_weights.add (txn, 1, 100);
-	rep_weights.add (txn, 2, 200);
-	ASSERT_EQ (2, rep_weights.size ());
-	rep_weights.move_add_sub (txn, 2, 100, 3, 120);
-	ASSERT_EQ (3, rep_weights.size ());
-	ASSERT_EQ (3, store->rep_weight.count (txn));
 
-	// Reduce rep weights to 0
-	rep_weights.sub (txn, 1, 100);
+	rep_weights.add (txn, rep1, 100);
+	rep_weights.add (txn, rep2, 200);
 	ASSERT_EQ (2, rep_weights.size ());
 	ASSERT_EQ (2, store->rep_weight.count (txn));
 
-	rep_weights.move_add_sub (txn, 3, 120, 2, 100);
+	// Moving weight into a rep that has none creates it
+	rep_weights.move_add_sub (txn, rep2, 100, rep3, 120);
+	ASSERT_EQ (120, rep_weights.get (rep3));
+	ASSERT_EQ (120, store->rep_weight.get (txn, rep3));
+	ASSERT_EQ (3, rep_weights.size ());
+	ASSERT_EQ (3, store->rep_weight.count (txn));
+
+	// Subtracting all of a rep's weight removes it
+	rep_weights.sub (txn, rep1, 100);
+	ASSERT_EQ (0, rep_weights.get (rep1));
+	ASSERT_EQ (0, store->rep_weight.get (txn, rep1));
+	ASSERT_EQ (2, rep_weights.size ());
+	ASSERT_EQ (2, store->rep_weight.count (txn));
+
+	// Moving all of a rep's weight away removes it
+	rep_weights.move_add_sub (txn, rep3, 120, rep2, 100);
+	ASSERT_EQ (0, rep_weights.get (rep3));
+	ASSERT_EQ (0, store->rep_weight.get (txn, rep3));
+	ASSERT_EQ (200, rep_weights.get (rep2));
 	ASSERT_EQ (1, rep_weights.size ());
 	ASSERT_EQ (1, store->rep_weight.count (txn));
 
-	rep_weights.sub (txn, 2, 200);
+	rep_weights.sub (txn, rep2, 200);
+	ASSERT_EQ (0, rep_weights.size ());
+	ASSERT_EQ (0, store->rep_weight.count (txn));
+
+	// An account without balance changing its representative touches neither rep
+	rep_weights.move_add_sub (txn, rep1, 0, rep3, 0);
 	ASSERT_EQ (0, rep_weights.size ());
 	ASSERT_EQ (0, store->rep_weight.count (txn));
 }
 
-TEST (ledger, rep_cache_min_weight)
+/*
+ * The cache only holds reps at or above the minimum weight while the store always keeps the exact weight, so a rep enters the cache when it reaches the minimum and leaves it when it falls below.
+ */
+TEST (ledger, rep_weights_cache_min_weight)
 {
 	auto store{ nano::test::make_store () };
-	nano::uint128_t min_weight{ 10 };
+	nano::uint128_t const min_weight{ 10 };
 	nano::rep_weights rep_weights{ store->rep_weight, min_weight };
+	nano::account const rep{ 1 };
 	auto txn{ store->tx_begin_write () };
 
-	// one below min weight
-	rep_weights.add (txn, 1, 9);
+	// Below the minimum: stored but not cached
+	rep_weights.add (txn, rep, 9);
+	ASSERT_EQ (0, rep_weights.get (rep));
+	ASSERT_EQ (9, store->rep_weight.get (txn, rep));
 	ASSERT_EQ (0, rep_weights.size ());
 	ASSERT_EQ (1, store->rep_weight.count (txn));
 
-	// exactly min weight
-	rep_weights.add (txn, 1, 1);
+	// Exactly the minimum enters the cache
+	rep_weights.add (txn, rep, 1);
+	ASSERT_EQ (10, rep_weights.get (rep));
+	ASSERT_EQ (10, store->rep_weight.get (txn, rep));
 	ASSERT_EQ (1, rep_weights.size ());
-	ASSERT_EQ (1, store->rep_weight.count (txn));
 
-	// above min weight
-	rep_weights.add (txn, 1, 1);
+	// Above the minimum stays cached
+	rep_weights.add (txn, rep, 1);
+	ASSERT_EQ (11, rep_weights.get (rep));
 	ASSERT_EQ (1, rep_weights.size ());
-	ASSERT_EQ (1, store->rep_weight.count (txn));
 
-	// fall blow min weight
-	rep_weights.sub (txn, 1, 5);
+	// Falling below the minimum leaves the cache but not the store
+	rep_weights.sub (txn, rep, 5);
+	ASSERT_EQ (0, rep_weights.get (rep));
+	ASSERT_EQ (6, store->rep_weight.get (txn, rep));
 	ASSERT_EQ (0, rep_weights.size ());
 	ASSERT_EQ (1, store->rep_weight.count (txn));
+}
+
+/*
+ * move_add_sub takes the old balance from the old representative and gives the new balance to the new one, which is how a block changing both is applied and rolled back.
+ * Store and cache agree after every step, reps dropping to zero disappear from both, and the committed and unused totals shift by the balance difference.
+ * Equal amounts are a plain move, and a rep shared by both sides only sees the balance difference.
+ */
+TEST (ledger, rep_weights_move_add_sub)
+{
+	auto store{ nano::test::make_store () };
+	nano::rep_weights rep_weights{ store->rep_weight };
+	nano::account const rep1{ 1 };
+	nano::account const rep2{ 2 };
+	auto txn{ store->tx_begin_write () };
+
+	// Account for the whole supply up front so the totals can be verified after every step
+	auto const supply = std::numeric_limits<nano::uint128_t>::max ();
+	rep_weights.put_unused (supply);
+	rep_weights.add (txn, rep1, 100);
+	rep_weights.add (txn, rep2, 50);
+
+	auto expect = [&] (nano::uint128_t const & weight1, nano::uint128_t const & weight2) {
+		ASSERT_EQ (weight1, rep_weights.get (rep1));
+		ASSERT_EQ (weight2, rep_weights.get (rep2));
+		ASSERT_EQ (weight1, store->rep_weight.get (txn, rep1));
+		ASSERT_EQ (weight2, store->rep_weight.get (txn, rep2));
+		size_t const held = (weight1 != 0) + (weight2 != 0);
+		ASSERT_EQ (held, rep_weights.size ());
+		ASSERT_EQ (held, store->rep_weight.count (txn));
+		ASSERT_EQ (weight1 + weight2, rep_weights.get_weight_committed ());
+		ASSERT_EQ (supply - weight1 - weight2, rep_weights.get_weight_unused ());
+		rep_weights.verify_consistency (0);
+	};
+	expect (100, 50);
+
+	// Receive with a representative change: the destination gains more than the source loses
+	rep_weights.move_add_sub (txn, rep1, 100, rep2, 120);
+	expect (0, 170);
+
+	// Send with a representative change: the destination gains less than the source loses
+	rep_weights.move_add_sub (txn, rep2, 120, rep1, 100);
+	expect (100, 50);
+
+	// Equal amounts are a plain move
+	rep_weights.move_add_sub (txn, rep1, 100, rep2, 100);
+	expect (0, 150);
+
+	// The same rep on both sides only sees the balance difference, and nothing when the balance is unchanged
+	rep_weights.move_add_sub (txn, rep2, 150, rep2, 180);
+	expect (0, 180);
+	rep_weights.move_add_sub (txn, rep2, 180, rep2, 130);
+	expect (0, 130);
+	rep_weights.move_add_sub (txn, rep2, 130, rep2, 130);
+	expect (0, 130);
+}
+
+/*
+ * With a cache minimum, move_add_sub keeps the exact weights in the store while the cache only follows reps at or above the minimum.
+ */
+TEST (ledger, rep_weights_move_add_sub_min_weight)
+{
+	auto store{ nano::test::make_store () };
+	nano::uint128_t const min_weight{ 10 };
+	nano::rep_weights rep_weights{ store->rep_weight, min_weight };
+	nano::account const rep1{ 1 };
+	nano::account const rep2{ 2 };
+	auto txn{ store->tx_begin_write () };
+
+	rep_weights.add (txn, rep1, 15);
+	rep_weights.add (txn, rep2, 5); // Below the minimum: stored but not cached
+	ASSERT_EQ (1, rep_weights.size ());
+	ASSERT_EQ (2, store->rep_weight.count (txn));
+
+	// The destination crosses the minimum and enters the cache while the source drops out of both
+	rep_weights.move_add_sub (txn, rep1, 15, rep2, 12);
+	ASSERT_EQ (0, rep_weights.get (rep1));
+	ASSERT_EQ (17, rep_weights.get (rep2));
+	ASSERT_EQ (0, store->rep_weight.get (txn, rep1));
+	ASSERT_EQ (17, store->rep_weight.get (txn, rep2));
+	ASSERT_EQ (1, rep_weights.size ());
+	ASSERT_EQ (1, store->rep_weight.count (txn));
+
+	// The source falls below the minimum: dropped from the cache but kept in the store
+	rep_weights.move_add_sub (txn, rep2, 10, rep1, 12);
+	ASSERT_EQ (12, rep_weights.get (rep1));
+	ASSERT_EQ (0, rep_weights.get (rep2));
+	ASSERT_EQ (12, store->rep_weight.get (txn, rep1));
+	ASSERT_EQ (7, store->rep_weight.get (txn, rep2));
+	ASSERT_EQ (1, rep_weights.size ());
+	ASSERT_EQ (2, store->rep_weight.count (txn));
 }
 
 /*
@@ -1135,6 +1369,73 @@ TEST (ledger, rep_weights_batch_snapshot)
 			auto weights = rep_weights.get (reps);
 			++reads;
 			if (weights.at (rep1) + weights.at (rep2) != total)
+			{
+				++inconsistent;
+			}
+		};
+		read ();
+		first_read.count_down ();
+		while (!done)
+		{
+			read ();
+		}
+	});
+
+	writer.join ();
+	reader.join ();
+
+	ASSERT_EQ (0, inconsistent.load ());
+	ASSERT_GT (reads.load (), 0);
+	ASSERT_EQ (100, rep_weights.get (rep1));
+	ASSERT_EQ (50, rep_weights.get (rep2));
+}
+
+/*
+ * A block that changes representative and balance at once updates two reps and the totals as one cache update: a batch read sees the old state or the new state, never a hybrid.
+ * A writer applies such an update back and forth between two reps while a reader keeps batch-reading both; every observed pair must be one of the two legitimate states.
+ * Applying it as a move followed by a separate add or sub would expose the state between the two steps, where the balance difference is missing from or left behind on one rep.
+ */
+TEST (ledger, rep_weights_move_add_sub_snapshot)
+{
+	auto store{ nano::test::make_store () };
+	nano::rep_weights rep_weights{ store->rep_weight };
+	nano::account const rep1{ 1 };
+	nano::account const rep2{ 2 };
+	std::vector<nano::account> const reps{ rep1, rep2 };
+
+	{
+		auto txn{ store->tx_begin_write () };
+		rep_weights.add (txn, rep1, 100);
+		rep_weights.add (txn, rep2, 50);
+	}
+
+	// The update moves everything from rep1 to rep2 and adds 20 on the way, the reverse takes the 20 away again, so exactly two states are legitimate
+	auto legitimate = [] (nano::uint128_t const & weight1, nano::uint128_t const & weight2) {
+		return (weight1 == 100 && weight2 == 50) || (weight1 == 0 && weight2 == 170);
+	};
+
+	std::atomic<bool> done{ false };
+	std::atomic<size_t> reads{ 0 };
+	std::atomic<size_t> inconsistent{ 0 };
+	std::latch first_read{ 1 };
+
+	// The write transaction is opened on the writer thread, as the store requires
+	std::thread writer ([&] {
+		first_read.wait (); // Hold the writer until the reader has taken its first snapshot, so the run cannot end unobserved
+		auto txn{ store->tx_begin_write () };
+		for (size_t i = 0; i < 2000; ++i)
+		{
+			rep_weights.move_add_sub (txn, rep1, 100, rep2, 120);
+			rep_weights.move_add_sub (txn, rep2, 120, rep1, 100);
+		}
+		done = true;
+	});
+
+	std::thread reader ([&] {
+		auto read = [&] {
+			auto weights = rep_weights.get (reps);
+			++reads;
+			if (!legitimate (weights.at (rep1), weights.at (rep2)))
 			{
 				++inconsistent;
 			}

--- a/nano/core_test/online_reps.cpp
+++ b/nano/core_test/online_reps.cpp
@@ -9,10 +9,15 @@
 #include <nano/node/transport/fake.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/node/wallet.hpp>
+#include <nano/secure/ledger.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
+
+#include <atomic>
+#include <latch>
+#include <thread>
 
 TEST (online_reps, basic)
 {
@@ -343,4 +348,71 @@ TEST (online_reps, weight_change_recalculation)
 	// The bug was that online weight would not recalculate for existing representatives
 	// With the fix, it should now reflect the updated weight
 	ASSERT_TIMELY_EQ (5s, node.online_reps.online (), initial_weight + additional_weight);
+}
+
+/*
+ * The online weight is one consistent snapshot of the observed reps: a weight moving between two of them is never counted twice or dropped.
+ * Since the quorum threshold is derived from this total, a torn read would skew it for a whole sampling period.
+ * A writer shuffles weight between two reps while a reader keeps re-observing both and checking the total.
+ */
+TEST (online_reps, weight_snapshot)
+{
+	nano::test::system system;
+	auto & node = *system.add_node ();
+
+	nano::keypair rep1, rep2;
+	auto const weight1 = nano::nano_ratio * 1000;
+	auto const weight2 = nano::nano_ratio * 500;
+	auto const amount = nano::nano_ratio * 100; // Both reps stay above the vote weight minimum throughout
+	auto const total = weight1 + weight2;
+
+	{
+		auto transaction = node.ledger.tx_begin_write ();
+		node.ledger.rep_weights.add (transaction, rep1.pub, weight1);
+		node.ledger.rep_weights.add (transaction, rep2.pub, weight2);
+	}
+
+	std::atomic<bool> done{ false };
+	std::atomic<size_t> reads{ 0 };
+	std::atomic<size_t> inconsistent{ 0 };
+	std::latch first_read{ 1 };
+
+	// The write transaction is opened on the writer thread, as the store requires
+	std::thread writer ([&] {
+		first_read.wait (); // Hold the writer until the reader has taken its first snapshot, so the run cannot end unobserved
+		auto transaction = node.ledger.tx_begin_write ();
+		for (size_t i = 0; i < 2000; ++i)
+		{
+			node.ledger.rep_weights.move (transaction, rep1.pub, rep2.pub, amount);
+			node.ledger.rep_weights.move (transaction, rep2.pub, rep1.pub, amount);
+		}
+		done = true;
+	});
+
+	// Observing a new rep recalculates the online total, so clearing and re-observing both reps recomputes it from scratch each time
+	std::thread reader ([&] {
+		auto read = [&] {
+			node.online_reps.clear ();
+			node.online_reps.observe (rep1.pub);
+			node.online_reps.observe (rep2.pub);
+			++reads;
+			if (node.online_reps.online () != total)
+			{
+				++inconsistent;
+			}
+		};
+		read ();
+		first_read.count_down ();
+		while (!done)
+		{
+			read ();
+		}
+	});
+
+	writer.join ();
+	reader.join ();
+
+	ASSERT_EQ (0, inconsistent.load ());
+	ASSERT_GT (reads.load (), 0);
+	ASSERT_EQ (total, node.online_reps.online ());
 }

--- a/nano/core_test/online_reps.cpp
+++ b/nano/core_test/online_reps.cpp
@@ -16,7 +16,6 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
-#include <latch>
 #include <thread>
 
 TEST (online_reps, basic)
@@ -372,26 +371,37 @@ TEST (online_reps, weight_snapshot)
 		node.ledger.rep_weights.add (transaction, rep2.pub, weight2);
 	}
 
+	size_t const rounds{ 100 };
 	std::atomic<bool> done{ false };
 	std::atomic<size_t> reads{ 0 };
 	std::atomic<size_t> inconsistent{ 0 };
-	std::latch first_read{ 1 };
+
+	// Each update is followed by at least one snapshot before the next, so the reader keeps pace with the writer and cannot miss the run
+	auto await_read = [&] {
+		auto const target = reads.load () + 1;
+		while (reads.load () < target)
+		{
+			std::this_thread::yield ();
+		}
+	};
 
 	// The write transaction is opened on the writer thread, as the store requires
 	std::thread writer ([&] {
-		first_read.wait (); // Hold the writer until the reader has taken its first snapshot, so the run cannot end unobserved
 		auto transaction = node.ledger.tx_begin_write ();
-		for (size_t i = 0; i < 2000; ++i)
+		for (size_t i = 0; i < rounds; ++i)
 		{
 			node.ledger.rep_weights.move (transaction, rep1.pub, rep2.pub, amount);
+			await_read ();
 			node.ledger.rep_weights.move (transaction, rep2.pub, rep1.pub, amount);
+			await_read ();
 		}
 		done = true;
 	});
 
 	// Observing a new rep recalculates the online total, so clearing and re-observing both reps recomputes it from scratch each time
 	std::thread reader ([&] {
-		auto read = [&] {
+		while (!done)
+		{
 			node.online_reps.clear ();
 			node.online_reps.observe (rep1.pub);
 			node.online_reps.observe (rep2.pub);
@@ -400,12 +410,6 @@ TEST (online_reps, weight_snapshot)
 			{
 				++inconsistent;
 			}
-		};
-		read ();
-		first_read.count_down ();
-		while (!done)
-		{
-			read ();
 		}
 	});
 
@@ -413,6 +417,6 @@ TEST (online_reps, weight_snapshot)
 	reader.join ();
 
 	ASSERT_EQ (0, inconsistent.load ());
-	ASSERT_GT (reads.load (), 0);
+	ASSERT_GE (reads.load (), 2 * rounds);
 	ASSERT_EQ (total, node.online_reps.online ());
 }

--- a/nano/core_test/vote_processor.cpp
+++ b/nano/core_test/vote_processor.cpp
@@ -141,7 +141,7 @@ TEST (vote_processor, weights)
 	system.wallet (0)->send_sync (nano::dev::genesis_key.pub, key2.pub, level2);
 
 	// Wait for representatives
-	ASSERT_TIMELY_EQ (10s, node.ledger.rep_weights.get_rep_amounts ().size (), 4);
+	ASSERT_TIMELY_EQ (10s, node.ledger.rep_weights.get_all ().size (), 4);
 
 	// Wait for rep tiers to be updated
 	node.stats.clear ();

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -205,7 +205,7 @@ int main (int argc, char * const * argv)
 				auto const bootstrap_weights = node->get_bootstrap_weights ();
 				auto const & hardcoded = bootstrap_weights.representatives;
 				auto const hardcoded_height = bootstrap_weights.max_blocks;
-				auto const ledger_unfiltered = node->ledger.rep_weights.get_rep_amounts ();
+				auto const ledger_unfiltered = node->ledger.rep_weights.get_all ();
 				auto const ledger_height = node->ledger.block_count ();
 
 				auto get_total = [] (decltype (bootstrap_weights.representatives) const & reps) -> nano::uint128_union {
@@ -447,7 +447,7 @@ int main (int argc, char * const * argv)
 			auto node = inactive_node.node;
 			auto transaction (node->store.tx_begin_read ());
 			nano::uint128_t total;
-			auto rep_amounts = node->ledger.rep_weights.get_rep_amounts ();
+			auto rep_amounts = node->ledger.rep_weights.get_all ();
 			std::map<nano::account, nano::uint128_t> ordered_reps (rep_amounts.begin (), rep_amounts.end ());
 			for (auto const & rep : ordered_reps)
 			{

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -552,10 +552,17 @@ bool nano::election::publish (std::shared_ptr<nano::block> const & block)
 		// The ballot is full: look up the vote cache weight backing the new fork without holding the election mutex, then retry
 		lock.unlock ();
 
-		nano::uint128_t cached_tally{ 0 };
+		std::vector<nano::account> reps;
 		for (auto const & vote : node.vote_cache.find (block->hash ()))
 		{
-			cached_tally += node.ledger.weight (vote->account);
+			reps.push_back (vote->account);
+		}
+
+		// One batched read, so a weight moving between two of these reps while they are summed is counted once
+		nano::uint128_t cached_tally{ 0 };
+		for (auto const & [rep, weight] : node.ledger.weights (reps))
+		{
+			cached_tally += weight;
 		}
 
 		lock.lock ();

--- a/nano/node/election.cpp
+++ b/nano/node/election.cpp
@@ -36,7 +36,7 @@ nano::election::election (nano::node & node_a, std::shared_ptr<nano::block> cons
 	.vote_interval = node_a.config.network_params.network.vote_broadcast_interval,
 	.block_interval = node_a.config.network_params.network.block_broadcast_interval,
 	}),
-	ballot (block_a, [this] (nano::account const & account) { return node.ledger.weight (account); }),
+	ballot (block_a, [this] (std::span<nano::account const> reps) { return node.ledger.weights (reps); }),
 	behavior_m (election_behavior_a),
 	last_round{ .winner = block_a },
 	height (block_a->sideband ().height),

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -3791,7 +3791,7 @@ void nano::json_handler::representatives ()
 	{
 		bool const sorting = request.get<bool> ("sorting", false);
 		boost::property_tree::ptree representatives;
-		auto rep_amounts = node.ledger.rep_weights.get_rep_amounts ();
+		auto rep_amounts = node.ledger.rep_weights.get_all ();
 		if (!sorting) // Simple
 		{
 			for (auto & rep_amount : rep_amounts)
@@ -3846,7 +3846,7 @@ void nano::json_handler::representative_count ()
 		}
 		else
 		{
-			for (auto & rep_amount : node.ledger.rep_weights.get_rep_amounts ())
+			for (auto & rep_amount : node.ledger.rep_weights.get_all ())
 			{
 				if (rep_amount.second < threshold.number ())
 				{

--- a/nano/node/online_reps.cpp
+++ b/nano/node/online_reps.cpp
@@ -10,6 +10,8 @@
 #include <nano/secure/ledger.hpp>
 #include <nano/store/ledger/online_weight.hpp>
 
+#include <vector>
+
 nano::online_reps::online_reps (nano::node_config const & config_a, nano::node & node_a, nano::ledger & ledger_a, nano::stats & stats_a, nano::logger & logger_a) :
 	config{ config_a },
 	node{ node_a },
@@ -196,8 +198,18 @@ bool nano::online_reps::sample ()
 nano::uint128_t nano::online_reps::calculate_online () const
 {
 	debug_assert (!mutex.try_lock ());
-	return std::accumulate (reps.begin (), reps.end (), nano::uint128_t{ 0 }, [this] (nano::uint128_t current, rep_info const & info) {
-		return current + ledger.weight (info.account);
+
+	std::vector<nano::account> accounts;
+	accounts.reserve (reps.size ());
+	for (auto const & info : reps)
+	{
+		accounts.push_back (info.account);
+	}
+
+	// One consistent snapshot of all online reps: a weight moving between two of them is never counted twice or dropped, which would skew the quorum threshold derived from this total
+	auto const weights = ledger.weights (accounts);
+	return std::accumulate (weights.begin (), weights.end (), nano::uint128_t{ 0 }, [] (nano::uint128_t current, auto const & entry) {
+		return current + entry.second;
 	});
 }
 

--- a/nano/secure/election_ballot.cpp
+++ b/nano/secure/election_ballot.cpp
@@ -6,6 +6,16 @@
 
 #include <algorithm>
 
+namespace
+{
+// Weight of a rep in a queried snapshot, zero when the snapshot has no entry for it
+nano::uint128_t weight_of (nano::rep_weight_map const & weights, nano::account const & rep)
+{
+	auto existing = weights.find (rep);
+	return existing != weights.end () ? existing->second : nano::uint128_t{ 0 };
+}
+}
+
 /*
  * vote_info
  */
@@ -210,13 +220,26 @@ nano::uint128_t nano::election_ballot::block_weights::final_weight (nano::block_
 	return existing != final_weights.end () ? existing->second : 0;
 }
 
+nano::rep_weight_map nano::election_ballot::rep_weights () const
+{
+	std::vector<nano::account> reps;
+	reps.reserve (votes_m.size ());
+	for (auto const & [rep, info] : votes_m)
+	{
+		reps.push_back (rep);
+	}
+	return weight_query (reps);
+}
+
 auto nano::election_ballot::compute_weights () const -> block_weights
 {
+	auto const weights = rep_weights ();
+
 	// Accumulate the weight behind every voted-for hash, including hashes not held; make_tally filters those out
 	block_weights result;
 	for (auto const & [rep, info] : votes_m)
 	{
-		auto const rep_weight = weight_query (rep);
+		auto const rep_weight = weight_of (weights, rep);
 		result.weights[info.hash] += rep_weight;
 		// A final vote counts into both totals, so the final weight is always a subset of the block weight
 		if (info.final ())
@@ -352,11 +375,14 @@ std::unordered_map<nano::account, nano::vote_info> nano::election_ballot::votes 
 
 std::vector<nano::vote_with_weight_info> nano::election_ballot::votes_with_weight () const
 {
+	auto const weights = rep_weights ();
+
 	std::vector<nano::vote_with_weight_info> result;
 	result.reserve (votes_m.size ());
 	for (auto const & [rep, info] : votes_m)
 	{
-		result.push_back ({ rep, info.arrival, info.timestamp, info.hash, weight_query (rep) });
+		auto const rep_weight = weight_of (weights, rep);
+		result.push_back ({ rep, info.arrival, info.timestamp, info.hash, rep_weight });
 	}
 
 	// Heaviest reps first, ties ordered by account so the report is deterministic

--- a/nano/secure/election_ballot.hpp
+++ b/nano/secure/election_ballot.hpp
@@ -3,12 +3,14 @@
 #include <nano/lib/fwd.hpp>
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/numbers_templ.hpp>
+#include <nano/secure/rep_weights.hpp>
 
 #include <chrono>
 #include <functional>
 #include <map>
 #include <memory>
 #include <optional>
+#include <span>
 #include <unordered_map>
 #include <vector>
 
@@ -58,6 +60,7 @@ std::chrono::seconds calculate_vote_cooldown (nano::uint128_t weight, nano::uint
  * Consensus bookkeeping for a single election: records one vote per representative, holds the competing blocks (forks of a single root) and selects a winner and leader from those votes.
  * The entire state is { votes, blocks, winner, leader }; vote () writes the votes, insert () the blocks, evaluate () the winner and the leader, and every tally is computed fresh from the recorded votes.
  * Representative weight and time are supplied by the caller, making the class deterministic and self-contained; locking is the responsibility of the owning election.
+ * Every tally reads the weights of all voting reps with a single weight query, so one tally never mixes weights from before and after a concurrent ledger update.
  *
  * Invariants:
  * - One vote per representative, so a rep can never back two blocks at once.
@@ -72,7 +75,8 @@ class election_ballot final
 public:
 	static size_t constexpr default_max_blocks{ 10 };
 
-	using weight_fn = std::function<nano::uint128_t (nano::account const &)>;
+	// Weights of the given representatives, expected as one consistent snapshot; a rep missing from the result counts as zero
+	using weight_fn = std::function<nano::rep_weight_map (std::span<nano::account const>)>;
 
 	// The initial block becomes both the first winner and the first leader
 	election_ballot (std::shared_ptr<nano::block> const & initial, weight_fn weight_query, size_t max_blocks = default_max_blocks);
@@ -176,6 +180,9 @@ private:
 		// Weight behind the hash from final votes only, zero when nothing is tallied for it
 		nano::uint128_t final_weight (nano::block_hash const &) const;
 	};
+
+	// Weights of every rep with a recorded vote, fetched with a single weight query
+	nano::rep_weight_map rep_weights () const;
 
 	block_weights compute_weights () const;
 

--- a/nano/secure/ledger.cpp
+++ b/nano/secure/ledger.cpp
@@ -580,7 +580,7 @@ bool nano::ledger::bootstrap_height_reached () const
 	return cache.block_count >= bootstrap_weights.max_blocks;
 }
 
-std::unordered_map<nano::account, nano::uint128_t> nano::ledger::rep_weights_snapshot () const
+nano::rep_weight_map nano::ledger::rep_weights_snapshot () const
 {
 	if (!bootstrap_height_reached ())
 	{
@@ -588,7 +588,7 @@ std::unordered_map<nano::account, nano::uint128_t> nano::ledger::rep_weights_sna
 	}
 	else
 	{
-		return rep_weights.get_rep_amounts ();
+		return rep_weights.get_all ();
 	}
 }
 
@@ -606,6 +606,25 @@ nano::uint128_t nano::ledger::weight (nano::account const & account) const
 	else
 	{
 		return rep_weights.get (account);
+	}
+}
+
+nano::rep_weight_map nano::ledger::weights (std::span<nano::account const> reps) const
+{
+	if (!bootstrap_height_reached ())
+	{
+		nano::rep_weight_map result;
+		result.reserve (reps.size ());
+		for (auto const & rep : reps)
+		{
+			auto weight = bootstrap_weights.representatives.find (rep);
+			result[rep] = weight != bootstrap_weights.representatives.end () ? weight->second : 0;
+		}
+		return result;
+	}
+	else
+	{
+		return rep_weights.get (reps);
 	}
 }
 

--- a/nano/secure/ledger.hpp
+++ b/nano/secure/ledger.hpp
@@ -17,6 +17,7 @@
 #include <deque>
 #include <map>
 #include <memory>
+#include <span>
 
 namespace nano
 {
@@ -85,15 +86,29 @@ public:
 	/** Start read-only transaction */
 	secure::read_transaction tx_begin_read () const;
 
-	nano::uint128_t account_receivable (secure::transaction const &, nano::account const &, bool = false) const;
 	/**
-	 * Returns the cached vote weight for the given representative.
-	 * If the weight is below the cache limit it returns 0.
-	 * During bootstrap it returns the preconfigured bootstrap weights.
+	 * Returns the vote weight of the given representative from the in-memory cache, without a database lookup.
+	 * Returns 0 when the weight is below the cache minimum.
+	 * Returns the preconfigured bootstrap weight until the bootstrap height is reached.
 	 */
 	nano::uint128_t weight (nano::account const &) const;
-	/* Returns the exact vote weight for the given representative by doing a database lookup */
+	/**
+	 * Returns the vote weights of all given representatives from the in-memory cache as one consistent snapshot, without a database lookup.
+	 * Every requested representative has an entry, 0 when its weight is below the cache minimum.
+	 * Returns the preconfigured bootstrap weights until the bootstrap height is reached.
+	 */
+	nano::rep_weight_map weights (std::span<nano::account const>) const;
+	/**
+	 * Returns the vote weights of all representatives with a cached weight as one consistent snapshot, without a database lookup.
+	 * Returns the preconfigured bootstrap weights until the bootstrap height is reached.
+	 */
+	nano::rep_weight_map rep_weights_snapshot () const;
+	/**
+	 * Returns the vote weight of the given representative from the database, exact and unaffected by the cache minimum or bootstrap weights.
+	 */
 	nano::uint128_t weight_exact (secure::transaction const &, nano::account const &) const;
+
+	nano::uint128_t account_receivable (secure::transaction const &, nano::account const &, bool = false) const;
 	std::shared_ptr<nano::block> forked_block (secure::transaction const &, nano::block const &);
 	nano::root latest_root (secure::transaction const &, nano::account const &);
 	nano::block_hash representative_block (secure::transaction const &, nano::block_hash const &);
@@ -118,7 +133,6 @@ public:
 	nano::account epoch_signer (nano::link const &) const;
 	nano::link epoch_link (nano::epoch) const;
 	bool bootstrap_height_reached () const;
-	std::unordered_map<nano::account, nano::uint128_t> rep_weights_snapshot () const;
 
 	static nano::epoch version (nano::block const & block);
 	nano::epoch version (secure::transaction const &, nano::block_hash const & hash) const;

--- a/nano/secure/rep_weights.cpp
+++ b/nano/secure/rep_weights.cpp
@@ -103,7 +103,21 @@ nano::uint128_t nano::rep_weights::get (nano::account const & rep) const
 	return get_impl (rep);
 }
 
-std::unordered_map<nano::account, nano::uint128_t> nano::rep_weights::get_rep_amounts () const
+nano::rep_weight_map nano::rep_weights::get (std::span<nano::account const> reps) const
+{
+	nano::rep_weight_map result;
+	result.reserve (reps.size ());
+
+	// One lock acquisition for the whole batch: a concurrent move between two reps is seen either fully or not at all
+	std::shared_lock guard{ mutex };
+	for (auto const & rep : reps)
+	{
+		result[rep] = get_impl (rep);
+	}
+	return result;
+}
+
+nano::rep_weight_map nano::rep_weights::get_all () const
 {
 	std::shared_lock guard{ mutex };
 	return rep_amounts;

--- a/nano/secure/rep_weights.cpp
+++ b/nano/secure/rep_weights.cpp
@@ -40,48 +40,44 @@ void nano::rep_weights::sub (store::write_transaction const & txn, nano::account
 
 void nano::rep_weights::move (store::write_transaction const & txn, nano::account const & source_rep, nano::account const & dest_rep, nano::uint128_t const & amount)
 {
-	if (source_rep == dest_rep) // Nothing to move if reps are the same
+	move_add_sub (txn, source_rep, amount, dest_rep, amount);
+}
+
+void nano::rep_weights::move_add_sub (store::write_transaction const & txn, nano::account const & source_rep, nano::uint128_t const & amount_source, nano::account const & dest_rep, nano::uint128_t const & amount_dest)
+{
+	if (source_rep == dest_rep) // The same rep on both sides only sees the balance difference
 	{
+		if (amount_dest > amount_source)
+		{
+			add (txn, dest_rep, amount_dest - amount_source);
+		}
+		else if (amount_source > amount_dest)
+		{
+			sub (txn, source_rep, amount_source - amount_dest);
+		}
 		return;
 	}
 
 	auto const previous_weight_source = rep_weight_store.get (txn, source_rep);
 	auto const previous_weight_dest = rep_weight_store.get (txn, dest_rep);
-	release_assert (previous_weight_source >= amount, "source representative must have enough weight to move");
+	release_assert (previous_weight_source >= amount_source, "source representative must have enough weight to move");
 
-	auto const new_weight_source = previous_weight_source - amount;
-	auto const new_weight_dest = previous_weight_dest + amount;
+	auto const new_weight_source = previous_weight_source - amount_source;
+	auto const new_weight_dest = previous_weight_dest + amount_dest;
 	release_assert (new_weight_dest >= previous_weight_dest, "new weight for destination representative must be greater than or equal to previous weight");
-	release_assert (new_weight_source <= previous_weight_source, "new weight for source representative must be less than or equal to previous weight");
 
 	put_store (txn, source_rep, previous_weight_source, new_weight_source);
 	put_store (txn, dest_rep, previous_weight_dest, new_weight_dest);
 
+	// Both reps and the totals change under one lock, so a batch read sees the whole update or none of it
 	std::lock_guard guard{ mutex };
 	put_cache (source_rep, new_weight_source);
 	put_cache (dest_rep, new_weight_dest);
-}
 
-void nano::rep_weights::move_add_sub (store::write_transaction const & txn, nano::account const & source_rep, nano::uint128_t const & amount_source, nano::account const & dest_rep, nano::uint128_t const & amount_dest)
-{
-	if (amount_source == amount_dest)
-	{
-		move (txn, source_rep, dest_rep, amount_source);
-	}
-	else if (amount_dest > amount_source)
-	{
-		move (txn, source_rep, dest_rep, amount_source);
-		add (txn, dest_rep, amount_dest - amount_source);
-	}
-	else if (amount_source > amount_dest)
-	{
-		move (txn, source_rep, dest_rep, amount_dest);
-		sub (txn, source_rep, amount_source - amount_dest);
-	}
-	else
-	{
-		release_assert (false);
-	}
+	weight_committed += amount_dest;
+	weight_committed -= amount_source;
+	weight_unused += amount_source;
+	weight_unused -= amount_dest;
 }
 
 void nano::rep_weights::put (nano::account const & rep, nano::uint128_t const & weight)

--- a/nano/secure/rep_weights.hpp
+++ b/nano/secure/rep_weights.hpp
@@ -7,10 +7,14 @@
 
 #include <memory>
 #include <shared_mutex>
+#include <span>
 #include <unordered_map>
 
 namespace nano
 {
+// Vote weight per representative
+using rep_weight_map = std::unordered_map<nano::account, nano::uint128_t>;
+
 class rep_weights
 {
 public:
@@ -31,8 +35,14 @@ public:
 	void put_unused (nano::uint128_t const & weight);
 	void append_from (rep_weights const & other);
 
+	/* Cached weight of the representative, zero when it has no cached weight (unknown, below the cache minimum, or the zero account) */
 	nano::uint128_t get (nano::account const & rep) const;
-	std::unordered_map<nano::account, nano::uint128_t> get_rep_amounts () const;
+
+	/* Weights of all given representatives read under a single lock, so the result is one consistent snapshot; every requested rep has an entry, zero when it has no cached weight */
+	nano::rep_weight_map get (std::span<nano::account const> reps) const;
+
+	/* Copy of the whole cache read under a single lock: every representative with a cached weight, i.e. at or above the cache minimum */
+	nano::rep_weight_map get_all () const;
 
 	size_t size () const;
 	nano::container_info container_info () const;
@@ -48,7 +58,7 @@ private:
 	nano::uint128_t const min_weight;
 
 	mutable std::shared_mutex mutex;
-	std::unordered_map<nano::account, nano::uint128_t> rep_amounts;
+	nano::rep_weight_map rep_amounts;
 
 	// Used for consistency checking, use higher precision types to detect overflows
 	nano::uint256_t weight_committed{ 0 };

--- a/nano/secure/rep_weights.hpp
+++ b/nano/secure/rep_weights.hpp
@@ -27,7 +27,7 @@ public:
 	/* Move weight from one representative to another */
 	void move (store::write_transaction const &, nano::account const & source_rep, nano::account const & dest_rep, nano::uint128_t const & amount);
 
-	/* Move weight from one representative to another while adding or subtracting the weight */
+	/* Take amount_source from the source rep and give amount_dest to the destination rep in one cache update, as a block changing representative and balance at once requires */
 	void move_add_sub (store::write_transaction const &, nano::account const & source_rep, nano::uint128_t const & amount_source, nano::account const & dest_rep, nano::uint128_t const & amount_dest);
 
 	/* Only use this method when loading rep weights from the database table */

--- a/nano/test_common/CMakeLists.txt
+++ b/nano/test_common/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(
   chains.cpp
   common.hpp
   common.cpp
+  hooked_backend.hpp
+  hooked_backend.cpp
   ledger_context.hpp
   ledger_context.cpp
   make_store.hpp

--- a/nano/test_common/hooked_backend.cpp
+++ b/nano/test_common/hooked_backend.cpp
@@ -1,0 +1,165 @@
+#include <nano/test_common/common.hpp>
+#include <nano/test_common/hooked_backend.hpp>
+#include <nano/test_common/make_store.hpp>
+
+nano::test::hooked_backend::hooked_backend (std::unique_ptr<nano::store::backend> inner_a, nano::logger & logger) :
+	nano::store::backend{ logger, nano::store::txn_tracking_config{} },
+	inner{ std::move (inner_a) }
+{
+}
+
+void nano::test::hooked_backend::notify (nano::store::table table) const
+{
+	if (before_access)
+	{
+		before_access (table);
+	}
+}
+
+int nano::test::hooked_backend::get (nano::store::transaction const & txn, nano::store::table table, nano::store::db_val const & key, nano::store::db_val & value) const
+{
+	notify (table);
+	return inner->get (txn, table, key, value);
+}
+
+int nano::test::hooked_backend::put (nano::store::write_transaction const & txn, nano::store::table table, nano::store::db_val const & key, nano::store::db_val const & value)
+{
+	notify (table);
+	return inner->put (txn, table, key, value);
+}
+
+int nano::test::hooked_backend::del (nano::store::write_transaction const & txn, nano::store::table table, nano::store::db_val const & key)
+{
+	notify (table);
+	return inner->del (txn, table, key);
+}
+
+bool nano::test::hooked_backend::exists (nano::store::transaction const & txn, nano::store::table table, nano::store::db_val const & key) const
+{
+	notify (table);
+	return inner->exists (txn, table, key);
+}
+
+uint64_t nano::test::hooked_backend::count (nano::store::transaction const & txn, nano::store::table table) const
+{
+	return inner->count (txn, table);
+}
+
+bool nano::test::hooked_backend::count_is_exact (nano::store::table table) const
+{
+	return inner->count_is_exact (table);
+}
+
+int nano::test::hooked_backend::clear (nano::store::table table)
+{
+	return inner->clear (table);
+}
+
+bool nano::test::hooked_backend::table_open (nano::store::table table) const
+{
+	return inner->table_open (table);
+}
+
+bool nano::test::hooked_backend::drop_table_by_name (std::string const & name)
+{
+	return inner->drop_table_by_name (name);
+}
+
+bool nano::test::hooked_backend::table_exists (std::string const & name) const
+{
+	return inner->table_exists (name);
+}
+
+nano::store::iterator nano::test::hooked_backend::begin (nano::store::transaction const & txn, nano::store::table table) const
+{
+	return inner->begin (txn, table);
+}
+
+nano::store::iterator nano::test::hooked_backend::begin (nano::store::transaction const & txn, nano::store::table table, nano::store::db_val const & key) const
+{
+	return inner->begin (txn, table, key);
+}
+
+nano::store::iterator nano::test::hooked_backend::end (nano::store::transaction const & txn, nano::store::table table) const
+{
+	return inner->end (txn, table);
+}
+
+void nano::test::hooked_backend::copy_with_compaction (std::filesystem::path const & destination)
+{
+	inner->copy_with_compaction (destination);
+}
+
+void nano::test::hooked_backend::backup ()
+{
+	inner->backup ();
+}
+
+void nano::test::hooked_backend::collect_txn_tracker (boost::property_tree::ptree & tree, std::chrono::milliseconds min_read_time, std::chrono::milliseconds min_write_time) const
+{
+	inner->collect_txn_tracker (tree, min_read_time, min_write_time);
+}
+
+void nano::test::hooked_backend::collect_memory_stats (boost::property_tree::ptree & tree) const
+{
+	inner->collect_memory_stats (tree);
+}
+
+bool nano::test::hooked_backend::success (int status) const
+{
+	return inner->success (status);
+}
+
+bool nano::test::hooked_backend::not_found (int status) const
+{
+	return inner->not_found (status);
+}
+
+std::string nano::test::hooked_backend::error_string (int status) const
+{
+	return inner->error_string (status);
+}
+
+nano::store::read_transaction nano::test::hooked_backend::tx_begin_read () const
+{
+	return inner->tx_begin_read ();
+}
+
+nano::store::write_transaction nano::test::hooked_backend::tx_begin_write ()
+{
+	return inner->tx_begin_write ();
+}
+
+std::string nano::test::hooked_backend::get_vendor () const
+{
+	return inner->get_vendor ();
+}
+
+std::string nano::test::hooked_backend::get_database_path () const
+{
+	return inner->get_database_path ();
+}
+
+// The wrapped backend keeps its own open state, so the lifecycle goes through its public entry points
+void nano::test::hooked_backend::open_impl (nano::store::column_schema schema, nano::store::open_mode mode)
+{
+	inner->open (schema, mode);
+}
+
+void nano::test::hooked_backend::close_impl ()
+{
+	inner->close ();
+}
+
+void nano::test::hooked_backend::create_table_impl (nano::store::table table, std::string const &)
+{
+	inner->create_table (table);
+}
+
+nano::test::hooked_store nano::test::make_hooked_store ()
+{
+	auto backend = std::make_unique<nano::test::hooked_backend> (nano::test::make_backend (), nano::test::default_logger ());
+	auto & backend_ref = *backend;
+	auto store = std::make_unique<nano::store::ledger_store> (std::move (backend), nano::store::open_mode::read_write, nano::test::default_stats (), nano::test::default_logger ());
+	return { std::move (store), backend_ref };
+}

--- a/nano/test_common/hooked_backend.hpp
+++ b/nano/test_common/hooked_backend.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <nano/store/backend.hpp>
+#include <nano/store/ledger_store.hpp>
+
+#include <functional>
+#include <memory>
+
+namespace nano::test
+{
+/*
+ * Store backend that wraps another backend and runs a callback right before every point access, so a test can observe or interleave at exactly that moment.
+ * Everything else is forwarded unchanged, opening and table creation included, so a ledger store can be built on it like on the wrapped backend.
+ */
+class hooked_backend final : public nano::store::backend
+{
+public:
+	using hook = std::function<void (nano::store::table)>;
+
+	hooked_backend (std::unique_ptr<nano::store::backend> inner, nano::logger &);
+
+	// Runs on the calling thread before get, put, del and exists reach the wrapped backend
+	hook before_access;
+
+public: // nano::store::backend
+	int get (nano::store::transaction const &, nano::store::table, nano::store::db_val const & key, nano::store::db_val & value) const override;
+	int put (nano::store::write_transaction const &, nano::store::table, nano::store::db_val const & key, nano::store::db_val const & value) override;
+	int del (nano::store::write_transaction const &, nano::store::table, nano::store::db_val const & key) override;
+	bool exists (nano::store::transaction const &, nano::store::table, nano::store::db_val const & key) const override;
+	uint64_t count (nano::store::transaction const &, nano::store::table) const override;
+	bool count_is_exact (nano::store::table) const override;
+	int clear (nano::store::table) override;
+	bool table_open (nano::store::table) const override;
+	bool drop_table_by_name (std::string const & name) override;
+	bool table_exists (std::string const & name) const override;
+	nano::store::iterator begin (nano::store::transaction const &, nano::store::table) const override;
+	nano::store::iterator begin (nano::store::transaction const &, nano::store::table, nano::store::db_val const & key) const override;
+	nano::store::iterator end (nano::store::transaction const &, nano::store::table) const override;
+	void copy_with_compaction (std::filesystem::path const & destination) override;
+	void backup () override;
+	void collect_txn_tracker (boost::property_tree::ptree &, std::chrono::milliseconds min_read_time, std::chrono::milliseconds min_write_time) const override;
+	void collect_memory_stats (boost::property_tree::ptree &) const override;
+	bool success (int status) const override;
+	bool not_found (int status) const override;
+	std::string error_string (int status) const override;
+	nano::store::read_transaction tx_begin_read () const override;
+	nano::store::write_transaction tx_begin_write () override;
+	std::string get_vendor () const override;
+	std::string get_database_path () const override;
+
+protected:
+	void open_impl (nano::store::column_schema, nano::store::open_mode) override;
+	void close_impl () override;
+	void create_table_impl (nano::store::table, std::string const & name) override;
+
+private:
+	void notify (nano::store::table) const;
+
+	std::unique_ptr<nano::store::backend> inner;
+};
+
+// A ledger store built on a hooked backend, with the backend exposed so the test can install its hook
+struct hooked_store
+{
+	std::unique_ptr<nano::store::ledger_store> store;
+	hooked_backend & backend;
+};
+
+// Fresh ledger store on the default database backend, wrapped in a hooked_backend
+hooked_store make_hooked_store ();
+}


### PR DESCRIPTION
Makes every tally read the weights of all its representatives in one locked batch, so a tally is a consistent snapshot of the rep weight cache rather than a sequence of independent reads.
It also applies a block that changes representative and balance at once as a single cache update, so there is no half-applied state for such a read to see.

## Motivation

`election_ballot` read each voting rep's weight with a separate `rep_weights::get`, each taking its own shared lock, so a tally over N reps cost N lock acquisitions and could interleave with ledger updates that touch several reps at once. `online_reps::calculate_online` summed per-rep reads the same way. Reading the whole set under one lock is cheaper and gives every tally a single point-in-time view of the cache.

## Changes

- `nano::rep_weight_map` alias in `rep_weights.hpp` for the recurring rep-to-weight map, used consistently across `rep_weights`, `ledger` and `election_ballot`.
- `rep_weights::get (std::span<nano::account const>)` reads all requested reps under a single lock, with an entry for every requested rep. `get_rep_amounts` is renamed to `get_all`, and all three getters are documented.
- `ledger::weights` mirrors `ledger::weight` for a batch, resolving the bootstrap-versus-cache choice once. The ledger weight getters are grouped below `tx_begin_read` with aligned docs.
- `election_ballot::weight_fn` takes a span of reps and returns a `rep_weight_map`; `compute_weights` and `votes_with_weight` build the rep list once and issue exactly one query. A rep missing from the result counts as zero.
- `election` wires the ballot to `ledger::weights`; `online_reps::calculate_online` sums one batched snapshot.
- `rep_weights::move_add_sub` applies a block that changes representative and balance at once as one cache update: both reps and the committed and unused totals change under a single lock, and `move` becomes its equal-amount case.
- `election::publish` reads the vote cache weight behind an incoming fork with one batched `ledger::weights` call instead of one `ledger::weight` lookup per voter.

## Tests

- `election_ballot.weight_query_single_call_per_tally`: vote and insert-with-room never query; evaluate, tally, votes_with_weight and a full-ballot insert each query exactly once, naming every voting rep.
- `election_ballot.weight_query_snapshot`: a query that moves all weight between two reps after every call. Each tally sees the whole weight exactly once and the winner alternates with the move.
- `election_ballot.weight_query_missing_rep_is_zero`.
- `ledger.rep_weights_batch`: unknown rep, zero account, below-minimum rep, duplicates, empty input, agreement with the single read.
- `ledger.rep_weights_batch_snapshot`: a writer thread moves weight between two reps while a reader batch-reads both and checks the sum stays constant.
- `ledger.weights`: weight delegated to two reps through real blocks; the batch agrees with `weight` and `weight_exact` for every rep, bootstrap weights replace the cache below the bootstrap height, and the batch switches back to the cache once the height is reached.
- `ledger.weights_min_rep_weight`: a rep below the cache minimum reads zero from the batch and the single read while `weight_exact` keeps its value.
- `ledger.weights_snapshot`: the genesis account flips its representative between two reps through real change blocks on a writer thread while a reader batch-reads both; the two weights always sum to the genesis balance.
- `online_reps.weight_snapshot`: same shape at the node level, re-observing both reps while their weight moves; the online total stays constant.
- The snapshot tests guarantee that the reader observes every update: the writer waits after each update, block and rollback until the reader has taken another snapshot, and the iteration counts are a hundred rounds or blocks so the handshake stays cheap.
- `nano::test::hooked_backend` wraps the store backend and runs a callback before every point access, so a test can batch-read the cache from inside an update, before the cache lock is taken. `ledger.rep_weights_move_add_sub_mid_update` and `ledger.weights_snapshot_mid_update` use it and fail deterministically against the previous `move_add_sub`.
- `ledger.rep_weights_move_add_sub_snapshot` and `ledger.weights_snapshot_send_change`: the unequal-amount counterparts of the snapshot tests, a writer applying a representative change together with a balance change while a reader batch-reads both reps; every observed pair must be one of the legitimate states. Both fail against the previous `move_add_sub`.
- `ledger.weights_all_block_types`: every block type and its rollback checked against a model of each account's representative and balance, covering the cached and stored weights, the committed and unused totals, and a ledger rebuilt from the store.
- `ledger.rep_weights_move_add_sub`, `ledger.rep_weights_move_add_sub_min_weight` and `ledger.rep_weights_append_from`: unit tests for the update, its interaction with the cache minimum and the startup merge. The older `rep_weights` tests are renamed into the same scheme and documented.

## Not changed

`rep_crawler` and `rep_tiers` still sum per-rep reads; those totals are informational.


