### PR TITLE
Rename the RPC server classes and move the HTTP test client to test_common

### DIFF
--- a/nano/core_test/ipc.cpp
+++ b/nano/core_test/ipc.cpp
@@ -4,7 +4,7 @@
 #include <nano/node/ipc/ipc_config.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/nodeconfig.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/testutil.hpp>
 

--- a/nano/lib/rpc_handler_interface.hpp
+++ b/nano/lib/rpc_handler_interface.hpp
@@ -7,7 +7,7 @@
 
 namespace nano
 {
-class rpc;
+class rpc_server;
 
 /** Keeps information about http requests, and for v2+ includes path and header values of interest */
 class rpc_handler_request_params final
@@ -61,6 +61,6 @@ public:
 	/** Process RPC 2.0 request. This is called via the IPC API */
 	virtual void process_request_v2 (rpc_handler_request_params const & params_a, std::string const & body, std::function<void (std::shared_ptr<std::string> const &)> response) = 0;
 	virtual void stop () = 0;
-	virtual void rpc_instance (nano::rpc & rpc) = 0;
+	virtual void rpc_instance (nano::rpc_server & rpc) = 0;
 };
 }

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -19,7 +19,7 @@
 #include <nano/node/node.hpp>
 #include <nano/node/node_scope_guard.hpp>
 #include <nano/node/openclwork.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <csignal>
 #include <iostream>
@@ -139,7 +139,7 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 		std::unique_ptr<nano::ipc::ipc_server> ipc_server = std::make_unique<nano::ipc::ipc_server> (*node, config.rpc);
 		std::unique_ptr<boost::process::child> rpc_process;
 		std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
-		std::shared_ptr<nano::rpc> rpc;
+		std::shared_ptr<nano::rpc_server> rpc;
 
 		bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
 		if (rpc_enabled)

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -11,8 +11,8 @@
 #include <nano/node/cli.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/nodeconfig.hpp>
-#include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/program_options.hpp>
 

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -22,7 +22,7 @@
 #include <nano/node/openclwork.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/qt/qt.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
@@ -174,7 +174,7 @@ public:
 				nano::ipc::ipc_server ipc (*node, config.rpc);
 
 				std::unique_ptr<boost::process::child> rpc_process;
-				std::shared_ptr<nano::rpc> rpc;
+				std::shared_ptr<nano::rpc_server> rpc;
 				std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
 				bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
 				if (rpc_enabled)

--- a/nano/nano_wallet/entry_com.cpp
+++ b/nano/nano_wallet/entry_com.cpp
@@ -2,7 +2,7 @@
 #include <nano/lib/files.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/node/cli.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>

--- a/nano/node/ipc/ipc_server.cpp
+++ b/nano/node/ipc/ipc_server.cpp
@@ -254,7 +254,7 @@ public:
 		session_timer.restart ();
 		auto request_id_l (std::to_string (server.id_dispenser.fetch_add (1)));
 
-		// This is called when nano::rpc_handler#process_request is done. We convert to
+		// This is called when nano::json_handler::process_request is done. We convert to
 		// json and write the response to the ipc socket with a length prefix.
 		auto this_l (this->shared_from_this ());
 		auto response_handler_l ([this_l, request_id_l] (std::string const & body) {

--- a/nano/node/json_handler.hpp
+++ b/nano/node/json_handler.hpp
@@ -3,7 +3,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/node/fwd.hpp>
 #include <nano/node/ipc/flatbuffers_handler.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/property_tree/ptree.hpp>
 
@@ -206,7 +206,7 @@ public:
 		}
 	}
 
-	void rpc_instance (nano::rpc & rpc_a) override
+	void rpc_instance (nano::rpc_server & rpc_a) override
 	{
 		rpc = rpc_a;
 	}
@@ -214,7 +214,7 @@ public:
 private:
 	nano::node & node;
 	nano::ipc::ipc_server & ipc_server;
-	std::optional<std::reference_wrapper<nano::rpc>> rpc;
+	std::optional<std::reference_wrapper<nano::rpc_server>> rpc;
 	std::function<void ()> stop_callback;
 	nano::node_rpc_config const & node_rpc_config;
 };

--- a/nano/rpc/CMakeLists.txt
+++ b/nano/rpc/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(
   rpc
-  rpc.hpp
-  rpc.cpp
+  rpc_server.hpp
+  rpc_server.cpp
   rpc_connection.hpp
   rpc_connection.cpp
   rpc_handler.hpp

--- a/nano/rpc/CMakeLists.txt
+++ b/nano/rpc/CMakeLists.txt
@@ -4,8 +4,8 @@ add_library(
   rpc_server.cpp
   rpc_connection.hpp
   rpc_connection.cpp
-  rpc_handler.hpp
-  rpc_handler.cpp
+  rpc_dispatcher.hpp
+  rpc_dispatcher.cpp
   rpc_request_processor.hpp
   rpc_request_processor.cpp)
 

--- a/nano/rpc/rpc_connection.cpp
+++ b/nano/rpc/rpc_connection.cpp
@@ -6,7 +6,7 @@
 #include <nano/lib/rpcconfig.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/rpc/rpc_connection.hpp>
-#include <nano/rpc/rpc_handler.hpp>
+#include <nano/rpc/rpc_dispatcher.hpp>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
@@ -137,14 +137,14 @@ void nano::rpc_connection::parse_request (STREAM_TYPE & stream, std::shared_ptr<
 				{
 					case boost::beast::http::verb::post:
 					{
-						auto handler (std::make_shared<nano::rpc_handler> (this_l->rpc_config, req.body (), request_id, response_handler, this_l->rpc_handler_interface, this_l->logger));
+						auto dispatcher (std::make_shared<nano::rpc_dispatcher> (this_l->rpc_config, req.body (), request_id, response_handler, this_l->rpc_handler_interface, this_l->logger));
 						nano::rpc_handler_request_params request_params;
 						request_params.rpc_version = rpc_version_l;
 						request_params.credentials = header_field_credentials_l;
 						request_params.correlation_id = header_corr_id_l;
 						request_params.path = boost::algorithm::erase_first_copy (path_l, api_path_l);
 						request_params.path = boost::algorithm::erase_first_copy (request_params.path, "/");
-						handler->process_request (request_params);
+						dispatcher->process_request (request_params);
 						break;
 					}
 					case boost::beast::http::verb::options:

--- a/nano/rpc/rpc_dispatcher.cpp
+++ b/nano/rpc/rpc_dispatcher.cpp
@@ -5,7 +5,7 @@
 #include <nano/lib/numbers.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/lib/rpcconfig.hpp>
-#include <nano/rpc/rpc_handler.hpp>
+#include <nano/rpc/rpc_dispatcher.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
 
@@ -18,7 +18,7 @@ std::unordered_set<std::string> rpc_control_impl_set = create_rpc_control_impls 
 std::string filter_request (boost::property_tree::ptree tree_a);
 }
 
-nano::rpc_handler::rpc_handler (nano::rpc_config const & rpc_config, std::string const & body_a, std::string const & request_id_a, std::function<void (std::string const &)> const & response_a, nano::rpc_handler_interface & rpc_handler_interface_a, nano::logger & logger) :
+nano::rpc_dispatcher::rpc_dispatcher (nano::rpc_config const & rpc_config, std::string const & body_a, std::string const & request_id_a, std::function<void (std::string const &)> const & response_a, nano::rpc_handler_interface & rpc_handler_interface_a, nano::logger & logger) :
 	body (body_a),
 	request_id (request_id_a),
 	response (response_a),
@@ -28,7 +28,7 @@ nano::rpc_handler::rpc_handler (nano::rpc_config const & rpc_config, std::string
 {
 }
 
-void nano::rpc_handler::process_request (nano::rpc_handler_request_params const & request_params)
+void nano::rpc_dispatcher::process_request (nano::rpc_handler_request_params const & request_params)
 {
 	try
 	{

--- a/nano/rpc/rpc_dispatcher.hpp
+++ b/nano/rpc/rpc_dispatcher.hpp
@@ -13,10 +13,11 @@ class rpc_config;
 class rpc_handler_interface;
 class rpc_handler_request_params;
 
-class rpc_handler : public std::enable_shared_from_this<nano::rpc_handler>
+/** Parses the JSON envelope of one request, enforces control-level access and hands it to the backend */
+class rpc_dispatcher : public std::enable_shared_from_this<nano::rpc_dispatcher>
 {
 public:
-	rpc_handler (nano::rpc_config const & rpc_config, std::string const & body_a, std::string const & request_id_a, std::function<void (std::string const &)> const & response_a, nano::rpc_handler_interface & rpc_handler_interface_a, nano::logger &);
+	rpc_dispatcher (nano::rpc_config const & rpc_config, std::string const & body_a, std::string const & request_id_a, std::function<void (std::string const &)> const & response_a, nano::rpc_handler_interface & rpc_handler_interface_a, nano::logger &);
 	void process_request (nano::rpc_handler_request_params const & request_params);
 
 private:

--- a/nano/rpc/rpc_request_processor.hpp
+++ b/nano/rpc/rpc_request_processor.hpp
@@ -4,7 +4,7 @@
 #include <nano/lib/locks.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/lib/rpcconfig.hpp>
-#include <nano/rpc/rpc.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <atomic>
 #include <deque>
@@ -103,7 +103,7 @@ public:
 		rpc_request_processor.stop ();
 	}
 
-	void rpc_instance (nano::rpc & rpc) override
+	void rpc_instance (nano::rpc_server & rpc) override
 	{
 		rpc_request_processor.stop_callback = [&rpc] () {
 			rpc.stop ();

--- a/nano/rpc/rpc_server.cpp
+++ b/nano/rpc/rpc_server.cpp
@@ -2,14 +2,14 @@
 #include <nano/lib/logging.hpp>
 #include <nano/lib/network_formatting.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
-#include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_connection.hpp>
+#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/format.hpp>
 
 #include <iostream>
 
-nano::rpc::rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a) :
+nano::rpc_server::rpc_server (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a) :
 	config (std::move (config_a)),
 	io_ctx_shared (io_ctx_a),
 	io_ctx (*io_ctx_shared),
@@ -19,7 +19,7 @@ nano::rpc::rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_con
 	rpc_handler_interface.rpc_instance (*this);
 }
 
-nano::rpc::~rpc ()
+nano::rpc_server::~rpc_server ()
 {
 	if (!stopped)
 	{
@@ -27,7 +27,7 @@ nano::rpc::~rpc ()
 	}
 }
 
-void nano::rpc::start ()
+void nano::rpc_server::start ()
 {
 	auto endpoint (boost::asio::ip::tcp::endpoint (boost::asio::ip::make_address_v6 (config.address), config.port));
 
@@ -52,7 +52,7 @@ void nano::rpc::start ()
 	accept ();
 }
 
-void nano::rpc::accept ()
+void nano::rpc_server::accept ()
 {
 	auto connection (std::make_shared<nano::rpc_connection> (config, io_ctx, logger, rpc_handler_interface));
 	acceptor.async_accept (connection->socket,
@@ -77,7 +77,7 @@ void nano::rpc::accept ()
 	}));
 }
 
-void nano::rpc::stop ()
+void nano::rpc_server::stop ()
 {
 	stopped = true;
 	boost::system::error_code ec;
@@ -88,7 +88,7 @@ void nano::rpc::stop ()
 	}
 }
 
-std::shared_ptr<nano::rpc> nano::get_rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a)
+std::shared_ptr<nano::rpc_server> nano::get_rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a)
 {
-	return std::make_shared<nano::rpc> (io_ctx_a, config_a, rpc_handler_interface_a);
+	return std::make_shared<nano::rpc_server> (io_ctx_a, config_a, rpc_handler_interface_a);
 }

--- a/nano/rpc/rpc_server.hpp
+++ b/nano/rpc/rpc_server.hpp
@@ -17,11 +17,11 @@ namespace nano
 {
 class rpc_handler_interface;
 
-class rpc : public std::enable_shared_from_this<rpc>
+class rpc_server : public std::enable_shared_from_this<rpc_server>
 {
 public:
-	rpc (std::shared_ptr<boost::asio::io_context>, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
-	virtual ~rpc ();
+	rpc_server (std::shared_ptr<boost::asio::io_context>, nano::rpc_config config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
+	virtual ~rpc_server ();
 
 	void start ();
 	void stop ();
@@ -44,5 +44,5 @@ public:
 };
 
 /** Returns the correct RPC implementation based on TLS configuration */
-std::shared_ptr<nano::rpc> get_rpc (std::shared_ptr<boost::asio::io_context>, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
+std::shared_ptr<nano::rpc_server> get_rpc (std::shared_ptr<boost::asio::io_context>, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a);
 }

--- a/nano/rpc_test/CMakeLists.txt
+++ b/nano/rpc_test/CMakeLists.txt
@@ -2,9 +2,7 @@ add_executable(
   rpc_test
   common.hpp
   rpc_context.hpp
-  test_response.hpp
   rpc_context.cpp
-  test_response.cpp
   common.cpp
   enable_control.cpp
   entry.cpp

--- a/nano/rpc_test/enable_control.cpp
+++ b/nano/rpc_test/enable_control.cpp
@@ -17,7 +17,7 @@ std::string const control_disabled_message{ "RPC control is disabled" };
 
 /*
  * Every action the RPC layer gates behind enable_control.
- * Kept in sync by hand with create_rpc_control_impls() in nano/rpc/rpc_handler.cpp; the tests below fail if the two drift apart.
+ * Kept in sync by hand with create_rpc_control_impls() in nano/rpc/rpc_dispatcher.cpp; the tests below fail if the two drift apart.
  */
 std::vector<std::string> const control_actions{
 	"account_create",

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -34,8 +34,8 @@
 #include <nano/node/unchecked_map.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/node/wallet.hpp>
-#include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
+#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
 #include <nano/rpc_test/test_response.hpp>
@@ -6849,7 +6849,7 @@ TEST (rpc, simultaneous_calls)
 	ASSERT_TRUE (ipc_tcp_port.has_value ());
 	rpc_config.rpc_process.num_ipc_connections = 8;
 	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config, ipc_tcp_port.value ());
-	auto rpc = std::make_shared<nano::rpc> (system.io_ctx, rpc_config, ipc_rpc_processor);
+	auto rpc = std::make_shared<nano::rpc_server> (system.io_ctx, rpc_config, ipc_rpc_processor);
 	nano::test::start_stop_guard stop_guard{ *rpc };
 
 	boost::property_tree::ptree request;

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -38,7 +38,6 @@
 #include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
-#include <nano/rpc_test/test_response.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/secure/ledger_set_any.hpp>
 #include <nano/secure/ledger_set_cemented.hpp>
@@ -51,6 +50,7 @@
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/system.hpp>
 #include <nano/test_common/telemetry.hpp>
+#include <nano/test_common/test_response.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>

--- a/nano/rpc_test/rpc_context.cpp
+++ b/nano/rpc_test/rpc_context.cpp
@@ -11,7 +11,7 @@
 
 #include <boost/property_tree/json_parser.hpp>
 
-nano::test::rpc_context::rpc_context (std::shared_ptr<nano::rpc> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a)
+nano::test::rpc_context::rpc_context (std::shared_ptr<nano::rpc_server> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a)
 {
 	rpc = std::move (rpc_a);
 	ipc_server = std::move (ipc_server_a);
@@ -77,7 +77,7 @@ nano::test::rpc_context nano::test::add_rpc (nano::test::system & system, std::s
 	const auto ipc_tcp_port = ipc_server->listening_tcp_port ();
 	debug_assert (ipc_tcp_port.has_value ());
 	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (system.io_ctx, rpc_config, ipc_tcp_port.value ()));
-	auto rpc (std::make_shared<nano::rpc> (system.io_ctx, rpc_config, *ipc_rpc_processor));
+	auto rpc (std::make_shared<nano::rpc_server> (system.io_ctx, rpc_config, *ipc_rpc_processor));
 	rpc->start ();
 
 	return rpc_context{ rpc, ipc_server, ipc_rpc_processor, node_rpc_config };

--- a/nano/rpc_test/rpc_context.cpp
+++ b/nano/rpc_test/rpc_context.cpp
@@ -3,8 +3,8 @@
 #include <nano/rpc/rpc_request_processor.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
-#include <nano/rpc_test/test_response.hpp>
 #include <nano/test_common/system.hpp>
+#include <nano/test_common/test_response.hpp>
 #include <nano/test_common/testutil.hpp>
 
 #include <gtest/gtest.h>

--- a/nano/rpc_test/rpc_context.hpp
+++ b/nano/rpc_test/rpc_context.hpp
@@ -12,7 +12,7 @@ class node;
 class node_rpc_config;
 class public_key;
 class account;
-class rpc;
+class rpc_server;
 
 namespace ipc
 {
@@ -25,9 +25,9 @@ namespace test
 	class rpc_context
 	{
 	public:
-		rpc_context (std::shared_ptr<nano::rpc> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a);
+		rpc_context (std::shared_ptr<nano::rpc_server> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a);
 
-		std::shared_ptr<nano::rpc> rpc;
+		std::shared_ptr<nano::rpc_server> rpc;
 		std::shared_ptr<nano::ipc::ipc_server> ipc_server;
 		std::unique_ptr<nano::ipc_rpc_processor> ipc_rpc_processor;
 		std::unique_ptr<nano::node_rpc_config> node_rpc_config;

--- a/nano/slow_test/bootstrap.cpp
+++ b/nano/slow_test/bootstrap.cpp
@@ -13,8 +13,8 @@
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/transport/transport.hpp>
 #include <nano/node/unchecked_map.hpp>
-#include <nano/rpc/rpc.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
+#include <nano/rpc/rpc_server.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/rate_observer.hpp>
@@ -57,7 +57,7 @@ public:
 	nano::rpc_config rpc_config;
 	nano::ipc::ipc_server ipc;
 	nano::ipc_rpc_processor ipc_rpc_processor;
-	nano::rpc rpc;
+	nano::rpc_server rpc;
 };
 
 std::unique_ptr<rpc_wrapper> start_rpc (nano::test::system & system, nano::node & node, uint16_t port)

--- a/nano/test_common/CMakeLists.txt
+++ b/nano/test_common/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library(
   system.cpp
   telemetry.hpp
   telemetry.cpp
+  test_response.hpp
+  test_response.cpp
   testutil.hpp
   testutil.cpp)
 

--- a/nano/test_common/test_response.cpp
+++ b/nano/test_common/test_response.cpp
@@ -1,12 +1,8 @@
-#include <nano/node/ipc/ipc_server.hpp>
-#include <nano/rpc/rpc_request_processor.hpp>
-#include <nano/rpc_test/test_response.hpp>
-#include <nano/test_common/system.hpp>
-#include <nano/test_common/testutil.hpp>
-
-#include <gtest/gtest.h>
+#include <nano/test_common/test_response.hpp>
 
 #include <boost/property_tree/json_parser.hpp>
+
+#include <sstream>
 
 std::shared_ptr<nano::test::test_response> nano::test::test_response::prepare (boost::property_tree::ptree const & request, boost::asio::io_context & io_ctx)
 {
@@ -28,7 +24,7 @@ nano::test::test_response::test_response (private_tag, boost::property_tree::ptr
 
 void nano::test::test_response::run (uint16_t port)
 {
-	sock.async_connect (nano::tcp_endpoint (boost::asio::ip::address_v6::loopback (), port), [this, /* lifetime guard */ this_s = shared_from_this ()] (boost::system::error_code const & ec) {
+	sock.async_connect (boost::asio::ip::tcp::endpoint (boost::asio::ip::address_v6::loopback (), port), [this, /* lifetime guard */ this_s = shared_from_this ()] (boost::system::error_code const & ec) {
 		if (!ec)
 		{
 			std::stringstream ostream;

--- a/nano/test_common/test_response.hpp
+++ b/nano/test_common/test_response.hpp
@@ -12,7 +12,8 @@
 namespace nano::test
 {
 /**
- * Performs a single HTTP request against an RPC server and captures the response.
+ * Performs a single HTTP POST of a JSON document against a local port and captures the JSON response.
+ * It knows nothing about the RPC API, so it serves both the `rpc_server` unit tests and the RPC API tests.
  *
  * The in-flight async operations hold a reference to this object, so it stays alive until the
  * request either completes or the io_context is destroyed. Callers are free to drop their handle


### PR DESCRIPTION
## Problem

`nano::rpc` is the HTTP listener that accepts RPC connections, not the RPC API, and `rpc_handler` is the envelope parser that dispatches to an `rpc_handler_interface` backend, so both names read as the wrong layer. `test_response`, a plain JSON-over-HTTP test client, lived in `rpc_test` and pulled in the IPC server and request processor headers it never used.

## Change

Mechanical preparation for the RPC shutdown work in #5168, split out so it can land on its own, one commit per step:

1. Rename `nano::rpc` to `nano::rpc_server`, including the files.
2. Rename `rpc_handler` to `rpc_dispatcher`, including the files.
3. Move `test_response` to `test_common` with only the includes it needs, so the core suite can drive the server with the same client the RPC API tests use.

No behavioural change. clang-format re-sorts the includes the renames displaced.

## Verification

- Full debug build on macOS, wallet included.
- `rpc.version`, `rpc.stop`, `rpc.simultaneous_calls`, the `enable_control` tests, `rpc.account_balance`, `rpc.work_generate_with_peers_defaults_distributed` and `ipc.*` pass with both backends.
- `systest/rpc_stop.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
