### PR TITLE
Raise sub-5s test waits that depend on background threads

### DIFF
--- a/nano/core_test/active_elections.cpp
+++ b/nano/core_test/active_elections.cpp
@@ -229,7 +229,7 @@ TEST (active_elections, confirm_fork)
 	ASSERT_EQ (fork2->hash (), election->winner ()->hash ());
 
 	// Ledger view: fork2 cemented, fork1 not
-	ASSERT_TIMELY (3s, node.block_confirmed (fork2->hash ()));
+	ASSERT_TIMELY (5s, node.block_confirmed (fork2->hash ()));
 	ASSERT_FALSE (node.block_confirmed (fork1->hash ()));
 }
 
@@ -272,7 +272,7 @@ TEST (active_elections, confirm_fork_cache)
 	ASSERT_TIMELY (5s, election->confirmed ());
 	ASSERT_EQ (fork1->hash (), election->winner ()->hash ());
 
-	ASSERT_TIMELY (3s, node.block_confirmed (fork1->hash ()));
+	ASSERT_TIMELY (5s, node.block_confirmed (fork1->hash ()));
 }
 
 // TODO: Adjust for new behaviour of bounded buckets
@@ -869,7 +869,7 @@ TEST (active_elections, republish_winner)
 
 	node1.process_active (send1);
 	ASSERT_TIMELY (5s, nano::test::exists (node1, { send1 }));
-	ASSERT_TIMELY_EQ (3s, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in), 1);
+	ASSERT_TIMELY_EQ (5s, node2.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in), 1);
 
 	// Several forks
 	for (auto i (0); i < 5; i++)
@@ -1066,7 +1066,7 @@ TEST (active_elections, fork_replacement_tally)
 		node1.process_active (fork);
 
 		// Assert election exists and is the same for each fork
-		ASSERT_TIMELY (1s, election = node1.active.election (fork->qualified_root ()));
+		ASSERT_TIMELY (5s, election = node1.active.election (fork->qualified_root ()));
 	}
 
 	// Check overflow of blocks
@@ -1118,7 +1118,7 @@ TEST (active_elections, fork_replacement_tally)
 	auto & node2 (*system.add_node (node_config));
 	node1.network.filter.clear ();
 	ASSERT_TRUE (node2.network.flood_block (send_last, nano::transport::traffic_type::test));
-	ASSERT_TIMELY (3s, node1.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) > 0);
+	ASSERT_TIMELY (5s, node1.stats.count (nano::stat::type::message, nano::stat::detail::publish, nano::stat::dir::in) > 0);
 
 	// Correct block without votes is ignored
 	std::unordered_map<nano::block_hash, std::shared_ptr<nano::block>> blocks1;
@@ -1235,7 +1235,7 @@ TEST (active_elections, conflicting_block_vote_existing_election)
 	// Election must be confirmed
 	auto election (node.active.election (fork->qualified_root ()));
 	ASSERT_NE (nullptr, election);
-	ASSERT_TIMELY (3s, election->confirmed ());
+	ASSERT_TIMELY (5s, election->confirmed ());
 }
 
 // This tests the node's internal block activation logic
@@ -1304,17 +1304,17 @@ TEST (active_elections, activate_account_chain)
 	ASSERT_EQ (1, node.active.size ());
 	ASSERT_EQ (1, election1->blocks ().count (send->hash ()));
 	election1->force_confirm (); // Force confirm to trigger successor activation
-	ASSERT_TIMELY (3s, node.block_confirmed (send->hash ()));
+	ASSERT_TIMELY (5s, node.block_confirmed (send->hash ()));
 	// On cementing, the next election is started
-	ASSERT_TIMELY (3s, node.active.active (send2->qualified_root ()));
+	ASSERT_TIMELY (5s, node.active.active (send2->qualified_root ()));
 	auto election3 = node.active.election (send2->qualified_root ());
 	ASSERT_NE (nullptr, election3);
 	ASSERT_EQ (1, election3->blocks ().count (send2->hash ()));
 	election3->force_confirm (); // Force confirm to trigger successor and destination activation
-	ASSERT_TIMELY (3s, node.block_confirmed (send2->hash ()));
+	ASSERT_TIMELY (5s, node.block_confirmed (send2->hash ()));
 	// On cementing, the next election is started
-	ASSERT_TIMELY (3s, node.active.active (open->qualified_root ())); // Destination account activated
-	ASSERT_TIMELY (3s, node.active.active (send3->qualified_root ())); // Block successor activated
+	ASSERT_TIMELY (5s, node.active.active (open->qualified_root ())); // Destination account activated
+	ASSERT_TIMELY (5s, node.active.active (send3->qualified_root ())); // Block successor activated
 	auto election4 = node.active.election (send3->qualified_root ());
 	ASSERT_NE (nullptr, election4);
 	ASSERT_EQ (1, election4->blocks ().count (send3->hash ()));
@@ -1322,13 +1322,13 @@ TEST (active_elections, activate_account_chain)
 	ASSERT_NE (nullptr, election5);
 	ASSERT_EQ (1, election5->blocks ().count (open->hash ()));
 	election5->force_confirm ();
-	ASSERT_TIMELY (3s, node.block_confirmed (open->hash ()));
+	ASSERT_TIMELY (5s, node.block_confirmed (open->hash ()));
 	// Until send3 is also confirmed, the receive block should not activate
 	std::this_thread::sleep_for (200ms);
 	ASSERT_FALSE (node.active.active (receive->qualified_root ()));
 	election4->force_confirm ();
-	ASSERT_TIMELY (3s, node.block_confirmed (send3->hash ()));
-	ASSERT_TIMELY (3s, node.active.active (receive->qualified_root ())); // Destination account activated
+	ASSERT_TIMELY (5s, node.block_confirmed (send3->hash ()));
+	ASSERT_TIMELY (5s, node.active.active (receive->qualified_root ())); // Destination account activated
 }
 
 TEST (active_elections, activate_inactive)
@@ -1468,12 +1468,12 @@ TEST (active_elections, vacancy)
 	ASSERT_EQ (1, node.active.vacancy (nano::election_behavior::priority));
 	ASSERT_EQ (0, node.active.size ());
 	auto election1 = nano::test::start_election (system, node, send->hash ());
-	ASSERT_TIMELY (1s, updated);
+	ASSERT_TIMELY (5s, updated);
 	updated = false;
 	ASSERT_EQ (0, node.active.vacancy (nano::election_behavior::priority));
 	ASSERT_EQ (1, node.active.size ());
 	election1->force_confirm ();
-	ASSERT_TIMELY (1s, updated);
+	ASSERT_TIMELY (5s, updated);
 	ASSERT_EQ (1, node.active.vacancy (nano::election_behavior::priority));
 	ASSERT_EQ (0, node.active.size ());
 }

--- a/nano/core_test/confirmation_solicitor.cpp
+++ b/nano/core_test/confirmation_solicitor.cpp
@@ -59,7 +59,7 @@ TEST (confirmation_solicitor, batches)
 	ASSERT_EQ (1, representatives.size ());
 	ASSERT_EQ (channel1, representatives.front ().channel);
 	ASSERT_EQ (nano::dev::genesis_key.pub, representatives.front ().account);
-	ASSERT_TIMELY_EQ (3s, node2.network.size (), 1);
+	ASSERT_TIMELY_EQ (5s, node2.network.size (), 1);
 	auto send = test_block (system);
 	for (size_t i (0); i < nano::network::confirm_req_hashes_max; ++i)
 	{
@@ -96,7 +96,7 @@ TEST (confirmation_solicitor, different_hash)
 	ASSERT_EQ (1, representatives.size ());
 	ASSERT_EQ (channel1, representatives.front ().channel);
 	ASSERT_EQ (nano::dev::genesis_key.pub, representatives.front ().account);
-	ASSERT_TIMELY_EQ (3s, node2.network.size (), 1);
+	ASSERT_TIMELY_EQ (5s, node2.network.size (), 1);
 	auto send = test_block (system);
 	// The representative voted for something else, not the winner
 	std::unordered_map<nano::account, nano::vote_info> votes;
@@ -132,7 +132,7 @@ TEST (confirmation_solicitor, bypass_max_requests_cap)
 	}
 	ASSERT_EQ (max_representatives + 1, representatives.size ());
 	solicitor.prepare (representatives);
-	ASSERT_TIMELY_EQ (3s, node2.network.size (), 1);
+	ASSERT_TIMELY_EQ (5s, node2.network.size (), 1);
 	auto send = test_block (system);
 	// Every representative voted for something else, not the winner
 	std::unordered_map<nano::account, nano::vote_info> votes;

--- a/nano/core_test/election_scheduler.cpp
+++ b/nano/core_test/election_scheduler.cpp
@@ -184,7 +184,7 @@ TEST (election_scheduler, transition_optimistic_to_priority)
 	ASSERT_TIMELY (5s, node.vote_router.active (block->hash ()));
 	auto election = node.active.election (block->qualified_root ());
 	ASSERT_EQ (election->behavior (), nano::election_behavior::optimistic);
-	ASSERT_TIMELY_EQ (1s, 1, election->get_extended_status ().status.vote_broadcast_count);
+	ASSERT_TIMELY_EQ (5s, 1, election->get_extended_status ().status.vote_broadcast_count);
 
 	// Confirm first block to allow upgrading second block's election
 	nano::test::confirm (node.ledger, blocks.at (howmany_blocks - 1));
@@ -196,7 +196,7 @@ TEST (election_scheduler, transition_optimistic_to_priority)
 	ASSERT_EQ (election->behavior (), nano::election_behavior::priority);
 	ASSERT_EQ (1, node.stats.count (nano::stat::type::active_elections, nano::stat::detail::transition_priority));
 	// Verify vote broadcast after transitioning
-	ASSERT_TIMELY_EQ (1s, 2, election->get_extended_status ().status.vote_broadcast_count);
+	ASSERT_TIMELY_EQ (5s, 2, election->get_extended_status ().status.vote_broadcast_count);
 	ASSERT_TRUE (node.active.active (*block));
 }
 

--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -137,7 +137,7 @@ TEST (network, last_contacted)
 
 	auto channel1 = nano::test::establish_tcp (system, *node1, node0->network.endpoint ());
 	ASSERT_NE (nullptr, channel1);
-	ASSERT_TIMELY_EQ (3s, node0->network.size (), 1);
+	ASSERT_TIMELY_EQ (5s, node0->network.size (), 1);
 
 	// channel0 is the other side of channel1, same connection different endpoint
 	auto channel0 = node0->network.tcp_channels.find_node_id (node1->get_node_id ());
@@ -164,7 +164,7 @@ TEST (network, last_contacted)
 	node1->network.send_keepalive (channel1);
 	node1->network.send_keepalive (channel1);
 
-	ASSERT_TIMELY (3s, node0->stats.count (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in) >= keepalive_count + 3);
+	ASSERT_TIMELY (5s, node0->stats.count (nano::stat::type::message, nano::stat::detail::keepalive, nano::stat::dir::in) >= keepalive_count + 3);
 	ASSERT_EQ (node0->network.size (), 1);
 	auto timestamp_after_keepalive = channel0->get_last_packet_received ();
 	ASSERT_GT (timestamp_after_keepalive, timestamp_before_keepalive);
@@ -597,7 +597,7 @@ TEST (network, duplicate_detection)
 	tcp_channel->send (publish, nano::transport::traffic_type::test);
 	ASSERT_ALWAYS_EQ (100ms, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish_message), 0);
 	tcp_channel->send (publish, nano::transport::traffic_type::test);
-	ASSERT_TIMELY_EQ (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish_message), 1);
+	ASSERT_TIMELY_EQ (5s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_publish_message), 1);
 }
 
 TEST (network, duplicate_revert_publish)
@@ -646,7 +646,7 @@ TEST (network, duplicate_vote_detection)
 	tcp_channel->send (message, nano::transport::traffic_type::test);
 	ASSERT_ALWAYS_EQ (100ms, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_confirm_ack_message), 0);
 	tcp_channel->send (message, nano::transport::traffic_type::test);
-	ASSERT_TIMELY_EQ (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_confirm_ack_message), 1);
+	ASSERT_TIMELY_EQ (5s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_confirm_ack_message), 1);
 }
 
 // Ensures that the filter doesn't filter out votes that could not be queued for processing
@@ -706,7 +706,7 @@ TEST (network, expire_duplicate_filter)
 	tcp_channel->send (message, nano::transport::traffic_type::test);
 	ASSERT_ALWAYS_EQ (100ms, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_confirm_ack_message), 0);
 	tcp_channel->send (message, nano::transport::traffic_type::test);
-	ASSERT_TIMELY_EQ (2s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_confirm_ack_message), 1);
+	ASSERT_TIMELY_EQ (5s, node1.stats.count (nano::stat::type::filter, nano::stat::detail::duplicate_confirm_ack_message), 1);
 
 	// The filter should expire the vote after some time
 	ASSERT_TRUE (node1.network.filter.check (bytes.data (), bytes.size ()));

--- a/nano/core_test/node.cpp
+++ b/nano/core_test/node.cpp
@@ -568,7 +568,7 @@ TEST (node, fork_publish)
 	// Insert the genesis key so voting only begins once both forks are in the election
 	system.wallet (0)->insert_adhoc (nano::dev::genesis_key.prv);
 	// Wait until the genesis rep activated & makes vote
-	ASSERT_TIMELY_EQ (1s, election->votes ().size (), 1);
+	ASSERT_TIMELY_EQ (5s, election->votes ().size (), 1);
 	auto votes1 (election->votes ());
 	auto existing1 (votes1.find (nano::dev::genesis_key.pub));
 	ASSERT_NE (votes1.end (), existing1);
@@ -1484,7 +1484,7 @@ TEST (node, rep_self_vote)
 	ASSERT_NE (nullptr, election1);
 
 	// Wait until representatives are activated & make vote
-	ASSERT_TIMELY_EQ (1s, election1->votes ().size (), 2);
+	ASSERT_TIMELY_EQ (5s, election1->votes ().size (), 2);
 
 	// Election should receive votes from representatives hosted on the same node
 	auto rep_votes (election1->votes ());
@@ -2454,7 +2454,7 @@ TEST (node, fork_election_invalid_block_signature)
 	ASSERT_EQ (1, election->blocks ().size ());
 	node1.inbound (nano::messages::publish{ nano::dev::network_params.network, send3 }, channel1);
 	node1.inbound (nano::messages::publish{ nano::dev::network_params.network, send2 }, channel1);
-	ASSERT_TIMELY (3s, election->blocks ().size () > 1);
+	ASSERT_TIMELY (5s, election->blocks ().size () > 1);
 	ASSERT_EQ (election->blocks ()[send2->hash ()]->block_signature (), send2->block_signature ());
 }
 

--- a/nano/core_test/processing_queue.cpp
+++ b/nano/core_test/processing_queue.cpp
@@ -114,6 +114,6 @@ TEST (processing_queue, parallel)
 
 	// There are 16 threads and 16 items, each thread is waiting 1 second inside processing callback
 	// If processing is done in parallel it should take ~2 seconds to process every item, but keep some margin for slow machines
-	ASSERT_TIMELY_EQ (3s, processed, count);
+	ASSERT_TIMELY_EQ (5s, processed, count);
 	ASSERT_EQ (queue.size (), 0);
 }

--- a/nano/core_test/socket.cpp
+++ b/nano/core_test/socket.cpp
@@ -107,7 +107,7 @@ TEST (socket, disconnection_of_silent_connections)
 		ASSERT_FALSE (ec_a);
 		connected = true;
 	});
-	ASSERT_TIMELY (4s, connected);
+	ASSERT_TIMELY (5s, connected);
 
 	// Checking the connection was closed.
 	ASSERT_TIMELY (10s, server_data_socket_future.wait_for (0s) == std::future_status::ready);

--- a/nano/core_test/vote_generator.cpp
+++ b/nano/core_test/vote_generator.cpp
@@ -636,7 +636,7 @@ TEST (vote_generator_broadcaster, timer_trigger)
 
 	// Threshold is 100, so 2 entries won't trigger via threshold
 	// Timer with 250ms delay should trigger broadcast
-	ASSERT_TIMELY_EQ (1s, broadcast_count.load (), 2);
+	ASSERT_TIMELY_EQ (5s, broadcast_count.load (), 2);
 	ASSERT_TRUE (broadcaster.empty ());
 	ASSERT_EQ (broadcast_batch.load (), 2);
 }

--- a/nano/core_test/wallet.cpp
+++ b/nano/core_test/wallet.cpp
@@ -683,7 +683,7 @@ TEST (wallet, send_async)
 	std::atomic<bool> success (false);
 	system.wallet (0)->send_async (nano::dev::genesis_key.pub, key2.pub, std::numeric_limits<nano::uint128_t>::max (), [&success] (std::shared_ptr<nano::block> const & block_a) { ASSERT_NE (nullptr, block_a); success = true; });
 	thread.join ();
-	ASSERT_TIMELY (2s, success);
+	ASSERT_TIMELY (5s, success);
 }
 
 TEST (wallet, spend)
@@ -1329,7 +1329,7 @@ TEST (wallet, search_receivable)
 	// Pending search should create the receive block
 	ASSERT_EQ (2, node.ledger.block_count ());
 	ASSERT_FALSE (wallet.search_receivable ());
-	ASSERT_TIMELY_EQ (3s, node.balance (nano::dev::genesis_key.pub), nano::dev::constants.genesis_amount);
+	ASSERT_TIMELY_EQ (5s, node.balance (nano::dev::genesis_key.pub), nano::dev::constants.genesis_amount);
 	auto receive_hash = node.ledger.any.account_head (node.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
 	auto receive = node.block (receive_hash);
 	ASSERT_NE (nullptr, receive);

--- a/nano/core_test/wallets.cpp
+++ b/nano/core_test/wallets.cpp
@@ -287,7 +287,7 @@ TEST (wallets, search_receivable)
 		{
 			node.wallets.search_receivable (wallet_id);
 		}
-		ASSERT_TIMELY_EQ (3s, node.balance (nano::dev::genesis_key.pub), nano::dev::constants.genesis_amount);
+		ASSERT_TIMELY_EQ (5s, node.balance (nano::dev::genesis_key.pub), nano::dev::constants.genesis_amount);
 		auto receive_hash = node.ledger.any.account_head (node.ledger.tx_begin_read (), nano::dev::genesis_key.pub);
 		auto receive = node.block (receive_hash);
 		ASSERT_NE (nullptr, receive);

--- a/nano/core_test/websocket.cpp
+++ b/nano/core_test/websocket.cpp
@@ -178,7 +178,7 @@ TEST (websocket, started_election)
 	nano::messages::publish publish1{ nano::dev::network_params.network, send1 };
 	auto channel1 = std::make_shared<nano::transport::fake::channel> (*node1);
 	node1->inbound (publish1, channel1);
-	ASSERT_TIMELY (1s, node1->active.election (send1->qualified_root ()));
+	ASSERT_TIMELY (5s, node1->active.election (send1->qualified_root ()));
 	ASSERT_TIMELY_EQ (5s, future.wait_for (0s), std::future_status::ready);
 
 	auto response = future.get ();


### PR DESCRIPTION
## Summary

`websocket.started_election` failed on the Windows lmdb job in [run 34453027765](https://github.com/nanocurrency/nano-node/actions/runs/34453027765/job/102792908609): its 1s wait for the election to appear expired on a slow runner. The block has to pass through the block processor and scheduler before an election exists, and every other wait in that test already uses 5s.

This PR raises that wait and, after a case by case review of every `ASSERT_TIMELY` under 5s in `core_test`, the other waits that sit on the same kind of background latency:

- **Election creation via the block processor:** the websocket test, the fork loop in `active_elections.fork_replacement_tally`, `node.fork_election_invalid_block_signature`.
- **Cementing and successor activation:** `active_elections.activate_account_chain`, `confirm_fork`, `confirm_fork_cache`.
- **Local rep voting:** the two rep activation waits in `node.cpp`, and both vote broadcast counts in `election_scheduler.transition_optimistic_to_priority` (the 15s broadcast interval keeps the counts exact).
- **Real TCP delivery:** duplicate filter stats and `network.last_contacted`, publish arrival in `republish_winner` and `fork_replacement_tally`, channel registration in the `confirmation_solicitor` tests.
- **Wallet actions and callbacks:** `wallet.send_async`, both `search_receivable` balance waits, `active_elections.vacancy`, the vote broadcaster timer test, the loopback connect in `socket.cpp`.
- **`processing_queue.parallel`:** 3s to 5s. It still proves parallelism, since serial processing would take 32s.

## Left intentionally short

- Negative checks: every `ASSERT_ALWAYS` / `ASSERT_NEVER`, and the 200ms sleep before the receive activation check.
- The bandwidth limiter tests, which are commented as required to finish under 1s.
- Waits that are already satisfied by the time they run (the clock tick check in `last_contacted`, `!active.empty ()` after a loop that already confirmed the elections).
- The disabled `DISABLED_local_votes_cache*` tests, one of which uses a short wait as a negative check and would need a rewrite rather than a bigger number.

## Test plan

- [ ] CI green on all platforms
- Only timeout literals changed (36 lines across 11 files); no test logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
