### PR TITLE
Add peer blacklist by node id and address

### DIFF
--- a/nano/core_test/network.cpp
+++ b/nano/core_test/network.cpp
@@ -2,6 +2,7 @@
 #include <nano/lib/blocks.hpp>
 #include <nano/lib/files.hpp>
 #include <nano/lib/logging.hpp>
+#include <nano/lib/tomlconfig.hpp>
 #include <nano/messages/messages.hpp>
 #include <nano/node/block_processor.hpp>
 #include <nano/node/bootstrap/bootstrap_service.hpp>
@@ -31,6 +32,8 @@
 #include <boost/iostreams/stream_buffer.hpp>
 #include <boost/range/join.hpp>
 #include <boost/thread.hpp>
+
+#include <sstream>
 
 using namespace std::chrono_literals;
 
@@ -1177,4 +1180,111 @@ TEST (network, peer_discovery_via_peering_only_node)
 
 	// C brokered the introduction without ever holding a ledger
 	ASSERT_EQ (1, node_c->ledger.block_count ());
+}
+
+/*
+ * A blacklisted node id should never get a channel, whichever side connects, until the entry is removed
+ */
+TEST (network, blacklist_node_id)
+{
+	nano::test::system system;
+	auto node0 = system.make_disconnected_node ();
+	auto node1 = system.make_disconnected_node ();
+	node0->network.blacklist.add (node1->get_node_id ());
+
+	// The blacklisted node connects in
+	node1->network.merge_peer (node0->network.endpoint ());
+	ASSERT_TIMELY (5s, node0->stats.count (nano::stat::type::tcp_channels_rejected, nano::stat::detail::blacklisted) >= 1);
+	ASSERT_ALWAYS (500ms, node0->network.find_node_id (node1->get_node_id ()) == nullptr);
+	ASSERT_TIMELY (5s, node1->network.find_node_id (node0->get_node_id ()) == nullptr);
+
+	// This node connects out, the node id is only known after the handshake
+	node0->network.merge_peer (node1->network.endpoint ());
+	ASSERT_TIMELY (5s, node0->stats.count (nano::stat::type::tcp_channels_rejected, nano::stat::detail::blacklisted) >= 2);
+	ASSERT_ALWAYS (500ms, node0->network.find_node_id (node1->get_node_id ()) == nullptr);
+
+	// Removing the entry lets the peer connect, the failed attempt is forgotten first so it is contacted again
+	node0->network.blacklist.remove (node1->get_node_id ());
+	node1->network.cleanup (std::chrono::steady_clock::now ());
+	node1->network.syn_cookies.purge (std::chrono::steady_clock::now ());
+	node1->network.merge_peer (node0->network.endpoint ());
+	ASSERT_TIMELY (5s, node0->network.find_node_id (node1->get_node_id ()) != nullptr);
+}
+
+/*
+ * A blacklisted address should be refused by the listener and never reached out to
+ */
+TEST (network, blacklist_address)
+{
+	nano::test::system system;
+	auto node0 = system.make_disconnected_node ();
+	auto node1 = system.make_disconnected_node ();
+	node0->network.blacklist.add (node1->network.endpoint ().address ());
+
+	ASSERT_FALSE (node0->network.track_reachout (node1->network.endpoint ()));
+
+	node1->network.merge_peer (node0->network.endpoint ());
+	ASSERT_TIMELY (5s, node0->stats.count (nano::stat::type::tcp_listener_rejected, nano::stat::detail::blacklisted) >= 1);
+	ASSERT_ALWAYS (500ms, node0->network.find_node_id (node1->get_node_id ()) == nullptr);
+}
+
+/*
+ * Blacklist entries are parsed as node ids or addresses, anything else is a config error, and configured entries are applied on startup
+ */
+TEST (network, blacklist_config)
+{
+	auto parse = [] (std::string const & entries) {
+		std::stringstream ss;
+		ss << "blacklist = [" << entries << "]\n";
+		nano::tomlconfig toml;
+		toml.read (ss);
+		nano::network_config config{ nano::dev::network_params.network };
+		auto const error = config.deserialize (toml);
+		return std::make_pair (error, config);
+	};
+
+	nano::keypair peer;
+	auto const [error, config] = parse ("\"" + peer.pub.to_node_id () + "\", \"192.168.1.1\", \"::1\"");
+	ASSERT_FALSE (error);
+	ASSERT_EQ (3, config.blacklist.size ());
+
+	auto const [error_invalid, config_invalid] = parse ("\"not-a-peer\"");
+	ASSERT_TRUE (error_invalid);
+
+	// Entries given in the config are loaded when the node starts, a v4 address matches its v4 mapped v6 form
+	nano::test::system system;
+	auto node_config = system.default_config ();
+	node_config.network->blacklist = { peer.pub.to_node_id (), "192.168.1.1" };
+	auto & node = *system.add_node (node_config);
+	ASSERT_EQ (2, node.network.blacklist.size ());
+	ASSERT_TRUE (node.network.blacklist.blocked (peer.pub));
+	ASSERT_TRUE (node.network.blacklist.blocked (boost::asio::ip::make_address ("::ffff:192.168.1.1")));
+	ASSERT_FALSE (node.network.blacklist.blocked (boost::asio::ip::make_address ("192.168.1.2")));
+}
+
+/*
+ * Entries are node ids or addresses in either spelling, anything else is rejected, and removal works for both kinds
+ */
+TEST (peer_blacklist, entries)
+{
+	nano::peer_blacklist blacklist;
+	nano::keypair peer;
+
+	ASSERT_TRUE (blacklist.add (peer.pub.to_node_id ()));
+	ASSERT_TRUE (blacklist.add ("10.0.0.1"));
+	ASSERT_FALSE (blacklist.add ("not-a-peer"));
+	ASSERT_FALSE (blacklist.add (""));
+	ASSERT_EQ (2, blacklist.size ());
+
+	ASSERT_TRUE (blacklist.blocked (peer.pub));
+	ASSERT_FALSE (blacklist.blocked (nano::keypair{}.pub));
+	ASSERT_TRUE (blacklist.blocked (boost::asio::ip::make_address ("10.0.0.1")));
+	ASSERT_TRUE (blacklist.blocked (boost::asio::ip::make_address ("::ffff:10.0.0.1")));
+	ASSERT_FALSE (blacklist.blocked (boost::asio::ip::make_address ("10.0.0.2")));
+
+	blacklist.remove (peer.pub);
+	blacklist.remove (boost::asio::ip::make_address ("::ffff:10.0.0.1"));
+	ASSERT_EQ (0, blacklist.size ());
+	ASSERT_FALSE (blacklist.blocked (peer.pub));
+	ASSERT_FALSE (blacklist.blocked (boost::asio::ip::make_address ("10.0.0.1")));
 }

--- a/nano/lib/errors.cpp
+++ b/nano/lib/errors.cpp
@@ -290,6 +290,8 @@ std::string nano::error_network_messages::message (int ev) const
 			return "Connection rejected by local node";
 		case nano::error_network::peer_excluded:
 			return "Peer is excluded";
+		case nano::error_network::peer_blacklisted:
+			return "Peer is blacklisted";
 		case nano::error_network::max_connections_per_ip:
 			return "Maximum connections per IP reached";
 		case nano::error_network::max_connections_per_subnetwork:

--- a/nano/lib/errors.hpp
+++ b/nano/lib/errors.hpp
@@ -191,6 +191,7 @@ enum class error_network
 	generic = 1,
 	connection_rejected_locally,
 	peer_excluded,
+	peer_blacklisted,
 	max_connections_per_ip,
 	max_connections_per_subnetwork,
 	max_inbound_connections,

--- a/nano/lib/stats_enums.hpp
+++ b/nano/lib/stats_enums.hpp
@@ -429,6 +429,7 @@ enum class detail
 	max_attempts,
 	max_attempts_per_ip,
 	excluded,
+	blacklisted,
 	erase_dead,
 	connect_initiate,
 	connect_failure,

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -159,6 +159,8 @@ add_library(
   peer_history.cpp
   peer_exclusion.hpp
   peer_exclusion.cpp
+  peer_blacklist.hpp
+  peer_blacklist.cpp
   portmapping.hpp
   portmapping.cpp
   pruning.hpp

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -53,6 +53,7 @@ class node_config;
 class node_flags;
 class node_observers;
 class online_reps;
+class peer_blacklist;
 class peer_history;
 class peer_history_config;
 class port_mapping;

--- a/nano/node/network.cpp
+++ b/nano/node/network.cpp
@@ -48,6 +48,14 @@ nano::network::network (nano::node & node_a, uint16_t port_a) :
 		node.stats.inc (nano::stat::type::network, nano::stat::detail::connected);
 		node.logger.debug (nano::log::type::network, "Connected to: {}", channel);
 	});
+
+	for (auto const & entry : config.blacklist)
+	{
+		if (!blacklist.add (entry))
+		{
+			node.logger.warn (nano::log::type::network, "Ignoring invalid blacklist entry: {}", entry);
+		}
+	}
 }
 
 nano::network::~network ()
@@ -854,6 +862,7 @@ nano::container_info nano::network::container_info () const
 	info.add ("tcp_channels", tcp_channels.container_info ());
 	info.add ("syn_cookies", syn_cookies.container_info ());
 	info.add ("excluded_peers", excluded_peers.container_info ());
+	info.add ("blacklist", blacklist.container_info ());
 	return info;
 }
 
@@ -994,6 +1003,12 @@ nano::error nano::network_config::serialize (nano::tomlconfig & toml) const
 	toml.put ("duplicate_filter_cutoff", duplicate_filter_cutoff, "Time in seconds before a duplicate entry expires. \ntype:uint64");
 	toml.put ("minimum_fanout", minimum_fanout, "Minimum number of peers to fan out messages to. \ntype:size_t");
 
+	auto blacklist_l = toml.create_array ("blacklist", "A list of node ids (node_...) and IP addresses this node refuses to peer with.\ntype:array");
+	for (auto const & entry : blacklist)
+	{
+		blacklist_l->push_back (entry);
+	}
+
 	return toml.get_error ();
 }
 
@@ -1006,6 +1021,18 @@ nano::error nano::network_config::deserialize (nano::tomlconfig & toml)
 	toml.get ("duplicate_filter_size", duplicate_filter_size);
 	toml.get ("duplicate_filter_cutoff", duplicate_filter_cutoff);
 	toml.get ("minimum_fanout", minimum_fanout);
+
+	if (toml.has_key ("blacklist"))
+	{
+		blacklist.clear ();
+		toml.array_entries_required<std::string> ("blacklist", [this, &toml] (std::string entry) {
+			if (!nano::peer_blacklist::valid (entry))
+			{
+				toml.get_error ().set ("Invalid blacklist entry, expected a node id or an IP address: " + entry);
+			}
+			blacklist.push_back (entry);
+		});
+	}
 
 	return toml.get_error ();
 }

--- a/nano/node/network.hpp
+++ b/nano/node/network.hpp
@@ -8,6 +8,7 @@
 #include <nano/messages/fwd.hpp>
 #include <nano/messages/node_id_handshake.hpp>
 #include <nano/node/endpoint.hpp>
+#include <nano/node/peer_blacklist.hpp>
 #include <nano/node/peer_exclusion.hpp>
 #include <nano/node/transport/common.hpp>
 #include <nano/node/transport/fwd.hpp>
@@ -90,6 +91,9 @@ public:
 	uint64_t duplicate_filter_cutoff{ 60 };
 
 	size_t minimum_fanout{ 2 };
+
+	// Node ids and IP addresses this node refuses to peer with
+	std::vector<std::string> blacklist;
 };
 
 class network final
@@ -202,6 +206,7 @@ public:
 	nano::syn_cookies syn_cookies;
 	boost::asio::ip::tcp::resolver resolver;
 	nano::peer_exclusion excluded_peers;
+	nano::peer_blacklist blacklist;
 	nano::network_filter filter;
 	nano::transport::tcp_channels tcp_channels;
 	std::atomic<uint16_t> port{ 0 };

--- a/nano/node/peer_blacklist.cpp
+++ b/nano/node/peer_blacklist.cpp
@@ -1,0 +1,101 @@
+#include <nano/lib/container_info.hpp>
+#include <nano/node/peer_blacklist.hpp>
+#include <nano/node/transport/transport.hpp>
+
+#include <optional>
+#include <variant>
+
+namespace
+{
+using entry_t = std::variant<nano::account, boost::asio::ip::address>;
+
+std::optional<entry_t> parse (std::string const & entry)
+{
+	nano::account node_id;
+	if (!node_id.decode_node_id (entry))
+	{
+		return node_id;
+	}
+	boost::system::error_code ec;
+	auto const address = boost::asio::ip::make_address (entry, ec);
+	if (!ec)
+	{
+		return address;
+	}
+	return std::nullopt;
+}
+
+// Peers connect over v4 mapped v6 addresses, entries are kept in the same form so both spellings of an address match
+boost::asio::ip::address normalize (boost::asio::ip::address const & address)
+{
+	return nano::transport::mapped_from_v4_or_v6 (address);
+}
+}
+
+bool nano::peer_blacklist::valid (std::string const & entry)
+{
+	return parse (entry).has_value ();
+}
+
+bool nano::peer_blacklist::add (std::string const & entry)
+{
+	auto const parsed = parse (entry);
+	if (!parsed)
+	{
+		return false;
+	}
+	std::visit ([this] (auto const & value) { add (value); }, *parsed);
+	return true;
+}
+
+void nano::peer_blacklist::add (nano::account const & node_id)
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	node_ids.insert (node_id);
+}
+
+void nano::peer_blacklist::add (boost::asio::ip::address const & address)
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	addresses.insert (normalize (address));
+}
+
+bool nano::peer_blacklist::blocked (nano::account const & node_id) const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return node_ids.contains (node_id);
+}
+
+bool nano::peer_blacklist::blocked (boost::asio::ip::address const & address) const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return addresses.contains (normalize (address));
+}
+
+void nano::peer_blacklist::remove (nano::account const & node_id)
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	node_ids.erase (node_id);
+}
+
+void nano::peer_blacklist::remove (boost::asio::ip::address const & address)
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	addresses.erase (normalize (address));
+}
+
+std::size_t nano::peer_blacklist::size () const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+	return node_ids.size () + addresses.size ();
+}
+
+nano::container_info nano::peer_blacklist::container_info () const
+{
+	nano::lock_guard<nano::mutex> guard{ mutex };
+
+	nano::container_info info;
+	info.put ("node_ids", node_ids);
+	info.put ("addresses", addresses);
+	return info;
+}

--- a/nano/node/peer_blacklist.hpp
+++ b/nano/node/peer_blacklist.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <nano/lib/locks.hpp>
+#include <nano/lib/numbers.hpp>
+#include <nano/lib/numbers_templ.hpp>
+#include <nano/node/endpoint.hpp>
+#include <nano/node/endpoint_templ.hpp>
+#include <nano/node/fwd.hpp>
+
+#include <boost/asio/ip/address.hpp>
+
+#include <string>
+#include <unordered_set>
+
+namespace nano
+{
+/**
+ * Peers this node refuses to talk to, identified by node id or by IP address.
+ * Addresses are refused before a connection is made, node ids once the handshake reveals them, so a blacklisted peer never gets a channel in either direction.
+ */
+class peer_blacklist final
+{
+public:
+	// Whether the entry parses as a node id or an IP address
+	static bool valid (std::string const & entry);
+
+	// Add an entry given as a node id or an IP address
+	// @return false if the entry is neither
+	bool add (std::string const & entry);
+	void add (nano::account const & node_id);
+	void add (boost::asio::ip::address const &);
+
+	bool blocked (nano::account const & node_id) const;
+	bool blocked (boost::asio::ip::address const &) const;
+
+	void remove (nano::account const & node_id);
+	void remove (boost::asio::ip::address const &);
+
+	std::size_t size () const;
+	nano::container_info container_info () const;
+
+private:
+	std::unordered_set<nano::account> node_ids;
+	std::unordered_set<boost::asio::ip::address> addresses;
+	mutable nano::mutex mutex;
+};
+}

--- a/nano/node/transport/tcp_channels.cpp
+++ b/nano/node/transport/tcp_channels.cpp
@@ -76,6 +76,14 @@ auto nano::transport::tcp_channels::check (const nano::tcp_endpoint & endpoint, 
 		return channel_result::rejected;
 	}
 
+	if (node.network.blacklist.blocked (node_id) || node.network.blacklist.blocked (endpoint.address ()))
+	{
+		node.stats.inc (nano::stat::type::tcp_channels_rejected, nano::stat::detail::blacklisted);
+		node.logger.debug (nano::log::type::tcp_channels, "Rejected blacklisted channel: {} ({})", endpoint, nano::log::as_node_id (node_id));
+
+		return channel_result::rejected;
+	}
+
 	bool has_duplicate = std::any_of (channels.begin (), channels.end (), [&endpoint, &node_id] (auto const & channel) {
 		if (nano::transport::is_same_ip (channel.endpoint ().address (), endpoint.address ()))
 		{
@@ -302,6 +310,10 @@ bool nano::transport::tcp_channels::track_reachout (nano::endpoint const & endpo
 		return false;
 	}
 	if (node.network.excluded_peers.check (tcp_endpoint))
+	{
+		return false;
+	}
+	if (node.network.blacklist.blocked (tcp_endpoint.address ()))
 	{
 		return false;
 	}

--- a/nano/node/transport/tcp_listener.cpp
+++ b/nano/node/transport/tcp_listener.cpp
@@ -483,6 +483,14 @@ auto nano::transport::tcp_listener::check_limits (asio::ip::address const & ip, 
 		return accept_result::rejected_excluded;
 	}
 
+	if (node.network.blacklist.blocked (ip))
+	{
+		stats.inc (nano::stat::type::tcp_listener_rejected, nano::stat::detail::blacklisted, to_stat_dir (type));
+		logger.debug (nano::log::type::tcp_listener, "Rejected connection from blacklisted peer: {} ({})", ip, type);
+
+		return accept_result::rejected_blacklisted;
+	}
+
 	if (!node.flags.disable_max_peers_per_ip)
 	{
 		if (auto count = count_per_ip (ip); count >= node.config.network->max_peers_per_ip)
@@ -681,6 +689,8 @@ std::error_code nano::transport::to_error_code (nano::transport::tcp_listener::a
 	{
 		case accept_result::rejected_excluded:
 			return nano::error_network::peer_excluded;
+		case accept_result::rejected_blacklisted:
+			return nano::error_network::peer_blacklisted;
 		case accept_result::rejected_max_per_ip:
 			return nano::error_network::max_connections_per_ip;
 		case accept_result::rejected_max_per_subnetwork:

--- a/nano/node/transport/tcp_listener.hpp
+++ b/nano/node/transport/tcp_listener.hpp
@@ -40,6 +40,7 @@ public:
 		accepted,
 		rejected,
 		rejected_excluded,
+		rejected_blacklisted,
 		rejected_max_per_ip,
 		rejected_max_per_subnetwork,
 		rejected_max_inbound,


### PR DESCRIPTION
Adds a `[node.network] blacklist` option: a list of node ids (`node_...`) and IP addresses this node refuses to peer with. Addresses are refused before a connection is made, node ids once the handshake reveals them, so a blacklisted peer never gets a channel in either direction.

This is groundwork for upcoming test topologies where a node can reach some peers but not others. Pinning a peer out is also useful on its own for operators.

## Changes

- `nano::peer_blacklist` (`nano/node/peer_blacklist.{hpp,cpp}`): thread-safe sets of node ids and addresses with `add`, `remove` and `blocked`. Entries can be added as strings and are validated as a node id or an IP address. Addresses are kept in their v4-mapped v6 form so both spellings of a v4 address match.
- `network_config::blacklist` is serialized and deserialized as a TOML array; an entry that is neither a node id nor an address is a config error. `network` loads the configured entries on construction, owns the list as `network::blacklist` and reports it in `container_info`.
- `tcp_listener::check_limits` rejects inbound connections from a blacklisted address (`accept_result::rejected_blacklisted`, error code `peer_blacklisted`).
- `tcp_channels::check` rejects a channel once the handshake reveals a blacklisted node id or address, and `tcp_channels::track_reachout` never reaches out to a blacklisted address.
- Rejections are counted under the new `blacklisted` stat detail of `tcp_listener_rejected` and `tcp_channels_rejected`.

## Tests

- `network.blacklist_node_id`: a blacklisted node gets no channel whether it connects in or is connected to, and removing the entry lets it peer again.
- `network.blacklist_address`: a blacklisted address is refused by the listener and never reached out to.
- `network.blacklist_config`: config parsing accepts node ids and v4/v6 addresses and rejects anything else; configured entries are applied on startup, with a v4 address matching its mapped v6 form.
- `peer_blacklist.entries`: unit test for add, blocked and remove with both entry kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
