### PR TITLE
Fix RPC shutdown races by routing stop requests to the owner

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(
   peer_container.cpp
   rep_tiers.cpp
   rep_weight_store.cpp
+  rpc_server.cpp
   scheduler_buckets.cpp
   stats.cpp
   signal_manager.cpp

--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(
   core_test
   entry.cpp
+  fakes/rpc_handler.hpp
   fakes/websocket_client.hpp
   fakes/work_peer.hpp
   active_elections.cpp
@@ -72,6 +73,7 @@ add_executable(
   peer_container.cpp
   rep_tiers.cpp
   rep_weight_store.cpp
+  rpc_host.cpp
   rpc_server.cpp
   scheduler_buckets.cpp
   stats.cpp

--- a/nano/core_test/fakes/rpc_handler.hpp
+++ b/nano/core_test/fakes/rpc_handler.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <nano/lib/locks.hpp>
+#include <nano/lib/rpc_handler_interface.hpp>
+
+#include <atomic>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace nano::test
+{
+/** Echoes every request body back, so the server side can be tested without any RPC API */
+class echo_rpc_handler final : public nano::rpc_handler_interface
+{
+public:
+	void process_request (std::string const &, std::string const & body, std::function<void (std::string const &)> response) override
+	{
+		++requests;
+		response (body);
+	}
+
+	void process_request_v2 (nano::rpc_handler_request_params const &, std::string const & body, std::function<void (std::shared_ptr<std::string> const &)> response) override
+	{
+		++requests;
+		response (std::make_shared<std::string> (body));
+	}
+
+	std::atomic<int> requests{ 0 };
+};
+
+/** Holds every request until the test releases it, to keep connections in flight */
+class deferred_rpc_handler final : public nano::rpc_handler_interface
+{
+public:
+	void process_request (std::string const &, std::string const &, std::function<void (std::string const &)> response) override
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		pending.push_back (std::move (response));
+	}
+
+	void process_request_v2 (nano::rpc_handler_request_params const &, std::string const &, std::function<void (std::shared_ptr<std::string> const &)> response) override
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		pending.push_back ([response = std::move (response)] (std::string const & body) {
+			response (std::make_shared<std::string> (body));
+		});
+	}
+
+	std::size_t pending_count ()
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		return pending.size ();
+	}
+
+	void respond_all (std::string const & body)
+	{
+		decltype (pending) released;
+		{
+			nano::lock_guard<nano::mutex> lock{ mutex };
+			released.swap (pending);
+		}
+		for (auto & response : released)
+		{
+			response (body);
+		}
+	}
+
+private:
+	nano::mutex mutex;
+	std::deque<std::function<void (std::string const &)>> pending;
+};
+}

--- a/nano/core_test/ipc.cpp
+++ b/nano/core_test/ipc.cpp
@@ -25,7 +25,7 @@ TEST (ipc, asynchronous)
 	system.nodes[0]->config.ipc_config->transport_tcp.enabled = true;
 	system.nodes[0]->config.ipc_config->transport_tcp.port = system.get_available_port ();
 	nano::node_rpc_config node_rpc_config;
-	nano::ipc::ipc_server ipc (*system.nodes[0], node_rpc_config);
+	nano::ipc::ipc_server ipc (*system.nodes[0], node_rpc_config, [] () {});
 	nano::ipc::ipc_client client (system.nodes[0]->io_ctx_shared);
 
 	auto req (nano::ipc::prepare_request (nano::ipc::payload_encoding::json_v1, std::string (R"({"action": "block_count"})")));
@@ -65,7 +65,7 @@ TEST (ipc, synchronous)
 	system.nodes[0]->config.ipc_config->transport_tcp.enabled = true;
 	system.nodes[0]->config.ipc_config->transport_tcp.port = system.get_available_port ();
 	nano::node_rpc_config node_rpc_config;
-	nano::ipc::ipc_server ipc (*system.nodes[0], node_rpc_config);
+	nano::ipc::ipc_server ipc (*system.nodes[0], node_rpc_config, [] () {});
 	nano::ipc::ipc_client client (system.nodes[0]->io_ctx_shared);
 
 	// Start blocking IPC client in a separate thread

--- a/nano/core_test/ipc.cpp
+++ b/nano/core_test/ipc.cpp
@@ -59,6 +59,45 @@ TEST (ipc, asynchronous)
 	ipc.stop ();
 }
 
+/**
+ * A `stop` request is only reported to the owner once its acknowledgement has been written, so an
+ * owner that tears the IPC server down as soon as it is told does not cut the acknowledgement off
+ */
+TEST (ipc, stop_acknowledged_before_reported)
+{
+	nano::test::system system (1);
+	system.nodes[0]->config.ipc_config->transport_tcp.enabled = true;
+	system.nodes[0]->config.ipc_config->transport_tcp.port = system.get_available_port ();
+	nano::node_rpc_config node_rpc_config;
+	std::atomic<bool> stop_requested{ false };
+	nano::ipc::ipc_server ipc (*system.nodes[0], node_rpc_config, [&stop_requested] () { stop_requested = true; });
+	nano::ipc::ipc_client client (system.nodes[0]->io_ctx_shared);
+
+	auto req (nano::ipc::prepare_request (nano::ipc::payload_encoding::json_v1, std::string (R"({"action": "stop"})")));
+	auto res (std::make_shared<std::vector<uint8_t>> ());
+	std::atomic<bool> acknowledged{ false };
+	client.async_connect ("::1", ipc.listening_tcp_port ().value (), [&client, &req, &res, &acknowledged] (nano::error err) {
+		client.async_write (req, [&client, &res, &acknowledged] (nano::error err_a, size_t size_a) {
+			client.async_read (res, sizeof (uint32_t), [&client, &res, &acknowledged] (nano::error err_read_a, size_t size_read_a) {
+				uint32_t payload_size_l = boost::endian::big_to_native (*reinterpret_cast<uint32_t *> (res->data ()));
+				client.async_read (res, payload_size_l, [&res, &acknowledged] (nano::error err_read_a, size_t size_read_a) {
+					std::stringstream ss;
+					ss << std::string (res->begin (), res->end ());
+					boost::property_tree::ptree response;
+					boost::property_tree::read_json (ss, response);
+					acknowledged = response.count ("success") == 1;
+				});
+			});
+		});
+	});
+
+	// Behave like the owners do: stop the IPC server the moment the request is reported
+	ASSERT_TIMELY (5s, stop_requested);
+	ipc.stop ();
+	ASSERT_TIMELY (5s, acknowledged);
+	ASSERT_FALSE (system.nodes[0]->stopped);
+}
+
 TEST (ipc, synchronous)
 {
 	nano::test::system system (1);

--- a/nano/core_test/ipc.cpp
+++ b/nano/core_test/ipc.cpp
@@ -4,7 +4,7 @@
 #include <nano/node/ipc/ipc_config.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/nodeconfig.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 

--- a/nano/core_test/rpc_host.cpp
+++ b/nano/core_test/rpc_host.cpp
@@ -1,0 +1,130 @@
+#include <nano/core_test/fakes/rpc_handler.hpp>
+#include <nano/rpc/rpc_host.hpp>
+#include <nano/test_common/system.hpp>
+#include <nano/test_common/test_response.hpp>
+#include <nano/test_common/testutil.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <stdexcept>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+/*
+ * `rpc_host` runs a listener, a backend and the IO threads for both, in the order every owner
+ * uses. These tests drive it with backends that know nothing about the RPC API; the test thread
+ * plays the owner.
+ */
+
+namespace
+{
+nano::rpc_config host_config (nano::test::system & system, uint16_t port = 0)
+{
+	nano::rpc_config config{ nano::dev::network_params.network, port != 0 ? port : system.get_available_port (), true };
+	config.rpc_process.io_threads = 2;
+	return config;
+}
+
+bool accepts_connections (uint16_t port)
+{
+	boost::asio::io_context io_ctx;
+	boost::asio::ip::tcp::socket socket{ io_ctx };
+	boost::system::error_code ec;
+	socket.connect (boost::asio::ip::tcp::endpoint{ boost::asio::ip::address_v6::loopback (), port }, ec);
+	return !ec;
+}
+
+boost::property_tree::ptree echo_request ()
+{
+	boost::property_tree::ptree request;
+	request.put ("action", "echo");
+	return request;
+}
+}
+
+/**
+ * Starting serves requests through the backend, stopping releases the port and is idempotent
+ */
+TEST (rpc_host, start_stop)
+{
+	nano::test::system system;
+	nano::rpc_host host{ host_config (system) };
+	auto backend = std::make_unique<nano::test::echo_rpc_handler> ();
+	auto & requests = backend->requests;
+	host.start (std::move (backend));
+	ASSERT_NE (0, host.listening_port ());
+
+	auto request = echo_request ();
+	auto response = nano::test::test_response::send (request, host.listening_port (), *system.io_ctx);
+	ASSERT_TIMELY_EQ (5s, response->status, 200);
+	ASSERT_EQ ("echo", response->json.get<std::string> ("action"));
+	ASSERT_EQ (1, requests);
+
+	host.stop ();
+	ASSERT_FALSE (accepts_connections (host.listening_port ()));
+	host.stop ();
+}
+
+/**
+ * A host that is destroyed without an explicit stop, started or not, shuts down cleanly
+ */
+TEST (rpc_host, destroy_without_stop)
+{
+	nano::test::system system;
+	{
+		nano::rpc_host host{ host_config (system) };
+	}
+	uint16_t port{ 0 };
+	{
+		nano::rpc_host host{ host_config (system) };
+		host.start (std::make_unique<nano::test::echo_rpc_handler> ());
+		port = host.listening_port ();
+		ASSERT_TRUE (accepts_connections (port));
+	}
+	ASSERT_FALSE (accepts_connections (port));
+}
+
+/**
+ * Starting on a taken port throws and leaves a host that can still be destroyed
+ */
+TEST (rpc_host, bind_failure)
+{
+	nano::test::system system;
+	nano::rpc_host first{ host_config (system) };
+	first.start (std::make_unique<nano::test::echo_rpc_handler> ());
+
+	nano::rpc_host second{ host_config (system, first.listening_port ()) };
+	ASSERT_THROW (second.start (std::make_unique<nano::test::echo_rpc_handler> ()), std::runtime_error);
+}
+
+/**
+ * The owner's sequence, stop the listener then the IO threads, still writes a response that was
+ * in flight when `stop` was called: this is the acknowledgement of a `stop` request in production
+ */
+TEST (rpc_host, stop_writes_pending_response)
+{
+	nano::test::system system;
+	nano::rpc_host host{ host_config (system) };
+	auto backend = std::make_unique<nano::test::deferred_rpc_handler> ();
+	auto & handler = *backend;
+	host.start (std::move (backend));
+
+	auto request = echo_request ();
+	auto response = nano::test::test_response::send (request, host.listening_port (), *system.io_ctx);
+	ASSERT_TIMELY_EQ (5s, handler.pending_count (), 1);
+
+	// Release the response only once the owner is already inside `stop`
+	nano::test::join_guard releaser;
+	releaser.spawn ([&handler] () {
+		std::this_thread::sleep_for (500ms);
+		handler.respond_all (R"({ "released": "1" })");
+	});
+
+	host.stop ();
+	ASSERT_TIMELY_EQ (5s, response->status, 200);
+	ASSERT_EQ ("1", response->json.get<std::string> ("released"));
+}

--- a/nano/core_test/rpc_server.cpp
+++ b/nano/core_test/rpc_server.cpp
@@ -11,6 +11,8 @@
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/property_tree/ptree.hpp>
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <deque>
 #include <stdexcept>
@@ -87,11 +89,16 @@ private:
 	std::deque<std::function<void (std::string const &)>> pending;
 };
 
-/** An RPC server on its own IO threads, torn down in the same order the owners use */
+/**
+ * An RPC server with its handler on its own IO threads, torn down in the same order the owners use.
+ * Members are declared so that the runner's threads are joined first and the io_context dies last,
+ * after the handler has released any response it still holds and the connections behind it.
+ */
+template <class handler_type>
 class server_context
 {
 public:
-	server_context (nano::test::system & system, nano::rpc_handler_interface & handler, uint16_t port) :
+	server_context (nano::test::system & system, uint16_t port) :
 		config{ nano::dev::network_params.network, port, true },
 		server{ io_ctx, config, handler },
 		runner{ io_ctx, system.logger, 2 }
@@ -102,10 +109,10 @@ public:
 	{
 		server.stop ();
 		runner.abort ();
-		// The runner is declared last so its threads are joined before the server they may still be using is destroyed
 	}
 
 	std::shared_ptr<boost::asio::io_context> io_ctx{ std::make_shared<boost::asio::io_context> () };
+	handler_type handler;
 	nano::rpc_config config;
 	nano::rpc_server server;
 	nano::thread_runner runner;
@@ -120,6 +127,16 @@ public:
 		boost::system::error_code ec;
 		socket.connect (boost::asio::ip::tcp::endpoint{ boost::asio::ip::address_v6::loopback (), port }, ec);
 		connected = !ec;
+	}
+
+	// True once the server has closed its end
+	bool closed_by_peer ()
+	{
+		boost::system::error_code ec;
+		socket.non_blocking (true, ec);
+		std::array<char, 1> byte{};
+		socket.read_some (boost::asio::buffer (byte), ec);
+		return ec == boost::asio::error::eof || ec == boost::asio::error::connection_reset;
 	}
 
 	boost::asio::io_context io_ctx;
@@ -146,8 +163,7 @@ boost::property_tree::ptree echo_request ()
 TEST (rpc_server, start_stop)
 {
 	nano::test::system system;
-	echo_handler handler;
-	server_context ctx{ system, handler, system.get_available_port () };
+	server_context<echo_handler> ctx{ system, system.get_available_port () };
 
 	ctx.server.start ();
 	ASSERT_NE (0, ctx.server.listening_port ());
@@ -157,7 +173,7 @@ TEST (rpc_server, start_stop)
 	auto response = nano::test::test_response::send (request, ctx.server.listening_port (), *system.io_ctx);
 	ASSERT_TIMELY_EQ (5s, response->status, 200);
 	ASSERT_EQ ("echo", response->json.get<std::string> ("action"));
-	ASSERT_EQ (1, handler.requests);
+	ASSERT_EQ (1, ctx.handler.requests);
 
 	ctx.server.stop ();
 	ASSERT_FALSE (accepts_connections (ctx.server.listening_port ()));
@@ -169,18 +185,17 @@ TEST (rpc_server, start_stop)
 TEST (rpc_server, stop_idempotent)
 {
 	nano::test::system system;
-	echo_handler handler;
 	{
-		server_context ctx{ system, handler, system.get_available_port () };
+		server_context<echo_handler> ctx{ system, system.get_available_port () };
 		// Never started
 	}
 	{
-		server_context ctx{ system, handler, system.get_available_port () };
+		server_context<echo_handler> ctx{ system, system.get_available_port () };
 		ctx.server.stop ();
 		ctx.server.stop ();
 	}
 	{
-		server_context ctx{ system, handler, system.get_available_port () };
+		server_context<echo_handler> ctx{ system, system.get_available_port () };
 		ctx.server.start ();
 		auto const port = ctx.server.listening_port ();
 		ctx.server.stop ();
@@ -195,15 +210,14 @@ TEST (rpc_server, stop_idempotent)
 TEST (rpc_server, stop_releases_port)
 {
 	nano::test::system system;
-	echo_handler handler;
 	uint16_t port{ 0 };
 	{
-		server_context ctx{ system, handler, system.get_available_port () };
+		server_context<echo_handler> ctx{ system, system.get_available_port () };
 		ctx.server.start ();
 		port = ctx.server.listening_port ();
 	}
 
-	server_context ctx{ system, handler, port };
+	server_context<echo_handler> ctx{ system, port };
 	ASSERT_NO_THROW (ctx.server.start ());
 	ASSERT_EQ (port, ctx.server.listening_port ());
 
@@ -218,11 +232,10 @@ TEST (rpc_server, stop_releases_port)
 TEST (rpc_server, bind_failure)
 {
 	nano::test::system system;
-	echo_handler handler;
-	server_context first{ system, handler, system.get_available_port () };
+	server_context<echo_handler> first{ system, system.get_available_port () };
 	first.server.start ();
 
-	server_context second{ system, handler, first.server.listening_port () };
+	server_context<echo_handler> second{ system, first.server.listening_port () };
 	ASSERT_THROW (second.server.start (), std::runtime_error);
 }
 
@@ -232,8 +245,7 @@ TEST (rpc_server, bind_failure)
 TEST (rpc_server, concurrent_requests)
 {
 	nano::test::system system;
-	echo_handler handler;
-	server_context ctx{ system, handler, system.get_available_port () };
+	server_context<echo_handler> ctx{ system, system.get_available_port () };
 	ctx.server.start ();
 
 	constexpr int count = 64;
@@ -258,17 +270,16 @@ TEST (rpc_server, concurrent_requests)
 		ASSERT_EQ (200, response->status);
 		ASSERT_EQ ("echo", response->json.get<std::string> ("action"));
 	}
-	ASSERT_EQ (count, handler.requests);
+	ASSERT_EQ (count, ctx.handler.requests);
 }
 
 /**
- * Connections that were accepted but never sent a request do not keep `stop` from returning
+ * Connections that were accepted but never sent a request are closed by `stop` and do not delay it
  */
-TEST (rpc_server, stop_with_idle_connections)
+TEST (rpc_server, stop_closes_idle_connections)
 {
 	nano::test::system system;
-	echo_handler handler;
-	server_context ctx{ system, handler, system.get_available_port () };
+	server_context<echo_handler> ctx{ system, system.get_available_port () };
 	ctx.server.start ();
 
 	std::vector<std::unique_ptr<idle_connection>> connections;
@@ -280,29 +291,61 @@ TEST (rpc_server, stop_with_idle_connections)
 
 	ctx.server.stop ();
 	ASSERT_FALSE (accepts_connections (ctx.server.listening_port ()));
+	ASSERT_TIMELY (5s, std::all_of (connections.begin (), connections.end (), [] (auto const & connection) { return connection->closed_by_peer (); }));
 }
 
 /**
- * A request that is in flight when the server stops still receives its response
+ * `stop` waits for a request in flight, so its response is written before `stop` returns
  */
-TEST (rpc_server, stop_with_pending_requests)
+TEST (rpc_server, stop_drains_pending_request)
 {
 	nano::test::system system;
-	deferred_handler handler;
-	server_context ctx{ system, handler, system.get_available_port () };
+	server_context<deferred_handler> ctx{ system, system.get_available_port () };
 	ctx.server.start ();
 
 	auto request = echo_request ();
 	auto response = nano::test::test_response::send (request, ctx.server.listening_port (), *system.io_ctx);
-	ASSERT_TIMELY_EQ (5s, handler.pending_count (), 1);
+	ASSERT_TIMELY_EQ (5s, ctx.handler.pending_count (), 1);
+
+	// Release the response only once the owner is already waiting inside `stop`
+	std::atomic<bool> released{ false };
+	nano::test::join_guard releaser;
+	releaser.spawn ([&] () {
+		std::this_thread::sleep_for (500ms);
+		released = true;
+		ctx.handler.respond_all (R"({ "released": "1" })");
+	});
 
 	ctx.server.stop ();
+	ASSERT_TRUE (released);
 	ASSERT_FALSE (accepts_connections (ctx.server.listening_port ()));
-	ASSERT_EQ (0, response->status);
 
-	handler.respond_all (R"({ "released": "1" })");
 	ASSERT_TIMELY_EQ (5s, response->status, 200);
 	ASSERT_EQ ("1", response->json.get<std::string> ("released"));
+}
+
+/**
+ * A request that never completes only delays `stop` by the drain timeout, then its connection is closed
+ */
+TEST (rpc_server, stop_drain_timeout)
+{
+	nano::test::system system;
+	server_context<deferred_handler> ctx{ system, system.get_available_port () };
+	ctx.server.drain_timeout = 500ms;
+	ctx.server.start ();
+
+	auto request = echo_request ();
+	auto response = nano::test::test_response::send (request, ctx.server.listening_port (), *system.io_ctx);
+	ASSERT_TIMELY_EQ (5s, ctx.handler.pending_count (), 1);
+
+	auto const start = std::chrono::steady_clock::now ();
+	ctx.server.stop ();
+	ASSERT_GE (std::chrono::steady_clock::now () - start, 500ms);
+	ASSERT_FALSE (accepts_connections (ctx.server.listening_port ()));
+
+	// The client sees its connection dropped without a response
+	ASSERT_TIMELY (5s, response->status != 0);
+	ASSERT_NE (200, response->status);
 }
 
 /**
@@ -311,8 +354,7 @@ TEST (rpc_server, stop_with_pending_requests)
 TEST (rpc_server, stop_during_connects)
 {
 	nano::test::system system;
-	echo_handler handler;
-	server_context ctx{ system, handler, system.get_available_port () };
+	server_context<echo_handler> ctx{ system, system.get_available_port () };
 	ctx.server.start ();
 	auto const port = ctx.server.listening_port ();
 
@@ -343,8 +385,7 @@ TEST (rpc_server, stop_during_connects)
 TEST (rpc_server, stop_concurrent)
 {
 	nano::test::system system;
-	echo_handler handler;
-	server_context ctx{ system, handler, system.get_available_port () };
+	server_context<echo_handler> ctx{ system, system.get_available_port () };
 	ctx.server.start ();
 	auto const port = ctx.server.listening_port ();
 

--- a/nano/core_test/rpc_server.cpp
+++ b/nano/core_test/rpc_server.cpp
@@ -1,0 +1,370 @@
+#include <nano/lib/locks.hpp>
+#include <nano/lib/rpc_handler_interface.hpp>
+#include <nano/lib/thread_runner.hpp>
+#include <nano/rpc/rpc_server.hpp>
+#include <nano/test_common/system.hpp>
+#include <nano/test_common/test_response.hpp>
+#include <nano/test_common/testutil.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <atomic>
+#include <deque>
+#include <stdexcept>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+/*
+ * `rpc_server` only accepts connections and hands requests to a handler, so these tests drive it
+ * with handlers that know nothing about the RPC API. The server runs on its own IO threads, the
+ * way every owner runs it, and the test thread plays the owner: it is the only one calling `stop`.
+ */
+
+namespace
+{
+/** Echoes every request body back */
+class echo_handler final : public nano::rpc_handler_interface
+{
+public:
+	void process_request (std::string const &, std::string const & body, std::function<void (std::string const &)> response) override
+	{
+		++requests;
+		response (body);
+	}
+
+	void process_request_v2 (nano::rpc_handler_request_params const &, std::string const & body, std::function<void (std::shared_ptr<std::string> const &)> response) override
+	{
+		++requests;
+		response (std::make_shared<std::string> (body));
+	}
+
+	std::atomic<int> requests{ 0 };
+};
+
+/** Holds every request until the test releases it, to keep connections in flight */
+class deferred_handler final : public nano::rpc_handler_interface
+{
+public:
+	void process_request (std::string const &, std::string const &, std::function<void (std::string const &)> response) override
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		pending.push_back (std::move (response));
+	}
+
+	void process_request_v2 (nano::rpc_handler_request_params const &, std::string const &, std::function<void (std::shared_ptr<std::string> const &)> response) override
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		pending.push_back ([response = std::move (response)] (std::string const & body) {
+			response (std::make_shared<std::string> (body));
+		});
+	}
+
+	std::size_t pending_count ()
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		return pending.size ();
+	}
+
+	void respond_all (std::string const & body)
+	{
+		decltype (pending) released;
+		{
+			nano::lock_guard<nano::mutex> lock{ mutex };
+			released.swap (pending);
+		}
+		for (auto & response : released)
+		{
+			response (body);
+		}
+	}
+
+private:
+	nano::mutex mutex;
+	std::deque<std::function<void (std::string const &)>> pending;
+};
+
+/** An RPC server on its own IO threads, torn down in the same order the owners use */
+class server_context
+{
+public:
+	server_context (nano::test::system & system, nano::rpc_handler_interface & handler, uint16_t port) :
+		config{ nano::dev::network_params.network, port, true },
+		server{ io_ctx, config, handler },
+		runner{ io_ctx, system.logger, 2 }
+	{
+	}
+
+	~server_context ()
+	{
+		server.stop ();
+		runner.abort ();
+		// The runner is declared last so its threads are joined before the server they may still be using is destroyed
+	}
+
+	std::shared_ptr<boost::asio::io_context> io_ctx{ std::make_shared<boost::asio::io_context> () };
+	nano::rpc_config config;
+	nano::rpc_server server;
+	nano::thread_runner runner;
+};
+
+/** A raw TCP connection to the server that never sends anything */
+class idle_connection
+{
+public:
+	explicit idle_connection (uint16_t port)
+	{
+		boost::system::error_code ec;
+		socket.connect (boost::asio::ip::tcp::endpoint{ boost::asio::ip::address_v6::loopback (), port }, ec);
+		connected = !ec;
+	}
+
+	boost::asio::io_context io_ctx;
+	boost::asio::ip::tcp::socket socket{ io_ctx };
+	bool connected{ false };
+};
+
+bool accepts_connections (uint16_t port)
+{
+	return idle_connection{ port }.connected;
+}
+
+boost::property_tree::ptree echo_request ()
+{
+	boost::property_tree::ptree request;
+	request.put ("action", "echo");
+	return request;
+}
+}
+
+/**
+ * Starting binds a port and a request round-trips through the handler, stopping releases the port
+ */
+TEST (rpc_server, start_stop)
+{
+	nano::test::system system;
+	echo_handler handler;
+	server_context ctx{ system, handler, system.get_available_port () };
+
+	ctx.server.start ();
+	ASSERT_NE (0, ctx.server.listening_port ());
+	ASSERT_TRUE (accepts_connections (ctx.server.listening_port ()));
+
+	auto request = echo_request ();
+	auto response = nano::test::test_response::send (request, ctx.server.listening_port (), *system.io_ctx);
+	ASSERT_TIMELY_EQ (5s, response->status, 200);
+	ASSERT_EQ ("echo", response->json.get<std::string> ("action"));
+	ASSERT_EQ (1, handler.requests);
+
+	ctx.server.stop ();
+	ASSERT_FALSE (accepts_connections (ctx.server.listening_port ()));
+}
+
+/**
+ * Stopping is idempotent, before or after starting, and a server that was never started can be destroyed
+ */
+TEST (rpc_server, stop_idempotent)
+{
+	nano::test::system system;
+	echo_handler handler;
+	{
+		server_context ctx{ system, handler, system.get_available_port () };
+		// Never started
+	}
+	{
+		server_context ctx{ system, handler, system.get_available_port () };
+		ctx.server.stop ();
+		ctx.server.stop ();
+	}
+	{
+		server_context ctx{ system, handler, system.get_available_port () };
+		ctx.server.start ();
+		auto const port = ctx.server.listening_port ();
+		ctx.server.stop ();
+		ctx.server.stop ();
+		ASSERT_FALSE (accepts_connections (port));
+	}
+}
+
+/**
+ * A stopped server has released its port, so a new server can bind it
+ */
+TEST (rpc_server, stop_releases_port)
+{
+	nano::test::system system;
+	echo_handler handler;
+	uint16_t port{ 0 };
+	{
+		server_context ctx{ system, handler, system.get_available_port () };
+		ctx.server.start ();
+		port = ctx.server.listening_port ();
+	}
+
+	server_context ctx{ system, handler, port };
+	ASSERT_NO_THROW (ctx.server.start ());
+	ASSERT_EQ (port, ctx.server.listening_port ());
+
+	auto request = echo_request ();
+	auto response = nano::test::test_response::send (request, port, *system.io_ctx);
+	ASSERT_TIMELY_EQ (5s, response->status, 200);
+}
+
+/**
+ * Starting on a port that is already taken reports the failure to the owner as an exception
+ */
+TEST (rpc_server, bind_failure)
+{
+	nano::test::system system;
+	echo_handler handler;
+	server_context first{ system, handler, system.get_available_port () };
+	first.server.start ();
+
+	server_context second{ system, handler, first.server.listening_port () };
+	ASSERT_THROW (second.server.start (), std::runtime_error);
+}
+
+/**
+ * Many clients issuing requests from different threads at once are all served
+ */
+TEST (rpc_server, concurrent_requests)
+{
+	nano::test::system system;
+	echo_handler handler;
+	server_context ctx{ system, handler, system.get_available_port () };
+	ctx.server.start ();
+
+	constexpr int count = 64;
+	auto request = echo_request ();
+	std::vector<std::shared_ptr<nano::test::test_response>> responses;
+	for (int i = 0; i < count; ++i)
+	{
+		responses.push_back (nano::test::test_response::prepare (request, *system.io_ctx));
+	}
+
+	nano::test::join_guard threads;
+	for (auto & response : responses)
+	{
+		threads.spawn ([&response, port = ctx.server.listening_port ()] () {
+			response->run (port);
+		});
+	}
+
+	ASSERT_TIMELY (10s, std::all_of (responses.begin (), responses.end (), [] (auto const & response) { return response->status != 0; }));
+	for (auto const & response : responses)
+	{
+		ASSERT_EQ (200, response->status);
+		ASSERT_EQ ("echo", response->json.get<std::string> ("action"));
+	}
+	ASSERT_EQ (count, handler.requests);
+}
+
+/**
+ * Connections that were accepted but never sent a request do not keep `stop` from returning
+ */
+TEST (rpc_server, stop_with_idle_connections)
+{
+	nano::test::system system;
+	echo_handler handler;
+	server_context ctx{ system, handler, system.get_available_port () };
+	ctx.server.start ();
+
+	std::vector<std::unique_ptr<idle_connection>> connections;
+	for (int i = 0; i < 16; ++i)
+	{
+		connections.push_back (std::make_unique<idle_connection> (ctx.server.listening_port ()));
+		ASSERT_TRUE (connections.back ()->connected);
+	}
+
+	ctx.server.stop ();
+	ASSERT_FALSE (accepts_connections (ctx.server.listening_port ()));
+}
+
+/**
+ * A request that is in flight when the server stops still receives its response
+ */
+TEST (rpc_server, stop_with_pending_requests)
+{
+	nano::test::system system;
+	deferred_handler handler;
+	server_context ctx{ system, handler, system.get_available_port () };
+	ctx.server.start ();
+
+	auto request = echo_request ();
+	auto response = nano::test::test_response::send (request, ctx.server.listening_port (), *system.io_ctx);
+	ASSERT_TIMELY_EQ (5s, handler.pending_count (), 1);
+
+	ctx.server.stop ();
+	ASSERT_FALSE (accepts_connections (ctx.server.listening_port ()));
+	ASSERT_EQ (0, response->status);
+
+	handler.respond_all (R"({ "released": "1" })");
+	ASSERT_TIMELY_EQ (5s, response->status, 200);
+	ASSERT_EQ ("1", response->json.get<std::string> ("released"));
+}
+
+/**
+ * Stopping while clients keep connecting closes the acceptor without racing the accept loop
+ */
+TEST (rpc_server, stop_during_connects)
+{
+	nano::test::system system;
+	echo_handler handler;
+	server_context ctx{ system, handler, system.get_available_port () };
+	ctx.server.start ();
+	auto const port = ctx.server.listening_port ();
+
+	std::atomic<int> accepted{ 0 };
+	nano::test::join_guard threads;
+	for (int i = 0; i < 4; ++i)
+	{
+		threads.spawn ([&] (nano::test::stop_token const & stop) {
+			while (!stop.stop_requested ())
+			{
+				if (idle_connection{ port }.connected)
+				{
+					++accepted;
+				}
+			}
+		});
+	}
+
+	ASSERT_TIMELY (5s, accepted >= 50);
+	ctx.server.stop ();
+
+	ASSERT_FALSE (accepts_connections (port));
+}
+
+/**
+ * Concurrent `stop` calls from several owner threads are safe, only one of them closes the acceptor
+ */
+TEST (rpc_server, stop_concurrent)
+{
+	nano::test::system system;
+	echo_handler handler;
+	server_context ctx{ system, handler, system.get_available_port () };
+	ctx.server.start ();
+	auto const port = ctx.server.listening_port ();
+
+	nano::test::join_guard connectors;
+	connectors.spawn ([&] (nano::test::stop_token const & stop) {
+		while (!stop.stop_requested ())
+		{
+			idle_connection connection{ port };
+		}
+	});
+
+	{
+		nano::test::join_guard stoppers;
+		for (int i = 0; i < 8; ++i)
+		{
+			stoppers.spawn ([&] () {
+				ctx.server.stop ();
+			});
+		}
+	}
+
+	ASSERT_FALSE (accepts_connections (port));
+}

--- a/nano/core_test/rpc_server.cpp
+++ b/nano/core_test/rpc_server.cpp
@@ -1,5 +1,4 @@
-#include <nano/lib/locks.hpp>
-#include <nano/lib/rpc_handler_interface.hpp>
+#include <nano/core_test/fakes/rpc_handler.hpp>
 #include <nano/lib/thread_runner.hpp>
 #include <nano/rpc/rpc_server.hpp>
 #include <nano/test_common/system.hpp>
@@ -14,7 +13,6 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
-#include <deque>
 #include <stdexcept>
 #include <thread>
 
@@ -28,67 +26,6 @@ using namespace std::chrono_literals;
 
 namespace
 {
-/** Echoes every request body back */
-class echo_handler final : public nano::rpc_handler_interface
-{
-public:
-	void process_request (std::string const &, std::string const & body, std::function<void (std::string const &)> response) override
-	{
-		++requests;
-		response (body);
-	}
-
-	void process_request_v2 (nano::rpc_handler_request_params const &, std::string const & body, std::function<void (std::shared_ptr<std::string> const &)> response) override
-	{
-		++requests;
-		response (std::make_shared<std::string> (body));
-	}
-
-	std::atomic<int> requests{ 0 };
-};
-
-/** Holds every request until the test releases it, to keep connections in flight */
-class deferred_handler final : public nano::rpc_handler_interface
-{
-public:
-	void process_request (std::string const &, std::string const &, std::function<void (std::string const &)> response) override
-	{
-		nano::lock_guard<nano::mutex> lock{ mutex };
-		pending.push_back (std::move (response));
-	}
-
-	void process_request_v2 (nano::rpc_handler_request_params const &, std::string const &, std::function<void (std::shared_ptr<std::string> const &)> response) override
-	{
-		nano::lock_guard<nano::mutex> lock{ mutex };
-		pending.push_back ([response = std::move (response)] (std::string const & body) {
-			response (std::make_shared<std::string> (body));
-		});
-	}
-
-	std::size_t pending_count ()
-	{
-		nano::lock_guard<nano::mutex> lock{ mutex };
-		return pending.size ();
-	}
-
-	void respond_all (std::string const & body)
-	{
-		decltype (pending) released;
-		{
-			nano::lock_guard<nano::mutex> lock{ mutex };
-			released.swap (pending);
-		}
-		for (auto & response : released)
-		{
-			response (body);
-		}
-	}
-
-private:
-	nano::mutex mutex;
-	std::deque<std::function<void (std::string const &)>> pending;
-};
-
 /**
  * An RPC server with its handler on its own IO threads, torn down in the same order the owners use.
  * Members are declared so that the runner's threads are joined first and the io_context dies last,
@@ -163,7 +100,7 @@ boost::property_tree::ptree echo_request ()
 TEST (rpc_server, start_stop)
 {
 	nano::test::system system;
-	server_context<echo_handler> ctx{ system, system.get_available_port () };
+	server_context<nano::test::echo_rpc_handler> ctx{ system, system.get_available_port () };
 
 	ctx.server.start ();
 	ASSERT_NE (0, ctx.server.listening_port ());
@@ -186,16 +123,16 @@ TEST (rpc_server, stop_idempotent)
 {
 	nano::test::system system;
 	{
-		server_context<echo_handler> ctx{ system, system.get_available_port () };
+		server_context<nano::test::echo_rpc_handler> ctx{ system, system.get_available_port () };
 		// Never started
 	}
 	{
-		server_context<echo_handler> ctx{ system, system.get_available_port () };
+		server_context<nano::test::echo_rpc_handler> ctx{ system, system.get_available_port () };
 		ctx.server.stop ();
 		ctx.server.stop ();
 	}
 	{
-		server_context<echo_handler> ctx{ system, system.get_available_port () };
+		server_context<nano::test::echo_rpc_handler> ctx{ system, system.get_available_port () };
 		ctx.server.start ();
 		auto const port = ctx.server.listening_port ();
 		ctx.server.stop ();
@@ -212,12 +149,12 @@ TEST (rpc_server, stop_releases_port)
 	nano::test::system system;
 	uint16_t port{ 0 };
 	{
-		server_context<echo_handler> ctx{ system, system.get_available_port () };
+		server_context<nano::test::echo_rpc_handler> ctx{ system, system.get_available_port () };
 		ctx.server.start ();
 		port = ctx.server.listening_port ();
 	}
 
-	server_context<echo_handler> ctx{ system, port };
+	server_context<nano::test::echo_rpc_handler> ctx{ system, port };
 	ASSERT_NO_THROW (ctx.server.start ());
 	ASSERT_EQ (port, ctx.server.listening_port ());
 
@@ -232,10 +169,10 @@ TEST (rpc_server, stop_releases_port)
 TEST (rpc_server, bind_failure)
 {
 	nano::test::system system;
-	server_context<echo_handler> first{ system, system.get_available_port () };
+	server_context<nano::test::echo_rpc_handler> first{ system, system.get_available_port () };
 	first.server.start ();
 
-	server_context<echo_handler> second{ system, first.server.listening_port () };
+	server_context<nano::test::echo_rpc_handler> second{ system, first.server.listening_port () };
 	ASSERT_THROW (second.server.start (), std::runtime_error);
 }
 
@@ -245,7 +182,7 @@ TEST (rpc_server, bind_failure)
 TEST (rpc_server, concurrent_requests)
 {
 	nano::test::system system;
-	server_context<echo_handler> ctx{ system, system.get_available_port () };
+	server_context<nano::test::echo_rpc_handler> ctx{ system, system.get_available_port () };
 	ctx.server.start ();
 
 	constexpr int count = 64;
@@ -279,7 +216,7 @@ TEST (rpc_server, concurrent_requests)
 TEST (rpc_server, stop_closes_idle_connections)
 {
 	nano::test::system system;
-	server_context<echo_handler> ctx{ system, system.get_available_port () };
+	server_context<nano::test::echo_rpc_handler> ctx{ system, system.get_available_port () };
 	ctx.server.start ();
 
 	std::vector<std::unique_ptr<idle_connection>> connections;
@@ -300,7 +237,7 @@ TEST (rpc_server, stop_closes_idle_connections)
 TEST (rpc_server, stop_drains_pending_request)
 {
 	nano::test::system system;
-	server_context<deferred_handler> ctx{ system, system.get_available_port () };
+	server_context<nano::test::deferred_rpc_handler> ctx{ system, system.get_available_port () };
 	ctx.server.start ();
 
 	auto request = echo_request ();
@@ -330,7 +267,7 @@ TEST (rpc_server, stop_drains_pending_request)
 TEST (rpc_server, stop_drain_timeout)
 {
 	nano::test::system system;
-	server_context<deferred_handler> ctx{ system, system.get_available_port () };
+	server_context<nano::test::deferred_rpc_handler> ctx{ system, system.get_available_port () };
 	ctx.server.drain_timeout = 500ms;
 	ctx.server.start ();
 
@@ -354,7 +291,7 @@ TEST (rpc_server, stop_drain_timeout)
 TEST (rpc_server, stop_during_connects)
 {
 	nano::test::system system;
-	server_context<echo_handler> ctx{ system, system.get_available_port () };
+	server_context<nano::test::echo_rpc_handler> ctx{ system, system.get_available_port () };
 	ctx.server.start ();
 	auto const port = ctx.server.listening_port ();
 
@@ -385,7 +322,7 @@ TEST (rpc_server, stop_during_connects)
 TEST (rpc_server, stop_concurrent)
 {
 	nano::test::system system;
-	server_context<echo_handler> ctx{ system, system.get_available_port () };
+	server_context<nano::test::echo_rpc_handler> ctx{ system, system.get_available_port () };
 	ctx.server.start ();
 	auto const port = ctx.server.listening_port ();
 

--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -43,6 +43,7 @@ enum class type
 	rpc_connection,
 	http_callbacks,
 	rpc_request,
+	rpc_process,
 	ipc,
 	ipc_server,
 	websocket,

--- a/nano/lib/rpc_handler_interface.hpp
+++ b/nano/lib/rpc_handler_interface.hpp
@@ -7,7 +7,7 @@
 
 namespace nano
 {
-class rpc;
+class rpc_server;
 
 /** Keeps information about http requests, and for v2+ includes path and header values of interest */
 class rpc_handler_request_params final
@@ -61,6 +61,6 @@ public:
 	/** Process RPC 2.0 request. This is called via the IPC API */
 	virtual void process_request_v2 (rpc_handler_request_params const & params_a, std::string const & body, std::function<void (std::shared_ptr<std::string> const &)> response) = 0;
 	virtual void stop () = 0;
-	virtual void rpc_instance (nano::rpc & rpc) = 0;
+	virtual void rpc_instance (nano::rpc_server & rpc) = 0;
 };
 }

--- a/nano/lib/rpc_handler_interface.hpp
+++ b/nano/lib/rpc_handler_interface.hpp
@@ -7,8 +7,6 @@
 
 namespace nano
 {
-class rpc_server;
-
 /** Keeps information about http requests, and for v2+ includes path and header values of interest */
 class rpc_handler_request_params final
 {
@@ -60,7 +58,5 @@ public:
 	virtual void process_request (std::string const & action, std::string const & body, std::function<void (std::string const &)> response) = 0;
 	/** Process RPC 2.0 request. This is called via the IPC API */
 	virtual void process_request_v2 (rpc_handler_request_params const & params_a, std::string const & body, std::function<void (std::shared_ptr<std::string> const &)> response) = 0;
-	virtual void stop () = 0;
-	virtual void rpc_instance (nano::rpc_server & rpc) = 0;
 };
 }

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -28,7 +28,7 @@ nano::error nano::rpc_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("max_request_size", max_request_size, "Maximum number of bytes allowed in request bodies.\ntype:uint64");
 
 	nano::tomlconfig rpc_process_l;
-	rpc_process_l.put ("io_threads", rpc_process.io_threads, "Number of threads used to serve IO.\ntype:uint32");
+	rpc_process_l.put ("io_threads", rpc_process.io_threads, "Number of threads used to serve RPC IO, whether the RPC runs in-process or in a separate process.\ntype:uint32");
 	rpc_process_l.put ("ipc_address", rpc_process.ipc_address, "Address of IPC server.\ntype:string,ip");
 	rpc_process_l.put ("ipc_port", rpc_process.ipc_port, "Listening port of IPC server.\ntype:uint16");
 	rpc_process_l.put ("num_ipc_connections", rpc_process.num_ipc_connections, "Number of IPC connections to establish.\ntype:uint32");

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -25,6 +25,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::io_ipc:
 			thread_role_name_string = "I/O (IPC)";
 			break;
+		case nano::thread_role::name::io_rpc:
+			thread_role_name_string = "I/O (RPC)";
+			break;
 		case nano::thread_role::name::work:
 			thread_role_name_string = "Work pool";
 			break;

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -13,6 +13,7 @@ enum class name
 	io,
 	io_daemon,
 	io_ipc,
+	io_rpc,
 	work,
 	message_processing,
 	vote_processing,

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -136,7 +136,14 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 
 		std::atomic stopped{ false };
 
-		std::unique_ptr<nano::ipc::ipc_server> ipc_server = std::make_unique<nano::ipc::ipc_server> (*node, config.rpc);
+		// Invoked from an IO thread when a stop request arrives over RPC or IPC, only wakes the main thread
+		auto stop_callback = [this, &stopped] () {
+			logger.warn (nano::log::type::daemon, "Stop request received, stopping...");
+			stopped = true;
+			stopped.notify_all ();
+		};
+
+		std::unique_ptr<nano::ipc::ipc_server> ipc_server = std::make_unique<nano::ipc::ipc_server> (*node, config.rpc, stop_callback);
 		std::unique_ptr<boost::process::child> rpc_process;
 		std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
 		std::shared_ptr<nano::rpc_server> rpc;
@@ -147,12 +154,6 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 			// In process RPC
 			if (!config.rpc.child_process.enable)
 			{
-				auto stop_callback = [this, &stopped] () {
-					logger.warn (nano::log::type::daemon, "RPC stop request received, stopping...");
-					stopped = true;
-					stopped.notify_all ();
-				};
-
 				// Launch rpc in-process
 				nano::rpc_config rpc_config{ config.node.network_params.network };
 				if (auto error = nano::read_rpc_config_toml (data_path, rpc_config, flags.rpc_config_overrides))

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -165,7 +165,7 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 				logger.debug (nano::log::type::daemon, "Starting in-process RPC server on port {}", rpc_config.port);
 
 				rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, *ipc_server, config.rpc, stop_callback);
-				rpc = nano::get_rpc (io_ctx, rpc_config, *rpc_handler);
+				rpc = std::make_shared<nano::rpc_server> (io_ctx, rpc_config, *rpc_handler);
 				rpc->start ();
 			}
 			else

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -19,7 +19,7 @@
 #include <nano/node/node_scope_guard.hpp>
 #include <nano/node/openclwork.hpp>
 #include <nano/node/rpc_process.hpp>
-#include <nano/rpc/rpc_server.hpp>
+#include <nano/rpc/rpc_host.hpp>
 
 #include <csignal>
 #include <iostream>
@@ -145,8 +145,7 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 
 		std::unique_ptr<nano::ipc::ipc_server> ipc_server = std::make_unique<nano::ipc::ipc_server> (*node, config.rpc, stop_callback);
 		std::unique_ptr<nano::rpc_process> rpc_process;
-		std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
-		std::shared_ptr<nano::rpc_server> rpc;
+		std::unique_ptr<nano::rpc_host> rpc;
 
 		bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
 		if (rpc_enabled)
@@ -164,9 +163,8 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 
 				logger.debug (nano::log::type::daemon, "Starting in-process RPC server on port {}", rpc_config.port);
 
-				rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, *ipc_server, config.rpc, stop_callback);
-				rpc = std::make_shared<nano::rpc_server> (io_ctx, rpc_config, *rpc_handler);
-				rpc->start ();
+				rpc = std::make_unique<nano::rpc_host> (rpc_config);
+				rpc->start (std::make_unique<nano::inprocess_rpc_handler> (*node, *ipc_server, config.rpc, stop_callback));
 			}
 			else
 			{

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -19,7 +19,7 @@
 #include <nano/node/node.hpp>
 #include <nano/node/node_scope_guard.hpp>
 #include <nano/node/openclwork.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <csignal>
 #include <iostream>
@@ -139,7 +139,7 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 		std::unique_ptr<nano::ipc::ipc_server> ipc_server = std::make_unique<nano::ipc::ipc_server> (*node, config.rpc);
 		std::unique_ptr<boost::process::child> rpc_process;
 		std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
-		std::shared_ptr<nano::rpc> rpc;
+		std::shared_ptr<nano::rpc_server> rpc;
 
 		bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
 		if (rpc_enabled)

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -1,4 +1,3 @@
-#include <nano/boost/process/child.hpp>
 #include <nano/lib/files.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/memory.hpp>
@@ -19,6 +18,7 @@
 #include <nano/node/node.hpp>
 #include <nano/node/node_scope_guard.hpp>
 #include <nano/node/openclwork.hpp>
+#include <nano/node/rpc_process.hpp>
 #include <nano/rpc/rpc_server.hpp>
 
 #include <csignal>
@@ -144,7 +144,7 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 		};
 
 		std::unique_ptr<nano::ipc::ipc_server> ipc_server = std::make_unique<nano::ipc::ipc_server> (*node, config.rpc, stop_callback);
-		std::unique_ptr<boost::process::child> rpc_process;
+		std::unique_ptr<nano::rpc_process> rpc_process;
 		std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
 		std::shared_ptr<nano::rpc_server> rpc;
 
@@ -170,18 +170,11 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 			}
 			else
 			{
-				// Spawn a child rpc process
-				if (!std::filesystem::exists (config.rpc.child_process.rpc_path))
-				{
-					throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.child_process.rpc_path);
-				}
-
 				logger.warn (nano::log::type::daemon, "RPC is configured to run in a separate process, this is experimental and is not recommended for production use. Please consider using the in-process RPC instead.");
 
 				logger.debug (nano::log::type::daemon, "Spawning RPC process with command: {}", config.rpc.child_process.rpc_path);
 
-				std::string network{ node->network_params.network.get_current_network_as_string () };
-				rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path.string (), "--network", network);
+				rpc_process = std::make_unique<nano::rpc_process> (config.rpc, data_path, node->network_params.network.get_current_network_as_string (), logger);
 			}
 			debug_assert (rpc || rpc_process);
 		}
@@ -218,19 +211,19 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 
 		logger.info (nano::log::type::daemon, "Stopping...");
 
+		// Stop accepting requests, then the node, then drop whatever is still queued on the IO threads
 		if (rpc)
 		{
 			rpc->stop ();
 		}
 		ipc_server->stop ();
 		node->stop ();
-		io_ctx->stop ();
-		runner->join ();
-
 		if (rpc_process)
 		{
-			rpc_process->wait ();
+			rpc_process->stop ();
 		}
+		io_ctx->stop ();
+		runner->join ();
 	}
 	catch (std::exception const & ex)
 	{

--- a/nano/nano_node/entry.cpp
+++ b/nano/nano_node/entry.cpp
@@ -1365,7 +1365,7 @@ int main (int argc, char * const * argv)
 			nano::inactive_node inactive_node_l (data_path, node_flags);
 
 			nano::node_rpc_config config;
-			nano::ipc::ipc_server server (*inactive_node_l.node, config);
+			nano::ipc::ipc_server server (*inactive_node_l.node, config, [] () {}); // The command exits as soon as the response is printed
 			auto handler_l (std::make_shared<nano::json_handler> (*inactive_node_l.node, config, command_l.str (), response_handler_l));
 			handler_l->process_request ();
 		}

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -55,7 +55,7 @@ void run (std::filesystem::path const & data_path, std::vector<std::string> cons
 			};
 
 			nano::ipc_rpc_processor ipc_rpc_processor (io_ctx, rpc_config, stop_callback);
-			auto rpc = nano::get_rpc (io_ctx, rpc_config, ipc_rpc_processor);
+			auto rpc = std::make_shared<nano::rpc_server> (io_ctx, rpc_config, ipc_rpc_processor);
 			rpc->start ();
 
 			auto signal_handler = [&stopped, &logger] (int signum) {

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -4,15 +4,14 @@
 #include <nano/lib/logging.hpp>
 #include <nano/lib/networks.hpp>
 #include <nano/lib/signal_manager.hpp>
-#include <nano/lib/thread_runner.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/lib/version.hpp>
 #include <nano/node/cli.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/nodeconfig.hpp>
+#include <nano/rpc/rpc_host.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
-#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -33,17 +32,11 @@ void run (std::filesystem::path const & data_path, std::vector<std::string> cons
 	boost::system::error_code error_chmod;
 	nano::set_secure_perm_directory (data_path, error_chmod);
 
-	std::unique_ptr<nano::thread_runner> runner;
-
 	nano::network_params network_params{ nano::get_active_network () };
 	nano::rpc_config rpc_config{ network_params.network };
 	auto error = nano::read_rpc_config_toml (data_path, rpc_config, config_overrides);
 	if (!error)
 	{
-		std::shared_ptr<boost::asio::io_context> io_ctx = std::make_shared<boost::asio::io_context> ();
-
-		runner = std::make_unique<nano::thread_runner> (io_ctx, logger, rpc_config.rpc_process.io_threads, nano::thread_role::name::io_daemon);
-
 		try
 		{
 			std::atomic stopped{ false };
@@ -54,9 +47,8 @@ void run (std::filesystem::path const & data_path, std::vector<std::string> cons
 				stopped.notify_all ();
 			};
 
-			nano::ipc_rpc_processor ipc_rpc_processor (io_ctx, rpc_config, stop_callback);
-			auto rpc = std::make_shared<nano::rpc_server> (io_ctx, rpc_config, ipc_rpc_processor);
-			rpc->start ();
+			nano::rpc_host rpc{ rpc_config };
+			rpc.start (std::make_unique<nano::ipc_rpc_processor> (rpc.io_context (), rpc_config, stop_callback));
 
 			auto signal_handler = [&stopped, &logger] (int signum) {
 				logger.warn (nano::log::type::daemon_rpc, "Interrupt signal received ({}), stopping...", nano::to_signal_name (signum));
@@ -73,9 +65,7 @@ void run (std::filesystem::path const & data_path, std::vector<std::string> cons
 
 			logger.info (nano::log::type::daemon_rpc, "Stopping...");
 
-			rpc->stop ();
-			io_ctx->stop ();
-			runner->join ();
+			rpc.stop ();
 		}
 		catch (std::runtime_error const & e)
 		{

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -11,7 +11,7 @@
 #include <nano/node/cli.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/nodeconfig.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
 
 #include <boost/program_options.hpp>

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -11,8 +11,8 @@
 #include <nano/node/cli.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/nodeconfig.hpp>
-#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -46,11 +46,17 @@ void run (std::filesystem::path const & data_path, std::vector<std::string> cons
 
 		try
 		{
-			nano::ipc_rpc_processor ipc_rpc_processor (io_ctx, rpc_config);
+			std::atomic stopped{ false };
+
+			auto stop_callback = [&stopped, &logger] () {
+				logger.warn (nano::log::type::daemon_rpc, "Stop request acknowledged by node, stopping...");
+				stopped = true;
+				stopped.notify_all ();
+			};
+
+			nano::ipc_rpc_processor ipc_rpc_processor (io_ctx, rpc_config, stop_callback);
 			auto rpc = nano::get_rpc (io_ctx, rpc_config, ipc_rpc_processor);
 			rpc->start ();
-
-			std::atomic stopped{ false };
 
 			auto signal_handler = [&stopped, &logger] (int signum) {
 				logger.warn (nano::log::type::daemon_rpc, "Interrupt signal received ({}), stopping...", nano::to_signal_name (signum));

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -22,7 +22,7 @@
 #include <nano/node/rpc_process.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/qt/qt.hpp>
-#include <nano/rpc/rpc_server.hpp>
+#include <nano/rpc/rpc_host.hpp>
 
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
@@ -179,8 +179,7 @@ public:
 				nano::ipc::ipc_server ipc (*node, config.rpc, stop_callback);
 
 				std::unique_ptr<nano::rpc_process> rpc_process;
-				std::shared_ptr<nano::rpc_server> rpc;
-				std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
+				std::unique_ptr<nano::rpc_host> rpc;
 				bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
 				if (rpc_enabled)
 				{
@@ -199,9 +198,8 @@ public:
 
 						logger.debug (nano::log::type::daemon, "Starting in-process RPC server on port {}", rpc_config.port);
 
-						rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, ipc, config.rpc, stop_callback);
-						rpc = std::make_shared<nano::rpc_server> (io_ctx, rpc_config, *rpc_handler);
-						rpc->start ();
+						rpc = std::make_unique<nano::rpc_host> (rpc_config);
+						rpc->start (std::make_unique<nano::inprocess_rpc_handler> (*node, ipc, config.rpc, stop_callback));
 					}
 					else
 					{

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -22,7 +22,7 @@
 #include <nano/node/openclwork.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/qt/qt.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
@@ -174,7 +174,7 @@ public:
 				nano::ipc::ipc_server ipc (*node, config.rpc);
 
 				std::unique_ptr<boost::process::child> rpc_process;
-				std::shared_ptr<nano::rpc> rpc;
+				std::shared_ptr<nano::rpc_server> rpc;
 				std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
 				bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
 				if (rpc_enabled)

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -200,7 +200,7 @@ public:
 						logger.debug (nano::log::type::daemon, "Starting in-process RPC server on port {}", rpc_config.port);
 
 						rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, ipc, config.rpc, stop_callback);
-						rpc = nano::get_rpc (io_ctx, rpc_config, *rpc_handler);
+						rpc = std::make_shared<nano::rpc_server> (io_ctx, rpc_config, *rpc_handler);
 						rpc->start ();
 					}
 					else

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -194,7 +194,11 @@ public:
 
 						logger.debug (nano::log::type::daemon, "Starting in-process RPC server on port {}", rpc_config.port);
 
-						rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, ipc, config.rpc);
+						auto stop_callback = [&application] () {
+							// Runs on an IO thread, hand the shutdown over to the Qt event loop
+							QMetaObject::invokeMethod (&application, "quit", Qt::QueuedConnection);
+						};
+						rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, ipc, config.rpc, stop_callback);
 						rpc = nano::get_rpc (io_ctx, rpc_config, *rpc_handler);
 						rpc->start ();
 					}

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -1,4 +1,3 @@
-#include <nano/boost/process/child.hpp>
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/cli.hpp>
 #include <nano/lib/errors.hpp>
@@ -20,6 +19,7 @@
 #include <nano/node/node_rpc_config.hpp>
 #include <nano/node/node_scope_guard.hpp>
 #include <nano/node/openclwork.hpp>
+#include <nano/node/rpc_process.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/qt/qt.hpp>
 #include <nano/rpc/rpc_server.hpp>
@@ -178,7 +178,7 @@ public:
 				};
 				nano::ipc::ipc_server ipc (*node, config.rpc, stop_callback);
 
-				std::unique_ptr<boost::process::child> rpc_process;
+				std::unique_ptr<nano::rpc_process> rpc_process;
 				std::shared_ptr<nano::rpc_server> rpc;
 				std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
 				bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
@@ -205,33 +205,25 @@ public:
 					}
 					else
 					{
-						// Spawn a child rpc process
-						if (!std::filesystem::exists (config.rpc.child_process.rpc_path))
-						{
-							throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.child_process.rpc_path);
-						}
-
 						logger.warn (nano::log::type::daemon, "RPC is configured to run in a separate process, this is experimental and is not recommended for production use. Please consider using the in-process RPC instead.");
 
 						logger.debug (nano::log::type::daemon, "Spawning RPC process with command: {}", config.rpc.child_process.rpc_path);
 
-						std::string network{ node->network_params.network.get_current_network_as_string () };
-						rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path.string (), "--network", network);
+						rpc_process = std::make_unique<nano::rpc_process> (config.rpc, data_path, node->network_params.network.get_current_network_as_string (), logger);
 					}
 				}
 				QObject::connect (&application, &QApplication::aboutToQuit, [&] () {
-					ipc.stop ();
-					node->stop ();
+					// Same order as the daemon: stop accepting requests, then the node, then drop whatever is still queued on the IO threads
 					if (rpc)
 					{
 						rpc->stop ();
 					}
-#if USE_BOOST_PROCESS
+					ipc.stop ();
+					node->stop ();
 					if (rpc_process)
 					{
-						rpc_process->terminate ();
+						rpc_process->stop ();
 					}
-#endif
 					runner.abort ();
 				});
 				QApplication::postEvent (&processor, new nano_qt::eventloop_event ([&] () {

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -171,7 +171,12 @@ public:
 				debug_assert (wallet->exists (wallet_config.account));
 				write_wallet_config (wallet_config, data_path);
 				node->start ();
-				nano::ipc::ipc_server ipc (*node, config.rpc);
+
+				// Invoked from an IO thread when a stop request arrives over RPC or IPC, hands the shutdown over to the Qt event loop
+				auto stop_callback = [&application] () {
+					QMetaObject::invokeMethod (&application, "quit", Qt::QueuedConnection);
+				};
+				nano::ipc::ipc_server ipc (*node, config.rpc, stop_callback);
 
 				std::unique_ptr<boost::process::child> rpc_process;
 				std::shared_ptr<nano::rpc_server> rpc;
@@ -194,10 +199,6 @@ public:
 
 						logger.debug (nano::log::type::daemon, "Starting in-process RPC server on port {}", rpc_config.port);
 
-						auto stop_callback = [&application] () {
-							// Runs on an IO thread, hand the shutdown over to the Qt event loop
-							QMetaObject::invokeMethod (&application, "quit", Qt::QueuedConnection);
-						};
 						rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, ipc, config.rpc, stop_callback);
 						rpc = nano::get_rpc (io_ctx, rpc_config, *rpc_handler);
 						rpc->start ();

--- a/nano/nano_wallet/entry_com.cpp
+++ b/nano/nano_wallet/entry_com.cpp
@@ -2,7 +2,7 @@
 #include <nano/lib/files.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/cli.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>

--- a/nano/nano_wallet/entry_com.cpp
+++ b/nano/nano_wallet/entry_com.cpp
@@ -2,7 +2,7 @@
 #include <nano/lib/files.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/cli.hpp>
-#include <nano/rpc/rpc_server.hpp>
+#include <nano/rpc/rpc_host.hpp>
 
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -175,6 +175,8 @@ add_library(
   vote_replier.cpp
   rpc_callbacks.hpp
   rpc_callbacks.cpp
+  rpc_process.hpp
+  rpc_process.cpp
   scheduler/bucket.cpp
   scheduler/bucket.hpp
   scheduler/component.hpp
@@ -265,7 +267,8 @@ target_link_libraries(
   Boost::thread
   rocksdb
   ${CMAKE_DL_LIBS}
-  ${psapi_lib})
+  ${psapi_lib}
+  Boost::process)
 
 target_compile_definitions(
   node PRIVATE -DTAG_VERSION_STRING=${TAG_VERSION_STRING}

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -254,7 +254,7 @@ public:
 		session_timer.restart ();
 		auto request_id_l (std::to_string (server.id_dispenser.fetch_add (1)));
 
-		// This is called when nano::rpc_handler#process_request is done. We convert to
+		// This is called when nano::json_handler::process_request is done. We convert to
 		// json and write the response to the ipc socket with a length prefix.
 		auto this_l (this->shared_from_this ());
 		auto response_handler_l ([this_l, request_id_l] (std::string const & body) {

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -279,6 +279,11 @@ public:
 				{
 					this_l->node.logger.error (nano::log::type::ipc, "Write failed: {}", error_a.message ());
 				}
+				// Only report a stop request once its acknowledgement has been written, the owner may tear this session down in response
+				if (this_l->stop_requested.exchange (false))
+				{
+					this_l->server.stop_callback ();
+				}
 			});
 
 			// Do not call any member variables here (like session_timer) as it's possible that the next request may already be underway.
@@ -288,7 +293,9 @@ public:
 		auto body (std::string (reinterpret_cast<char *> (buffer.data ()), buffer.size ()));
 
 		// Note that if the rpc action is async, the shared_ptr<json_handler> lifetime will be extended by the action handler
-		auto handler (std::make_shared<nano::json_handler> (node, server.node_rpc_config, body, response_handler_l, server.stop_callback));
+		auto handler (std::make_shared<nano::json_handler> (node, server.node_rpc_config, body, response_handler_l, [this_l] () {
+			this_l->stop_requested = true;
+		}));
 		// For unsafe actions to be allowed, the unsafe encoding must be used AND the transport config must allow it
 		handler->process_request (allow_unsafe && config_transport.allow_unsafe);
 	}
@@ -405,6 +412,9 @@ public:
 	}
 
 private:
+	/** Set by a `stop` request, reported to the owner once the acknowledgement has been written */
+	std::atomic<bool> stop_requested{ false };
+
 	/** Holds the buffer and callback for queued writes */
 	class queue_item
 	{

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -288,19 +288,7 @@ public:
 		auto body (std::string (reinterpret_cast<char *> (buffer.data ()), buffer.size ()));
 
 		// Note that if the rpc action is async, the shared_ptr<json_handler> lifetime will be extended by the action handler
-		auto handler (std::make_shared<nano::json_handler> (node, server.node_rpc_config, body, response_handler_l, [server_w = server.weak_from_this ()] () {
-			// TODO: Previously this was stopping node.io_ctx, which was wrong. Investigate what's going on here. Why isn't it using stop_callback passed externally?
-			// This is running on the IO thread, so attempting to directly stop the server will cause it to try joining itself.
-			// This RPC/IPC system is really badly designed...
-			std::thread ([server_w] () {
-				std::this_thread::sleep_for (std::chrono::seconds (1));
-				if (auto server = server_w.lock ())
-				{
-					server->stop ();
-				}
-			})
-			.detach ();
-		}));
+		auto handler (std::make_shared<nano::json_handler> (node, server.node_rpc_config, body, response_handler_l, server.stop_callback));
 		// For unsafe actions to be allowed, the unsafe encoding must be used AND the transport config must allow it
 		handler->process_request (allow_unsafe && config_transport.allow_unsafe);
 	}
@@ -591,11 +579,13 @@ std::optional<std::uint16_t> socket_transport<ACCEPTOR_TYPE, SOCKET_TYPE, ENDPOI
 
 }
 
-nano::ipc::ipc_server::ipc_server (nano::node & node_a, nano::node_rpc_config const & node_rpc_config_a) :
+nano::ipc::ipc_server::ipc_server (nano::node & node_a, nano::node_rpc_config const & node_rpc_config_a, std::function<void ()> stop_callback_a) :
 	node (node_a),
 	node_rpc_config (node_rpc_config_a),
+	stop_callback (std::move (stop_callback_a)),
 	broker (std::make_shared<nano::ipc::broker> (node_a))
 {
+	debug_assert (stop_callback);
 	try
 	{
 		nano::error access_config_error (reload_access_config ());
@@ -646,10 +636,6 @@ void nano::ipc::ipc_server::stop ()
 	for (auto & transport : transports)
 	{
 		transport->stop ();
-	}
-	if (signals)
-	{
-		signals->cancel ();
 	}
 }
 

--- a/nano/node/ipc/ipc_server.hpp
+++ b/nano/node/ipc/ipc_server.hpp
@@ -7,9 +7,8 @@
 #include <nano/node/ipc/ipc_broker.hpp>
 #include <nano/node/node_rpc_config.hpp>
 
-#include <boost/asio/signal_set.hpp>
-
 #include <atomic>
+#include <functional>
 #include <memory>
 
 namespace nano
@@ -19,11 +18,15 @@ class error;
 namespace ipc
 {
 	class access;
-	/** The IPC server accepts connections on one or more configured transports */
+	/**
+	 * The IPC server accepts connections on one or more configured transports.
+	 * A `stop` request received over IPC is only reported through `stop_callback`; shutting the
+	 * node and this server down is the owner's responsibility and must not happen on an IO thread.
+	 */
 	class ipc_server final : public std::enable_shared_from_this<ipc_server>
 	{
 	public:
-		ipc_server (nano::node & node, nano::node_rpc_config const & node_rpc_config);
+		ipc_server (nano::node & node, nano::node_rpc_config const & node_rpc_config, std::function<void ()> stop_callback);
 		~ipc_server ();
 		void stop ();
 
@@ -31,6 +34,7 @@ namespace ipc
 
 		nano::node & node;
 		nano::node_rpc_config const & node_rpc_config;
+		std::function<void ()> const stop_callback;
 
 		/** Unique counter/id shared across sessions */
 		std::atomic<uint64_t> id_dispenser{ 1 };
@@ -47,7 +51,6 @@ namespace ipc
 		nano::ipc::access access;
 		std::unique_ptr<dsock_file_remover> file_remover;
 		std::vector<std::shared_ptr<nano::ipc::transport>> transports;
-		std::shared_ptr<boost::asio::signal_set> signals;
 	};
 }
 }

--- a/nano/node/json_handler.cpp
+++ b/nano/node/json_handler.cpp
@@ -5536,10 +5536,7 @@ void nano::json_handler::populate_backlog ()
 void nano::inprocess_rpc_handler::process_request (std::string const &, std::string const & body_a, std::function<void (std::string const &)> response_a)
 {
 	// Note that if the rpc action is async, the shared_ptr<json_handler> lifetime will be extended by the action handler
-	auto handler (std::make_shared<nano::json_handler> (node, node_rpc_config, body_a, response_a, [this] () {
-		this->stop_callback ();
-		this->stop ();
-	}));
+	auto handler (std::make_shared<nano::json_handler> (node, node_rpc_config, body_a, response_a, stop_callback));
 	handler->process_request ();
 }
 

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -3,7 +3,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/node/fwd.hpp>
 #include <nano/node/ipc/flatbuffers_handler.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/property_tree/ptree.hpp>
 
@@ -206,7 +206,7 @@ public:
 		}
 	}
 
-	void rpc_instance (nano::rpc & rpc_a) override
+	void rpc_instance (nano::rpc_server & rpc_a) override
 	{
 		rpc = rpc_a;
 	}
@@ -214,7 +214,7 @@ public:
 private:
 	nano::node & node;
 	nano::ipc::ipc_server & ipc_server;
-	std::optional<std::reference_wrapper<nano::rpc>> rpc;
+	std::optional<std::reference_wrapper<nano::rpc_server>> rpc;
 	std::function<void ()> stop_callback;
 	nano::node_rpc_config const & node_rpc_config;
 };

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <nano/lib/numbers.hpp>
+#include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/node/fwd.hpp>
 #include <nano/node/ipc/flatbuffers_handler.hpp>
-#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/property_tree/ptree.hpp>
 
@@ -183,38 +183,30 @@ public:
 	std::function<void ()> create_worker_task (std::function<void (std::shared_ptr<nano::json_handler> const &)> const &);
 };
 
+/**
+ * Serves RPC requests inside the node process.
+ * A `stop` request is only reported through `stop_callback`; shutting the node and the
+ * RPC server down is the owner's responsibility and must not happen on the IO thread
+ * that handles the request.
+ */
 class inprocess_rpc_handler final : public nano::rpc_handler_interface
 {
 public:
-	inprocess_rpc_handler (
-	nano::node & node_a, nano::ipc::ipc_server & ipc_server_a, nano::node_rpc_config const & node_rpc_config_a, std::function<void ()> stop_callback_a = [] () {}) :
+	inprocess_rpc_handler (nano::node & node_a, nano::ipc::ipc_server & ipc_server_a, nano::node_rpc_config const & node_rpc_config_a, std::function<void ()> stop_callback_a) :
 		node (node_a),
 		ipc_server (ipc_server_a),
-		stop_callback (stop_callback_a),
+		stop_callback (std::move (stop_callback_a)),
 		node_rpc_config (node_rpc_config_a)
 	{
+		debug_assert (stop_callback);
 	}
 
 	void process_request (std::string const &, std::string const & body_a, std::function<void (std::string const &)> response_a) override;
 	void process_request_v2 (rpc_handler_request_params const & params_a, std::string const & body_a, std::function<void (std::shared_ptr<std::string> const &)> response_a) override;
 
-	void stop () override
-	{
-		if (rpc)
-		{
-			rpc->get ().stop ();
-		}
-	}
-
-	void rpc_instance (nano::rpc_server & rpc_a) override
-	{
-		rpc = rpc_a;
-	}
-
 private:
 	nano::node & node;
 	nano::ipc::ipc_server & ipc_server;
-	std::optional<std::reference_wrapper<nano::rpc_server>> rpc;
 	std::function<void ()> stop_callback;
 	nano::node_rpc_config const & node_rpc_config;
 };

--- a/nano/node/rpc_process.cpp
+++ b/nano/node/rpc_process.cpp
@@ -1,0 +1,39 @@
+#include <nano/node/node_rpc_config.hpp>
+#include <nano/node/rpc_process.hpp>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+nano::rpc_process::rpc_process (nano::node_rpc_config const & config, std::filesystem::path const & data_path, std::string_view network, nano::logger & logger_a) :
+	logger{ logger_a }
+{
+	auto const & path = config.child_process.rpc_path;
+	if (!std::filesystem::exists (path))
+	{
+		throw std::runtime_error ("RPC is configured to spawn a new process however the file cannot be found at: " + path);
+	}
+
+	child = boost::process::child (path, "--daemon", "--data_path", data_path.string (), "--network", std::string (network));
+}
+
+void nano::rpc_process::stop ()
+{
+	std::error_code ec;
+
+	auto const deadline = std::chrono::steady_clock::now () + 5s;
+	while (child.running (ec) && std::chrono::steady_clock::now () < deadline)
+	{
+		std::this_thread::sleep_for (100ms);
+	}
+
+	if (child.running (ec))
+	{
+		logger.warn (nano::log::type::rpc_process, "RPC process did not exit on its own, terminating it");
+		child.terminate (ec);
+	}
+	child.wait (ec);
+}

--- a/nano/node/rpc_process.hpp
+++ b/nano/node/rpc_process.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <nano/boost/process/child.hpp>
+#include <nano/lib/logging.hpp>
+
+#include <filesystem>
+#include <string_view>
+
+namespace nano
+{
+class node_rpc_config;
+
+/**
+ * The `nano_rpc` child spawned when RPC is configured to run in a separate process.
+ * The child talks to the node over IPC. A `stop` request that came through it makes it exit on
+ * its own once the node acknowledges the request; any other shutdown terminates it from here.
+ */
+class rpc_process final
+{
+public:
+	// Throws `std::runtime_error` when the configured executable does not exist
+	rpc_process (nano::node_rpc_config const &, std::filesystem::path const & data_path, std::string_view network, nano::logger &);
+
+	// Gives the child a moment to exit on its own and terminates it otherwise
+	void stop ();
+
+private:
+	nano::logger & logger;
+	boost::process::child child;
+};
+}

--- a/nano/rpc/CMakeLists.txt
+++ b/nano/rpc/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(
   rpc
-  rpc.hpp
-  rpc.cpp
+  rpc_server.hpp
+  rpc_server.cpp
   rpc_connection.hpp
   rpc_connection.cpp
   rpc_handler.hpp

--- a/nano/rpc/CMakeLists.txt
+++ b/nano/rpc/CMakeLists.txt
@@ -4,8 +4,8 @@ add_library(
   rpc_server.cpp
   rpc_connection.hpp
   rpc_connection.cpp
-  rpc_handler.hpp
-  rpc_handler.cpp
+  rpc_dispatcher.hpp
+  rpc_dispatcher.cpp
   rpc_request_processor.hpp
   rpc_request_processor.cpp)
 

--- a/nano/rpc/CMakeLists.txt
+++ b/nano/rpc/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(
   rpc_connection.cpp
   rpc_dispatcher.hpp
   rpc_dispatcher.cpp
+  rpc_host.hpp
+  rpc_host.cpp
   rpc_request_processor.hpp
   rpc_request_processor.cpp)
 

--- a/nano/rpc/rpc_connection.cpp
+++ b/nano/rpc/rpc_connection.cpp
@@ -1,4 +1,5 @@
 #include <nano/boost/asio/bind_executor.hpp>
+#include <nano/boost/asio/dispatch.hpp>
 #include <nano/boost/asio/post.hpp>
 #include <nano/lib/json_error_response.hpp>
 #include <nano/lib/logging.hpp>
@@ -7,6 +8,7 @@
 #include <nano/lib/utility.hpp>
 #include <nano/rpc/rpc_connection.hpp>
 #include <nano/rpc/rpc_dispatcher.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -15,15 +17,46 @@
 #endif
 #include <boost/format.hpp>
 
-nano::rpc_connection::rpc_connection (nano::rpc_config const & rpc_config, boost::asio::io_context & io_ctx, nano::logger & logger, nano::rpc_handler_interface & rpc_handler_interface) :
+nano::rpc_connection::rpc_connection (nano::rpc_config const & rpc_config, boost::asio::io_context & io_ctx, nano::logger & logger, nano::rpc_handler_interface & rpc_handler_interface, std::shared_ptr<nano::rpc_connection_tracker> tracker_a) :
 	socket (io_ctx),
 	strand (io_ctx.get_executor ()),
 	io_ctx (io_ctx),
 	logger (logger),
 	rpc_config (rpc_config),
-	rpc_handler_interface (rpc_handler_interface)
+	rpc_handler_interface (rpc_handler_interface),
+	tracker (std::move (tracker_a))
 {
 	responded.clear ();
+}
+
+void nano::rpc_connection::close ()
+{
+	boost::asio::dispatch (strand, [this_l = shared_from_this ()] () {
+		boost::system::error_code ec;
+		this_l->socket.shutdown (boost::asio::ip::tcp::socket::shutdown_both, ec);
+		this_l->socket.close (ec);
+	});
+}
+
+bool nano::rpc_connection::serving () const
+{
+	return serving_m;
+}
+
+void nano::rpc_connection::request_begin ()
+{
+	if (!serving_m.exchange (true))
+	{
+		tracker->request_begin ();
+	}
+}
+
+void nano::rpc_connection::request_end ()
+{
+	if (serving_m.exchange (false))
+	{
+		tracker->request_end ();
+	}
 }
 
 void nano::rpc_connection::parse_connection ()
@@ -59,7 +92,7 @@ void nano::rpc_connection::write_result (std::string body, unsigned version, boo
 
 void nano::rpc_connection::write_completion_handler (std::shared_ptr<nano::rpc_connection> const & rpc_connection)
 {
-	// Intentional no-op
+	request_end ();
 }
 
 template <typename STREAM_TYPE>
@@ -83,11 +116,16 @@ void nano::rpc_connection::read (STREAM_TYPE & stream)
 
 			this_l->parse_request (stream, header_parser);
 		}
+		else if (ec == boost::asio::error::operation_aborted)
+		{
+			// Closed while idle, nothing to respond to
+		}
 		else
 		{
 			this_l->logger.error (nano::log::type::rpc_connection, "RPC header error: {}", ec.message ());
 
 			// Respond with the reason for the invalid header
+			this_l->request_begin ();
 			auto response_handler ([this_l, &stream] (std::string const & tree_a) {
 				this_l->write_result (tree_a, 11);
 				boost::beast::http::async_write (stream, this_l->res, boost::asio::bind_executor (this_l->strand, [this_l] (boost::system::error_code const & ec, size_t bytes_transferred) {
@@ -110,6 +148,7 @@ void nano::rpc_connection::parse_request (STREAM_TYPE & stream, std::shared_ptr<
 	boost::beast::http::async_read (stream, buffer, *body_parser, boost::asio::bind_executor (strand, [this_l, body_parser, header_field_credentials_l, header_corr_id_l, path_l, &stream] (boost::system::error_code const & ec, size_t bytes_transferred) {
 		if (!ec)
 		{
+			this_l->request_begin ();
 			boost::asio::post (this_l->io_ctx, [this_l, body_parser, header_field_credentials_l, header_corr_id_l, path_l, &stream] () {
 				auto & req (body_parser->get ());
 				auto start (std::chrono::steady_clock::now ());
@@ -164,7 +203,7 @@ void nano::rpc_connection::parse_request (STREAM_TYPE & stream, std::shared_ptr<
 				}
 			});
 		}
-		else
+		else if (ec != boost::asio::error::operation_aborted)
 		{
 			this_l->logger.error (nano::log::type::rpc_connection, "RPC read error: {}", ec.message ());
 		}

--- a/nano/rpc/rpc_connection.cpp
+++ b/nano/rpc/rpc_connection.cpp
@@ -6,7 +6,7 @@
 #include <nano/lib/rpcconfig.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/rpc/rpc_connection.hpp>
-#include <nano/rpc/rpc_handler.hpp>
+#include <nano/rpc/rpc_dispatcher.hpp>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -137,14 +137,14 @@ void nano::rpc_connection::parse_request (STREAM_TYPE & stream, std::shared_ptr<
 				{
 					case boost::beast::http::verb::post:
 					{
-						auto handler (std::make_shared<nano::rpc_handler> (this_l->rpc_config, req.body (), request_id, response_handler, this_l->rpc_handler_interface, this_l->logger));
+						auto dispatcher (std::make_shared<nano::rpc_dispatcher> (this_l->rpc_config, req.body (), request_id, response_handler, this_l->rpc_handler_interface, this_l->logger));
 						nano::rpc_handler_request_params request_params;
 						request_params.rpc_version = rpc_version_l;
 						request_params.credentials = header_field_credentials_l;
 						request_params.correlation_id = header_corr_id_l;
 						request_params.path = boost::algorithm::erase_first_copy (path_l, api_path_l);
 						request_params.path = boost::algorithm::erase_first_copy (request_params.path, "/");
-						handler->process_request (request_params);
+						dispatcher->process_request (request_params);
 						break;
 					}
 					case boost::beast::http::verb::options:

--- a/nano/rpc/rpc_connection.hpp
+++ b/nano/rpc/rpc_connection.hpp
@@ -15,17 +15,27 @@ using socket_type = boost::asio::basic_stream_socket<boost::asio::ip::tcp, boost
 namespace nano
 {
 class rpc_config;
+class rpc_connection_tracker;
 class rpc_handler_interface;
 
+/**
+ * One accepted HTTP connection: reads a single request, hands it to the backend and writes the response.
+ * A connection is serving a request from the moment the request has been read until its response
+ * has been written, and reports both transitions to the tracker of the server that accepted it.
+ */
 class rpc_connection : public std::enable_shared_from_this<nano::rpc_connection>
 {
 public:
-	rpc_connection (nano::rpc_config const & rpc_config, boost::asio::io_context & io_ctx, nano::logger &, nano::rpc_handler_interface & rpc_handler_interface_a);
+	rpc_connection (nano::rpc_config const & rpc_config, boost::asio::io_context & io_ctx, nano::logger &, nano::rpc_handler_interface & rpc_handler_interface_a, std::shared_ptr<nano::rpc_connection_tracker>);
 	virtual ~rpc_connection () = default;
 	virtual void parse_connection ();
 	virtual void write_completion_handler (std::shared_ptr<nano::rpc_connection> const & rpc_connection);
 	void prepare_head (unsigned version, boost::beast::http::status status = boost::beast::http::status::ok);
 	void write_result (std::string body, unsigned version, boost::beast::http::status status = boost::beast::http::status::ok);
+
+	// Closes the socket from its strand, safe to call from any thread
+	void close ();
+	bool serving () const;
 
 	socket_type socket;
 	boost::beast::flat_buffer buffer;
@@ -38,6 +48,12 @@ public:
 	nano::rpc_handler_interface & rpc_handler_interface;
 
 protected:
+	void request_begin ();
+	void request_end ();
+
+	std::shared_ptr<nano::rpc_connection_tracker> tracker;
+	std::atomic<bool> serving_m{ false };
+
 	template <typename STREAM_TYPE>
 	void read (STREAM_TYPE & stream);
 

--- a/nano/rpc/rpc_dispatcher.cpp
+++ b/nano/rpc/rpc_dispatcher.cpp
@@ -5,7 +5,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/lib/rpcconfig.hpp>
-#include <nano/rpc/rpc_handler.hpp>
+#include <nano/rpc/rpc_dispatcher.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
 
@@ -18,7 +18,7 @@ std::unordered_set<std::string> rpc_control_impl_set = create_rpc_control_impls 
 std::string filter_request (boost::property_tree::ptree tree_a);
 }
 
-nano::rpc_handler::rpc_handler (nano::rpc_config const & rpc_config, std::string const & body_a, std::string const & request_id_a, std::function<void (std::string const &)> const & response_a, nano::rpc_handler_interface & rpc_handler_interface_a, nano::logger & logger) :
+nano::rpc_dispatcher::rpc_dispatcher (nano::rpc_config const & rpc_config, std::string const & body_a, std::string const & request_id_a, std::function<void (std::string const &)> const & response_a, nano::rpc_handler_interface & rpc_handler_interface_a, nano::logger & logger) :
 	body (body_a),
 	request_id (request_id_a),
 	response (response_a),
@@ -28,7 +28,7 @@ nano::rpc_handler::rpc_handler (nano::rpc_config const & rpc_config, std::string
 {
 }
 
-void nano::rpc_handler::process_request (nano::rpc_handler_request_params const & request_params)
+void nano::rpc_dispatcher::process_request (nano::rpc_handler_request_params const & request_params)
 {
 	try
 	{

--- a/nano/rpc/rpc_dispatcher.hpp
+++ b/nano/rpc/rpc_dispatcher.hpp
@@ -13,10 +13,11 @@ class rpc_config;
 class rpc_handler_interface;
 class rpc_handler_request_params;
 
-class rpc_handler : public std::enable_shared_from_this<nano::rpc_handler>
+/** Parses the JSON envelope of one request, enforces control-level access and hands it to the backend */
+class rpc_dispatcher : public std::enable_shared_from_this<nano::rpc_dispatcher>
 {
 public:
-	rpc_handler (nano::rpc_config const & rpc_config, std::string const & body_a, std::string const & request_id_a, std::function<void (std::string const &)> const & response_a, nano::rpc_handler_interface & rpc_handler_interface_a, nano::logger &);
+	rpc_dispatcher (nano::rpc_config const & rpc_config, std::string const & body_a, std::string const & request_id_a, std::function<void (std::string const &)> const & response_a, nano::rpc_handler_interface & rpc_handler_interface_a, nano::logger &);
 	void process_request (nano::rpc_handler_request_params const & request_params);
 
 private:

--- a/nano/rpc/rpc_host.cpp
+++ b/nano/rpc/rpc_host.cpp
@@ -1,0 +1,56 @@
+#include <nano/lib/rpc_handler_interface.hpp>
+#include <nano/lib/thread_runner.hpp>
+#include <nano/rpc/rpc_host.hpp>
+#include <nano/rpc/rpc_server.hpp>
+
+nano::rpc_host::rpc_host (nano::rpc_config config_a) :
+	config{ std::move (config_a) },
+	io_ctx{ std::make_shared<boost::asio::io_context> () }
+{
+}
+
+nano::rpc_host::~rpc_host ()
+{
+	stop ();
+}
+
+std::shared_ptr<boost::asio::io_context> const & nano::rpc_host::io_context () const
+{
+	return io_ctx;
+}
+
+void nano::rpc_host::start (std::unique_ptr<nano::rpc_handler_interface> backend_a)
+{
+	debug_assert (!stopped);
+	debug_assert (!server);
+	release_assert (backend_a);
+
+	backend = std::move (backend_a);
+	server = std::make_unique<nano::rpc_server> (io_ctx, config, *backend);
+	runner = std::make_unique<nano::thread_runner> (io_ctx, logger, config.rpc_process.io_threads, nano::thread_role::name::io_rpc);
+	server->start ();
+}
+
+void nano::rpc_host::stop ()
+{
+	if (stopped.exchange (true))
+	{
+		return;
+	}
+	if (server)
+	{
+		server->stop (); // Every response that was started is written before this returns
+	}
+	if (runner)
+	{
+		runner->abort (); // Whatever the backend still has queued is dropped
+		runner->join ();
+	}
+	backend.reset ();
+}
+
+std::uint16_t nano::rpc_host::listening_port () const
+{
+	release_assert (server);
+	return server->listening_port ();
+}

--- a/nano/rpc/rpc_host.hpp
+++ b/nano/rpc/rpc_host.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <nano/lib/logging.hpp>
+#include <nano/lib/rpcconfig.hpp>
+
+#include <boost/asio/io_context.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+
+namespace nano
+{
+class rpc_handler_interface;
+class rpc_server;
+class thread_runner;
+
+/**
+ * Hosts an RPC endpoint: the HTTP listener, the backend that serves its requests and the IO
+ * threads they run on. `start` and `stop` encode the one order every owner needs, so the
+ * standalone `nano_rpc` process, the daemon, the wallet and the test harness all run the same
+ * code. A `stop` request arriving over RPC is reported to the owner by the backend; the owner
+ * decides what to do about it and calls `stop` from a thread of its own.
+ */
+class rpc_host final
+{
+public:
+	explicit rpc_host (nano::rpc_config);
+	~rpc_host ();
+
+	// The io_context a backend must use for its own asynchronous work
+	std::shared_ptr<boost::asio::io_context> const & io_context () const;
+
+	// Binds the listener and serves requests through `backend`, throws if the port cannot be bound
+	void start (std::unique_ptr<nano::rpc_handler_interface> backend);
+	// Drains the listener, stops the IO threads and releases the backend; idempotent, never from an IO thread
+	void stop ();
+
+	// Port the listener is bound to, only meaningful after `start`
+	std::uint16_t listening_port () const;
+
+	nano::rpc_config const config;
+
+private:
+	nano::logger logger{ "rpc" };
+	std::shared_ptr<boost::asio::io_context> io_ctx;
+	std::unique_ptr<nano::rpc_handler_interface> backend;
+	std::unique_ptr<nano::rpc_server> server;
+	std::unique_ptr<nano::thread_runner> runner; // Last, so its threads are joined before anything they use goes away
+	std::atomic<bool> stopped{ false };
+};
+}

--- a/nano/rpc/rpc_request_processor.cpp
+++ b/nano/rpc/rpc_request_processor.cpp
@@ -5,14 +5,16 @@
 
 #include <boost/endian/conversion.hpp>
 
-nano::rpc_request_processor::rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a) :
+nano::rpc_request_processor::rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a, std::function<void ()> stop_callback_a) :
 	ipc_address{ rpc_config.rpc_process.ipc_address },
 	ipc_port{ ipc_port_a },
+	stop_callback{ std::move (stop_callback_a) },
 	thread{ [this] () {
 		nano::thread_role::set (nano::thread_role::name::rpc_request_processor);
 		this->run ();
 	} }
 {
+	debug_assert (stop_callback);
 	nano::lock_guard<nano::mutex> lk{ this->request_mutex };
 	this->connections.reserve (rpc_config.rpc_process.num_ipc_connections);
 	for (auto i = 0u; i < rpc_config.rpc_process.num_ipc_connections; ++i)
@@ -27,8 +29,8 @@ nano::rpc_request_processor::rpc_request_processor (std::shared_ptr<boost::asio:
 	}
 }
 
-nano::rpc_request_processor::rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config) :
-	rpc_request_processor (std::move (io_ctx), rpc_config, rpc_config.rpc_process.ipc_port)
+nano::rpc_request_processor::rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::function<void ()> stop_callback_a) :
+	rpc_request_processor (std::move (io_ctx), rpc_config, rpc_config.rpc_process.ipc_port, std::move (stop_callback_a))
 {
 }
 
@@ -73,7 +75,8 @@ void nano::rpc_request_processor::read_payload (std::shared_ptr<nano::ipc_connec
 			rpc_request->response (std::string (res->begin (), res->end ()));
 			if (rpc_request->action == "stop")
 			{
-				this->stop_callback ();
+				// The node has acknowledged the stop request, let the owner shut this process down
+				stop_callback ();
 			}
 		}
 		else

--- a/nano/rpc/rpc_request_processor.hpp
+++ b/nano/rpc/rpc_request_processor.hpp
@@ -4,7 +4,6 @@
 #include <nano/lib/locks.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/lib/rpcconfig.hpp>
-#include <nano/rpc/rpc_server.hpp>
 
 #include <atomic>
 #include <deque>
@@ -45,15 +44,19 @@ struct rpc_request
 	std::function<void (std::string const &)> response;
 };
 
+/**
+ * Forwards RPC requests to a node over IPC.
+ * When the node acknowledges a `stop` request, `stop_callback` is invoked so the owner can shut
+ * this process down; the processor never stops itself or the RPC server.
+ */
 class rpc_request_processor
 {
 public:
-	rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config);
-	rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a);
+	rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::function<void ()> stop_callback);
+	rpc_request_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a, std::function<void ()> stop_callback);
 	~rpc_request_processor ();
 	void stop ();
 	void add (std::shared_ptr<rpc_request> const & request);
-	std::function<void ()> stop_callback;
 
 private:
 	void run ();
@@ -69,18 +72,19 @@ private:
 	nano::condition_variable condition;
 	std::string const ipc_address;
 	uint16_t const ipc_port;
+	std::function<void ()> const stop_callback;
 	std::thread thread;
 };
 
 class ipc_rpc_processor final : public nano::rpc_handler_interface
 {
 public:
-	ipc_rpc_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config) :
-		rpc_request_processor (std::move (io_ctx), rpc_config)
+	ipc_rpc_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::function<void ()> stop_callback) :
+		rpc_request_processor (std::move (io_ctx), rpc_config, std::move (stop_callback))
 	{
 	}
-	ipc_rpc_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a) :
-		rpc_request_processor (std::move (io_ctx), rpc_config, ipc_port_a)
+	ipc_rpc_processor (std::shared_ptr<boost::asio::io_context> io_ctx, nano::rpc_config & rpc_config, std::uint16_t ipc_port_a, std::function<void ()> stop_callback) :
+		rpc_request_processor (std::move (io_ctx), rpc_config, ipc_port_a, std::move (stop_callback))
 	{
 	}
 
@@ -96,18 +100,6 @@ public:
 			auto resp_l (std::make_shared<std::string> (resp));
 			response_a (resp_l);
 		}));
-	}
-
-	void stop () override
-	{
-		rpc_request_processor.stop ();
-	}
-
-	void rpc_instance (nano::rpc_server & rpc) override
-	{
-		rpc_request_processor.stop_callback = [&rpc] () {
-			rpc.stop ();
-		};
 	}
 
 private:

--- a/nano/rpc/rpc_request_processor.hpp
+++ b/nano/rpc/rpc_request_processor.hpp
@@ -4,7 +4,7 @@
 #include <nano/lib/locks.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/lib/rpcconfig.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <atomic>
 #include <deque>
@@ -103,7 +103,7 @@ public:
 		rpc_request_processor.stop ();
 	}
 
-	void rpc_instance (nano::rpc & rpc) override
+	void rpc_instance (nano::rpc_server & rpc) override
 	{
 		rpc_request_processor.stop_callback = [&rpc] () {
 			rpc.stop ();

--- a/nano/rpc/rpc_server.cpp
+++ b/nano/rpc/rpc_server.cpp
@@ -1,34 +1,34 @@
-#include <nano/boost/asio/bind_executor.hpp>
-#include <nano/lib/logging.hpp>
 #include <nano/lib/network_formatting.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/rpc/rpc_connection.hpp>
 #include <nano/rpc/rpc_server.hpp>
 
-#include <boost/format.hpp>
+#include <stdexcept>
 
-#include <iostream>
+using namespace std::chrono_literals;
 
-nano::rpc_server::rpc_server (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a) :
-	config (std::move (config_a)),
-	io_ctx_shared (io_ctx_a),
-	io_ctx (*io_ctx_shared),
-	acceptor (io_ctx),
-	rpc_handler_interface (rpc_handler_interface_a)
+nano::rpc_server::rpc_server (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config config_a, nano::rpc_handler_interface & handler_a) :
+	config{ std::move (config_a) },
+	handler{ handler_a },
+	io_ctx{ std::move (io_ctx_a) },
+	strand{ io_ctx->get_executor () },
+	acceptor{ *io_ctx },
+	task{ strand }
 {
 }
 
 nano::rpc_server::~rpc_server ()
 {
-	if (!stopped)
-	{
-		stop ();
-	}
+	// Owners stop the server themselves, this only covers a server that was never started
+	stop ();
 }
 
 void nano::rpc_server::start ()
 {
-	auto endpoint (boost::asio::ip::tcp::endpoint (boost::asio::ip::make_address_v6 (config.address), config.port));
+	debug_assert (!stopped);
+	debug_assert (!task.joinable ());
+
+	boost::asio::ip::tcp::endpoint const endpoint{ boost::asio::ip::make_address_v6 (config.address), config.port };
 
 	bool const is_loopback = (endpoint.address ().is_loopback () || (endpoint.address ().to_v6 ().is_v4_mapped () && boost::asio::ip::make_address_v4 (boost::asio::ip::v4_mapped, endpoint.address ().to_v6 ()).is_loopback ()));
 	if (!is_loopback && config.enable_control)
@@ -36,58 +36,78 @@ void nano::rpc_server::start ()
 		logger.warn (nano::log::type::rpc, "WARNING: Control-level RPCs are enabled on non-local address {}, potentially allowing wallet access outside local computer", endpoint.address ());
 	}
 
-	acceptor.open (endpoint.protocol ());
-	acceptor.set_option (boost::asio::ip::tcp::acceptor::reuse_address (true));
-
-	boost::system::error_code ec;
-	acceptor.bind (endpoint, ec);
-	if (ec)
+	try
 	{
-		logger.critical (nano::log::type::rpc, "Error while binding for RPC on port: {} ({})", endpoint.port (), ec.message ());
-		throw std::runtime_error (ec.message ());
+		acceptor.open (endpoint.protocol ());
+		acceptor.set_option (boost::asio::ip::tcp::acceptor::reuse_address (true));
+		acceptor.bind (endpoint);
+		acceptor.listen ();
 	}
-	logger.info (nano::log::type::rpc, "RPC listening address: {}", acceptor.local_endpoint ());
-	acceptor.listen ();
-	accept ();
-}
+	catch (boost::system::system_error const & ex)
+	{
+		logger.critical (nano::log::type::rpc, "Error while binding for RPC on port: {} ({})", endpoint.port (), ex.code ().message ());
+		throw std::runtime_error (ex.code ().message ());
+	}
 
-void nano::rpc_server::accept ()
-{
-	auto connection (std::make_shared<nano::rpc_connection> (config, io_ctx, logger, rpc_handler_interface));
-	acceptor.async_accept (connection->socket,
-	boost::asio::bind_executor (connection->strand, [this_w = std::weak_ptr{ shared_from_this () }, connection] (boost::system::error_code const & ec) {
-		auto this_l = this_w.lock ();
-		if (!this_l)
-		{
-			return;
-		}
-		if (ec != boost::asio::error::operation_aborted && this_l->acceptor.is_open ())
-		{
-			this_l->accept ();
-		}
-		if (!ec)
-		{
-			connection->parse_connection ();
-		}
-		else
-		{
-			this_l->logger.error (nano::log::type::rpc, "Error accepting RPC connection: {}", ec.message ());
-		}
-	}));
+	port = acceptor.local_endpoint ().port ();
+	logger.info (nano::log::type::rpc, "RPC listening address: {}", acceptor.local_endpoint ());
+
+	task = nano::async::task (strand, run ());
 }
 
 void nano::rpc_server::stop ()
 {
-	stopped = true;
+	if (stopped.exchange (true))
+	{
+		return;
+	}
+	// Joining the accept task from a thread that runs this io_context could deadlock, owners stop from their main thread
+	debug_assert (!io_ctx->get_executor ().running_in_this_thread ());
+
+	if (task.joinable ())
+	{
+		task.cancel ();
+		task.join ();
+	}
+
 	boost::system::error_code ec;
 	acceptor.close (ec);
 	if (ec)
 	{
-		logger.error (nano::log::type::rpc, "Error while closing RPC acceptor during shutdown: {}", ec.message ());
+		logger.error (nano::log::type::rpc, "Error while closing RPC acceptor: {}", ec.message ());
 	}
+
+	logger.debug (nano::log::type::rpc, "Stopped");
 }
 
-std::shared_ptr<nano::rpc_server> nano::get_rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a)
+std::uint16_t nano::rpc_server::listening_port () const
 {
-	return std::make_shared<nano::rpc_server> (io_ctx_a, config_a, rpc_handler_interface_a);
+	return port;
+}
+
+asio::awaitable<void> nano::rpc_server::run ()
+{
+	debug_assert (strand.running_in_this_thread ());
+
+	while (!stopped)
+	{
+		auto connection = std::make_shared<nano::rpc_connection> (config, *io_ctx, logger, handler);
+
+		boost::system::error_code ec;
+		co_await acceptor.async_accept (connection->socket, asio::redirect_error (asio::use_awaitable, ec));
+		debug_assert (strand.running_in_this_thread ());
+
+		if (stopped || ec == asio::error::operation_aborted)
+		{
+			break;
+		}
+		if (ec)
+		{
+			logger.error (nano::log::type::rpc, "Error accepting RPC connection: {}", ec.message ());
+			co_await nano::async::sleep_for (10ms); // Prevent a busy loop on persistent errors
+			continue;
+		}
+
+		connection->parse_connection ();
+	}
 }

--- a/nano/rpc/rpc_server.cpp
+++ b/nano/rpc/rpc_server.cpp
@@ -2,14 +2,14 @@
 #include <nano/lib/logging.hpp>
 #include <nano/lib/network_formatting.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc/rpc_connection.hpp>
 
 #include <boost/format.hpp>
 
 #include <iostream>
 
-nano::rpc::rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a) :
+nano::rpc_server::rpc_server (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a) :
 	config (std::move (config_a)),
 	io_ctx_shared (io_ctx_a),
 	io_ctx (*io_ctx_shared),
@@ -19,7 +19,7 @@ nano::rpc::rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_con
 	rpc_handler_interface.rpc_instance (*this);
 }
 
-nano::rpc::~rpc ()
+nano::rpc_server::~rpc_server ()
 {
 	if (!stopped)
 	{
@@ -27,7 +27,7 @@ nano::rpc::~rpc ()
 	}
 }
 
-void nano::rpc::start ()
+void nano::rpc_server::start ()
 {
 	auto endpoint (boost::asio::ip::tcp::endpoint (boost::asio::ip::make_address_v6 (config.address), config.port));
 
@@ -52,7 +52,7 @@ void nano::rpc::start ()
 	accept ();
 }
 
-void nano::rpc::accept ()
+void nano::rpc_server::accept ()
 {
 	auto connection (std::make_shared<nano::rpc_connection> (config, io_ctx, logger, rpc_handler_interface));
 	acceptor.async_accept (connection->socket,
@@ -77,7 +77,7 @@ void nano::rpc::accept ()
 	}));
 }
 
-void nano::rpc::stop ()
+void nano::rpc_server::stop ()
 {
 	stopped = true;
 	boost::system::error_code ec;
@@ -88,7 +88,7 @@ void nano::rpc::stop ()
 	}
 }
 
-std::shared_ptr<nano::rpc> nano::get_rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a)
+std::shared_ptr<nano::rpc_server> nano::get_rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a)
 {
-	return std::make_shared<nano::rpc> (io_ctx_a, config_a, rpc_handler_interface_a);
+	return std::make_shared<nano::rpc_server> (io_ctx_a, config_a, rpc_handler_interface_a);
 }

--- a/nano/rpc/rpc_server.cpp
+++ b/nano/rpc/rpc_server.cpp
@@ -77,6 +77,13 @@ void nano::rpc_server::stop ()
 		logger.error (nano::log::type::rpc, "Error while closing RPC acceptor: {}", ec.message ());
 	}
 
+	connections->close_idle ();
+	if (!connections->wait_drained (drain_timeout))
+	{
+		logger.warn (nano::log::type::rpc, "Closing {} connection(s) still serving a request after waiting {}ms", connections->in_flight (), drain_timeout.count ());
+		connections->close_all ();
+	}
+
 	logger.debug (nano::log::type::rpc, "Stopped");
 }
 
@@ -91,7 +98,7 @@ asio::awaitable<void> nano::rpc_server::run ()
 
 	while (!stopped)
 	{
-		auto connection = std::make_shared<nano::rpc_connection> (config, *io_ctx, logger, handler);
+		auto connection = std::make_shared<nano::rpc_connection> (config, *io_ctx, logger, handler, connections);
 
 		boost::system::error_code ec;
 		co_await acceptor.async_accept (connection->socket, asio::redirect_error (asio::use_awaitable, ec));
@@ -108,6 +115,78 @@ asio::awaitable<void> nano::rpc_server::run ()
 			continue;
 		}
 
+		connections->add (connection);
 		connection->parse_connection ();
 	}
+}
+
+/*
+ * rpc_connection_tracker
+ */
+
+void nano::rpc_connection_tracker::add (std::shared_ptr<nano::rpc_connection> const & connection)
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	purge ();
+	connections.push_back (connection);
+}
+
+void nano::rpc_connection_tracker::request_begin ()
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	++in_flight_m;
+}
+
+void nano::rpc_connection_tracker::request_end ()
+{
+	{
+		nano::lock_guard<nano::mutex> lock{ mutex };
+		debug_assert (in_flight_m > 0);
+		--in_flight_m;
+	}
+	condition.notify_all ();
+}
+
+std::size_t nano::rpc_connection_tracker::in_flight () const
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	return in_flight_m;
+}
+
+void nano::rpc_connection_tracker::close_idle ()
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	purge ();
+	for (auto const & weak : connections)
+	{
+		if (auto connection = weak.lock (); connection && !connection->serving ())
+		{
+			connection->close ();
+		}
+	}
+}
+
+void nano::rpc_connection_tracker::close_all ()
+{
+	nano::lock_guard<nano::mutex> lock{ mutex };
+	purge ();
+	for (auto const & weak : connections)
+	{
+		if (auto connection = weak.lock ())
+		{
+			connection->close ();
+		}
+	}
+}
+
+bool nano::rpc_connection_tracker::wait_drained (std::chrono::milliseconds timeout)
+{
+	nano::unique_lock<nano::mutex> lock{ mutex };
+	return condition.wait_for (lock, timeout, [this] () { return in_flight_m == 0; });
+}
+
+void nano::rpc_connection_tracker::purge ()
+{
+	debug_assert (!mutex.try_lock ());
+	connections.remove_if ([] (auto const & weak) { return weak.expired (); });
 }

--- a/nano/rpc/rpc_server.cpp
+++ b/nano/rpc/rpc_server.cpp
@@ -2,8 +2,8 @@
 #include <nano/lib/logging.hpp>
 #include <nano/lib/network_formatting.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
-#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc/rpc_connection.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/format.hpp>
 
@@ -16,7 +16,6 @@ nano::rpc_server::rpc_server (std::shared_ptr<boost::asio::io_context> io_ctx_a,
 	acceptor (io_ctx),
 	rpc_handler_interface (rpc_handler_interface_a)
 {
-	rpc_handler_interface.rpc_instance (*this);
 }
 
 nano::rpc_server::~rpc_server ()

--- a/nano/rpc/rpc_server.hpp
+++ b/nano/rpc/rpc_server.hpp
@@ -17,11 +17,11 @@ namespace nano
 {
 class rpc_handler_interface;
 
-class rpc : public std::enable_shared_from_this<rpc>
+class rpc_server : public std::enable_shared_from_this<rpc_server>
 {
 public:
-	rpc (std::shared_ptr<boost::asio::io_context>, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
-	virtual ~rpc ();
+	rpc_server (std::shared_ptr<boost::asio::io_context>, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
+	virtual ~rpc_server ();
 
 	void start ();
 	void stop ();
@@ -44,5 +44,5 @@ public:
 };
 
 /** Returns the correct RPC implementation based on TLS configuration */
-std::shared_ptr<nano::rpc> get_rpc (std::shared_ptr<boost::asio::io_context>, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
+std::shared_ptr<nano::rpc_server> get_rpc (std::shared_ptr<boost::asio::io_context>, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
 }

--- a/nano/rpc/rpc_server.hpp
+++ b/nano/rpc/rpc_server.hpp
@@ -1,48 +1,50 @@
 #pragma once
 
-#include <nano/boost/asio/ip/tcp.hpp>
+#include <nano/lib/async.hpp>
 #include <nano/lib/logging.hpp>
-#include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/lib/rpcconfig.hpp>
 
-namespace boost
-{
-namespace asio
-{
-	class io_context;
-}
-}
+#include <atomic>
+#include <cstdint>
+#include <memory>
 
 namespace nano
 {
 class rpc_handler_interface;
 
-class rpc_server : public std::enable_shared_from_this<rpc_server>
+/**
+ * Accepts HTTP connections for the RPC API and hands every request to a `rpc_handler_interface`.
+ *
+ * The accept loop is a task running on a strand owned by this object, so the acceptor is only
+ * touched from that strand while the loop runs. `stop` cancels and joins the loop before closing
+ * the acceptor; it is idempotent and may be called from any thread that is not running this
+ * server's `io_context`, since joining from such a thread could deadlock. Connections that were
+ * already accepted are not interrupted, they finish their request on their own.
+ */
+class rpc_server final
 {
 public:
-	rpc_server (std::shared_ptr<boost::asio::io_context>, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
-	virtual ~rpc_server ();
+	rpc_server (std::shared_ptr<boost::asio::io_context>, nano::rpc_config, nano::rpc_handler_interface &);
+	~rpc_server ();
 
 	void start ();
 	void stop ();
 
-	virtual void accept ();
+	// Port the acceptor is bound to, only meaningful after `start`
+	std::uint16_t listening_port () const;
 
-	std::uint16_t listening_port () const
-	{
-		return acceptor.local_endpoint ().port ();
-	}
+	nano::rpc_config const config;
 
-public:
+private:
+	asio::awaitable<void> run ();
+
 	nano::logger logger{ "rpc" };
-	nano::rpc_config config;
-	std::shared_ptr<boost::asio::io_context> io_ctx_shared;
-	boost::asio::io_context & io_ctx;
+	nano::rpc_handler_interface & handler;
+	std::shared_ptr<boost::asio::io_context> io_ctx;
+	nano::async::strand strand;
 	boost::asio::ip::tcp::acceptor acceptor;
-	nano::rpc_handler_interface & rpc_handler_interface;
-	bool stopped{ false };
+	nano::async::task task;
+	std::atomic<bool> stopped{ false };
+	std::uint16_t port{ 0 };
 };
-
-/** Returns the correct RPC implementation based on TLS configuration */
-std::shared_ptr<nano::rpc_server> get_rpc (std::shared_ptr<boost::asio::io_context>, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
 }

--- a/nano/rpc/rpc_server.hpp
+++ b/nano/rpc/rpc_server.hpp
@@ -1,25 +1,60 @@
 #pragma once
 
 #include <nano/lib/async.hpp>
+#include <nano/lib/locks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/rpcconfig.hpp>
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
+#include <list>
 #include <memory>
 
 namespace nano
 {
+class rpc_connection;
 class rpc_handler_interface;
+
+/**
+ * Tracks the connections a server has accepted and how many of them are serving a request,
+ * so that stopping the server can close the idle ones and wait for the rest to finish.
+ * Shared between the server and its connections, since connections may outlive the server.
+ */
+class rpc_connection_tracker final
+{
+public:
+	void add (std::shared_ptr<nano::rpc_connection> const &);
+	void request_begin ();
+	void request_end ();
+
+	std::size_t in_flight () const;
+	// Closes every connection that is not serving a request
+	void close_idle ();
+	// Closes every connection, including those still serving a request
+	void close_all ();
+	// Waits until no request is in flight, returns false if the timeout expires first
+	bool wait_drained (std::chrono::milliseconds timeout);
+
+private:
+	void purge ();
+
+	mutable nano::mutex mutex;
+	nano::condition_variable condition;
+	std::size_t in_flight_m{ 0 };
+	std::list<std::weak_ptr<nano::rpc_connection>> connections;
+};
 
 /**
  * Accepts HTTP connections for the RPC API and hands every request to a `rpc_handler_interface`.
  *
  * The accept loop is a task running on a strand owned by this object, so the acceptor is only
- * touched from that strand while the loop runs. `stop` cancels and joins the loop before closing
- * the acceptor; it is idempotent and may be called from any thread that is not running this
- * server's `io_context`, since joining from such a thread could deadlock. Connections that were
- * already accepted are not interrupted, they finish their request on their own.
+ * touched from that strand while the loop runs. `stop` cancels and joins the loop, closes the
+ * acceptor, closes the connections that are not serving a request and waits for the ones that
+ * are, so every response that was started is written before `stop` returns. Connections still
+ * serving a request when `drain_timeout` expires are closed. `stop` is idempotent and may be
+ * called from any thread that is not running this server's `io_context`, since joining from
+ * such a thread could deadlock.
  */
 class rpc_server final
 {
@@ -34,6 +69,8 @@ public:
 	std::uint16_t listening_port () const;
 
 	nano::rpc_config const config;
+	// How long `stop` waits for requests in flight before closing their connections
+	std::chrono::milliseconds drain_timeout{ std::chrono::seconds{ 5 } };
 
 private:
 	asio::awaitable<void> run ();
@@ -43,6 +80,7 @@ private:
 	std::shared_ptr<boost::asio::io_context> io_ctx;
 	nano::async::strand strand;
 	boost::asio::ip::tcp::acceptor acceptor;
+	std::shared_ptr<nano::rpc_connection_tracker> connections{ std::make_shared<nano::rpc_connection_tracker> () };
 	nano::async::task task;
 	std::atomic<bool> stopped{ false };
 	std::uint16_t port{ 0 };

--- a/nano/rpc_test/CMakeLists.txt
+++ b/nano/rpc_test/CMakeLists.txt
@@ -2,9 +2,7 @@ add_executable(
   rpc_test
   common.hpp
   rpc_context.hpp
-  test_response.hpp
   rpc_context.cpp
-  test_response.cpp
   common.cpp
   enable_control.cpp
   entry.cpp

--- a/nano/rpc_test/enable_control.cpp
+++ b/nano/rpc_test/enable_control.cpp
@@ -17,7 +17,7 @@ std::string const control_disabled_message{ "RPC control is disabled" };
 
 /*
  * Every action the RPC layer gates behind enable_control.
- * Kept in sync by hand with create_rpc_control_impls() in nano/rpc/rpc_handler.cpp; the tests below fail if the two drift apart.
+ * Kept in sync by hand with create_rpc_control_impls() in nano/rpc/rpc_dispatcher.cpp; the tests below fail if the two drift apart.
  */
 std::vector<std::string> const control_actions{
 	"account_create",

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -438,14 +438,14 @@ TEST (rpc, stop)
 {
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
-	std::atomic<bool> stop_requested{ false };
-	auto const rpc_ctx = add_rpc (system, node, { .stop_callback = [&stop_requested] () { stop_requested = true; } });
+	std::atomic<int> stop_requests{ 0 };
+	auto const rpc_ctx = add_rpc (system, node, { .stop_callback = [&stop_requests] () { ++stop_requests; } });
 	boost::property_tree::ptree request;
 	request.put ("action", "stop");
 	auto response (wait_response (system, rpc_ctx, request));
 	ASSERT_EQ ("", response.get<std::string> ("success"));
-	// The request is only reported to the owner, nothing is torn down by the handler chain
-	ASSERT_TIMELY (5s, stop_requested);
+	// The request is only reported to the owner, once by the node's IPC server and once by the RPC side, nothing is torn down by the handler chain
+	ASSERT_TIMELY_EQ (5s, stop_requests, 2);
 	ASSERT_FALSE (node->stopped);
 }
 
@@ -6848,7 +6848,7 @@ TEST (rpc, simultaneous_calls)
 	auto node = add_ipc_enabled_node (system);
 
 	nano::node_rpc_config node_rpc_config;
-	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
+	nano::ipc::ipc_server ipc_server (*node, node_rpc_config, [] () {});
 	nano::rpc_config rpc_config{ nano::dev::network_params.network, system.get_available_port (), true };
 	const auto ipc_tcp_port = ipc_server.listening_tcp_port ();
 	ASSERT_TRUE (ipc_tcp_port.has_value ());

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -34,8 +34,8 @@
 #include <nano/node/unchecked_map.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/node/wallet.hpp>
-#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
+#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
 #include <nano/rpc_test/test_response.hpp>
@@ -438,10 +438,15 @@ TEST (rpc, stop)
 {
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
-	auto const rpc_ctx = add_rpc (system, node);
+	std::atomic<bool> stop_requested{ false };
+	auto const rpc_ctx = add_rpc (system, node, { .stop_callback = [&stop_requested] () { stop_requested = true; } });
 	boost::property_tree::ptree request;
 	request.put ("action", "stop");
 	auto response (wait_response (system, rpc_ctx, request));
+	ASSERT_EQ ("", response.get<std::string> ("success"));
+	// The request is only reported to the owner, nothing is torn down by the handler chain
+	ASSERT_TIMELY (5s, stop_requested);
+	ASSERT_FALSE (node->stopped);
 }
 
 TEST (rpc, wallet_add)
@@ -6848,7 +6853,7 @@ TEST (rpc, simultaneous_calls)
 	const auto ipc_tcp_port = ipc_server.listening_tcp_port ();
 	ASSERT_TRUE (ipc_tcp_port.has_value ());
 	rpc_config.rpc_process.num_ipc_connections = 8;
-	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config, ipc_tcp_port.value ());
+	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config, ipc_tcp_port.value (), [] () {});
 	auto rpc = std::make_shared<nano::rpc_server> (system.io_ctx, rpc_config, ipc_rpc_processor);
 	nano::test::start_stop_guard stop_guard{ *rpc };
 

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -38,7 +38,6 @@
 #include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
-#include <nano/test_common/test_response.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_cemented.hpp>
@@ -51,6 +50,7 @@
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/telemetry.hpp>
+#include <nano/test_common/test_response.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
@@ -6840,22 +6840,12 @@ TEST (rpc, active_difficulty)
 }
 
 // This is mainly to check for threading issues with TSAN
-// TODO: Use multiple threads to run io context
 TEST (rpc, simultaneous_calls)
 {
 	// This tests simultaneous calls to the same node in different threads
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
-
-	nano::node_rpc_config node_rpc_config;
-	nano::ipc::ipc_server ipc_server (*node, node_rpc_config, [] () {});
-	nano::rpc_config rpc_config{ nano::dev::network_params.network, system.get_available_port (), true };
-	const auto ipc_tcp_port = ipc_server.listening_tcp_port ();
-	ASSERT_TRUE (ipc_tcp_port.has_value ());
-	rpc_config.rpc_process.num_ipc_connections = 8;
-	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config, ipc_tcp_port.value (), [] () {});
-	auto rpc = std::make_shared<nano::rpc_server> (system.io_ctx, rpc_config, ipc_rpc_processor);
-	nano::test::start_stop_guard stop_guard{ *rpc };
+	auto const rpc_ctx = add_rpc (system, node, { .num_ipc_connections = 8 });
 
 	boost::property_tree::ptree request;
 	request.put ("action", "account_block_count");
@@ -6873,7 +6863,7 @@ TEST (rpc, simultaneous_calls)
 	nano::test::join_guard threads;
 	for (int i = 0; i < num; ++i)
 	{
-		threads.spawn ([&test_responses, &promise, &count, i, port = rpc->listening_port ()] () {
+		threads.spawn ([&test_responses, &promise, &count, i, port = rpc_ctx.rpc->listening_port ()] () {
 			test_responses[i]->run (port);
 			if (--count == 0)
 			{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -38,7 +38,7 @@
 #include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
-#include <nano/rpc_test/test_response.hpp>
+#include <nano/test_common/test_response.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_cemented.hpp>

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -34,8 +34,8 @@
 #include <nano/node/unchecked_map.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/node/wallet.hpp>
+#include <nano/rpc/rpc_host.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
-#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
 #include <nano/secure/ledger.hpp>
@@ -442,11 +442,14 @@ TEST (rpc, stop)
 	auto const rpc_ctx = add_rpc (system, node, { .stop_callback = [&stop_requests] () { ++stop_requests; } });
 	boost::property_tree::ptree request;
 	request.put ("action", "stop");
-	auto response (wait_response (system, rpc_ctx, request));
-	ASSERT_EQ ("", response.get<std::string> ("success"));
-	// The request is only reported to the owner, once by the node's IPC server and once by the RPC side, nothing is torn down by the handler chain
+	auto response = test_response::send (request, rpc_ctx.host->listening_port (), *system.io_ctx);
+	// The request is only reported to the owner, once by the node's IPC server and once by the RPC side after the node acknowledged it; nothing is torn down by the handler chain
 	ASSERT_TIMELY_EQ (5s, stop_requests, 2);
 	ASSERT_FALSE (node->stopped);
+	// React the way `nano_rpc` does, stopping the host at once; the acknowledgement must still reach the client
+	rpc_ctx.host->stop ();
+	ASSERT_TIMELY_EQ (5s, response->status, 200);
+	ASSERT_EQ ("", response->json.get<std::string> ("success"));
 }
 
 TEST (rpc, wallet_add)
@@ -1944,7 +1947,7 @@ TEST (rpc, version)
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
 	request1.put ("action", "version");
-	auto response1 = test_response::send (request1, rpc_ctx.rpc->listening_port (), *system.io_ctx);
+	auto response1 = test_response::send (request1, rpc_ctx.host->listening_port (), *system.io_ctx);
 	ASSERT_TIMELY (5s, response1->status != 0);
 	ASSERT_EQ (200, response1->status);
 	ASSERT_EQ ("1", response1->json.get<std::string> ("rpc_version"));
@@ -2015,7 +2018,7 @@ TEST (rpc, work_generate_with_peers_defaults_distributed)
 	// Set up requesting node (node2) with local work generation disabled and work_peers pointing to node1's RPC
 	nano::node_config config2 = system.default_config ();
 	config2.work_threads = 0;
-	config2.work_peers.emplace_back ("::1", rpc_ctx_peer.rpc->listening_port ());
+	config2.work_peers.emplace_back ("::1", rpc_ctx_peer.host->listening_port ());
 	auto node2 = add_ipc_enabled_node (system, config2);
 	auto const rpc_ctx = add_rpc (system, node2);
 	ASSERT_FALSE (node2->local_work_generation_enabled ());
@@ -2340,7 +2343,7 @@ TEST (rpc, DISABLED_work_peer_one)
 	auto node1 = add_ipc_enabled_node (system);
 	auto & node2 = *system.add_node ();
 	auto const rpc_ctx = add_rpc (system, node1);
-	node2.config.work_peers.emplace_back (node1->network.endpoint ().address ().to_string (), rpc_ctx.rpc->listening_port ());
+	node2.config.work_peers.emplace_back (node1->network.endpoint ().address ().to_string (), rpc_ctx.host->listening_port ());
 	nano::keypair key1;
 	std::atomic<uint64_t> work (0);
 	node2.work_generate (nano::work_version::work_1, key1.pub, node1->network_params.work.base, [&work] (std::optional<uint64_t> work_a) {
@@ -2366,9 +2369,9 @@ TEST (rpc, DISABLED_work_peer_many)
 	const auto rpc_ctx_2 = add_rpc (system2, node2);
 	const auto rpc_ctx_3 = add_rpc (system3, node3);
 	const auto rpc_ctx_4 = add_rpc (system4, node4);
-	node1.config.work_peers.emplace_back (node2->network.endpoint ().address ().to_string (), rpc_ctx_2.rpc->listening_port ());
-	node1.config.work_peers.emplace_back (node3->network.endpoint ().address ().to_string (), rpc_ctx_3.rpc->listening_port ());
-	node1.config.work_peers.emplace_back (node4->network.endpoint ().address ().to_string (), rpc_ctx_4.rpc->listening_port ());
+	node1.config.work_peers.emplace_back (node2->network.endpoint ().address ().to_string (), rpc_ctx_2.host->listening_port ());
+	node1.config.work_peers.emplace_back (node3->network.endpoint ().address ().to_string (), rpc_ctx_3.host->listening_port ());
+	node1.config.work_peers.emplace_back (node4->network.endpoint ().address ().to_string (), rpc_ctx_4.host->listening_port ());
 
 	std::array<std::atomic<uint64_t>, 10> works{};
 	for (auto & work : works)
@@ -6863,7 +6866,7 @@ TEST (rpc, simultaneous_calls)
 	nano::test::join_guard threads;
 	for (int i = 0; i < num; ++i)
 	{
-		threads.spawn ([&test_responses, &promise, &count, i, port = rpc_ctx.rpc->listening_port ()] () {
+		threads.spawn ([&test_responses, &promise, &count, i, port = rpc_ctx.host->listening_port ()] () {
 			test_responses[i]->run (port);
 			if (--count == 0)
 			{

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -34,7 +34,7 @@
 #include <nano/node/unchecked_map.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/node/wallet.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
@@ -6849,7 +6849,7 @@ TEST (rpc, simultaneous_calls)
 	ASSERT_TRUE (ipc_tcp_port.has_value ());
 	rpc_config.rpc_process.num_ipc_connections = 8;
 	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config, ipc_tcp_port.value ());
-	auto rpc = std::make_shared<nano::rpc> (system.io_ctx, rpc_config, ipc_rpc_processor);
+	auto rpc = std::make_shared<nano::rpc_server> (system.io_ctx, rpc_config, ipc_rpc_processor);
 	nano::test::start_stop_guard stop_guard{ *rpc };
 
 	boost::property_tree::ptree request;

--- a/nano/rpc_test/rpc_context.cpp
+++ b/nano/rpc_test/rpc_context.cpp
@@ -1,23 +1,29 @@
+#include <nano/lib/thread_runner.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
 #include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
-#include <nano/test_common/test_response.hpp>
 #include <nano/test_common/system.hpp>
+#include <nano/test_common/test_response.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>
 
 #include <boost/property_tree/json_parser.hpp>
 
-nano::test::rpc_context::rpc_context (std::shared_ptr<nano::rpc_server> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a)
+nano::test::rpc_context::~rpc_context ()
 {
-	rpc = std::move (rpc_a);
-	ipc_server = std::move (ipc_server_a);
-	ipc_rpc_processor = std::move (ipc_rpc_processor_a);
-	node_rpc_config = std::move (node_rpc_config_a);
+	// Same order as the owners use: stop accepting, then drop whatever is still queued on the IO threads
+	if (rpc)
+	{
+		rpc->stop ();
+	}
+	if (runner)
+	{
+		runner->abort ();
+	}
 }
 
 void nano::test::wait_response_impl (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time, boost::property_tree::ptree & response_json)
@@ -68,18 +74,22 @@ bool nano::test::check_block_response_count (nano::test::system & system, rpc_co
 
 nano::test::rpc_context nano::test::add_rpc (nano::test::system & system, std::shared_ptr<nano::node> const & node_a, rpc_options const & options)
 {
-	auto node_rpc_config (std::make_unique<nano::node_rpc_config> ());
-	auto ipc_server (std::make_shared<nano::ipc::ipc_server> (*node_a, *node_rpc_config, options.stop_callback));
+	rpc_context ctx;
+	ctx.io_ctx = std::make_shared<boost::asio::io_context> ();
+	ctx.node_rpc_config = std::make_unique<nano::node_rpc_config> ();
+	ctx.ipc_server = std::make_shared<nano::ipc::ipc_server> (*node_a, *ctx.node_rpc_config, options.stop_callback);
+
 	nano::rpc_config rpc_config (node_a->network_params.network, system.get_available_port (), options.enable_control);
 	if (options.num_ipc_connections)
 	{
 		rpc_config.rpc_process.num_ipc_connections = *options.num_ipc_connections;
 	}
-	const auto ipc_tcp_port = ipc_server->listening_tcp_port ();
-	debug_assert (ipc_tcp_port.has_value ());
-	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (system.io_ctx, rpc_config, ipc_tcp_port.value (), options.stop_callback));
-	auto rpc (std::make_shared<nano::rpc_server> (system.io_ctx, rpc_config, *ipc_rpc_processor));
-	rpc->start ();
 
-	return rpc_context{ rpc, ipc_server, ipc_rpc_processor, node_rpc_config };
+	auto const ipc_tcp_port = ctx.ipc_server->listening_tcp_port ();
+	debug_assert (ipc_tcp_port.has_value ());
+	ctx.ipc_rpc_processor = std::make_unique<nano::ipc_rpc_processor> (ctx.io_ctx, rpc_config, ipc_tcp_port.value (), options.stop_callback);
+	ctx.rpc = std::make_shared<nano::rpc_server> (ctx.io_ctx, rpc_config, *ctx.ipc_rpc_processor);
+	ctx.runner = std::make_unique<nano::thread_runner> (ctx.io_ctx, system.logger, 2);
+	ctx.rpc->start ();
+	return ctx;
 }

--- a/nano/rpc_test/rpc_context.cpp
+++ b/nano/rpc_test/rpc_context.cpp
@@ -1,8 +1,7 @@
-#include <nano/lib/thread_runner.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
+#include <nano/rpc/rpc_host.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
-#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
 #include <nano/test_common/system.hpp>
@@ -15,20 +14,15 @@
 
 nano::test::rpc_context::~rpc_context ()
 {
-	// Same order as the owners use: stop accepting, then drop whatever is still queued on the IO threads
-	if (rpc)
+	if (host)
 	{
-		rpc->stop ();
-	}
-	if (runner)
-	{
-		runner->abort ();
+		host->stop ();
 	}
 }
 
 void nano::test::wait_response_impl (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time, boost::property_tree::ptree & response_json)
 {
-	auto response = test_response::send (request, rpc_ctx.rpc->listening_port (), *system.io_ctx);
+	auto response = test_response::send (request, rpc_ctx.host->listening_port (), *system.io_ctx);
 	ASSERT_TIMELY (time, response->status != 0);
 	ASSERT_EQ (200, response->status);
 	response_json = response->json;
@@ -48,7 +42,7 @@ void nano::test::wait_responses_impl (nano::test::system & system, rpc_context c
 	in_flight.reserve (requests.size ());
 	for (auto & request : requests)
 	{
-		in_flight.push_back (test_response::send (request, rpc_ctx.rpc->listening_port (), *system.io_ctx));
+		in_flight.push_back (test_response::send (request, rpc_ctx.host->listening_port (), *system.io_ctx));
 	}
 	ASSERT_TIMELY (time, std::all_of (in_flight.begin (), in_flight.end (), [] (auto const & response) { return response->status != 0; }));
 	for (auto const & response : in_flight)
@@ -75,11 +69,11 @@ bool nano::test::check_block_response_count (nano::test::system & system, rpc_co
 nano::test::rpc_context nano::test::add_rpc (nano::test::system & system, std::shared_ptr<nano::node> const & node_a, rpc_options const & options)
 {
 	rpc_context ctx;
-	ctx.io_ctx = std::make_shared<boost::asio::io_context> ();
 	ctx.node_rpc_config = std::make_unique<nano::node_rpc_config> ();
 	ctx.ipc_server = std::make_shared<nano::ipc::ipc_server> (*node_a, *ctx.node_rpc_config, options.stop_callback);
 
 	nano::rpc_config rpc_config (node_a->network_params.network, system.get_available_port (), options.enable_control);
+	rpc_config.rpc_process.io_threads = 2;
 	if (options.num_ipc_connections)
 	{
 		rpc_config.rpc_process.num_ipc_connections = *options.num_ipc_connections;
@@ -87,9 +81,7 @@ nano::test::rpc_context nano::test::add_rpc (nano::test::system & system, std::s
 
 	auto const ipc_tcp_port = ctx.ipc_server->listening_tcp_port ();
 	debug_assert (ipc_tcp_port.has_value ());
-	ctx.ipc_rpc_processor = std::make_unique<nano::ipc_rpc_processor> (ctx.io_ctx, rpc_config, ipc_tcp_port.value (), options.stop_callback);
-	ctx.rpc = std::make_shared<nano::rpc_server> (ctx.io_ctx, rpc_config, *ctx.ipc_rpc_processor);
-	ctx.runner = std::make_unique<nano::thread_runner> (ctx.io_ctx, system.logger, 2);
-	ctx.rpc->start ();
+	ctx.host = std::make_unique<nano::rpc_host> (rpc_config);
+	ctx.host->start (std::make_unique<nano::ipc_rpc_processor> (ctx.host->io_context (), rpc_config, ipc_tcp_port.value (), options.stop_callback));
 	return ctx;
 }

--- a/nano/rpc_test/rpc_context.cpp
+++ b/nano/rpc_test/rpc_context.cpp
@@ -69,7 +69,7 @@ bool nano::test::check_block_response_count (nano::test::system & system, rpc_co
 nano::test::rpc_context nano::test::add_rpc (nano::test::system & system, std::shared_ptr<nano::node> const & node_a, rpc_options const & options)
 {
 	auto node_rpc_config (std::make_unique<nano::node_rpc_config> ());
-	auto ipc_server (std::make_shared<nano::ipc::ipc_server> (*node_a, *node_rpc_config));
+	auto ipc_server (std::make_shared<nano::ipc::ipc_server> (*node_a, *node_rpc_config, options.stop_callback));
 	nano::rpc_config rpc_config (node_a->network_params.network, system.get_available_port (), options.enable_control);
 	if (options.num_ipc_connections)
 	{

--- a/nano/rpc_test/rpc_context.cpp
+++ b/nano/rpc_test/rpc_context.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/property_tree/json_parser.hpp>
 
-nano::test::rpc_context::rpc_context (std::shared_ptr<nano::rpc> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a)
+nano::test::rpc_context::rpc_context (std::shared_ptr<nano::rpc_server> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a)
 {
 	rpc = std::move (rpc_a);
 	ipc_server = std::move (ipc_server_a);
@@ -77,7 +77,7 @@ nano::test::rpc_context nano::test::add_rpc (nano::test::system & system, std::s
 	const auto ipc_tcp_port = ipc_server->listening_tcp_port ();
 	debug_assert (ipc_tcp_port.has_value ());
 	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (system.io_ctx, rpc_config, ipc_tcp_port.value ()));
-	auto rpc (std::make_shared<nano::rpc> (system.io_ctx, rpc_config, *ipc_rpc_processor));
+	auto rpc (std::make_shared<nano::rpc_server> (system.io_ctx, rpc_config, *ipc_rpc_processor));
 	rpc->start ();
 
 	return rpc_context{ rpc, ipc_server, ipc_rpc_processor, node_rpc_config };

--- a/nano/rpc_test/rpc_context.cpp
+++ b/nano/rpc_test/rpc_context.cpp
@@ -4,7 +4,7 @@
 #include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
-#include <nano/rpc_test/test_response.hpp>
+#include <nano/test_common/test_response.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 

--- a/nano/rpc_test/rpc_context.cpp
+++ b/nano/rpc_test/rpc_context.cpp
@@ -1,6 +1,7 @@
 #include <nano/lib/threading.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
+#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
 #include <nano/rpc_test/test_response.hpp>
@@ -76,7 +77,7 @@ nano::test::rpc_context nano::test::add_rpc (nano::test::system & system, std::s
 	}
 	const auto ipc_tcp_port = ipc_server->listening_tcp_port ();
 	debug_assert (ipc_tcp_port.has_value ());
-	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (system.io_ctx, rpc_config, ipc_tcp_port.value ()));
+	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (system.io_ctx, rpc_config, ipc_tcp_port.value (), options.stop_callback));
 	auto rpc (std::make_shared<nano::rpc_server> (system.io_ctx, rpc_config, *ipc_rpc_processor));
 	rpc->start ();
 

--- a/nano/rpc_test/rpc_context.hpp
+++ b/nano/rpc_test/rpc_context.hpp
@@ -52,7 +52,7 @@ namespace test
 		bool enable_control{ true };
 		// Overrides the RPC → IPC connection count; the dev network default of 1 processes requests one at a time
 		std::optional<unsigned> num_ipc_connections{};
-		// Invoked when the node acknowledges a `stop` request, the harness never stops anything on its own
+		// Invoked when a `stop` request reaches the node over IPC and again when the RPC side sees the acknowledgement, the harness never stops anything on its own
 		std::function<void ()> stop_callback{ [] () {} };
 	};
 

--- a/nano/rpc_test/rpc_context.hpp
+++ b/nano/rpc_test/rpc_context.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <boost/asio/io_context.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include <functional>
@@ -10,13 +9,11 @@
 
 namespace nano
 {
-class ipc_rpc_processor;
 class node;
 class node_rpc_config;
 class public_key;
 class account;
-class rpc_server;
-class thread_runner;
+class rpc_host;
 
 namespace ipc
 {
@@ -28,9 +25,9 @@ namespace test
 	class system;
 
 	/**
-	 * An RPC server wired to a node over IPC, as the standalone `nano_rpc` process is.
-	 * The server and its IPC client run on dedicated IO threads like in production; only the
-	 * test client side is driven by the polled `system` io_context.
+	 * An RPC host wired to a node over IPC, built the same way the standalone `nano_rpc` process
+	 * builds it, so the tests run the production composition. Only the test client side is driven
+	 * by the polled `system` io_context.
 	 */
 	class rpc_context
 	{
@@ -39,13 +36,9 @@ namespace test
 		rpc_context (rpc_context &&) = default;
 		~rpc_context ();
 
-		std::shared_ptr<boost::asio::io_context> io_ctx;
 		std::unique_ptr<nano::node_rpc_config> node_rpc_config;
 		std::shared_ptr<nano::ipc::ipc_server> ipc_server;
-		std::unique_ptr<nano::ipc_rpc_processor> ipc_rpc_processor;
-		std::shared_ptr<nano::rpc_server> rpc;
-		// Declared last so its threads are joined before the objects they may still be using are destroyed
-		std::unique_ptr<nano::thread_runner> runner;
+		std::unique_ptr<nano::rpc_host> host;
 	};
 
 	void wait_response_impl (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time, boost::property_tree::ptree & response_json);

--- a/nano/rpc_test/rpc_context.hpp
+++ b/nano/rpc_test/rpc_context.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <boost/asio/io_context.hpp>
 #include <boost/property_tree/ptree.hpp>
 
 #include <functional>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -14,6 +16,7 @@ class node_rpc_config;
 class public_key;
 class account;
 class rpc_server;
+class thread_runner;
 
 namespace ipc
 {
@@ -23,15 +26,26 @@ namespace ipc
 namespace test
 {
 	class system;
+
+	/**
+	 * An RPC server wired to a node over IPC, as the standalone `nano_rpc` process is.
+	 * The server and its IPC client run on dedicated IO threads like in production; only the
+	 * test client side is driven by the polled `system` io_context.
+	 */
 	class rpc_context
 	{
 	public:
-		rpc_context (std::shared_ptr<nano::rpc_server> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a);
+		rpc_context () = default;
+		rpc_context (rpc_context &&) = default;
+		~rpc_context ();
 
-		std::shared_ptr<nano::rpc_server> rpc;
+		std::shared_ptr<boost::asio::io_context> io_ctx;
+		std::unique_ptr<nano::node_rpc_config> node_rpc_config;
 		std::shared_ptr<nano::ipc::ipc_server> ipc_server;
 		std::unique_ptr<nano::ipc_rpc_processor> ipc_rpc_processor;
-		std::unique_ptr<nano::node_rpc_config> node_rpc_config;
+		std::shared_ptr<nano::rpc_server> rpc;
+		// Declared last so its threads are joined before the objects they may still be using are destroyed
+		std::unique_ptr<nano::thread_runner> runner;
 	};
 
 	void wait_response_impl (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time, boost::property_tree::ptree & response_json);

--- a/nano/rpc_test/rpc_context.hpp
+++ b/nano/rpc_test/rpc_context.hpp
@@ -2,6 +2,7 @@
 
 #include <boost/property_tree/ptree.hpp>
 
+#include <functional>
 #include <optional>
 #include <vector>
 
@@ -51,6 +52,8 @@ namespace test
 		bool enable_control{ true };
 		// Overrides the RPC → IPC connection count; the dev network default of 1 processes requests one at a time
 		std::optional<unsigned> num_ipc_connections{};
+		// Invoked when the node acknowledges a `stop` request, the harness never stops anything on its own
+		std::function<void ()> stop_callback{ [] () {} };
 	};
 
 	rpc_context add_rpc (nano::test::system &, std::shared_ptr<nano::node> const &, rpc_options const & options = {});

--- a/nano/rpc_test/rpc_context.hpp
+++ b/nano/rpc_test/rpc_context.hpp
@@ -12,7 +12,7 @@ class node;
 class node_rpc_config;
 class public_key;
 class account;
-class rpc;
+class rpc_server;
 
 namespace ipc
 {
@@ -25,9 +25,9 @@ namespace test
 	class rpc_context
 	{
 	public:
-		rpc_context (std::shared_ptr<nano::rpc> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a);
+		rpc_context (std::shared_ptr<nano::rpc_server> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a);
 
-		std::shared_ptr<nano::rpc> rpc;
+		std::shared_ptr<nano::rpc_server> rpc;
 		std::shared_ptr<nano::ipc::ipc_server> ipc_server;
 		std::unique_ptr<nano::ipc_rpc_processor> ipc_rpc_processor;
 		std::unique_ptr<nano::node_rpc_config> node_rpc_config;

--- a/nano/slow_test/bootstrap.cpp
+++ b/nano/slow_test/bootstrap.cpp
@@ -13,7 +13,7 @@
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/transport/transport.hpp>
 #include <nano/node/unchecked_map.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/network.hpp>
@@ -57,7 +57,7 @@ public:
 	nano::rpc_config rpc_config;
 	nano::ipc::ipc_server ipc;
 	nano::ipc_rpc_processor ipc_rpc_processor;
-	nano::rpc rpc;
+	nano::rpc_server rpc;
 };
 
 std::unique_ptr<rpc_wrapper> start_rpc (nano::test::system & system, nano::node & node, uint16_t port)

--- a/nano/slow_test/bootstrap.cpp
+++ b/nano/slow_test/bootstrap.cpp
@@ -13,8 +13,8 @@
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/transport/transport.hpp>
 #include <nano/node/unchecked_map.hpp>
+#include <nano/rpc/rpc_host.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
-#include <nano/rpc/rpc_server.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/rate_observer.hpp>
@@ -42,22 +42,20 @@ public:
 		node_rpc_config{},
 		rpc_config{ node.network_params.network, port, true },
 		ipc{ node, node_rpc_config, [] () {} },
-		ipc_rpc_processor{ system.io_ctx, rpc_config, [] () {} },
-		rpc{ system.io_ctx, rpc_config, ipc_rpc_processor }
+		rpc{ rpc_config }
 	{
 	}
 
 	void start ()
 	{
-		rpc.start ();
+		rpc.start (std::make_unique<nano::ipc_rpc_processor> (rpc.io_context (), rpc_config, [] () {}));
 	}
 
 public:
 	nano::node_rpc_config node_rpc_config;
 	nano::rpc_config rpc_config;
 	nano::ipc::ipc_server ipc;
-	nano::ipc_rpc_processor ipc_rpc_processor;
-	nano::rpc_server rpc;
+	nano::rpc_host rpc;
 };
 
 std::unique_ptr<rpc_wrapper> start_rpc (nano::test::system & system, nano::node & node, uint16_t port)

--- a/nano/slow_test/bootstrap.cpp
+++ b/nano/slow_test/bootstrap.cpp
@@ -41,7 +41,7 @@ public:
 	rpc_wrapper (nano::test::system & system, nano::node & node, uint16_t port) :
 		node_rpc_config{},
 		rpc_config{ node.network_params.network, port, true },
-		ipc{ node, node_rpc_config },
+		ipc{ node, node_rpc_config, [] () {} },
 		ipc_rpc_processor{ system.io_ctx, rpc_config, [] () {} },
 		rpc{ system.io_ctx, rpc_config, ipc_rpc_processor }
 	{

--- a/nano/slow_test/bootstrap.cpp
+++ b/nano/slow_test/bootstrap.cpp
@@ -13,8 +13,8 @@
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/transport/transport.hpp>
 #include <nano/node/unchecked_map.hpp>
-#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
+#include <nano/rpc/rpc_server.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/rate_observer.hpp>
@@ -42,7 +42,7 @@ public:
 		node_rpc_config{},
 		rpc_config{ node.network_params.network, port, true },
 		ipc{ node, node_rpc_config },
-		ipc_rpc_processor{ system.io_ctx, rpc_config },
+		ipc_rpc_processor{ system.io_ctx, rpc_config, [] () {} },
 		rpc{ system.io_ctx, rpc_config, ipc_rpc_processor }
 	{
 	}

--- a/nano/test_common/CMakeLists.txt
+++ b/nano/test_common/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(
   system.cpp
   telemetry.hpp
   telemetry.cpp
+  test_response.hpp
+  test_response.cpp
   testutil.hpp
   testutil.cpp)
 

--- a/nano/test_common/test_response.cpp
+++ b/nano/test_common/test_response.cpp
@@ -1,12 +1,8 @@
-#include <nano/node/ipc/ipc_server.hpp>
-#include <nano/rpc/rpc_request_processor.hpp>
-#include <nano/rpc_test/test_response.hpp>
-#include <nano/test_common/system.hpp>
-#include <nano/test_common/testutil.hpp>
-
-#include <gtest/gtest.h>
+#include <nano/test_common/test_response.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
+
+#include <sstream>
 
 std::shared_ptr<nano::test::test_response> nano::test::test_response::prepare (boost::property_tree::ptree const & request, boost::asio::io_context & io_ctx)
 {
@@ -28,7 +24,7 @@ nano::test::test_response::test_response (private_tag, boost::property_tree::ptr
 
 void nano::test::test_response::run (uint16_t port)
 {
-	sock.async_connect (nano::tcp_endpoint (boost::asio::ip::address_v6::loopback (), port), [this, /* lifetime guard */ this_s = shared_from_this ()] (boost::system::error_code const & ec) {
+	sock.async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), port), [this, /* lifetime guard */ this_s = shared_from_this ()] (boost::system::error_code const & ec) {
 		if (!ec)
 		{
 			std::stringstream ostream;

--- a/nano/test_common/test_response.hpp
+++ b/nano/test_common/test_response.hpp
@@ -12,7 +12,8 @@
 namespace nano::test
 {
 /**
- * Performs a single HTTP request against an RPC server and captures the response.
+ * Performs a single HTTP POST of a JSON document against a local port and captures the JSON response.
+ * It knows nothing about the RPC API, so it serves both the `rpc_server` unit tests and the RPC API tests.
  *
  * The in-flight async operations hold a reference to this object, so it stays alive until the
  * request either completes or the io_context is destroyed. Callers are free to drop their handle

--- a/nano/test_common/testutil.hpp
+++ b/nano/test_common/testutil.hpp
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <type_traits>
 
 #define GTEST_TEST_ERROR_CODE(expression, text, actual, expected, fail)                       \
 	GTEST_AMBIGUOUS_ELSE_BLOCKER_                                                             \
@@ -145,8 +146,28 @@ private:
 	std::tuple<Ts &...> refs;
 };
 
+/** Lets a worker spawned by `join_guard` see that its guard is winding down */
+class stop_token
+{
+public:
+	explicit stop_token (std::atomic<bool> const & requested_a) :
+		requested{ requested_a }
+	{
+	}
+
+	bool stop_requested () const
+	{
+		return requested;
+	}
+
+private:
+	std::atomic<bool> const & requested;
+};
+
 /**
- * Owns a set of worker threads and joins them all on destruction
+ * Owns a set of worker threads and joins them all on destruction, the way `std::jthread` does.
+ * A worker that takes a `stop_token` is asked to stop before the join, so a looping worker winds
+ * down even when a test returns early from a failed assertion.
  * Declare it after everything the threads reference, so they are joined before those objects go out of scope
  */
 class join_guard
@@ -158,6 +179,7 @@ public:
 
 	~join_guard ()
 	{
+		request_stop ();
 		for (auto & thread : threads)
 		{
 			if (thread.joinable ())
@@ -170,10 +192,25 @@ public:
 	template <class T>
 	void spawn (T && func)
 	{
-		threads.emplace_back (std::forward<T> (func));
+		if constexpr (std::is_invocable_v<T, stop_token const &>)
+		{
+			threads.emplace_back ([func = std::forward<T> (func), token = stop_token{ stop }] () mutable {
+				func (token);
+			});
+		}
+		else
+		{
+			threads.emplace_back (std::forward<T> (func));
+		}
+	}
+
+	void request_stop ()
+	{
+		stop = true;
 	}
 
 private:
+	std::atomic<bool> stop{ false };
 	std::deque<std::thread> threads;
 };
 

--- a/systest/rpc_stop.sh
+++ b/systest/rpc_stop.sh
@@ -35,8 +35,13 @@ done
 RPC_PORT=$(jq -r '.rpc_port' "$RUNTIME_INFO")
 [ "$RPC_PORT" != "0" ] && [ -n "$RPC_PORT" ] && [ "$RPC_PORT" != "null" ] || { echo "FAIL: invalid rpc_port"; exit 1; }
 
-# Send the stop rpc command
-curl -g -d '{ "action": "stop" }' "[::1]:$RPC_PORT"
+# Send the stop rpc command, the node must acknowledge it before shutting down
+RESPONSE=$(curl -g -s -d '{ "action": "stop" }' "[::1]:$RPC_PORT")
+echo "$RESPONSE"
+if ! echo "$RESPONSE" | grep -q '"success"'; then
+    echo "FAIL: stop request was not acknowledged"
+    exit 1
+fi
 
 # Check if the process has stopped using a timeout to avoid infinite waiting
 if wait $NODE_PID; then

--- a/systest/rpc_stop_child_process.sh
+++ b/systest/rpc_stop_child_process.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -eux
+
+# Test that a stop request sent to the nano_rpc child process is acknowledged, stops the node,
+# and lets the child exit on its own rather than being terminated by the node
+
+source "$(dirname "$0")/lib/common.sh"
+
+if [ -z "${NANO_RPC_EXE-}" ] || [ ! -x "$NANO_RPC_EXE" ]; then
+    echo "SKIP: NANO_RPC_EXE is not set or not executable"
+    exit 0
+fi
+NANO_RPC_EXE="$(cd "$(dirname "$NANO_RPC_EXE")" && pwd)/$(basename "$NANO_RPC_EXE")"
+
+DATADIR=$(new_datadir)
+RUNTIME_INFO="$DATADIR/runtime_info.json"
+
+# The child reads its ports from the RPC config file, so they cannot be ephemeral
+RPC_PORT=$((20000 + RANDOM % 20000))
+IPC_PORT=$((40000 + RANDOM % 20000))
+cat > "$DATADIR/config-rpc.toml" <<EOF
+enable_control = true
+port = $RPC_PORT
+[process]
+ipc_port = $IPC_PORT
+EOF
+
+$NANO_NODE_EXE --daemon --network dev --data_path "$DATADIR" \
+    --enable_rpc \
+    --runtime_info_file "$RUNTIME_INFO" \
+    --config rpc.child_process.enable=true \
+    --config "rpc.child_process.rpc_path=$NANO_RPC_EXE" \
+    --config node.ipc.tcp.enable=true \
+    --config node.ipc.tcp.port=$IPC_PORT \
+    --config node.peering_port=0 &
+NODE_PID=$!
+register_pid $NODE_PID
+
+wait_for_file "$RUNTIME_INFO" $NODE_PID
+
+# Wait for the child to serve requests
+RESPONSE=""
+for i in {1..60}; do
+    RESPONSE=$(curl -g -s -m 2 -d '{ "action": "version" }' "[::1]:$RPC_PORT" || true)
+    [ -n "$RESPONSE" ] && break
+    sleep 0.5
+done
+if [ -z "$RESPONSE" ]; then
+    echo "FAIL: RPC child process did not start serving requests"
+    exit 1
+fi
+
+RESPONSE=$(curl -g -s -m 5 -d '{ "action": "stop" }' "[::1]:$RPC_PORT")
+echo "$RESPONSE"
+if ! echo "$RESPONSE" | grep -q '"success"'; then
+    echo "FAIL: stop request was not acknowledged"
+    exit 1
+fi
+
+if wait $NODE_PID; then
+    echo "Node stopped successfully"
+else
+    echo "FAIL: node did not stop cleanly"
+    exit 1
+fi
+
+if grep -q "did not exit on its own" "$DATADIR"/log/log_*.log; then
+    echo "FAIL: the RPC child process had to be terminated"
+    exit 1
+fi
+echo "RPC child process exited on its own"


### PR DESCRIPTION
## Problem

The macOS `[rocksdb]` job on #5166 ([run 34399011818](https://github.com/nanocurrency/nano-node/actions/runs/34399011818/job/102625904679)) failed in `rpc_stop.sh`: `nano_node` segfaulted while shutting down after a `stop` RPC. The core dump shows the main thread inside `acceptor.close()` in `nano::rpc::stop` reading a reactor pointer that another thread had just cleared:

```
frame #0: boost::asio::detail::kqueue_reactor::deregister_descriptor(...) at kqueue_reactor.ipp:343
frame #3: nano::rpc::stop at rpc.cpp:84
frame #4: nano::daemon::run at daemon.cpp:222
```

The acceptor was being closed twice, concurrently. The in-process handler's `stop` lambda first fired the daemon's callback (which wakes the main thread, which closes the acceptor) and then called `rpc->stop()` itself on the IO thread. Tracing the `stop` action through every deployment mode showed each one had its own partial notion of shutdown:

| Mode | What `stop` actually did |
|---|---|
| In-process daemon | Acceptor closed twice from two threads (this crash) |
| Wallet | Only the RPC acceptor closed; node and GUI kept running |
| Child process | Node stopped only its IPC transports on a detached thread; `nano_rpc` closed its listener but never exited |

`rpc_handler_interface` carried `stop` and `rpc_instance` hooks whose only purpose was to let handlers close the listener serving them, the IPC session stopped the IPC server via a detached sleep-then-stop thread, and every owner composed listener, backend and IO threads by hand with its own stop order, which the test harness then copied by hand.

## Change

Two things that were conflated are split: a request to shut down is a signal to the owner; actually stopping components is the owner's job, done once, in order, from the main thread. Handlers never stop themselves or their siblings from an IO thread, and a stop request is only reported once its acknowledgement has been written. The composition every owner needs lives in one class. One commit per step:

1. Rename `nano::rpc` to `nano::rpc_server` (mechanical).
2. Strip `stop`/`rpc_instance` from `rpc_handler_interface`. A `stop` request only reaches an owner-supplied callback: the in-process handler forwards it, the standalone processor invokes it once the node acknowledges, the wallet quits its application, `nano_rpc` wakes its main thread.
3. Same for IPC: `ipc_server` takes the owner's callback, sessions only report the request, the detached thread and the never-assigned `signal_set` are gone.
4. Move the HTTP test client to `test_common`.
5. Rewrite `rpc_server` in the `tcp_listener` shape: the accept loop is a `nano::async::task` on a strand, `stop` is idempotent, cancels and joins the loop before closing the acceptor, and asserts it is not called from the server's own `io_context`. Leftovers of the removed TLS variant go away.
6. `core_test/rpc_server.cpp`: API-agnostic lifecycle tests with fake backends, including stop during a connect storm and concurrent stops, the crash scenario, for the sanitizer jobs. `nano::test::join_guard` gains `std::jthread` semantics for looping workers.
7. Same shutdown order in daemon and wallet; `nano::rpc_process` spawns and stops the `nano_rpc` child for both (grace period, then terminate).
8. Rename `rpc_handler` to `rpc_dispatcher`: it parses the envelope and dispatches to a backend, it is not a handler.
9. `rpc_server::stop` drains: idle connections are closed, responses in flight are written before `stop` returns, bounded by `drain_timeout`. Addresses the review comment on `rpc_request_processor`.
10. The IPC session reports a `stop` only from the write completion of its acknowledgement. Addresses the review comment on `ipc_server`.
11. Introduce `rpc_host`: owns listener, backend and IO threads, `start`/`stop` encode the one order. `nano_rpc` runs on it; core tests cover it, including a response in flight when the owner stops.
12. Daemon and wallet run their RPC on `rpc_host`, on the host's own IO threads sized by the existing `[process] io_threads` setting.
13. The RPC test harness runs on `rpc_host` exactly as `nano_rpc` does, so nothing is copied by hand; the `stop` test reacts like `nano_rpc` and checks the acknowledgement still arrives.
14. `rpc_stop.sh` checks the acknowledgement; new `rpc_stop_child_process.sh` covers out-of-process mode, which had no automated test.

## Verification

- Full `rpc_test` on both backends and full `core_test` pass locally; every commit builds on its own.
- Core `rpc_server`, `rpc_host` and `ipc` tests pass repeatedly under ASAN and TSAN with no reports in RPC code (TSAN reports in node-backed IPC tests are LMDB internals).
- `rpc_stop.sh` and `rpc_stop_child_process.sh` pass repeatedly; the child exits on its own after relaying a stop, and is terminated after the grace period when the daemon is signalled.

Not verified locally: `nano_wallet/entry.cpp` (no Qt available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
