### PR TITLE
Introduce rpc_host and run every RPC owner on it

### DIFF
--- a/nano/core_test/CMakeLists.txt
+++ b/nano/core_test/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(
   core_test
   entry.cpp
+  fakes/rpc_handler.hpp
   fakes/websocket_client.hpp
   fakes/work_peer.hpp
   active_elections.cpp
@@ -72,6 +73,7 @@ add_executable(
   peer_container.cpp
   rep_tiers.cpp
   rep_weight_store.cpp
+  rpc_host.cpp
   scheduler_buckets.cpp
   stats.cpp
   signal_manager.cpp

--- a/nano/core_test/fakes/rpc_handler.hpp
+++ b/nano/core_test/fakes/rpc_handler.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <nano/lib/rpc_handler_interface.hpp>
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace nano::test
+{
+/** Echoes every request body back, so the server side can be tested without any RPC API */
+class echo_rpc_handler final : public nano::rpc_handler_interface
+{
+public:
+	void process_request (std::string const &, std::string const & body, std::function<void (std::string const &)> response) override
+	{
+		++requests;
+		response (body);
+	}
+
+	void process_request_v2 (nano::rpc_handler_request_params const &, std::string const & body, std::function<void (std::shared_ptr<std::string> const &)> response) override
+	{
+		++requests;
+		response (std::make_shared<std::string> (body));
+	}
+
+	void stop () override
+	{
+	}
+
+	void rpc_instance (nano::rpc_server &) override
+	{
+	}
+
+	std::atomic<int> requests{ 0 };
+};
+}

--- a/nano/core_test/rpc_host.cpp
+++ b/nano/core_test/rpc_host.cpp
@@ -1,0 +1,107 @@
+#include <nano/core_test/fakes/rpc_handler.hpp>
+#include <nano/lib/config.hpp>
+#include <nano/rpc/rpc_host.hpp>
+#include <nano/test_common/system.hpp>
+#include <nano/test_common/test_response.hpp>
+#include <nano/test_common/testutil.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+#include <stdexcept>
+
+using namespace std::chrono_literals;
+
+/*
+ * `rpc_host` runs a listener, a backend and the IO threads for both, in the order every owner
+ * uses. These tests drive it with a backend that knows nothing about the RPC API; the test thread
+ * plays the owner.
+ */
+
+namespace
+{
+nano::rpc_config host_config (nano::test::system & system, uint16_t port = 0)
+{
+	nano::rpc_config config{ nano::dev::network_params.network, port != 0 ? port : system.get_available_port (), true };
+	config.rpc_process.io_threads = 2;
+	return config;
+}
+
+bool accepts_connections (uint16_t port)
+{
+	boost::asio::io_context io_ctx;
+	boost::asio::ip::tcp::socket socket{ io_ctx };
+	boost::system::error_code ec;
+	socket.connect (boost::asio::ip::tcp::endpoint{ boost::asio::ip::address_v6::loopback (), port }, ec);
+	return !ec;
+}
+
+boost::property_tree::ptree echo_request ()
+{
+	boost::property_tree::ptree request;
+	request.put ("action", "echo");
+	return request;
+}
+}
+
+/**
+ * Starting serves requests through the backend, stopping releases the port and is idempotent
+ */
+TEST (rpc_host, start_stop)
+{
+	nano::test::system system;
+	nano::rpc_host host{ host_config (system) };
+	auto backend = std::make_unique<nano::test::echo_rpc_handler> ();
+	auto & requests = backend->requests;
+	host.start (std::move (backend));
+	ASSERT_NE (0, host.listening_port ());
+
+	auto request = echo_request ();
+	auto response = nano::test::test_response::send (request, host.listening_port (), *system.io_ctx);
+	ASSERT_TIMELY_EQ (5s, response->status, 200);
+	ASSERT_EQ ("echo", response->json.get<std::string> ("action"));
+	ASSERT_EQ (1, requests);
+
+	host.stop ();
+	ASSERT_FALSE (accepts_connections (host.listening_port ()));
+	host.stop ();
+}
+
+/**
+ * A host that is destroyed without an explicit stop, started or not, shuts down cleanly
+ */
+TEST (rpc_host, destroy_without_stop)
+{
+	nano::test::system system;
+	{
+		nano::rpc_host host{ host_config (system) };
+	}
+	uint16_t port{ 0 };
+	{
+		nano::rpc_host host{ host_config (system) };
+		host.start (std::make_unique<nano::test::echo_rpc_handler> ());
+		port = host.listening_port ();
+		ASSERT_TRUE (accepts_connections (port));
+	}
+	ASSERT_FALSE (accepts_connections (port));
+}
+
+/**
+ * Starting on a taken port throws and leaves a host that can still be destroyed
+ */
+TEST (rpc_host, bind_failure)
+{
+	if (nano::is_windows_build ())
+	{
+		GTEST_SKIP () << "Windows lets a second acceptor with SO_REUSEADDR bind a port in use";
+	}
+
+	nano::test::system system;
+	nano::rpc_host first{ host_config (system) };
+	first.start (std::make_unique<nano::test::echo_rpc_handler> ());
+
+	nano::rpc_host second{ host_config (system, first.listening_port ()) };
+	ASSERT_THROW (second.start (std::make_unique<nano::test::echo_rpc_handler> ()), std::runtime_error);
+}

--- a/nano/lib/config.hpp
+++ b/nano/lib/config.hpp
@@ -61,6 +61,39 @@ consteval bool is_sanitizer_build ()
 }
 }
 
+/*
+ * Platform info
+ */
+namespace nano
+{
+consteval bool is_windows_build ()
+{
+#ifdef _WIN32
+	return true;
+#else
+	return false;
+#endif
+}
+
+consteval bool is_macos_build ()
+{
+#ifdef __APPLE__
+	return true;
+#else
+	return false;
+#endif
+}
+
+consteval bool is_linux_build ()
+{
+#ifdef __linux__
+	return true;
+#else
+	return false;
+#endif
+}
+}
+
 namespace nano
 {
 uint16_t test_node_port ();

--- a/nano/lib/rpcconfig.cpp
+++ b/nano/lib/rpcconfig.cpp
@@ -28,7 +28,7 @@ nano::error nano::rpc_config::serialize_toml (nano::tomlconfig & toml) const
 	toml.put ("max_request_size", max_request_size, "Maximum number of bytes allowed in request bodies.\ntype:uint64");
 
 	nano::tomlconfig rpc_process_l;
-	rpc_process_l.put ("io_threads", rpc_process.io_threads, "Number of threads used to serve IO.\ntype:uint32");
+	rpc_process_l.put ("io_threads", rpc_process.io_threads, "Number of threads used to serve RPC IO, whether the RPC runs in-process or in a separate process.\ntype:uint32");
 	rpc_process_l.put ("ipc_address", rpc_process.ipc_address, "Address of IPC server.\ntype:string,ip");
 	rpc_process_l.put ("ipc_port", rpc_process.ipc_port, "Listening port of IPC server.\ntype:uint16");
 	rpc_process_l.put ("num_ipc_connections", rpc_process.num_ipc_connections, "Number of IPC connections to establish.\ntype:uint32");

--- a/nano/lib/thread_roles.cpp
+++ b/nano/lib/thread_roles.cpp
@@ -25,6 +25,9 @@ std::string nano::thread_role::get_string (nano::thread_role::name role)
 		case nano::thread_role::name::io_ipc:
 			thread_role_name_string = "I/O (IPC)";
 			break;
+		case nano::thread_role::name::io_rpc:
+			thread_role_name_string = "I/O (RPC)";
+			break;
 		case nano::thread_role::name::work:
 			thread_role_name_string = "Work pool";
 			break;

--- a/nano/lib/thread_roles.hpp
+++ b/nano/lib/thread_roles.hpp
@@ -13,6 +13,7 @@ enum class name
 	io,
 	io_daemon,
 	io_ipc,
+	io_rpc,
 	work,
 	message_processing,
 	vote_processing,

--- a/nano/nano_node/daemon.cpp
+++ b/nano/nano_node/daemon.cpp
@@ -19,7 +19,7 @@
 #include <nano/node/node_scope_guard.hpp>
 #include <nano/node/openclwork.hpp>
 #include <nano/node/rpc_process.hpp>
-#include <nano/rpc/rpc_server.hpp>
+#include <nano/rpc/rpc_host.hpp>
 
 #include <csignal>
 #include <iostream>
@@ -138,8 +138,7 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 
 		std::unique_ptr<nano::ipc::ipc_server> ipc_server = std::make_unique<nano::ipc::ipc_server> (*node, config.rpc);
 		std::unique_ptr<nano::rpc_process> rpc_process;
-		std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
-		std::shared_ptr<nano::rpc_server> rpc;
+		std::unique_ptr<nano::rpc_host> rpc;
 
 		bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
 		if (rpc_enabled)
@@ -163,9 +162,8 @@ void nano::daemon::run (std::filesystem::path const & data_path, nano::node_flag
 
 				logger.debug (nano::log::type::daemon, "Starting in-process RPC server on port {}", rpc_config.port);
 
-				rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, *ipc_server, config.rpc, stop_callback);
-				rpc = nano::get_rpc (io_ctx, rpc_config, *rpc_handler);
-				rpc->start ();
+				rpc = std::make_unique<nano::rpc_host> (rpc_config);
+				rpc->start (std::make_unique<nano::inprocess_rpc_handler> (*node, *ipc_server, config.rpc, stop_callback));
 			}
 			else
 			{

--- a/nano/nano_rpc/entry.cpp
+++ b/nano/nano_rpc/entry.cpp
@@ -4,15 +4,14 @@
 #include <nano/lib/logging.hpp>
 #include <nano/lib/networks.hpp>
 #include <nano/lib/signal_manager.hpp>
-#include <nano/lib/thread_runner.hpp>
 #include <nano/lib/threading.hpp>
 #include <nano/lib/utility.hpp>
 #include <nano/lib/version.hpp>
 #include <nano/node/cli.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
 #include <nano/node/nodeconfig.hpp>
+#include <nano/rpc/rpc_host.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
-#include <nano/rpc/rpc_server.hpp>
 
 #include <boost/program_options.hpp>
 
@@ -33,22 +32,15 @@ void run (std::filesystem::path const & data_path, std::vector<std::string> cons
 	boost::system::error_code error_chmod;
 	nano::set_secure_perm_directory (data_path, error_chmod);
 
-	std::unique_ptr<nano::thread_runner> runner;
-
 	nano::network_params network_params{ nano::get_active_network () };
 	nano::rpc_config rpc_config{ network_params.network };
 	auto error = nano::read_rpc_config_toml (data_path, rpc_config, config_overrides);
 	if (!error)
 	{
-		std::shared_ptr<boost::asio::io_context> io_ctx = std::make_shared<boost::asio::io_context> ();
-
-		runner = std::make_unique<nano::thread_runner> (io_ctx, logger, rpc_config.rpc_process.io_threads, nano::thread_role::name::io_daemon);
-
 		try
 		{
-			nano::ipc_rpc_processor ipc_rpc_processor (io_ctx, rpc_config);
-			auto rpc = nano::get_rpc (io_ctx, rpc_config, ipc_rpc_processor);
-			rpc->start ();
+			auto rpc = std::make_unique<nano::rpc_host> (rpc_config);
+			rpc->start (std::make_unique<nano::ipc_rpc_processor> (rpc->io_context (), rpc_config));
 
 			std::atomic stopped{ false };
 
@@ -68,8 +60,6 @@ void run (std::filesystem::path const & data_path, std::vector<std::string> cons
 			logger.info (nano::log::type::daemon_rpc, "Stopping...");
 
 			rpc->stop ();
-			io_ctx->stop ();
-			runner->join ();
 		}
 		catch (std::runtime_error const & e)
 		{

--- a/nano/nano_wallet/entry.cpp
+++ b/nano/nano_wallet/entry.cpp
@@ -22,7 +22,7 @@
 #include <nano/node/rpc_process.hpp>
 #include <nano/node/wallet.hpp>
 #include <nano/qt/qt.hpp>
-#include <nano/rpc/rpc_server.hpp>
+#include <nano/rpc/rpc_host.hpp>
 
 #include <boost/format.hpp>
 #include <boost/program_options.hpp>
@@ -174,8 +174,7 @@ public:
 				nano::ipc::ipc_server ipc (*node, config.rpc);
 
 				std::unique_ptr<nano::rpc_process> rpc_process;
-				std::shared_ptr<nano::rpc_server> rpc;
-				std::unique_ptr<nano::rpc_handler_interface> rpc_handler;
+				std::unique_ptr<nano::rpc_host> rpc;
 				bool const rpc_enabled = config.rpc_enable || flags.enable_rpc;
 				if (rpc_enabled)
 				{
@@ -194,9 +193,8 @@ public:
 
 						logger.debug (nano::log::type::daemon, "Starting in-process RPC server on port {}", rpc_config.port);
 
-						rpc_handler = std::make_unique<nano::inprocess_rpc_handler> (*node, ipc, config.rpc);
-						rpc = nano::get_rpc (io_ctx, rpc_config, *rpc_handler);
-						rpc->start ();
+						rpc = std::make_unique<nano::rpc_host> (rpc_config);
+						rpc->start (std::make_unique<nano::inprocess_rpc_handler> (*node, ipc, config.rpc));
 					}
 					else
 					{

--- a/nano/rpc/CMakeLists.txt
+++ b/nano/rpc/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(
   rpc_connection.cpp
   rpc_dispatcher.hpp
   rpc_dispatcher.cpp
+  rpc_host.hpp
+  rpc_host.cpp
   rpc_request_processor.hpp
   rpc_request_processor.cpp)
 

--- a/nano/rpc/rpc_host.cpp
+++ b/nano/rpc/rpc_host.cpp
@@ -1,0 +1,57 @@
+#include <nano/lib/assert.hpp>
+#include <nano/lib/rpc_handler_interface.hpp>
+#include <nano/lib/thread_runner.hpp>
+#include <nano/rpc/rpc_host.hpp>
+#include <nano/rpc/rpc_server.hpp>
+
+nano::rpc_host::rpc_host (nano::rpc_config config_a) :
+	config{ std::move (config_a) },
+	io_ctx{ std::make_shared<boost::asio::io_context> () }
+{
+}
+
+nano::rpc_host::~rpc_host ()
+{
+	stop ();
+}
+
+std::shared_ptr<boost::asio::io_context> const & nano::rpc_host::io_context () const
+{
+	return io_ctx;
+}
+
+void nano::rpc_host::start (std::unique_ptr<nano::rpc_handler_interface> backend_a)
+{
+	debug_assert (!stopped);
+	debug_assert (!server);
+	release_assert (backend_a);
+
+	backend = std::move (backend_a);
+	server = std::make_shared<nano::rpc_server> (io_ctx, config, *backend);
+	runner = std::make_unique<nano::thread_runner> (io_ctx, logger, config.rpc_process.io_threads, nano::thread_role::name::io_rpc);
+	server->start ();
+}
+
+void nano::rpc_host::stop ()
+{
+	if (stopped.exchange (true))
+	{
+		return;
+	}
+	if (server)
+	{
+		server->stop ();
+	}
+	if (runner)
+	{
+		runner->abort (); // Whatever is still queued on the IO threads is dropped
+		runner->join ();
+	}
+	backend.reset ();
+}
+
+std::uint16_t nano::rpc_host::listening_port () const
+{
+	release_assert (server);
+	return server->listening_port ();
+}

--- a/nano/rpc/rpc_host.hpp
+++ b/nano/rpc/rpc_host.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <nano/lib/logging.hpp>
+#include <nano/lib/rpcconfig.hpp>
+
+#include <boost/asio/io_context.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+
+namespace nano
+{
+class rpc_handler_interface;
+class rpc_server;
+class thread_runner;
+
+/**
+ * Hosts an RPC endpoint: the HTTP listener, the backend that serves its requests and the IO
+ * threads both run on. `start` brings them up and `stop` takes them down in a fixed order, so
+ * the standalone `nano_rpc` process, the daemon, the wallet and the test harness share one
+ * shutdown sequence. `stop` blocks until the IO threads have exited, so calling it from one of
+ * them, for example from a request handler, would deadlock; owners call it from their own thread.
+ */
+class rpc_host final
+{
+public:
+	explicit rpc_host (nano::rpc_config);
+	~rpc_host ();
+
+	// The io_context a backend must use for its own asynchronous work
+	std::shared_ptr<boost::asio::io_context> const & io_context () const;
+
+	// Binds the listener and serves requests through `backend`, throws if the port cannot be bound
+	void start (std::unique_ptr<nano::rpc_handler_interface> backend);
+	// Closes the listener, stops the IO threads and releases the backend; idempotent
+	void stop ();
+
+	// Port the listener is bound to, only meaningful after `start`
+	std::uint16_t listening_port () const;
+
+	nano::rpc_config const config;
+
+private:
+	nano::logger logger{ "rpc" };
+	std::shared_ptr<boost::asio::io_context> io_ctx;
+	std::unique_ptr<nano::rpc_handler_interface> backend;
+	std::shared_ptr<nano::rpc_server> server;
+	std::unique_ptr<nano::thread_runner> runner; // Last, so its threads are joined before anything they use goes away
+	std::atomic<bool> stopped{ false };
+};
+}

--- a/nano/rpc/rpc_server.cpp
+++ b/nano/rpc/rpc_server.cpp
@@ -60,9 +60,14 @@ void nano::rpc_server::accept ()
 		{
 			return;
 		}
-		if (ec != boost::asio::error::operation_aborted && this_l->acceptor.is_open ())
+		if (ec != boost::asio::error::operation_aborted)
 		{
-			this_l->accept ();
+			// Re-arming runs on an IO thread while the owner may be closing the acceptor on its own
+			nano::lock_guard<nano::mutex> lock{ this_l->mutex };
+			if (!this_l->stopped)
+			{
+				this_l->accept ();
+			}
 		}
 		if (!ec)
 		{
@@ -81,6 +86,7 @@ void nano::rpc_server::stop ()
 	{
 		return;
 	}
+	nano::lock_guard<nano::mutex> lock{ mutex };
 	boost::system::error_code ec;
 	acceptor.close (ec);
 	if (ec)

--- a/nano/rpc/rpc_server.cpp
+++ b/nano/rpc/rpc_server.cpp
@@ -21,10 +21,7 @@ nano::rpc_server::rpc_server (std::shared_ptr<boost::asio::io_context> io_ctx_a,
 
 nano::rpc_server::~rpc_server ()
 {
-	if (!stopped)
-	{
-		stop ();
-	}
+	stop ();
 }
 
 void nano::rpc_server::start ()
@@ -47,6 +44,7 @@ void nano::rpc_server::start ()
 		logger.critical (nano::log::type::rpc, "Error while binding for RPC on port: {} ({})", endpoint.port (), ec.message ());
 		throw std::runtime_error (ec.message ());
 	}
+	port = acceptor.local_endpoint ().port ();
 	logger.info (nano::log::type::rpc, "RPC listening address: {}", acceptor.local_endpoint ());
 	acceptor.listen ();
 	accept ();
@@ -70,7 +68,7 @@ void nano::rpc_server::accept ()
 		{
 			connection->parse_connection ();
 		}
-		else
+		else if (ec != boost::asio::error::operation_aborted)
 		{
 			this_l->logger.error (nano::log::type::rpc, "Error accepting RPC connection: {}", ec.message ());
 		}
@@ -79,13 +77,21 @@ void nano::rpc_server::accept ()
 
 void nano::rpc_server::stop ()
 {
-	stopped = true;
+	if (stopped.exchange (true))
+	{
+		return;
+	}
 	boost::system::error_code ec;
 	acceptor.close (ec);
 	if (ec)
 	{
 		logger.error (nano::log::type::rpc, "Error while closing RPC acceptor during shutdown: {}", ec.message ());
 	}
+}
+
+std::uint16_t nano::rpc_server::listening_port () const
+{
+	return port;
 }
 
 std::shared_ptr<nano::rpc_server> nano::get_rpc (std::shared_ptr<boost::asio::io_context> io_ctx_a, nano::rpc_config const & config_a, nano::rpc_handler_interface & rpc_handler_interface_a)

--- a/nano/rpc/rpc_server.hpp
+++ b/nano/rpc/rpc_server.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <nano/boost/asio/ip/tcp.hpp>
+#include <nano/lib/locks.hpp>
 #include <nano/lib/logging.hpp>
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/lib/rpcconfig.hpp>
@@ -32,6 +33,7 @@ public:
 	boost::asio::io_context & io_ctx;
 	boost::asio::ip::tcp::acceptor acceptor;
 	nano::rpc_handler_interface & rpc_handler_interface;
+	nano::mutex mutex; // Guards the acceptor
 	std::atomic<bool> stopped{ false };
 	std::uint16_t port{ 0 };
 };

--- a/nano/rpc/rpc_server.hpp
+++ b/nano/rpc/rpc_server.hpp
@@ -5,13 +5,7 @@
 #include <nano/lib/rpc_handler_interface.hpp>
 #include <nano/lib/rpcconfig.hpp>
 
-namespace boost
-{
-namespace asio
-{
-	class io_context;
-}
-}
+#include <atomic>
 
 namespace nano
 {
@@ -28,10 +22,8 @@ public:
 
 	virtual void accept ();
 
-	std::uint16_t listening_port () const
-	{
-		return acceptor.local_endpoint ().port ();
-	}
+	// Port the acceptor was bound to, only meaningful after `start`
+	std::uint16_t listening_port () const;
 
 public:
 	nano::logger logger{ "rpc" };
@@ -40,7 +32,8 @@ public:
 	boost::asio::io_context & io_ctx;
 	boost::asio::ip::tcp::acceptor acceptor;
 	nano::rpc_handler_interface & rpc_handler_interface;
-	bool stopped{ false };
+	std::atomic<bool> stopped{ false };
+	std::uint16_t port{ 0 };
 };
 
 /** Returns the correct RPC implementation based on TLS configuration */

--- a/nano/rpc_test/rpc.cpp
+++ b/nano/rpc_test/rpc.cpp
@@ -34,8 +34,8 @@
 #include <nano/node/unchecked_map.hpp>
 #include <nano/node/vote_processor.hpp>
 #include <nano/node/wallet.hpp>
+#include <nano/rpc/rpc_host.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
-#include <nano/rpc/rpc_server.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
 #include <nano/secure/ledger.hpp>
@@ -1939,7 +1939,7 @@ TEST (rpc, version)
 	auto const rpc_ctx = add_rpc (system, node1);
 	boost::property_tree::ptree request1;
 	request1.put ("action", "version");
-	auto response1 = test_response::send (request1, rpc_ctx.rpc->listening_port (), *system.io_ctx);
+	auto response1 = test_response::send (request1, rpc_ctx.host->listening_port (), *system.io_ctx);
 	ASSERT_TIMELY (5s, response1->status != 0);
 	ASSERT_EQ (200, response1->status);
 	ASSERT_EQ ("1", response1->json.get<std::string> ("rpc_version"));
@@ -2010,7 +2010,7 @@ TEST (rpc, work_generate_with_peers_defaults_distributed)
 	// Set up requesting node (node2) with local work generation disabled and work_peers pointing to node1's RPC
 	nano::node_config config2 = system.default_config ();
 	config2.work_threads = 0;
-	config2.work_peers.emplace_back ("::1", rpc_ctx_peer.rpc->listening_port ());
+	config2.work_peers.emplace_back ("::1", rpc_ctx_peer.host->listening_port ());
 	auto node2 = add_ipc_enabled_node (system, config2);
 	auto const rpc_ctx = add_rpc (system, node2);
 	ASSERT_FALSE (node2->local_work_generation_enabled ());
@@ -2335,7 +2335,7 @@ TEST (rpc, DISABLED_work_peer_one)
 	auto node1 = add_ipc_enabled_node (system);
 	auto & node2 = *system.add_node ();
 	auto const rpc_ctx = add_rpc (system, node1);
-	node2.config.work_peers.emplace_back (node1->network.endpoint ().address ().to_string (), rpc_ctx.rpc->listening_port ());
+	node2.config.work_peers.emplace_back (node1->network.endpoint ().address ().to_string (), rpc_ctx.host->listening_port ());
 	nano::keypair key1;
 	std::atomic<uint64_t> work (0);
 	node2.work_generate (nano::work_version::work_1, key1.pub, node1->network_params.work.base, [&work] (std::optional<uint64_t> work_a) {
@@ -2361,9 +2361,9 @@ TEST (rpc, DISABLED_work_peer_many)
 	const auto rpc_ctx_2 = add_rpc (system2, node2);
 	const auto rpc_ctx_3 = add_rpc (system3, node3);
 	const auto rpc_ctx_4 = add_rpc (system4, node4);
-	node1.config.work_peers.emplace_back (node2->network.endpoint ().address ().to_string (), rpc_ctx_2.rpc->listening_port ());
-	node1.config.work_peers.emplace_back (node3->network.endpoint ().address ().to_string (), rpc_ctx_3.rpc->listening_port ());
-	node1.config.work_peers.emplace_back (node4->network.endpoint ().address ().to_string (), rpc_ctx_4.rpc->listening_port ());
+	node1.config.work_peers.emplace_back (node2->network.endpoint ().address ().to_string (), rpc_ctx_2.host->listening_port ());
+	node1.config.work_peers.emplace_back (node3->network.endpoint ().address ().to_string (), rpc_ctx_3.host->listening_port ());
+	node1.config.work_peers.emplace_back (node4->network.endpoint ().address ().to_string (), rpc_ctx_4.host->listening_port ());
 
 	std::array<std::atomic<uint64_t>, 10> works{};
 	for (auto & work : works)
@@ -6835,22 +6835,12 @@ TEST (rpc, active_difficulty)
 }
 
 // This is mainly to check for threading issues with TSAN
-// TODO: Use multiple threads to run io context
 TEST (rpc, simultaneous_calls)
 {
 	// This tests simultaneous calls to the same node in different threads
 	nano::test::system system;
 	auto node = add_ipc_enabled_node (system);
-
-	nano::node_rpc_config node_rpc_config;
-	nano::ipc::ipc_server ipc_server (*node, node_rpc_config);
-	nano::rpc_config rpc_config{ nano::dev::network_params.network, system.get_available_port (), true };
-	const auto ipc_tcp_port = ipc_server.listening_tcp_port ();
-	ASSERT_TRUE (ipc_tcp_port.has_value ());
-	rpc_config.rpc_process.num_ipc_connections = 8;
-	nano::ipc_rpc_processor ipc_rpc_processor (system.io_ctx, rpc_config, ipc_tcp_port.value ());
-	auto rpc = std::make_shared<nano::rpc_server> (system.io_ctx, rpc_config, ipc_rpc_processor);
-	nano::test::start_stop_guard stop_guard{ *rpc };
+	auto const rpc_ctx = add_rpc (system, node, { .num_ipc_connections = 8 });
 
 	boost::property_tree::ptree request;
 	request.put ("action", "account_block_count");
@@ -6868,7 +6858,7 @@ TEST (rpc, simultaneous_calls)
 	nano::test::join_guard threads;
 	for (int i = 0; i < num; ++i)
 	{
-		threads.spawn ([&test_responses, &promise, &count, i, port = rpc->listening_port ()] () {
+		threads.spawn ([&test_responses, &promise, &count, i, port = rpc_ctx.host->listening_port ()] () {
 			test_responses[i]->run (port);
 			if (--count == 0)
 			{

--- a/nano/rpc_test/rpc_context.cpp
+++ b/nano/rpc_test/rpc_context.cpp
@@ -1,5 +1,6 @@
 #include <nano/lib/threading.hpp>
 #include <nano/node/ipc/ipc_server.hpp>
+#include <nano/rpc/rpc_host.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
 #include <nano/rpc_test/common.hpp>
 #include <nano/rpc_test/rpc_context.hpp>
@@ -11,17 +12,17 @@
 
 #include <boost/property_tree/json_parser.hpp>
 
-nano::test::rpc_context::rpc_context (std::shared_ptr<nano::rpc_server> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a)
+nano::test::rpc_context::~rpc_context ()
 {
-	rpc = std::move (rpc_a);
-	ipc_server = std::move (ipc_server_a);
-	ipc_rpc_processor = std::move (ipc_rpc_processor_a);
-	node_rpc_config = std::move (node_rpc_config_a);
+	if (host)
+	{
+		host->stop ();
+	}
 }
 
 void nano::test::wait_response_impl (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time, boost::property_tree::ptree & response_json)
 {
-	auto response = test_response::send (request, rpc_ctx.rpc->listening_port (), *system.io_ctx);
+	auto response = test_response::send (request, rpc_ctx.host->listening_port (), *system.io_ctx);
 	ASSERT_TIMELY (time, response->status != 0);
 	ASSERT_EQ (200, response->status);
 	response_json = response->json;
@@ -41,7 +42,7 @@ void nano::test::wait_responses_impl (nano::test::system & system, rpc_context c
 	in_flight.reserve (requests.size ());
 	for (auto & request : requests)
 	{
-		in_flight.push_back (test_response::send (request, rpc_ctx.rpc->listening_port (), *system.io_ctx));
+		in_flight.push_back (test_response::send (request, rpc_ctx.host->listening_port (), *system.io_ctx));
 	}
 	ASSERT_TIMELY (time, std::all_of (in_flight.begin (), in_flight.end (), [] (auto const & response) { return response->status != 0; }));
 	for (auto const & response : in_flight)
@@ -67,18 +68,20 @@ bool nano::test::check_block_response_count (nano::test::system & system, rpc_co
 
 nano::test::rpc_context nano::test::add_rpc (nano::test::system & system, std::shared_ptr<nano::node> const & node_a, rpc_options const & options)
 {
-	auto node_rpc_config (std::make_unique<nano::node_rpc_config> ());
-	auto ipc_server (std::make_shared<nano::ipc::ipc_server> (*node_a, *node_rpc_config));
+	rpc_context ctx;
+	ctx.node_rpc_config = std::make_unique<nano::node_rpc_config> ();
+	ctx.ipc_server = std::make_shared<nano::ipc::ipc_server> (*node_a, *ctx.node_rpc_config);
+
 	nano::rpc_config rpc_config (node_a->network_params.network, system.get_available_port (), options.enable_control);
+	rpc_config.rpc_process.io_threads = 2;
 	if (options.num_ipc_connections)
 	{
 		rpc_config.rpc_process.num_ipc_connections = *options.num_ipc_connections;
 	}
-	const auto ipc_tcp_port = ipc_server->listening_tcp_port ();
-	debug_assert (ipc_tcp_port.has_value ());
-	auto ipc_rpc_processor (std::make_unique<nano::ipc_rpc_processor> (system.io_ctx, rpc_config, ipc_tcp_port.value ()));
-	auto rpc (std::make_shared<nano::rpc_server> (system.io_ctx, rpc_config, *ipc_rpc_processor));
-	rpc->start ();
 
-	return rpc_context{ rpc, ipc_server, ipc_rpc_processor, node_rpc_config };
+	auto const ipc_tcp_port = ctx.ipc_server->listening_tcp_port ();
+	debug_assert (ipc_tcp_port.has_value ());
+	ctx.host = std::make_unique<nano::rpc_host> (rpc_config);
+	ctx.host->start (std::make_unique<nano::ipc_rpc_processor> (ctx.host->io_context (), rpc_config, ipc_tcp_port.value ()));
+	return ctx;
 }

--- a/nano/rpc_test/rpc_context.hpp
+++ b/nano/rpc_test/rpc_context.hpp
@@ -2,57 +2,64 @@
 
 #include <boost/property_tree/ptree.hpp>
 
+#include <memory>
 #include <optional>
 #include <vector>
 
 namespace nano
 {
-class ipc_rpc_processor;
 class node;
 class node_rpc_config;
 class public_key;
 class account;
-class rpc_server;
-
-namespace ipc
-{
-	class ipc_server;
+class rpc_host;
 }
 
-namespace test
+namespace nano::ipc
 {
-	class system;
-	class rpc_context
-	{
-	public:
-		rpc_context (std::shared_ptr<nano::rpc_server> & rpc_a, std::shared_ptr<nano::ipc::ipc_server> & ipc_server_a, std::unique_ptr<nano::ipc_rpc_processor> & ipc_rpc_processor_a, std::unique_ptr<nano::node_rpc_config> & node_rpc_config_a);
-
-		std::shared_ptr<nano::rpc_server> rpc;
-		std::shared_ptr<nano::ipc::ipc_server> ipc_server;
-		std::unique_ptr<nano::ipc_rpc_processor> ipc_rpc_processor;
-		std::unique_ptr<nano::node_rpc_config> node_rpc_config;
-	};
-
-	void wait_response_impl (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time, boost::property_tree::ptree & response_json);
-
-	boost::property_tree::ptree wait_response (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time = 5s);
-
-	void wait_responses_impl (nano::test::system & system, rpc_context const & rpc_ctx, std::vector<boost::property_tree::ptree> & requests, std::chrono::duration<double, std::nano> const & time, std::vector<boost::property_tree::ptree> & responses);
-
-	// Sends all requests at once and waits for every response, returned in request order.
-	// Concurrent processing requires the server to be started with more than one IPC connection, see rpc_options::num_ipc_connections
-	std::vector<boost::property_tree::ptree> wait_responses (nano::test::system & system, rpc_context const & rpc_ctx, std::vector<boost::property_tree::ptree> & requests, std::chrono::duration<double, std::nano> const & time = 5s);
-
-	bool check_block_response_count (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, uint64_t size_count);
-
-	// Configuration for the RPC server started by add_rpc
-	struct rpc_options
-	{
-		bool enable_control{ true };
-		// Overrides the RPC → IPC connection count; the dev network default of 1 processes requests one at a time
-		std::optional<unsigned> num_ipc_connections{};
-	};
-
-	rpc_context add_rpc (nano::test::system &, std::shared_ptr<nano::node> const &, rpc_options const & options = {});
+class ipc_server;
 }
+
+namespace nano::test
+{
+class system;
+
+/**
+ * An RPC host wired to a node over IPC, built the same way the standalone `nano_rpc` process
+ * builds it, so the tests run the production composition on its own IO threads. Only the test
+ * client and the node itself are driven by the polled `system` io_context.
+ */
+class rpc_context
+{
+public:
+	rpc_context () = default;
+	rpc_context (rpc_context &&) = default;
+	~rpc_context ();
+
+	std::unique_ptr<nano::node_rpc_config> node_rpc_config;
+	std::shared_ptr<nano::ipc::ipc_server> ipc_server;
+	std::unique_ptr<nano::rpc_host> host;
+};
+
+void wait_response_impl (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time, boost::property_tree::ptree & response_json);
+
+boost::property_tree::ptree wait_response (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, std::chrono::duration<double, std::nano> const & time = 5s);
+
+void wait_responses_impl (nano::test::system & system, rpc_context const & rpc_ctx, std::vector<boost::property_tree::ptree> & requests, std::chrono::duration<double, std::nano> const & time, std::vector<boost::property_tree::ptree> & responses);
+
+// Sends all requests at once and waits for every response, returned in request order.
+// Concurrent processing requires the server to be started with more than one IPC connection, see rpc_options::num_ipc_connections
+std::vector<boost::property_tree::ptree> wait_responses (nano::test::system & system, rpc_context const & rpc_ctx, std::vector<boost::property_tree::ptree> & requests, std::chrono::duration<double, std::nano> const & time = 5s);
+
+bool check_block_response_count (nano::test::system & system, rpc_context const & rpc_ctx, boost::property_tree::ptree & request, uint64_t size_count);
+
+// Configuration for the RPC server started by add_rpc
+struct rpc_options
+{
+	bool enable_control{ true };
+	// Overrides the RPC → IPC connection count; the dev network default of 1 processes requests one at a time
+	std::optional<unsigned> num_ipc_connections{};
+};
+
+rpc_context add_rpc (nano::test::system &, std::shared_ptr<nano::node> const &, rpc_options const & options = {});
 }

--- a/nano/slow_test/bootstrap.cpp
+++ b/nano/slow_test/bootstrap.cpp
@@ -13,8 +13,8 @@
 #include <nano/node/nodeconfig.hpp>
 #include <nano/node/transport/transport.hpp>
 #include <nano/node/unchecked_map.hpp>
+#include <nano/rpc/rpc_host.hpp>
 #include <nano/rpc/rpc_request_processor.hpp>
-#include <nano/rpc/rpc_server.hpp>
 #include <nano/secure/ledger.hpp>
 #include <nano/test_common/network.hpp>
 #include <nano/test_common/rate_observer.hpp>
@@ -42,22 +42,20 @@ public:
 		node_rpc_config{},
 		rpc_config{ node.network_params.network, port, true },
 		ipc{ node, node_rpc_config },
-		ipc_rpc_processor{ system.io_ctx, rpc_config },
-		rpc{ system.io_ctx, rpc_config, ipc_rpc_processor }
+		rpc{ rpc_config }
 	{
 	}
 
 	void start ()
 	{
-		rpc.start ();
+		rpc.start (std::make_unique<nano::ipc_rpc_processor> (rpc.io_context (), rpc_config));
 	}
 
 public:
 	nano::node_rpc_config node_rpc_config;
 	nano::rpc_config rpc_config;
 	nano::ipc::ipc_server ipc;
-	nano::ipc_rpc_processor ipc_rpc_processor;
-	nano::rpc_server rpc;
+	nano::rpc_host rpc;
 };
 
 std::unique_ptr<rpc_wrapper> start_rpc (nano::test::system & system, nano::node & node, uint16_t port)


### PR DESCRIPTION
## Problem

Every RPC owner composes the same three things by hand: an HTTP listener, the backend that serves its requests and the IO threads they run on. `nano_rpc` builds its own `io_context` and `thread_runner`, the daemon and the wallet put the listener on the node's `io_context`, and the RPC test harness copies the daemon's arrangement with nothing pinning the two together. Each owner also spells out its own stop order.

The in-process daemon is where this bit: a `stop` request closed the RPC acceptor from an IO thread while the main thread closed it again, which is the `rpc_stop.sh` segfault on macOS in #5166's CI run.

## Change

`rpc_host` owns the composition, split out of #5168 as the base for the shutdown rework:

- `start` binds the listener and serves requests through the backend on the host's own IO threads; `stop` closes the listener, stops the threads and releases the backend, once.
- `nano_rpc`, the daemon, the wallet, the RPC test harness and the slow-test wrapper run on it. In-process RPC therefore serves on dedicated threads sized by the existing `[process] io_threads` setting instead of the node's `io_context`, and the `nano_rpc` IO threads report the role "I/O (RPC)".
- `rpc_server::stop` is idempotent through an atomic exchange, which removes the concurrent double close. The bound port is cached at start so `listening_port` stays valid after the acceptor is closed, and a cancelled accept no longer logs an error.
- Stop semantics are otherwise unchanged here: handlers still close the listener themselves and `nano_rpc` still only closes its listener on a `stop`. Routing stop requests to the owner and draining responses in flight follow in the next PRs.
- Core tests drive the host with an echo backend from `core_test/fakes`; the bind-failure test skips on Windows through new `consteval` platform predicates in `config.hpp`, beside the sanitizer ones.

## Verification

- Full debug build on macOS, wallet included; format check clean.
- Full `rpc_test` suite on both backends, `rpc_host.*` and `ipc.*` on both backends.
- `rpc.stop`, `rpc.simultaneous_calls`, `rpc.version` and `rpc_host.*` looped 30 times each without a failure.
- `systest/rpc_stop.sh` and `systest/rpc_child_process_terminate.sh` pass, the latter with the new `nano_rpc` as the child.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
