### PR TITLE
Extract rpc_process and terminate the RPC child after a grace period

### DIFF
--- a/nano/lib/logging_enums.hpp
+++ b/nano/lib/logging_enums.hpp
@@ -43,6 +43,7 @@ enum class type
 	rpc_connection,
 	http_callbacks,
 	rpc_request,
+	rpc_process,
 	ipc,
 	ipc_server,
 	websocket,

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -1,4 +1,3 @@
-#include <nano/boost/process/child.hpp>
 #include <nano/lib/files.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/memory.hpp>
@@ -19,6 +18,7 @@
 #include <nano/node/node.hpp>
 #include <nano/node/node_scope_guard.hpp>
 #include <nano/node/openclwork.hpp>
+#include <nano/node/rpc_process.hpp>
 #include <nano/rpc/rpc_server.hpp>
 
 #include <csignal>
@@ -137,7 +137,7 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 		std::atomic stopped{ false };
 
 		std::unique_ptr<nano::ipc::ipc_server> ipc_server = std::make_unique<nano::ipc::ipc_server> (*node, config.rpc);
-		std::unique_ptr<boost::process::child> rpc_process;
+		std::unique_ptr<nano::rpc_process> rpc_process;
 		std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
 		std::shared_ptr<nano::rpc_server> rpc;
 
@@ -169,18 +169,11 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 			}
 			else
 			{
-				// Spawn a child rpc process
-				if (!std::filesystem::exists (config.rpc.child_process.rpc_path))
-				{
-					throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.child_process.rpc_path);
-				}
-
 				logger.warn (nano::log::type::daemon, "RPC is configured to run in a separate process, this is experimental and is not recommended for production use. Please consider using the in-process RPC instead.");
 
 				logger.debug (nano::log::type::daemon, "Spawning RPC process with command: {}", config.rpc.child_process.rpc_path);
 
-				std::string network{ node->network_params.network.get_current_network_as_string () };
-				rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path.string (), "--network", network);
+				rpc_process = std::make_unique<nano::rpc_process> (config.rpc, data_path, node->network_params.network.get_current_network_as_string (), logger);
 			}
 			debug_assert (rpc || rpc_process);
 		}
@@ -228,7 +221,7 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 
 		if (rpc_process)
 		{
-			rpc_process->wait ();
+			rpc_process->stop ();
 		}
 	}
 	catch (std::exception const & ex)

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -1,4 +1,3 @@
-#include <nano/boost/process/child.hpp>
 #include <nano/crypto_lib/random_pool.hpp>
 #include <nano/lib/cli.hpp>
 #include <nano/lib/errors.hpp>
@@ -20,6 +19,7 @@
 #include <nano/node/node_rpc_config.hpp>
 #include <nano/node/node_scope_guard.hpp>
 #include <nano/node/openclwork.hpp>
+#include <nano/node/rpc_process.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/qt/qt.hpp>
 #include <nano/rpc/rpc_server.hpp>
@@ -173,7 +173,7 @@ public:
 				node->start ();
 				nano::ipc::ipc_server ipc (*node, config.rpc);
 
-				std::unique_ptr<boost::process::child> rpc_process;
+				std::unique_ptr<nano::rpc_process> rpc_process;
 				std::shared_ptr<nano::rpc_server> rpc;
 				std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
 				bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
@@ -200,18 +200,11 @@ public:
 					}
 					else
 					{
-						// Spawn a child rpc process
-						if (!std::filesystem::exists (config.rpc.child_process.rpc_path))
-						{
-							throw std::runtime_error (std::string ("RPC is configured to spawn a new process however the file cannot be found at: ") + config.rpc.child_process.rpc_path);
-						}
-
 						logger.warn (nano::log::type::daemon, "RPC is configured to run in a separate process, this is experimental and is not recommended for production use. Please consider using the in-process RPC instead.");
 
 						logger.debug (nano::log::type::daemon, "Spawning RPC process with command: {}", config.rpc.child_process.rpc_path);
 
-						std::string network{ node->network_params.network.get_current_network_as_string () };
-						rpc_process = std::make_unique<boost::process::child> (config.rpc.child_process.rpc_path, "--daemon", "--data_path", data_path.string (), "--network", network);
+						rpc_process = std::make_unique<nano::rpc_process> (config.rpc, data_path, node->network_params.network.get_current_network_as_string (), logger);
 					}
 				}
 				QObject::connect (&application, &QApplication::aboutToQuit, [&] () {
@@ -221,12 +214,10 @@ public:
 					{
 						rpc->stop ();
 					}
-#if USE_BOOST_PROCESS
 					if (rpc_process)
 					{
-						rpc_process->terminate ();
+						rpc_process->stop ();
 					}
-#endif
 					runner.abort ();
 				});
 				QApplication::postEvent (&processor, new nano_qt::eventloop_event ([&] () {

--- a/nano/node/CMakeLists.txt
+++ b/nano/node/CMakeLists.txt
@@ -175,6 +175,8 @@ add_library(
   vote_replier.cpp
   rpc_callbacks.hpp
   rpc_callbacks.cpp
+  rpc_process.hpp
+  rpc_process.cpp
   scheduler/bucket.cpp
   scheduler/bucket.hpp
   scheduler/component.hpp
@@ -265,7 +267,8 @@ target_link_libraries(
   Boost::thread
   rocksdb
   ${CMAKE_DL_LIBS}
-  ${psapi_lib})
+  ${psapi_lib}
+  Boost::process)
 
 target_compile_definitions(
   node PRIVATE -DTAG_VERSION_STRING=${TAG_VERSION_STRING}

--- a/nano/node/fwd.hpp
+++ b/nano/node/fwd.hpp
@@ -51,6 +51,7 @@ class network_params;
 class node;
 class node_config;
 class node_flags;
+class node_rpc_config;
 class node_observers;
 class online_reps;
 class peer_history;

--- a/nano/node/rpc_process.cpp
+++ b/nano/node/rpc_process.cpp
@@ -1,0 +1,39 @@
+#include <nano/lib/logging.hpp>
+#include <nano/node/node_rpc_config.hpp>
+#include <nano/node/rpc_process.hpp>
+
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+nano::rpc_process::rpc_process (nano::node_rpc_config const & config, std::filesystem::path const & data_path, std::string_view network, nano::logger & logger_a) :
+	logger{ logger_a }
+{
+	auto const & path = config.child_process.rpc_path;
+	if (!std::filesystem::exists (path))
+	{
+		throw std::runtime_error ("RPC is configured to spawn a new process however the file cannot be found at: " + path);
+	}
+
+	child = boost::process::child (path, "--daemon", "--data_path", data_path.string (), "--network", std::string (network));
+}
+
+void nano::rpc_process::stop ()
+{
+	std::error_code ec;
+
+	auto const deadline = std::chrono::steady_clock::now () + grace_period;
+	while (child.running (ec) && std::chrono::steady_clock::now () < deadline)
+	{
+		std::this_thread::sleep_for (100ms);
+	}
+
+	if (child.running (ec))
+	{
+		logger.warn (nano::log::type::rpc_process, "RPC process did not exit on its own, terminating it");
+		child.terminate (ec);
+	}
+	child.wait (ec);
+}

--- a/nano/node/rpc_process.hpp
+++ b/nano/node/rpc_process.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <nano/boost/process/child.hpp>
+#include <nano/node/fwd.hpp>
+
+#include <chrono>
+#include <filesystem>
+#include <string_view>
+
+namespace nano
+{
+/**
+ * The `nano_rpc` child spawned when RPC is configured to run in a separate process.
+ * The child serves RPC on its own and talks to the node over IPC. Stopping gives it a moment
+ * to exit on its own, as it does when both processes were signalled together, and terminates
+ * it otherwise, so the owner never waits on it indefinitely.
+ */
+class rpc_process final
+{
+public:
+	// How long `stop` waits for the child to exit on its own before terminating it
+	static constexpr std::chrono::seconds grace_period{ 5 };
+
+public:
+	// Spawns the child, throws `std::runtime_error` when the configured executable does not exist
+	rpc_process (nano::node_rpc_config const &, std::filesystem::path const & data_path, std::string_view network, nano::logger &);
+
+	// Waits up to `grace_period` for the child to exit on its own, then terminates it
+	void stop ();
+
+private:
+	nano::logger & logger;
+	boost::process::child child;
+};
+}

--- a/systest/rpc_child_process_terminate.sh
+++ b/systest/rpc_child_process_terminate.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+set -eux
+
+# Test that a node running its RPC in a child process shuts down when signalled, terminating the
+# child after the grace period instead of waiting on it forever
+
+source "$(dirname "$0")/lib/common.sh"
+
+if [ -z "${NANO_RPC_EXE-}" ] || [ ! -x "$NANO_RPC_EXE" ]; then
+    echo "SKIP: NANO_RPC_EXE is not set or not executable"
+    exit 0
+fi
+NANO_RPC_EXE="$(cd "$(dirname "$NANO_RPC_EXE")" && pwd)/$(basename "$NANO_RPC_EXE")"
+
+DATADIR=$(new_datadir)
+RUNTIME_INFO="$DATADIR/runtime_info.json"
+
+# The child reads its ports from the RPC config file, so they cannot be ephemeral
+RPC_PORT=$((20000 + RANDOM % 20000))
+IPC_PORT=$((40000 + RANDOM % 20000))
+cat > "$DATADIR/config-rpc.toml" <<TOML
+enable_control = true
+port = $RPC_PORT
+[process]
+ipc_port = $IPC_PORT
+TOML
+
+$NANO_NODE_EXE --daemon --network dev --data_path "$DATADIR" \
+    --enable_rpc \
+    --runtime_info_file "$RUNTIME_INFO" \
+    --config rpc.child_process.enable=true \
+    --config "rpc.child_process.rpc_path=$NANO_RPC_EXE" \
+    --config node.ipc.tcp.enable=true \
+    --config node.ipc.tcp.port=$IPC_PORT \
+    --config node.peering_port=0 &
+NODE_PID=$!
+register_pid $NODE_PID
+
+wait_for_file "$RUNTIME_INFO" $NODE_PID
+
+# Wait for the child to serve requests
+RESPONSE=""
+for i in {1..60}; do
+    RESPONSE=$(curl -g -s -m 2 -d '{ "action": "version" }' "[::1]:$RPC_PORT" || true)
+    [ -n "$RESPONSE" ] && break
+    sleep 0.5
+done
+if [ -z "$RESPONSE" ]; then
+    echo "FAIL: RPC child process did not start serving requests"
+    exit 1
+fi
+
+# Signal only the node, the child knows nothing about it and keeps running until terminated
+kill -TERM $NODE_PID
+if wait $NODE_PID; then
+    echo "Node stopped successfully"
+else
+    echo "FAIL: node did not stop cleanly"
+    exit 1
+fi
+
+if ! grep -q "did not exit on its own" "$DATADIR"/log/log_*.log; then
+    echo "FAIL: the RPC child process was not terminated by the node"
+    exit 1
+fi
+
+if curl -g -s -m 2 -d '{ "action": "version" }' "[::1]:$RPC_PORT"; then
+    echo "FAIL: the RPC child process is still serving requests"
+    exit 1
+fi
+echo "RPC child process was terminated"


### PR DESCRIPTION
## Problem

When RPC runs in a child process, the daemon spawns `nano_rpc` and, on shutdown, `wait`s on it after everything else has stopped. The child only exits when it is signalled itself, so a `SIGTERM` that reaches only the daemon hangs it forever. The wallet's `terminate` call sits behind `#if USE_BOOST_PROCESS`, which nothing defines, so quitting the wallet orphans the child. Both owners also duplicate the spawn code, including the existence check of the configured executable.

## Change

`nano::rpc_process` owns the child for both the daemon and the wallet. The constructor spawns it and, as before, throws when the executable is missing. `stop` gives the child a grace period of five seconds to exit on its own, as it does when both processes were signalled together, and terminates it otherwise, so an owner never waits on it indefinitely. The daemon's stop order is otherwise unchanged.

Preparation for the RPC shutdown work in #5168, split out so it can land on its own.

## Verification

- Full debug build on macOS, wallet included.
- New `systest/rpc_child_process_terminate.sh` starts the node in child-process mode, signals only the daemon and checks that it exits, that the child was terminated after the grace period and that the child's port stopped serving. It skips when `NANO_RPC_EXE` is not set; CI sets it.
- `systest/rpc_stop.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
